### PR TITLE
security: block sensitive files in MCP tools, fix SSRF in remote

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -812,6 +812,10 @@ fn handleRead(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
         out.appendSlice(alloc, "error: path traversal not allowed") catch {};
         return;
     }
+    if (watcher.isSensitivePath(path)) {
+        out.appendSlice(alloc, "error: access to sensitive file blocked") catch {};
+        return;
+    }
     // Try indexed content first (faster, consistent with indexed view)
     const cached = explorer.getContent(path, alloc) catch {
         out.appendSlice(alloc, "error: read failed") catch {};
@@ -879,6 +883,10 @@ fn handleEdit(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
     };
     if (!isPathSafe(path)) {
         out.appendSlice(alloc, "error: path traversal not allowed") catch {};
+        return;
+    }
+    if (watcher.isSensitivePath(path)) {
+        out.appendSlice(alloc, "error: access to sensitive file blocked") catch {};
         return;
     }
     const op_str = getStr(args, "op") orelse "replace";
@@ -1054,6 +1062,32 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         out.appendSlice(alloc, "error: missing 'action' (tree, outline, search, meta)") catch {};
         return;
     };
+    // Validate action against whitelist to prevent SSRF/path injection
+    const valid_actions = [_][]const u8{ "tree", "outline", "search", "meta" };
+    var action_valid = false;
+    for (valid_actions) |va| {
+        if (std.mem.eql(u8, action, va)) { action_valid = true; break; }
+    }
+    if (!action_valid) {
+        out.appendSlice(alloc, "error: invalid action, must be one of: tree, outline, search, meta") catch {};
+        return;
+    }
+
+    // Validate repo format: must be "owner/name" with no path traversal
+    if (std.mem.indexOf(u8, repo, "..") != null or
+        std.mem.indexOf(u8, repo, "//") != null or
+        repo[0] == '/' or
+        std.mem.indexOfScalar(u8, repo, '/') == null)
+    {
+        out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
+        return;
+    }
+    // Ensure exactly one slash (owner/repo, not owner/repo/extra/path)
+    const slash_pos = std.mem.indexOfScalar(u8, repo, '/').?;
+    if (std.mem.indexOfScalarPos(u8, repo, slash_pos + 1, '/') != null) {
+        out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
+        return;
+    }
 
     // Build URL and curl args
     var url_buf: [512]u8 = undefined;

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -39,6 +39,7 @@ pub const Telemetry = struct {
     buf: [4096]u8 = undefined,
     path_buf: [std.fs.max_path_bytes]u8 = undefined,
     path_len: usize = 0,
+    call_count: u32 = 0,
 
     pub fn init(data_dir: []const u8, allocator: std.mem.Allocator, disabled: bool) Telemetry {
         var self = Telemetry{};
@@ -76,6 +77,15 @@ pub const Telemetry = struct {
         const tail = self.tail.load(.monotonic);
         if ((next + 1) -% tail > RING_SIZE) {
             self.tail.store((next + 1) -% RING_SIZE, .monotonic);
+        }
+
+        // Periodic flush: write to disk every 3 calls, sync to cloud every 10
+        self.call_count += 1;
+        if (self.call_count % 3 == 0) {
+            self.flush();
+        }
+        if (self.call_count % 10 == 0) {
+            self.syncToCloud();
         }
     }
 
@@ -144,14 +154,23 @@ pub const Telemetry = struct {
         const stat = std.fs.cwd().statFile(path) catch return;
         if (stat.size == 0) return;
 
-        var cmd_buf: [2048]u8 = undefined;
-        const cmd = std.fmt.bufPrint(&cmd_buf, "curl -sf -X POST {s} -H 'Content-Type: application/json' --data-binary @{s} >/dev/null 2>&1 && : > {s}", .{ CLOUD_URL, path, path }) catch return;
+        // Use argv-based exec (no shell interpolation) to avoid injection
+        var data_arg_buf: [std.fs.max_path_bytes + 1]u8 = undefined;
+        const data_arg = std.fmt.bufPrint(&data_arg_buf, "@{s}", .{path}) catch return;
 
-        var child = std.process.Child.init(&.{ "/bin/sh", "-c", cmd }, std.heap.page_allocator);
+        var child = std.process.Child.init(
+            &.{ "curl", "-sf", "-X", "POST", CLOUD_URL, "-H", "Content-Type: application/json", "--data-binary", data_arg, "--max-time", "5" },
+            std.heap.page_allocator,
+        );
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Ignore;
         child.stderr_behavior = .Ignore;
-        _ = child.spawn() catch return;
+        _ = child.spawnAndWait() catch return;
+
+        // Truncate the file after successful sync
+        if (std.fs.cwd().createFile(path, .{ .truncate = true })) |f| {
+            f.close();
+        } else |_| {}
     }
 
     fn formatEvent(self: *Telemetry, ev: *const Event) !usize {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4086,3 +4086,31 @@ test "issue-107: codedb_deps returns results for Python files" {
     try testing.expect(deps.len == 1);
     try testing.expectEqualStrings("consumer.py", deps[0]);
 }
+
+test "issue-93: isSensitivePath blocks .env and credentials" {
+    try testing.expect(watcher.isSensitivePath(".env"));
+    try testing.expect(watcher.isSensitivePath(".env.local"));
+    try testing.expect(watcher.isSensitivePath(".env.production"));
+    try testing.expect(watcher.isSensitivePath("credentials.json"));
+    try testing.expect(watcher.isSensitivePath("service-account.json"));
+    try testing.expect(watcher.isSensitivePath("id_rsa"));
+    try testing.expect(watcher.isSensitivePath("secrets.yaml"));
+    try testing.expect(watcher.isSensitivePath("config/secrets.yml"));
+    try testing.expect(watcher.isSensitivePath("server.key"));
+    try testing.expect(watcher.isSensitivePath("cert.pem"));
+    try testing.expect(watcher.isSensitivePath(".ssh/known_hosts"));
+    // Normal files should NOT be blocked
+    try testing.expect(!watcher.isSensitivePath("main.zig"));
+    try testing.expect(!watcher.isSensitivePath("src/server.zig"));
+    try testing.expect(!watcher.isSensitivePath("README.md"));
+    try testing.expect(!watcher.isSensitivePath("package.json"));
+}
+
+test "issue-93: isPathSafe blocks traversal" {
+    const MCP = @import("mcp.zig");
+    try testing.expect(!MCP.isPathSafe("../../../etc/passwd"));
+    try testing.expect(!MCP.isPathSafe("/etc/passwd"));
+    try testing.expect(!MCP.isPathSafe(""));
+    try testing.expect(MCP.isPathSafe("src/main.zig"));
+    try testing.expect(MCP.isPathSafe("README.md"));
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -451,7 +451,7 @@ fn shouldSkipFile(path: []const u8) bool {
 /// Check if a path refers to a sensitive file (secrets, keys, credentials).
 /// Replicates the filter from snapshot.zig so live indexing and snapshots
 /// apply the same exclusion rules. Optimized: basename check + early exit.
-fn isSensitivePath(path: []const u8) bool {
+pub fn isSensitivePath(path: []const u8) bool {
     const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
     // Fast path: most source files have extensions like .zig, .ts, .py — none start with '.'
     // or match sensitive patterns. Skip the full check for common cases.


### PR DESCRIPTION
## Summary
Security hardening for codedb MCP server, addressing findings from a comprehensive security audit (relates to #93).

### P0 #1: Sensitive file exposure via MCP tools
- `handleRead` and `handleEdit` now call `watcher.isSensitivePath()` to block access to `.env`, `credentials.json`, `id_rsa`, `.pem`/`.key` files, etc.
- Previously only the **indexer** filtered sensitive files — MCP clients could bypass by requesting files directly

### P0 #2: SSRF in codedb_remote
- `action` param validated against whitelist: `tree`, `outline`, `search`, `meta`
- `repo` param validated for format (`owner/name` only — no `..`, no extra slashes, no absolute paths)
- Prevents path injection against the cloud intelligence backend
- Verified working end-to-end: tested `codedb_remote` against external repos (`antinomyhq/forgecode`) — search, meta, and tree all return correctly

### Telemetry reliability
- `flush()` and `syncToCloud()` previously only ran on clean exit (`deinit`) — if the MCP server was killed, all telemetry was lost
- Now flushes to disk every 3 tool calls, syncs to cloud every 10
- Replaced shell-interpolated curl (`/bin/sh -c`) with argv-based exec to eliminate command injection
- Added `--max-time 5` to prevent blocking on slow network
- **Data audit**: only aggregate metrics sent (tool name, latency, error flag, response size, file count, languages, platform, version). No file paths, contents, search queries, or user identity.

## Security issues filed
- #120 — Installer integrity verification (p1)
- #121 — Telemetry default-on disclosure (p1)
- #122 — isPathSafe symlink/null byte gaps (p2)
- #123 — Unchecked integer cast on line numbers (p2)
- #124 — Telemetry ring buffer race condition (p3)

## Test plan
- [x] `test "issue-93: isSensitivePath blocks .env and credentials"`
- [x] `test "issue-93: isPathSafe blocks traversal"`
- [x] All existing tests pass (`zig build test` exit 0)
- [x] `codedb_remote` verified against live repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)