### PR TITLE
feat(explore): add PHP/Laravel language support

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1007,13 +1007,17 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
         in_block_comment: bool = false,
     };
 
-    fn parsePhpLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline, state: *PhpParseState) !void {
+    fn parsePhpLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline, state: *PhpParseState) !void {
         const a = self.allocator;
 
+        var line = raw_line;
         if (line.len == 0) return;
         if (state.in_block_comment) {
-            if (std.mem.indexOf(u8, line, "*/") != null) state.in_block_comment = false;
-            return;
+            if (std.mem.indexOf(u8, line, "*/")) |end| {
+                state.in_block_comment = false;
+                line = std.mem.trim(u8, line[end + 2 ..], " \t");
+                if (line.len == 0) return;
+            } else return;
         }
         if (startsWith(line, "<?php")) return;
         if (startsWith(line, "//") or startsWith(line, "#")) return;
@@ -1120,7 +1124,7 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
             while (items.next()) |item| {
                 const raw_item = std.mem.trim(u8, item, " \t");
                 if (raw_item.len == 0) continue;
-                const trimmed_item = if (std.mem.indexOf(u8, raw_item, " as ")) |as_pos| raw_item[0..as_pos] else raw_item;
+                const trimmed_item = phpStripAlias(raw_item);
                 const full_ns = try a.alloc(u8, base.len + trimmed_item.len);
                 defer a.free(full_ns);
                 @memcpy(full_ns[0..base.len], base);
@@ -1138,11 +1142,19 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
                 .line_start = line_num,
                 .line_end = line_num,
             });
-            const ns = if (std.mem.indexOf(u8, use_body, " as ")) |as_pos| use_body[0..as_pos] else use_body;
+            const ns = phpStripAlias(use_body);
             const path_copy = try phpNamespaceToPath(a, ns);
             errdefer a.free(path_copy);
             try outline.imports.append(a, path_copy);
         }
+    }
+
+    fn phpStripAlias(s: []const u8) []const u8 {
+        if (s.len < 4) return s;
+        for (0..s.len - 3) |i| {
+            if (s[i] == ' ' and (s[i + 1] == 'a' or s[i + 1] == 'A') and (s[i + 2] == 's' or s[i + 2] == 'S') and s[i + 3] == ' ') return s[0..i];
+        }
+        return s;
     }
 
     fn phpMatchConstant(_: *Explorer, line: []const u8) ?[]const u8 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4000,3 +4000,48 @@ test "issue-php-16: PHP escaped quotes do not end string mode" {
     try testing.expectEqual(@as(usize, 2), method_count);
     try testing.expectEqual(@as(usize, 1), function_count);
 }
+
+test "issue-php-17: PHP code after block comment terminator is parsed" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("app/Services/Inline.php",
+        \\<?php
+        \\
+        \\/*
+        \\function fake() {
+        \\}
+        \\*/ function realFunc()
+        \\{
+        \\}
+    );
+
+    var outline = (try explorer.getOutline("app/Services/Inline.php", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    var function_count: usize = 0;
+    for (outline.symbols.items) |sym| {
+        if (sym.kind == .function) function_count += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), function_count);
+}
+
+test "issue-php-18: PHP use-as alias case-insensitive" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("app/Controllers/CaseTest.php",
+        \\<?php
+        \\
+        \\use App\Models\User AS UserModel;
+        \\use App\Services\{Cache AS CacheAlias, Logger};
+    );
+
+    var outline = (try explorer.getOutline("app/Controllers/CaseTest.php", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    try testing.expectEqual(@as(usize, 3), outline.imports.items.len);
+    try testing.expectEqualStrings("app/Models/User.php", outline.imports.items[0]);
+    try testing.expectEqualStrings("app/Services/Cache.php", outline.imports.items[1]);
+    try testing.expectEqualStrings("app/Services/Logger.php", outline.imports.items[2]);
+}


### PR DESCRIPTION
## Summary

Adds a line-based PHP parser to `src/explore.zig` so that `codedb_outline`, `codedb_symbol`, and `codedb_deps` work correctly for PHP/Laravel codebases.

### Recognised constructs
- `class`, `abstract class`, `final class`, `readonly class` (PHP 8.2)
- `interface`, `trait`, `enum` (PHP 8.1)
- Methods (`public`/`protected`/`private`/`static`/`abstract function`)
- Top-level functions (outside class context)
- Constants (`const`, `public const`, `protected const`, `private const`)
- `use`-imports with namespace → path conversion (`App\Models\Candidate` → `app/Models/Candidate.php`)
- Grouped use-statements: `use App\Models\{User, Candidate, Role};`

### Implementation details
- Brace-depth tracking (`PhpParseState`) correctly distinguishes methods from top-level functions, even with deeply nested control structures
- New `SymbolKind` variants: `class_def`, `interface_def`
- New `Language` variant: `php`
- Free function `phpNamespaceToPath` converts PHP namespaces to file paths (PSR-4 convention, lowercase first segment)

### Changes
- `src/explore.zig` — PHP parser + dispatcher registration (+193 lines)
- `src/tests.zig` — 13 tests covering all constructs (+352 lines)

## Test plan
- [x] `zig build test` — all 13 `issue-php-*` tests pass
- [x] `zig build -Doptimize=ReleaseFast` — clean release build
- [ ] Manual: run `codedb outline` on a Laravel project's model/controller files

🤖 Generated with [Claude Code](https://claude.ai/code)