### PR TITLE
fix: complete multi-instance atomicity for snapshots, trigrams, and data log

### DIFF
--- a/src/index.zig
+++ b/src/index.zig
@@ -555,8 +555,9 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
             });
         }
 
-        // Step 4: Write postings file atomically
-        const postings_tmp = try std.fmt.allocPrint(self.allocator, "{s}/trigram.postings.tmp", .{dir_path});
+        // Step 4: Write postings file atomically (random suffix prevents collisions)
+        const post_rand = std.crypto.random.int(u64);
+        const postings_tmp = try std.fmt.allocPrint(self.allocator, "{s}/trigram.postings.{x}.tmp", .{ dir_path, post_rand });
         defer self.allocator.free(postings_tmp);
         const postings_final = try std.fmt.allocPrint(self.allocator, "{s}/trigram.postings", .{dir_path});
         defer self.allocator.free(postings_final);
@@ -596,8 +597,9 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
         }
         try std.fs.cwd().rename(postings_tmp, postings_final);
 
-        // Step 5: Write lookup file atomically
-        const lookup_tmp = try std.fmt.allocPrint(self.allocator, "{s}/trigram.lookup.tmp", .{dir_path});
+        // Step 5: Write lookup file atomically (random suffix prevents collisions)
+        const lk_rand = std.crypto.random.int(u64);
+        const lookup_tmp = try std.fmt.allocPrint(self.allocator, "{s}/trigram.lookup.{x}.tmp", .{ dir_path, lk_rand });
         defer self.allocator.free(lookup_tmp);
         const lookup_final = try std.fmt.allocPrint(self.allocator, "{s}/trigram.lookup", .{dir_path});
         defer self.allocator.free(lookup_final);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -310,6 +310,9 @@ pub fn loadSnapshot(
     store: *@import("store.zig").Store,
     allocator: std.mem.Allocator,
 ) bool {
+    // Clean up stale temp files from previous crashed writers
+    cleanupStaleTmpFiles(snapshot_path);
+
     const file = std.fs.cwd().openFile(snapshot_path, .{}) catch return false;
     defer file.close();
 
@@ -471,4 +474,27 @@ fn isSensitivePath(path: []const u8) bool {
 fn endsWith(s: []const u8, suffix: []const u8) bool {
     if (s.len < suffix.len) return false;
     return std.mem.eql(u8, s[s.len - suffix.len ..], suffix);
+}
+
+fn cleanupStaleTmpFiles(output_path: []const u8) void {
+    // Derive parent directory and basename from output_path
+    const sep = std.mem.lastIndexOfScalar(u8, output_path, '/');
+    const dir_path = if (sep) |s| output_path[0..s] else ".";
+    const basename = if (sep) |s| output_path[s + 1 ..] else output_path;
+
+    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var iter = dir.iterate();
+    while (iter.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const name = entry.name;
+        // Match: starts with basename, ends with .tmp
+        if (name.len > basename.len and
+            std.mem.startsWith(u8, name, basename) and
+            endsWith(name, ".tmp"))
+        {
+            dir.deleteFile(name) catch {};
+        }
+    }
 }

--- a/src/store.zig
+++ b/src/store.zig
@@ -78,6 +78,15 @@ pub const Store = struct {
         var data_len: u32 = 0;
         if (diff) |d| {
             if (self.data_log) |log| {
+                // Advisory lock for cross-process safety
+                const fd = log.handle;
+                _ = std.posix.flock(fd, std.posix.LOCK.EX) catch {};
+                defer _ = std.posix.flock(fd, std.posix.LOCK.UN) catch {};
+
+                // Re-stat to get current end position (another process may have appended)
+                const stat = log.stat() catch return error.Unexpected;
+                self.data_log_pos = stat.size;
+
                 data_offset = self.data_log_pos;
                 data_len = @intCast(d.len);
                 try log.seekTo(self.data_log_pos);


### PR DESCRIPTION
## Summary

Follow-up to PR #52 — makes **all** shared file writes safe when multiple codedb instances index the same repo concurrently.

### Changes

| File | Fix | Why |
|------|-----|-----|
| `snapshot.zig` | Stale `.tmp` cleanup on `loadSnapshot` | Crashed writers leave orphaned temp files; reader-side cleanup avoids deleting active writers' files |
| `index.zig` | Random temp suffix for `trigram.postings` and `trigram.lookup` | Two instances rebuilding trigrams no longer clobber each other |
| `store.zig` | `flock(LOCK_EX)` on `data_log` + re-stat for EOF | Cross-process append safety; each writer re-discovers the actual file end before writing |

### Why reader-side cleanup, not writer-side?

Writer-side cleanup (`writeSnapshot` deletes `*.tmp`) would delete another concurrent writer's in-progress temp file → write failure. Reader-side (`loadSnapshot`) runs once on startup when no concurrent writes are happening to this instance's snapshot path.

## Test plan
- [x] `issue-47` test passes (concurrent snapshot writes)
- [x] 233/234 tests pass (issue-43 is pre-existing failing test)
- [x] All CLI commands work with zero leaks