### PR TITLE
fix: sensitive metadata leak + scanBg UAF (P0 issues #39, #42)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -447,9 +447,9 @@ pub fn main() !void {
         var scan_done = std.atomic.Value(bool).init(snapshot_loaded);
 
         var queue = watcher.EventQueue{};
+        var scan_thread: ?std.Thread = null;
         if (!snapshot_loaded) {
-            const scan_thread = try std.Thread.spawn(.{}, scanBg, .{ &store, &explorer, root, allocator, &scan_done, data_dir, abs_root });
-            scan_thread.detach();
+            scan_thread = try std.Thread.spawn(.{}, scanBg, .{ &store, &explorer, root, allocator, &scan_done, data_dir, abs_root });
         }
 
         const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ &store, &explorer, &queue, root, &prerender, &shutdown, &scan_done });
@@ -460,6 +460,7 @@ pub fn main() !void {
         mcp_server.run(allocator, &store, &explorer, &agents, &prerender);
 
         shutdown.store(true, .release);
+        if (scan_thread) |st| st.join();
         watch_thread.join();
         isr_thread.join();
         idle_thread.join();

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -76,11 +76,16 @@ pub fn writeSnapshot(
         var total_bytes: u64 = 0;
         var ct_iter = explorer.contents.valueIterator();
         while (ct_iter.next()) |v| total_bytes += v.*.len;
+        var file_count_meta: u32 = 0;
+        var fc_iter = explorer.outlines.keyIterator();
+        while (fc_iter.next()) |k| {
+            if (!isSensitivePath(k.*)) file_count_meta += 1;
+        }
 
         try writer.print(
             \\{{"file_count":{d},"total_bytes":{d},"indexed_at":{d},"format_version":{d}}}
         , .{
-            explorer.outlines.count(),
+            file_count_meta,
             total_bytes,
             std.time.timestamp(),
             FORMAT_VERSION,
@@ -99,6 +104,7 @@ pub fn writeSnapshot(
         var first = true;
         var iter = explorer.outlines.iterator();
         while (iter.next()) |entry| {
+            if (isSensitivePath(entry.key_ptr.*)) continue;
             if (!first) try writer.writeByte(',');
             first = false;
             const outline = entry.value_ptr;
@@ -127,6 +133,7 @@ pub fn writeSnapshot(
         var first = true;
         var iter = explorer.outlines.iterator();
         while (iter.next()) |entry| {
+            if (isSensitivePath(entry.key_ptr.*)) continue;
             if (!first) try writer.writeByte(',');
             first = false;
             try writer.print("\"{s}\":[", .{entry.key_ptr.*});


### PR DESCRIPTION
## Summary

### Issue #39 — sensitive file metadata leaks into snapshot
`writeSnapshot` filtered `.env`, credentials, keys from CONTENT but not TREE/OUTLINE. File paths, languages, line counts, and symbol names were still written.

**Fix:** Added `if (isSensitivePath(...)) continue;` to TREE and OUTLINE iterators. Updated META `file_count` to exclude sensitive files.

### Issue #42 — scanBg thread outlives allocator
`scanBg` was spawned with `.detach()` — when MCP shuts down, `main` frees GPA/data_dir while the scan thread may still be using them.

**Fix:** Store the thread handle, join it on shutdown alongside watch/isr/idle threads.

## Test plan
- [x] 233/234 tests pass (issue-43 is pre-existing)
- [x] issue-39 test (sensitive metadata) passes
- [x] issue-42 test (UAF) passes