### PR TITLE
install: fix release download routing and add Codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/justrach/codedb2/releases/latest"><img src="https://img.shields.io/github/v/release/justrach/codedb2?style=flat-square&label=version" alt="Release" /></a>
-  <a href="https://github.com/justrach/codedb2/blob/main/LICENSE"><img src="https://img.shields.io/github/license/justrach/codedb2?style=flat-square" alt="License" /></a>
+  <a href="https://github.com/justrach/codedb/releases/latest"><img src="https://img.shields.io/github/v/release/justrach/codedb?style=flat-square&label=version" alt="Release" /></a>
+  <a href="https://github.com/justrach/codedb/blob/main/LICENSE"><img src="https://img.shields.io/github/license/justrach/codedb?style=flat-square" alt="License" /></a>
   <img src="https://img.shields.io/badge/zig-0.15-f7a41d?style=flat-square" alt="Zig 0.15" />
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Alpha" />
-  <a href="https://deepwiki.com/justrach/codedb2"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+  <a href="https://deepwiki.com/justrach/codedb"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
 <h1 align="center">codedb</h1>
@@ -73,7 +73,7 @@ Downloads the binary for your platform and auto-registers codedb as an MCP serve
 | Linux ARM64 | `codedb-linux-arm64` | — |
 | Linux x86_64 | `codedb-linux-x86_64` | — |
 
-Or install manually from [GitHub Releases](https://github.com/justrach/codedb2/releases/latest).
+Or install manually from [GitHub Releases](https://github.com/justrach/codedb/releases/latest).
 
 ---
 
@@ -318,8 +318,8 @@ rm -f codedb.snapshot      # remove snapshot from project
 **Requirements:** Zig 0.15+
 
 ```bash
-git clone https://github.com/justrach/codedb2.git
-cd codedb2
+git clone https://github.com/justrach/codedb.git
+cd codedb
 zig build                              # debug build
 zig build -Doptimize=ReleaseFast       # release build
 zig build test                         # run tests

--- a/install/worker.js
+++ b/install/worker.js
@@ -1,5 +1,5 @@
-const GITHUB_REPO = "justrach/codedb2";
-const FALLBACK_VERSION = "0.2.0";
+const GITHUB_REPO = "justrach/codedb";
+const FALLBACK_VERSION = "0.2.1";
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/install/install.sh`;
 
 export default {
@@ -75,51 +75,14 @@ async function serveLatestVersion() {
 }
 
 async function proxyReleaseBinary(version, assetName) {
-  // First, get the release by tag to find the asset download URL
   const tag = `v${version}`;
-  const releaseResp = await fetch(
-    `https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${tag}`,
-    { headers: { "User-Agent": "codedb-worker", Accept: "application/vnd.github.v3+json" } }
-  );
+  const assetUrl = `https://github.com/${GITHUB_REPO}/releases/download/${tag}/${assetName}`;
 
-  if (!releaseResp.ok) {
-    return new Response(`release ${tag} not found`, { status: 404 });
-  }
-
-  const release = await releaseResp.json();
-
-  // Find the matching asset
-  // Asset names on GitHub: "codedb-darwin-arm64", "codedb-linux-x86_64", etc.
-  // If the release just has "codedb" (no platform suffix), try exact match first then bare name
-  let asset = release.assets.find((a) => a.name === assetName);
-  if (!asset) {
-    // Fallback: if only "codedb" exists in release, map to it
-    const bare = assetName.replace(/-darwin-arm64|-darwin-x86_64|-linux-arm64|-linux-x86_64/, "");
-    asset = release.assets.find((a) => a.name === bare);
-  }
-
-  if (!asset) {
-    return new Response(
-      `asset "${assetName}" not found in release ${tag}\navailable: ${release.assets.map((a) => a.name).join(", ")}`,
-      { status: 404 }
-    );
-  }
-
-  // Proxy the binary from GitHub
-  const binaryResp = await fetch(asset.browser_download_url, {
-    headers: { "User-Agent": "codedb-worker" },
-    redirect: "follow",
-  });
-
-  if (!binaryResp.ok) {
-    return new Response("failed to download binary", { status: 502 });
-  }
-
-  return new Response(binaryResp.body, {
+  return new Response(null, {
+    status: 302,
     headers: {
-      "Content-Type": "application/octet-stream",
-      "Content-Disposition": `attachment; filename="${assetName}"`,
-      "Cache-Control": "public, max-age=86400",
+      Location: assetUrl,
+      "Cache-Control": "public, max-age=300",
     },
   });
 }

--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 VERSION="${RELEASE_VERSION:-${1:-0.1.0}}"
 CERT="Developer ID Application: Rachit Pradhan (WWP9DLJ27P)"
 REPO="$(cd "$(dirname "$0")" && pwd)"
-GITHUB_REPO="justrach/codedb2"
+GITHUB_REPO="justrach/codedb"
 DRY_RUN=false
 
 # Platforms to build

--- a/skills/codedb-install/SKILL.md
+++ b/skills/codedb-install/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: codedb-install
+description: Install codedb for Codex users and register it as an MCP server. Use when someone wants to install the hosted release build, build codedb from source, re-register a local codedb binary in Codex, or switch Codex to a different codedb executable.
+---
+
+# codedb Install
+
+Use this skill when a Codex user wants `codedb` available as an MCP server.
+
+Prefer the hosted installer for normal setup:
+
+```bash
+curl -fsSL https://codedb.codegraff.com/install.sh | sh
+```
+
+Use a source build when the user wants local changes, debug builds, or a branch that is not yet released:
+
+```bash
+git clone https://github.com/justrach/codedb.git
+cd codedb
+zig build -Doptimize=ReleaseFast
+```
+
+The built binary will usually be at `zig-out/bin/codedb`.
+
+After either path, verify the binary starts:
+
+```bash
+/absolute/path/to/codedb --help
+```
+
+Then register that binary in Codex with the helper script:
+
+```bash
+./skills/codedb-install/scripts/register_codex_mcp.sh /absolute/path/to/codedb
+```
+
+The script appends this MCP entry only when it is not already present:
+
+```toml
+[mcp_servers.codedb]
+command = "/absolute/path/to/codedb"
+args = ["mcp"]
+startup_timeout_sec = 30
+```
+
+If the user wants to replace an existing `codedb` entry with a different binary, edit `~/.codex/config.toml` directly after checking the current value.

--- a/skills/codedb-install/agents/openai.yaml
+++ b/skills/codedb-install/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Install codedb"
+  short_description: "Install or build codedb and register it as a Codex MCP server."
+  default_prompt: "Use this skill to install the latest codedb release or build codedb from source, then register it in Codex MCP config."

--- a/skills/codedb-install/scripts/register_codex_mcp.sh
+++ b/skills/codedb-install/scripts/register_codex_mcp.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: register_codex_mcp.sh /absolute/path/to/codedb" >&2
+  exit 1
+fi
+
+codedb_bin="$1"
+
+case "$codedb_bin" in
+  /*) ;;
+  *)
+    echo "error: expected an absolute path" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -x "$codedb_bin" ]; then
+  echo "error: binary is not executable: $codedb_bin" >&2
+  exit 1
+fi
+
+config_dir="${HOME}/.codex"
+config="${config_dir}/config.toml"
+
+mkdir -p "$config_dir"
+
+if [ -f "$config" ] && grep -q '\[mcp_servers\.codedb\]' "$config" 2>/dev/null; then
+  echo "codedb already registered in $config"
+  exit 0
+fi
+
+{
+  [ -f "$config" ] && [ -s "$config" ] && echo ""
+  echo '[mcp_servers.codedb]'
+  echo "command = \"$codedb_bin\""
+  echo 'args = ["mcp"]'
+  echo 'startup_timeout_sec = 30'
+} >> "$config"
+
+echo "registered codedb in $config"

--- a/website/app/benchmarks.zig
+++ b/website/app/benchmarks.zig
@@ -147,7 +147,7 @@ const html =
     \\    <div class="nav-links" id="nav-links">
     \\      <a href="/benchmarks">Benchmarks</a>
     \\      <a href="/quickstart">Install</a>
-    \\      <a href="https://github.com/justrach/codedb2">GitHub</a>
+    \\      <a href="https://github.com/justrach/codedb">GitHub</a>
     \\      <a href="/quickstart" class="nav-cta">Get started</a>
     \\    </div>
     \\  </div>
@@ -338,17 +338,17 @@ const html =
     \\      Apple M4 Pro, 48GB RAM. MCP = pre-indexed warm queries (20 iterations avg).<br>
     \\      CLI and external tools include process startup (3 iterations avg).<br>
     \\      Ground truth verified against Python reference implementation.<br><br>
-    \\      <a href="https://github.com/justrach/codedb2">View source on GitHub &rarr;</a>
+    \\      <a href="https://github.com/justrach/codedb">View source on GitHub &rarr;</a>
     \\    </div>
     \\    <div class="method-ctas">
     \\      <a href="/quickstart" class="btn">Get started</a>
-    \\      <a href="https://github.com/justrach/codedb2" class="btn btn-ghost">GitHub</a>
+    \\      <a href="https://github.com/justrach/codedb" class="btn btn-ghost">GitHub</a>
     \\    </div>
     \\  </div>
     \\</div>
     \\
     \\<footer class="layout-footer">
-    \\  codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb2">GitHub</a>
+    \\  codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb">GitHub</a>
     \\</footer>
     \\
     \\<script>

--- a/website/app/index.zig
+++ b/website/app/index.zig
@@ -150,7 +150,7 @@ const html =
     \\    <div class="nav-links" id="nav-links">
     \\      <a href="/benchmarks">Benchmarks</a>
     \\      <a href="/quickstart">Install</a>
-    \\      <a href="https://github.com/justrach/codedb2">GitHub</a>
+    \\      <a href="https://github.com/justrach/codedb">GitHub</a>
     \\      <a href="/quickstart" class="nav-cta">Get started</a>
     \\    </div>
     \\  </div>
@@ -168,7 +168,7 @@ const html =
     \\  </div>
     \\  <div class="hero-actions">
     \\    <a href="/quickstart" class="btn">Get started</a>
-    \\    <a href="https://github.com/justrach/codedb2" class="btn btn-outline">GitHub</a>
+    \\    <a href="https://github.com/justrach/codedb" class="btn btn-outline">GitHub</a>
     \\  </div>
     \\</div>
     \\
@@ -354,14 +354,14 @@ const html =
     \\    </div>
     \\    <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
     \\      <a href="/quickstart" class="btn">Quick start guide</a>
-    \\      <a href="https://github.com/justrach/codedb2" class="btn btn-outline">GitHub</a>
+    \\      <a href="https://github.com/justrach/codedb" class="btn btn-outline">GitHub</a>
     \\    </div>
     \\  </div>
     \\</div>
     \\
     \\<!-- Footer -->
     \\<div class="layout-footer">
-    \\  <p>codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb2">GitHub</a></p>
+    \\  <p>codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb">GitHub</a></p>
     \\</div>
     \\
     \\<script>

--- a/website/app/layout.zig
+++ b/website/app/layout.zig
@@ -134,7 +134,7 @@ pub fn wrap(allocator: std.mem.Allocator, path: []const u8, body: []const u8, me
         \\    <div class="nav-links" id="nav-links">
         \\      <a href="/benchmarks">Benchmarks</a>
         \\      <a href="/quickstart">Install</a>
-        \\      <a href="https://github.com/justrach/codedb2">GitHub</a>
+        \\      <a href="https://github.com/justrach/codedb">GitHub</a>
         \\      <a href="/quickstart" class="nav-cta">Get started</a>
         \\    </div>
         \\  </div>
@@ -148,7 +148,7 @@ pub fn wrap(allocator: std.mem.Allocator, path: []const u8, body: []const u8, me
     w.writeAll(
         \\
         \\  <footer class="layout-footer">
-        \\    <p>codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb2">GitHub</a></p>
+        \\    <p>codedb &mdash; code intelligence for AI agents &middot; <a href="https://github.com/justrach/codedb">GitHub</a></p>
         \\  </footer>
         \\</div>
         \\<script>

--- a/website/app/quickstart.zig
+++ b/website/app/quickstart.zig
@@ -100,8 +100,8 @@ fn page() h.Node {
         h.h2(.{}, "Building from source"),
         h.p(.{}, "Requires Zig 0.15+:"),
         h.pre(.{},
-            \\git clone https://github.com/justrach/codedb2.git
-            \\cd codedb2
+            \\git clone https://github.com/justrach/codedb.git
+            \\cd codedb
             \\zig build                              # debug build
             \\zig build -Doptimize=ReleaseFast       # release build
             \\zig build test                         # run tests
@@ -109,7 +109,7 @@ fn page() h.Node {
 
         h.div(.{ .class = "hero-actions" }, .{
             h.a(.{ .href = "/benchmarks", .class = "btn" }, "See benchmarks"),
-            h.a(.{ .href = "https://github.com/justrach/codedb2", .class = "btn btn-outline" }, "GitHub"),
+            h.a(.{ .href = "https://github.com/justrach/codedb", .class = "btn btn-outline" }, "GitHub"),
         }),
     });
 }


### PR DESCRIPTION
## Summary
- fix hosted versioned download routing by redirecting exact asset URLs to GitHub releases
- update repo links and source-build docs to use justrach/codedb
- add an in-repo Codex skill for installing or building codedb and registering it as an MCP server

## Verification
- deployed updated install worker to codedb.codegraff.com
- verified the versioned asset URL returns a 302 to the exact GitHub release asset
- verified curl install flow completes successfully
- verified the installed binary starts and can run CLI commands
- tested the skill helper script in an isolated HOME