### PR TITLE
fix: remove stale freq_table_heap tracking after snapshot load

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -114,11 +114,6 @@ pub fn main() !void {
         };
 
         if (snapshot_loaded) {
-            // If snapshot loaded a freq table, track it for cleanup
-            if (index_mod.active_pair_freq != &index_mod.default_pair_freq) {
-                // The pointer was heap-allocated by loadSnapshot
-                freq_table_heap = @constCast(index_mod.active_pair_freq);
-            }
             const t_scan = std.time.nanoTimestamp();
             var dur_buf: [64]u8 = undefined;
             const scan_elapsed = std.time.nanoTimestamp() - t_scan;


### PR DESCRIPTION
## Summary
- `setFrequencyTable` now copies into static storage (from earlier fix)
- `loadSnapshot` frees `ft` internally after the copy
- `main.zig` was still tracking `active_pair_freq` as a heap pointer and would `allocator.destroy()` static memory on exit — instant crash when loading from snapshot

## Test plan
- [x] `zig build test` — 233/233 pass
- [x] All CLI commands run without leaks