### PR TITLE
fix: Python deps matching via module path extraction

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -798,9 +798,27 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
                 .line_start = line_num,
                 .line_end = line_num,
             });
-            const import_copy = try a.dupe(u8, line);
-            errdefer a.free(import_copy);
-            try outline.imports.append(a, import_copy);
+            // Extract module path and convert dots to slashes for dep matching.
+            // "from mypackage.utils.helpers import X" → "mypackage/utils/helpers.py"
+            // "import os.path" → "os/path.py"
+            if (extractPythonModulePath(line)) |mod_path| {
+                var buf: [512]u8 = undefined;
+                var pos: usize = 0;
+                for (mod_path) |c| {
+                    if (pos >= buf.len - 3) break;
+                    buf[pos] = if (c == '.') '/' else c;
+                    pos += 1;
+                }
+                if (pos + 3 <= buf.len) {
+                    buf[pos] = '.';
+                    buf[pos + 1] = 'p';
+                    buf[pos + 2] = 'y';
+                    pos += 3;
+                }
+                const import_copy = try a.dupe(u8, buf[0..pos]);
+                errdefer a.free(import_copy);
+                try outline.imports.append(a, import_copy);
+            }
         }
     }
     fn parseTsLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
@@ -1872,4 +1890,30 @@ fn skipKeywords(s: []const u8) []const u8 {
         }
     }
     return result;
+}
+
+/// Extract the module path from a Python import line.
+/// "from mypackage.utils.helpers import X" → "mypackage.utils.helpers"
+/// "import os.path" → "os.path"
+/// "from . import foo" / "from .rel import bar" → null (relative imports too ambiguous)
+fn extractPythonModulePath(line: []const u8) ?[]const u8 {
+    if (startsWith(line, "from ")) {
+        const rest = std.mem.trimLeft(u8, line[5..], " \t");
+        // Skip relative imports (start with dot)
+        if (rest.len > 0 and rest[0] == '.') return null;
+        // "from module.path import ..." — extract up to " import"
+        if (std.mem.indexOf(u8, rest, " import")) |imp_pos| {
+            const mod = std.mem.trimRight(u8, rest[0..imp_pos], " \t");
+            if (mod.len > 0) return mod;
+        }
+        return null;
+    } else if (startsWith(line, "import ")) {
+        const rest = std.mem.trimLeft(u8, line[7..], " \t");
+        // "import os.path" or "import foo" — take up to comma or space
+        var end: usize = 0;
+        while (end < rest.len and rest[end] != ' ' and rest[end] != ',' and rest[end] != '\t') : (end += 1) {}
+        if (end > 0) return rest[0..end];
+        return null;
+    }
+    return null;
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4068,3 +4068,21 @@ test "issue-php-18: PHP use-as alias case-insensitive" {
     try testing.expectEqualStrings("app/Services/Cache.php", outline.imports.items[1]);
     try testing.expectEqualStrings("app/Services/Logger.php", outline.imports.items[2]);
 }
+
+test "issue-107: codedb_deps returns results for Python files" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("mypackage/utils/helpers.py", "def helper_func():\n    pass\n");
+    try explorer.indexFile("consumer.py", "from mypackage.utils.helpers import helper_func\n");
+
+    const deps = try explorer.getImportedBy("mypackage/utils/helpers.py", testing.allocator);
+    defer {
+        for (deps) |d| testing.allocator.free(d);
+        testing.allocator.free(deps);
+    }
+
+    try testing.expect(deps.len == 1);
+    try testing.expectEqualStrings("consumer.py", deps[0]);
+}


### PR DESCRIPTION
## Summary
Fixes #107 — `codedb_deps` always returned `(no dependents found)` for Python files.

- `parsePythonLine` now extracts the module path from Python import lines and converts dots to slashes:
  - `from mypackage.utils.helpers import X` → stores `mypackage/utils/helpers.py`
  - `import os.path` → stores `os/path.py`
  - Relative imports (`from . import foo`) are skipped (too ambiguous without project structure)
- `getImportedBy` already matches on both full path and basename, so `helpers.py` now matches

## Test plan
- [x] New test `issue-107: codedb_deps returns results for Python files` — **verified fails on old code, passes on fix**
- [x] All existing tests pass (`zig build test` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)