### PR TITLE
fix: singleton MCP awareness with PID lock (#110)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -515,11 +515,11 @@ fn mainImpl() !void {
         } else |_| {}
 
         // Write our PID (best-effort — process ID via /proc or getpid)
+        const my_tid = std.Thread.getCurrentId();
         if (std.fs.cwd().createFile(pid_path, .{ .truncate = true })) |f| {
             defer f.close();
-            // Use std.Thread.getCurrentId as a proxy (it's the TID on Linux, PID on macOS)
             var pidbuf: [32]u8 = undefined;
-            const pid_str = std.fmt.bufPrint(&pidbuf, "{d}\n", .{std.Thread.getCurrentId()}) catch "";
+            const pid_str = std.fmt.bufPrint(&pidbuf, "{d}\n", .{my_tid}) catch "";
             f.writeAll(pid_str) catch {};
         } else |_| {}
 
@@ -550,8 +550,16 @@ fn mainImpl() !void {
         watch_thread.join();
         idle_thread.join();
 
-        // Clean up PID lock
-        std.fs.cwd().deleteFile(pid_path) catch {};
+        // Only clean up PID lock if we still own it
+        if (std.fs.cwd().readFileAlloc(allocator, pid_path, 32)) |contents| {
+            defer allocator.free(contents);
+            const stored = std.mem.trim(u8, contents, " \n\r\t\x00");
+            var mybuf: [32]u8 = undefined;
+            const mystr = std.fmt.bufPrint(&mybuf, "{d}", .{my_tid}) catch "";
+            if (std.mem.eql(u8, stored, mystr)) {
+                std.fs.cwd().deleteFile(pid_path) catch {};
+            }
+        } else |_| {}
     } else {
         out.p("{s}\xe2\x9c\x97{s} unknown command: {s}{s}{s}\n", .{
             s.red, s.reset, s.bold, cmd, s.reset,

--- a/src/main.zig
+++ b/src/main.zig
@@ -503,6 +503,26 @@ fn mainImpl() !void {
         defer telem.deinit();
         telem.recordSessionStart();
 
+        // Singleton awareness: check/write PID file to detect duplicate instances
+        var pid_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const pid_path = std.fmt.bufPrint(&pid_path_buf, "{s}/mcp.pid", .{data_dir}) catch unreachable;
+        if (std.fs.cwd().readFileAlloc(allocator, pid_path, 32)) |contents| {
+            defer allocator.free(contents);
+            const trimmed = std.mem.trim(u8, contents, " \n\r\t\x00");
+            if (trimmed.len > 0) {
+                std.log.warn("another codedb mcp may be running for this project (see {s})", .{pid_path});
+            }
+        } else |_| {}
+
+        // Write our PID (best-effort — process ID via /proc or getpid)
+        if (std.fs.cwd().createFile(pid_path, .{ .truncate = true })) |f| {
+            defer f.close();
+            // Use std.Thread.getCurrentId as a proxy (it's the TID on Linux, PID on macOS)
+            var pidbuf: [32]u8 = undefined;
+            const pid_str = std.fmt.bufPrint(&pidbuf, "{d}\n", .{std.Thread.getCurrentId()}) catch "";
+            f.writeAll(pid_str) catch {};
+        } else |_| {}
+
         var shutdown = std.atomic.Value(bool).init(false);
         var scan_done = std.atomic.Value(bool).init(snapshot_loaded);
 
@@ -530,6 +550,9 @@ fn mainImpl() !void {
         watch_thread.join();
         idle_thread.join();
         if (scan_thread) |t| t.join();
+
+        // Clean up PID lock
+        std.fs.cwd().deleteFile(pid_path) catch {};
     } else {
         out.p("{s}\xe2\x9c\x97{s} unknown command: {s}{s}{s}\n", .{
             s.red, s.reset, s.bold, cmd, s.reset,
@@ -695,7 +718,6 @@ fn scanBg(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.m
         explorer.releaseContents();
         explorer.releaseSecondaryIndexes();
     }
-}
 }
 fn idleWatchdog(shutdown: *std.atomic.Value(bool)) void {
     const mcp = @import("mcp.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -549,7 +549,6 @@ fn mainImpl() !void {
         if (scan_thread) |st| st.join();
         watch_thread.join();
         idle_thread.join();
-        if (scan_thread) |t| t.join();
 
         // Clean up PID lock
         std.fs.cwd().deleteFile(pid_path) catch {};


### PR DESCRIPTION
## Summary
Addresses #110 — multiple MCP server instances accumulating per project.

### What this PR does
- Writes PID to `~/.codedb/projects/<hash>/mcp.pid` on MCP startup
- Warns if another instance may already be running for the same project
- Cleans up PID file on graceful exit

### Combined with existing fixes
- **2-minute idle timeout** (#131) — orphaned processes exit quickly instead of lingering 30 min
- **releaseContents** (#134) — large repos free ~300-500MB after indexing, reducing per-instance cost
- **PID awareness** (this PR) — warns about duplicate instances

### Future: true singleton mode
Full singleton (one server, multiple clients) would need MCP HTTP/SSE transport instead of stdio. This is tracked as a future enhancement — the stdio transport is inherently 1:1, so each MCP client must spawn its own process.

## Test plan
- [x] `zig build test` passes
- [x] Release build succeeds
- [ ] Manual test with OpenCode multi-window setup

Reported by @dezren39, @riccardodm97
