### PR TITLE
fix: telemetry ring buffer race + docs accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ All threads share a `shutdown: atomic.Value(bool)` for graceful termination.
 
 ## 🔒 Data & Privacy
 
-codedb collects anonymous usage telemetry to improve the tool. Telemetry is written to `~/.codedb/telemetry.ndjson` and synced to the codedb analytics endpoint on session close. **No source code, file contents, file paths, or search queries are collected** — only aggregate tool call counts, latency, and startup stats.
+codedb collects anonymous usage telemetry to improve the tool. Telemetry is **on by default** — written to `~/.codedb/telemetry.ndjson` and periodically synced to the codedb analytics endpoint. **No source code, file contents, file paths, or search queries are collected** — only aggregate tool call counts, latency, and startup stats.
 
 | Location | Contents | Purpose |
 |----------|----------|---------|
@@ -348,7 +348,7 @@ codedb collects anonymous usage telemetry to improve the tool. Telemetry is writ
 
 **Not stored:** No source code is sent anywhere. No file contents, file paths, or search queries are collected in telemetry. Sensitive files auto-excluded (`.env*`, `credentials.json`, `secrets.*`, `.pem`, `.key`, SSH keys, AWS configs).
 
-To disable the local telemetry log entirely, set `CODEDB_NO_TELEMETRY=1`.
+To disable telemetry: set `CODEDB_NO_TELEMETRY=1` or pass `--no-telemetry`.
 
 To sync the local NDJSON file into Postgres for analysis or dashboards, use [`scripts/sync-telemetry.py`](./scripts/sync-telemetry.py) with the schema in [`docs/telemetry/postgres-schema.sql`](./docs/telemetry/postgres-schema.sql). The data flow is documented in [`docs/telemetry.md`](./docs/telemetry.md).
 

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -40,6 +40,7 @@ pub const Telemetry = struct {
     path_buf: [std.fs.max_path_bytes]u8 = undefined,
     path_len: usize = 0,
     call_count: u32 = 0,
+    write_lock: std.Thread.Mutex = .{},
 
     pub fn init(data_dir: []const u8, allocator: std.mem.Allocator, disabled: bool) Telemetry {
         var self = Telemetry{};
@@ -69,6 +70,8 @@ pub const Telemetry = struct {
 
     pub fn record(self: *Telemetry, kind: Event.Kind) void {
         if (!self.enabled) return;
+
+        self.write_lock.lock();
         const next = self.head.fetchAdd(1, .monotonic);
         const slot = next % RING_SIZE;
         self.ring[slot] = .{
@@ -78,8 +81,8 @@ pub const Telemetry = struct {
         if ((next + 1) -% tail > RING_SIZE) {
             self.tail.store((next + 1) -% RING_SIZE, .monotonic);
         }
+        self.write_lock.unlock();
 
-        // Periodic flush: write to disk every 3 calls, sync to cloud every 10
         self.call_count += 1;
         if (self.call_count % 3 == 0) {
             self.flush();
@@ -134,6 +137,10 @@ pub const Telemetry = struct {
 
     pub fn flush(self: *Telemetry) void {
         const f = self.file orelse return;
+
+        self.write_lock.lock();
+        defer self.write_lock.unlock();
+
         const tail = self.tail.load(.monotonic);
         const head = self.head.load(.monotonic);
         if (tail == head) return;


### PR DESCRIPTION
## Summary
Fixes #121 and #124.

- **#124**: Added `write_lock` mutex to protect ring buffer writes in `record()` and reads in `flush()` — prevents partial-read races under concurrent tool calls
- **#121**: Updated README to accurately document telemetry as on-by-default (opt-out via `CODEDB_NO_TELEMETRY` or `--no-telemetry`), with clear disclosure of what's collected and what's not

## Test plan
- [x] All tests pass (`zig build test` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)