### PR TITLE
ci: publish Intel macOS release binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,131 @@
+name: release-binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build and upload assets for (for example v0.2.53)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  ZIG_VERSION: 0.15.2
+
+jobs:
+  build:
+    name: build-${{ matrix.asset_name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            zig_target: x86_64-macos
+            asset_name: codedb-darwin-x86_64
+            zig_archive: zig-x86_64-macos-0.15.2.tar.xz
+            zig_dir: zig-x86_64-macos-0.15.2
+          - runner: macos-14
+            zig_target: aarch64-macos
+            asset_name: codedb-darwin-arm64
+            zig_archive: zig-aarch64-macos-0.15.2.tar.xz
+            zig_dir: zig-aarch64-macos-0.15.2
+          - runner: ubuntu-24.04
+            zig_target: x86_64-linux
+            asset_name: codedb-linux-x86_64
+            zig_archive: zig-x86_64-linux-0.15.2.tar.xz
+            zig_dir: zig-x86_64-linux-0.15.2
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+      APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      CODEDB_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Zig
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -L "https://ziglang.org/download/${ZIG_VERSION}/${{ matrix.zig_archive }}" -o zig.tar.xz
+          tar -xf zig.tar.xz
+          echo "$PWD/${{ matrix.zig_dir }}" >> "$GITHUB_PATH"
+
+      - name: Import Apple signing certificate
+        if: runner.os == 'macOS' && env.APPLE_CERTIFICATE_P12 != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/codedb-signing.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/codedb-signing.keychain-db"
+          export CERT_PATH
+          python3 - <<'PY'
+          import base64
+          import os
+          import pathlib
+          pathlib.Path(os.environ["CERT_PATH"]).write_bytes(
+              base64.b64decode(os.environ["APPLE_CERTIFICATE_P12"])
+          )
+          PY
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "$KEYCHAIN_PATH"
+
+      - name: Build ${{ matrix.asset_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign_arg=()
+          if [[ "${{ runner.os }}" == "macOS" ]] && grep -q 'codesign-identity' build.zig; then
+            codesign_arg=(-Dcodesign-identity="${CODEDB_CODESIGN_IDENTITY:-"-"}")
+          fi
+          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} "${codesign_arg[@]}"
+          cp zig-out/bin/codedb "${{ matrix.asset_name }}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}
+          if-no-files-found: error
+
+  publish:
+    name: upload-release-assets
+    runs-on: ubuntu-24.04
+    needs: build
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Assemble release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          find dist -type f -name 'codedb-*' -exec cp {} assets/ \;
+          (
+            cd assets
+            sha256sum codedb-* | sort > checksums.sha256
+          )
+
+      - name: Upload assets to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" assets/codedb-* assets/checksums.sha256 --clobber

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,14 @@
+const builtin = @import("builtin");
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const codesign_identity = b.option(
+        []const u8,
+        "codesign-identity",
+        "macOS codesign identity. Defaults to ad-hoc signing ('-').",
+    ) orelse "-";
 
     // ── Exposed module: importable as @import("codedb") ──
     const codedb_mod = b.addModule("codedb", .{
@@ -26,9 +32,9 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("mcp", mcp_dep.module("mcp"));
     b.installArtifact(exe);
 
-    // ── macOS ad-hoc codesign (prevents SIGKILL on unsigned binaries) ──
-    if (target.result.os.tag == .macos) {
-        const codesign = b.addSystemCommand(&.{ "codesign", "-f", "-s", "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)" });
+    // ── macOS codesign (ad-hoc by default; configurable for release builds) ──
+    if (target.result.os.tag == .macos and builtin.os.tag == .macos) {
+        const codesign = b.addSystemCommand(&.{ "codesign", "-f", "-s", codesign_identity });
         codesign.addArtifactArg(exe);
         b.getInstallStep().dependOn(&codesign.step);
     }


### PR DESCRIPTION
## Linked issue
- Fixes #147
- Related #94

## Summary
- add a tagged/manual release workflow that publishes `codedb-darwin-x86_64`, `codedb-darwin-arm64`, and `codedb-linux-x86_64`
- build the Intel macOS binary on `macos-15-intel` so the installer target `codedb-darwin-x86_64` is actually shipped
- make macOS codesigning configurable in `build.zig` instead of hardcoding a local Developer ID into every macOS build

## Files touched
- `build.zig`
- `.github/workflows/release-binaries.yml`

## Repro
Before:
- `curl -I -fsSL https://codedb.codegraff.com/v0.2.53/codedb-darwin-x86_64` returns `404`
- `curl -fsSL https://github.com/justrach/codedb/releases/download/v0.2.53/checksums.sha256` has no `codedb-darwin-x86_64` entry

After:
- pending GitHub Actions verification on this branch, since the fix is release automation and cannot be fully exercised locally in this environment
- workflow also supports `workflow_dispatch` so maintainers can backfill `v0.2.53` after merge

## Checks run
- `git fetch upstream`
- `git rebase upstream/main`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-binaries.yml")'`
- `curl -I -fsSL https://ziglang.org/download/0.15.2/zig-x86_64-macos-0.15.2.tar.xz`
- `curl -I -fsSL https://ziglang.org/download/0.15.2/zig-aarch64-macos-0.15.2.tar.xz`
- `curl -I -fsSL https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz`

## Notes
- branch is rebased onto current `upstream/main`
- no generated files, lockfiles, or benchmark artifacts changed
- this submission matches `CONTRIBUTING.md`
