### PR TITLE
fix: non-git snapshot sentinel mismatch (0x00 vs 0xFF)

### DIFF
--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -198,7 +198,7 @@ pub fn writeSnapshot(
     if (git_head) |head| {
         try file.writeAll(&head);
     } else {
-        try file.writeAll(&([_]u8{0} ** 40));
+        try file.writeAll(&([_]u8{0xFF} ** 40));
     }
 
     var sc_buf: [4]u8 = undefined;


### PR DESCRIPTION
## Summary
`writeSnapshot` wrote `0x00 ** 40` for non-git repos, but `main.zig` checks for `0xFF ** 40` as the sentinel. **Non-git snapshots were silently rejected on every load** — instant startup never worked outside git repos.

One-line fix: write `0xFF ** 40` to match the check.

Found by gitagent swarm audit.

## Test plan
- [x] 233/234 tests pass (issue-43 is pre-existing)
- [x] issue-45 test (non-git snapshot loading) still passes