### PR TITLE
release: v0.2.3 — self-update, --version, Developer ID codesign

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
 
     // ── macOS ad-hoc codesign (prevents SIGKILL on unsigned binaries) ──
     if (target.result.os.tag == .macos) {
-        const codesign = b.addSystemCommand(&.{ "codesign", "-f", "-s", "-" });
+        const codesign = b.addSystemCommand(&.{ "codesign", "-f", "-s", "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)" });
         codesign.addArtifactArg(exe);
         b.getInstallStep().dependOn(&codesign.step);
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.2",
+    .version = "0.2.3",
     .minimum_zig_version = "0.15.0",
     .dependencies = .{
         .mcp_zig = .{

--- a/install/worker.js
+++ b/install/worker.js
@@ -1,5 +1,5 @@
 const GITHUB_REPO = "justrach/codedb";
-const FALLBACK_VERSION = "0.2.2";
+const FALLBACK_VERSION = "0.2.3";
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/install/install.sh`;
 
 export default {

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,6 +61,14 @@ fn mainImpl() !void {
         root = ".";
         cmd = "mcp";
         cmd_args_start = 2;
+    } else if (args.len >= 2 and (std.mem.eql(u8, args[1], "--version") or std.mem.eql(u8, args[1], "-v"))) {
+        root = ".";
+        cmd = "--version";
+        cmd_args_start = 2;
+    } else if (args.len >= 2 and std.mem.eql(u8, args[1], "--help")) {
+        root = ".";
+        cmd = "--help";
+        cmd_args_start = 2;
     } else if (args.len < 2) {
         printUsage(out, s);
         std.process.exit(1);
@@ -75,6 +83,29 @@ fn mainImpl() !void {
     } else {
         printUsage(out, s);
         std.process.exit(1);
+    }
+
+    // Handle --version early (no root needed)
+    if (std.mem.eql(u8, cmd, "--version") or std.mem.eql(u8, cmd, "-v") or std.mem.eql(u8, cmd, "version")) {
+        out.p("codedb 0.2.3\n", .{});
+        return;
+    }
+
+    // Handle update command (re-runs the install script)
+    if (std.mem.eql(u8, cmd, "update")) {
+        out.p("updating codedb...\n", .{});
+        var child = std.process.Child.init(
+            &.{ "/bin/sh", "-c", "curl -fsSL https://codedb.codegraff.com/install.sh | sh" },
+            allocator,
+        );
+        child.stdin_behavior = .Inherit;
+        child.stdout_behavior = .Inherit;
+        child.stderr_behavior = .Inherit;
+        _ = child.spawnAndWait() catch {
+            out.p("update failed\n", .{});
+            std.process.exit(1);
+        };
+        return;
     }
 
     if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, "${workspaceFolder}")) {
@@ -508,7 +539,7 @@ fn mainImpl() !void {
     }
 }
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "hot", "snapshot", "serve", "mcp" };
+    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "hot", "snapshot", "serve", "mcp", "update" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -404,7 +404,7 @@ fn handleInitialize(s: *Session, root: *const std.json.ObjectMap, id: ?std.json.
         s.client_roots_list_changed = mcpj.getBool(&r.object, "listChanged");
     }
     writeResult(s.alloc, s.stdout, id,
-        \\{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"codedb","version":"0.2.2"}}
+        \\{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"codedb","version":"0.2.3"}}
     );
 }
 

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -5,7 +5,7 @@ const index = @import("index.zig");
 
 const RING_SIZE = 256;
 const CLOUD_URL = "https://codedb.codegraff.com/telemetry/ingest";
-const VERSION = "0.2.2";
+const VERSION = "0.2.3";
 const PLATFORM = std.fmt.comptimePrint("{s}-{s}", .{ @tagName(builtin.os.tag), @tagName(builtin.cpu.arch) });
 
 pub const Event = struct {


### PR DESCRIPTION
## v0.2.3

### New commands
- `codedb update` — self-update by re-running the install script
- `codedb --version` / `codedb -v` — prints version (no root needed)

### Build
- **macOS binaries signed with Developer ID** (Rachit Pradhan, WWP9DLJ27P) — passes Gatekeeper/spctl
- No longer ad-hoc signed

### Changes since v0.2.2
- Sensitive files (.env, credentials, keys) excluded from live indexing (#97)
- Telemetry docs accurately describe auto-sync behavior (#97)
- BSD 3-Clause license added
- AGENTS.md for Codex review guidelines
- Benchmark numbers updated (openclaw 75s→2.9s, vitess 50s→~2s)
- All `codedb2` references renamed to `codedb`
- CLI fixes: deps field, root mismatch, --help/--version (#91)