### PR TITLE
fix: Python/TS parser bugs + integer cast safety

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -199,14 +199,22 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
                 if (triple_count > 0) in_py_docstring = false;
                 continue;
             }
-            if (triple_count == 1) { in_py_docstring = true; continue; }
+            // Only skip if the line is JUST a docstring opener (no code before it)
+            if (triple_count == 1 and (std.mem.eql(u8, trimmed, "\"\"\"") or std.mem.eql(u8, trimmed, "'''"))) {
+                in_py_docstring = true;
+                continue;
+            }
         }
 
         // Track JS/TS block comments (#113)
         if (outline.language == .typescript or outline.language == .javascript) {
             if (in_block_comment) {
-                if (std.mem.indexOf(u8, trimmed, "*/") != null) in_block_comment = false;
-                continue;
+                if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
+                    in_block_comment = false;
+                    // If there's code after */, don't skip — fall through to parse it
+                    const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
+                    if (after.len == 0) continue;
+                } else continue;
             }
             if (std.mem.startsWith(u8, trimmed, "/*")) {
                 if (std.mem.indexOf(u8, trimmed, "*/") == null) in_block_comment = true;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -185,10 +185,34 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
     var line_num: u32 = 0;
     var prev_line_trimmed: []const u8 = "";
     var php_state: PhpParseState = .{};
+    var in_py_docstring = false;
+    var in_block_comment = false;
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
         line_num += 1;
         const trimmed = std.mem.trim(u8, line, " \t");
+
+        // Track Python triple-quote docstrings (#111)
+        if (outline.language == .python) {
+            const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
+            if (in_py_docstring) {
+                if (triple_count > 0) in_py_docstring = false;
+                continue;
+            }
+            if (triple_count == 1) { in_py_docstring = true; continue; }
+        }
+
+        // Track JS/TS block comments (#113)
+        if (outline.language == .typescript or outline.language == .javascript) {
+            if (in_block_comment) {
+                if (std.mem.indexOf(u8, trimmed, "*/") != null) in_block_comment = false;
+                continue;
+            }
+            if (std.mem.startsWith(u8, trimmed, "/*")) {
+                if (std.mem.indexOf(u8, trimmed, "*/") == null) in_block_comment = true;
+                continue;
+            }
+        }
 
         if (outline.language == .zig) {
             try self.parseZigLine(trimmed, line_num, &outline);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -762,7 +762,7 @@ fn handleWord(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
 }
 
 fn handleHot(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {
-    const limit: usize = if (getInt(args, "limit")) |n| @intCast(@max(1, n)) else 10;
+    const limit: usize = if (getInt(args, "limit")) |n| @intCast(@min(@max(1, n), 1000)) else 10;
     const hot = explorer.getHotFiles(store, alloc, limit) catch {
         out.appendSlice(alloc, "error: hot files failed") catch {};
         return;
@@ -862,8 +862,8 @@ fn handleRead(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
     w.print("hash:{s}\n", .{hash_str}) catch {};
 
     if (has_range or compact) {
-        const start: u32 = if (line_start_raw) |n| @intCast(@max(1, n)) else 1;
-        const end: u32 = if (line_end_raw) |n| @intCast(@max(1, n)) else std.math.maxInt(u32);
+        const start: u32 = if (line_start_raw) |n| @intCast(@min(@max(1, n), std.math.maxInt(u32))) else 1;
+        const end: u32 = if (line_end_raw) |n| @intCast(@min(@max(1, n), std.math.maxInt(u32))) else std.math.maxInt(u32);
         const lang = explore_mod.detectLanguage(path);
         const extracted = explore_mod.extractLines(content, start, end, true, compact, lang, alloc) catch {
             out.appendSlice(alloc, "error: line extraction failed") catch {};
@@ -942,7 +942,7 @@ fn handleEdit(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
 }
 
 fn handleChanges(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store) void {
-    const since: u64 = if (getInt(args, "since")) |n| @intCast(@max(0, n)) else 0;
+    const since: u64 = if (getInt(args, "since")) |n| @intCast(@min(@max(0, n), std.math.maxInt(u64))) else 0;
     const changes = store.changesSinceDetailed(since, alloc) catch {
         out.appendSlice(alloc, "error: changes query failed") catch {};
         return;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4145,3 +4145,79 @@ test "issue-93: isPathSafe blocks traversal" {
     try testing.expect(MCP.isPathSafe("src/main.zig"));
     try testing.expect(MCP.isPathSafe("README.md"));
 }
+
+test "issue-111: Python triple-quote docstrings not parsed as code" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("docstring.py",
+        \\def real_func():
+        \\    """
+        \\    def fake_func():
+        \\        pass
+        \\    """
+        \\    pass
+    );
+
+    var outline = (try explorer.getOutline("docstring.py", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    var func_count: usize = 0;
+    for (outline.symbols.items) |sym| {
+        if (sym.kind == .function) func_count += 1;
+    }
+    // Only real_func should be found, not fake_func inside docstring
+    try testing.expect(func_count == 1);
+}
+
+test "issue-112: Python import-as alias stripped from dep path" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("utils.py", "def helper(): pass\n");
+    try explorer.indexFile("consumer.py", "import utils as u\n");
+
+    const deps = try explorer.getImportedBy("utils.py", testing.allocator);
+    defer {
+        for (deps) |d| testing.allocator.free(d);
+        testing.allocator.free(deps);
+    }
+    try testing.expect(deps.len == 1);
+}
+
+test "issue-113: TypeScript block comments not parsed as code" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("commented.ts",
+        \\export function realFunc() {}
+        \\/*
+        \\export function fakeFunc() {}
+        \\*/
+    );
+
+    var outline = (try explorer.getOutline("commented.ts", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    var func_count: usize = 0;
+    for (outline.symbols.items) |sym| {
+        if (sym.kind == .function) func_count += 1;
+    }
+    try testing.expect(func_count == 1);
+}
+
+test "issue-114: TypeScript import-as alias does not affect dep path" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("mod.ts", "export function hello() {}\n");
+    try explorer.indexFile("consumer.ts", "import { hello as h } from './mod'\n");
+
+    var outline = (try explorer.getOutline("consumer.ts", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    // The import dep path should be "./mod", not include the alias
+    try testing.expect(outline.imports.items.len == 1);
+    try testing.expectEqualStrings("./mod", outline.imports.items[0]);
+}


### PR DESCRIPTION
## Summary
Fixes #111, #112, #113, #114, #123 — parser correctness + integer safety.

### Parser fixes
- **#111** — Python triple-quote docstrings (`"""`, `'''`) now tracked as multi-line state. Lines inside docstrings no longer produce false symbol detections.
- **#112** — Python `import X as Y` aliases verified working (extractPythonModulePath already strips correctly). New test added.
- **#113** — TypeScript/JavaScript multi-line `/* ... */` block comments now tracked. Lines inside comments no longer produce false symbol detections.
- **#114** — TypeScript `import { X as Y } from "mod"` verified working (extractStringLiteral returns the module path, not the alias). New test added.

### Security
- **#123** — All `@intCast` on user-supplied values (line numbers, limits, since) now clamped to target type range before cast, preventing panic on overflow.

## Test plan
- [x] 4 new tests: issue-111, issue-112, issue-113, issue-114
- [x] All existing tests pass
- [ ] Codex review

Reported by @sanderdewijs (parser bugs via #87)
