### PR TITLE
ci: restore missing release artifacts and harden macOS release workflow

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -59,8 +59,11 @@ jobs:
             bench-head.json
             bench-report.md
 
+      - name: Publish summary
+        run: cat bench-report.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Comment PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,11 +39,19 @@ jobs:
             asset_name: codedb-linux-x86_64
             zig_archive: zig-x86_64-linux-0.15.2.tar.xz
             zig_dir: zig-x86_64-linux-0.15.2
+          - runner: ubuntu-24.04
+            zig_target: aarch64-linux
+            asset_name: codedb-linux-arm64
+            zig_archive: zig-x86_64-linux-0.15.2.tar.xz
+            zig_dir: zig-x86_64-linux-0.15.2
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-      APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      CODEDB_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+      APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      CODEDB_CODESIGN_IDENTITY: "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,8 +66,24 @@ jobs:
           tar -xf zig.tar.xz
           echo "$PWD/${{ matrix.zig_dir }}" >> "$GITHUB_PATH"
 
+      - name: Require macOS signing and notarization secrets
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -n "${APPLE_CERT_BASE64}" ]] || missing+=("APPLE_CERT_BASE64")
+          [[ -n "${APPLE_CERT_PASSWORD}" ]] || missing+=("APPLE_CERT_PASSWORD")
+          [[ -n "${APPLE_API_KEY_ID}" ]] || missing+=("APPLE_API_KEY_ID")
+          [[ -n "${APPLE_API_ISSUER_ID}" ]] || missing+=("APPLE_API_ISSUER_ID")
+          [[ -n "${APPLE_API_KEY_BASE64}" ]] || missing+=("APPLE_API_KEY_BASE64")
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required macOS release secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
       - name: Import Apple signing certificate
-        if: runner.os == 'macOS' && env.APPLE_CERTIFICATE_P12 != ''
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           set -euo pipefail
@@ -71,13 +95,13 @@ jobs:
           import os
           import pathlib
           pathlib.Path(os.environ["CERT_PATH"]).write_bytes(
-              base64.b64decode(os.environ["APPLE_CERTIFICATE_P12"])
+              base64.b64decode(os.environ["APPLE_CERT_BASE64"])
           )
           PY
           security create-keychain -p "" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "$KEYCHAIN_PATH"
@@ -92,6 +116,33 @@ jobs:
           fi
           zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} "${codesign_arg[@]}"
           cp zig-out/bin/codedb "${{ matrix.asset_name }}"
+
+      - name: Notarize ${{ matrix.asset_name }}
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          API_KEY_PATH="$RUNNER_TEMP/codedb-notary-key.p8"
+          export API_KEY_PATH
+          python3 - <<'PY'
+          import base64
+          import os
+          import pathlib
+          pathlib.Path(os.environ["API_KEY_PATH"]).write_bytes(
+              base64.b64decode(os.environ["APPLE_API_KEY_BASE64"])
+          )
+          PY
+          chmod 600 "$API_KEY_PATH"
+          codesign --verify --verbose=2 "${{ matrix.asset_name }}"
+          ditto -c -k --keepParent "${{ matrix.asset_name }}" "${{ matrix.asset_name }}.zip"
+          xcrun notarytool submit "${{ matrix.asset_name }}.zip" \
+            --key "$API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "${{ matrix.asset_name }}" || true
+          spctl --assess --type execute --verbose=4 "${{ matrix.asset_name }}"
+          rm -f "${{ matrix.asset_name }}.zip" "$API_KEY_PATH"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -71,6 +71,7 @@ jobs:
           mkdir -p scripts
           # Use the helper reviewed with this workflow revision, not the rebuilt tag.
           gh api repos/${{ github.repository }}/contents/scripts/notarize-macos.sh \
+            --method GET \
             -f ref="$HELPER_REF" \
             -H "Accept: application/vnd.github.raw" > scripts/notarize-macos.sh
           chmod +x scripts/notarize-macos.sh

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Require macOS signing and notarization secrets
         if: runner.os == 'macOS'
         env:
-          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
-          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
@@ -72,8 +72,8 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          [[ -n "${APPLE_CERT_BASE64}" ]] || missing+=("APPLE_CERT_BASE64")
-          [[ -n "${APPLE_CERT_PASSWORD}" ]] || missing+=("APPLE_CERT_PASSWORD")
+          [[ -n "${APPLE_CERTIFICATE_P12}" ]] || missing+=("APPLE_CERTIFICATE_P12")
+          [[ -n "${APPLE_CERTIFICATE_PASSWORD}" ]] || missing+=("APPLE_CERTIFICATE_PASSWORD")
           [[ -n "${APPLE_API_KEY_ID}" ]] || missing+=("APPLE_API_KEY_ID")
           [[ -n "${APPLE_API_ISSUER_ID}" ]] || missing+=("APPLE_API_ISSUER_ID")
           [[ -n "${APPLE_API_KEY_BASE64}" ]] || missing+=("APPLE_API_KEY_BASE64")
@@ -85,8 +85,8 @@ jobs:
       - name: Import Apple signing certificate
         if: runner.os == 'macOS'
         env:
-          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
-          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
@@ -98,13 +98,13 @@ jobs:
           import os
           import pathlib
           pathlib.Path(os.environ["CERT_PATH"]).write_bytes(
-              base64.b64decode(os.environ["APPLE_CERT_BASE64"])
+              base64.b64decode(os.environ["APPLE_CERTIFICATE_P12"])
           )
           PY
           security create-keychain -p "" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "$KEYCHAIN_PATH"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -46,12 +46,6 @@ jobs:
             zig_dir: zig-x86_64-linux-0.15.2
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
-      APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
-      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
-      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-      CODEDB_CODESIGN_IDENTITY: "Developer ID Application: Rachit Pradhan (WWP9DLJ27P)"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +62,12 @@ jobs:
 
       - name: Require macOS signing and notarization secrets
         if: runner.os == 'macOS'
+        env:
+          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -84,6 +84,9 @@ jobs:
 
       - name: Import Apple signing certificate
         if: runner.os == 'macOS'
+        env:
+          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
@@ -106,19 +109,30 @@ jobs:
           security default-keychain -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "$KEYCHAIN_PATH"
 
-      - name: Build ${{ matrix.asset_name }}
+      - name: Build ${{ matrix.asset_name }} (macOS)
+        if: runner.os == 'macOS'
+        env:
+          CODEDB_CODESIGN_IDENTITY: "${{ secrets.APPLE_CODESIGN_IDENTITY != '' && secrets.APPLE_CODESIGN_IDENTITY || 'Developer ID Application: Rachit Pradhan (WWP9DLJ27P)' }}"
         shell: bash
         run: |
           set -euo pipefail
-          codesign_arg=()
-          if [[ "${{ runner.os }}" == "macOS" ]] && grep -q 'codesign-identity' build.zig; then
-            codesign_arg=(-Dcodesign-identity="${CODEDB_CODESIGN_IDENTITY:-"-"}")
-          fi
-          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} "${codesign_arg[@]}"
+          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} -Dcodesign-identity="${CODEDB_CODESIGN_IDENTITY}"
+          cp zig-out/bin/codedb "${{ matrix.asset_name }}"
+
+      - name: Build ${{ matrix.asset_name }} (Linux)
+        if: runner.os != 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
           cp zig-out/bin/codedb "${{ matrix.asset_name }}"
 
       - name: Notarize ${{ matrix.asset_name }}
         if: runner.os == 'macOS'
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -116,8 +116,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} -Dcodesign-identity="${CODEDB_CODESIGN_IDENTITY}"
+          codesign_args=()
+          if grep -q 'codesign-identity' build.zig; then
+            codesign_args=(-Dcodesign-identity="${CODEDB_CODESIGN_IDENTITY}")
+          fi
+          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} "${codesign_args[@]}"
           cp zig-out/bin/codedb "${{ matrix.asset_name }}"
+
+      - name: Re-sign ${{ matrix.asset_name }} for notarization
+        if: runner.os == 'macOS'
+        env:
+          CODEDB_CODESIGN_IDENTITY: "${{ secrets.APPLE_CODESIGN_IDENTITY != '' && secrets.APPLE_CODESIGN_IDENTITY || 'Developer ID Application: Rachit Pradhan (WWP9DLJ27P)' }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          codesign -f -s "${CODEDB_CODESIGN_IDENTITY}" --options runtime --timestamp "${{ matrix.asset_name }}"
 
       - name: Build ${{ matrix.asset_name }} (Linux)
         if: runner.os != 'macOS'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -129,27 +129,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          API_KEY_PATH="$RUNNER_TEMP/codedb-notary-key.p8"
-          export API_KEY_PATH
-          python3 - <<'PY'
-          import base64
-          import os
-          import pathlib
-          pathlib.Path(os.environ["API_KEY_PATH"]).write_bytes(
-              base64.b64decode(os.environ["APPLE_API_KEY_BASE64"])
-          )
-          PY
-          chmod 600 "$API_KEY_PATH"
-          codesign --verify --verbose=2 "${{ matrix.asset_name }}"
-          ditto -c -k --keepParent "${{ matrix.asset_name }}" "${{ matrix.asset_name }}.zip"
-          xcrun notarytool submit "${{ matrix.asset_name }}.zip" \
-            --key "$API_KEY_PATH" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" \
-            --wait
-          xcrun stapler staple "${{ matrix.asset_name }}" || true
-          spctl --assess --type execute --verbose=4 "${{ matrix.asset_name }}"
-          rm -f "${{ matrix.asset_name }}.zip" "$API_KEY_PATH"
+          bash scripts/notarize-macos.sh "${{ matrix.asset_name }}"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,15 +60,18 @@ jobs:
           tar -xf zig.tar.xz
           echo "$PWD/${{ matrix.zig_dir }}" >> "$GITHUB_PATH"
 
-      - name: Fetch notarization helper from main
+      - name: Fetch notarization helper from workflow revision
         if: runner.os == 'macOS'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          HELPER_REF: ${{ github.workflow_sha || github.sha }}
         run: |
           set -euo pipefail
           mkdir -p scripts
+          # Use the helper reviewed with this workflow revision, not the rebuilt tag.
           gh api repos/${{ github.repository }}/contents/scripts/notarize-macos.sh \
+            -f ref="$HELPER_REF" \
             -H "Accept: application/vnd.github.raw" > scripts/notarize-macos.sh
           chmod +x scripts/notarize-macos.sh
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -84,30 +84,10 @@ jobs:
 
       - name: Import Apple signing certificate
         if: runner.os == 'macOS'
-        env:
-          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          CERT_PATH="$RUNNER_TEMP/codedb-signing.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/codedb-signing.keychain-db"
-          export CERT_PATH
-          python3 - <<'PY'
-          import base64
-          import os
-          import pathlib
-          pathlib.Path(os.environ["CERT_PATH"]).write_bytes(
-              base64.b64decode(os.environ["APPLE_CERTIFICATE_P12"])
-          )
-          PY
-          security create-keychain -p "" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" "$KEYCHAIN_PATH"
+        uses: apple-actions/import-codesign-certs@v5
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
       - name: Build ${{ matrix.asset_name }} (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,6 +60,18 @@ jobs:
           tar -xf zig.tar.xz
           echo "$PWD/${{ matrix.zig_dir }}" >> "$GITHUB_PATH"
 
+      - name: Fetch notarization helper from main
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p scripts
+          gh api repos/${{ github.repository }}/contents/scripts/notarize-macos.sh \
+            -H "Accept: application/vnd.github.raw" > scripts/notarize-macos.sh
+          chmod +x scripts/notarize-macos.sh
+
       - name: Require macOS signing and notarization secrets
         if: runner.os == 'macOS'
         env:

--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,11 @@ pub fn build(b: *std.Build) void {
 
     // ── macOS codesign (ad-hoc by default; configurable for release builds) ──
     if (target.result.os.tag == .macos and builtin.os.tag == .macos) {
-        const codesign = b.addSystemCommand(&.{ "codesign", "-f", "-s", codesign_identity });
+        const codesign_args = if (std.mem.eql(u8, codesign_identity, "-"))
+            &.{ "codesign", "-f", "-s", codesign_identity }
+        else
+            &.{ "codesign", "-f", "-s", codesign_identity, "--options", "runtime", "--timestamp" };
+        const codesign = b.addSystemCommand(codesign_args);
         codesign.addArtifactArg(exe);
         b.getInstallStep().dependOn(&codesign.step);
     }

--- a/build.zig
+++ b/build.zig
@@ -34,11 +34,10 @@ pub fn build(b: *std.Build) void {
 
     // ── macOS codesign (ad-hoc by default; configurable for release builds) ──
     if (target.result.os.tag == .macos and builtin.os.tag == .macos) {
-        const codesign_args = if (std.mem.eql(u8, codesign_identity, "-"))
-            &.{ "codesign", "-f", "-s", codesign_identity }
+        const codesign = if (std.mem.eql(u8, codesign_identity, "-"))
+            b.addSystemCommand(&.{ "codesign", "-f", "-s", codesign_identity })
         else
-            &.{ "codesign", "-f", "-s", codesign_identity, "--options", "runtime", "--timestamp" };
-        const codesign = b.addSystemCommand(codesign_args);
+            b.addSystemCommand(&.{ "codesign", "-f", "-s", codesign_identity, "--options", "runtime", "--timestamp" });
         codesign.addArtifactArg(exe);
         b.getInstallStep().dependOn(&codesign.step);
     }

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <binary-path>" >&2
+  exit 1
+fi
+
+binary_path="$1"
+
+: "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required}"
+: "${APPLE_API_ISSUER_ID:?APPLE_API_ISSUER_ID is required}"
+: "${APPLE_API_KEY_BASE64:?APPLE_API_KEY_BASE64 is required}"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/codedb-notary.XXXXXX")"
+api_key_path="$tmp_dir/codedb-notary-key.p8"
+zip_path="$tmp_dir/$(basename "$binary_path").zip"
+export API_KEY_PATH="$api_key_path"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+python3 - <<'PY'
+import base64
+import os
+import pathlib
+
+pathlib.Path(os.environ["API_KEY_PATH"]).write_bytes(
+    base64.b64decode(os.environ["APPLE_API_KEY_BASE64"])
+)
+PY
+
+chmod 600 "$api_key_path"
+codesign --verify --verbose=2 "$binary_path"
+ditto -c -k --keepParent "$binary_path" "$zip_path"
+xcrun notarytool submit "$zip_path" \
+  --key "$api_key_path" \
+  --key-id "$APPLE_API_KEY_ID" \
+  --issuer "$APPLE_API_ISSUER_ID" \
+  --wait
+xcrun stapler staple "$binary_path" || true
+spctl --assess --type execute --verbose=4 "$binary_path"


### PR DESCRIPTION
## Linked issues
- Fixes #94
- Follow-up to #149

## Summary
This PR restores the missing release artifacts from #149, hardens the macOS release path, keeps legacy tag rebuilds working, and makes benchmark reporting safe for forked PRs.

## What changed
- restores `codedb-linux-arm64` to the release matrix so ARM Linux installs keep working
- signs and notarizes macOS release binaries before upload
- scopes Apple signing and notarization secrets to macOS-only steps
- replaces the hand-rolled certificate import block with `apple-actions/import-codesign-certs@v5`
- moves notarization into `scripts/notarize-macos.sh`
- keeps `workflow_dispatch` compatible with older tags by only passing `-Dcodesign-identity` when the checked-out tag supports it
- fetches `scripts/notarize-macos.sh` from the workflow revision so legacy tag rebuilds use the reviewed helper from this PR rather than whatever shipped in the old tag
- updates `build.zig` so release signing uses runtime and timestamp options only for real identities, while keeping ad-hoc signing and non-macOS builds working
- publishes the benchmark report to the GitHub Actions job summary via `$GITHUB_STEP_SUMMARY` and skips PR comments for forked PRs, avoiding the `Resource not accessible by integration` failure

## Why this is needed
Before this branch:
- the release workflow from #149 stopped publishing `codedb-linux-arm64`
- macOS assets were uploaded without notarization
- Apple signing and notarization secrets were exposed to non-macOS matrix legs
- rebuilding older tags via `workflow_dispatch` could break once the workflow depended on newer helpers or newer `build.zig` options
- forked PRs could fail `bench-regression` after the benchmark completed because the workflow tried to post a PR comment with a restricted token

After this branch:
- release automation publishes `codedb-darwin-x86_64`, `codedb-darwin-arm64`, `codedb-linux-x86_64`, and `codedb-linux-arm64`
- macOS assets are signed with runtime and timestamp options and sent through `notarytool` before upload
- Apple secrets are limited to the macOS steps that actually consume them
- legacy tags can still be rebuilt from `workflow_dispatch`
- benchmark results remain visible for forked PRs in the Actions summary and artifacts even when PR comments are not permitted

## Files touched
- `.github/workflows/release-binaries.yml`
- `.github/workflows/bench-regression.yml`
- `build.zig`
- `scripts/notarize-macos.sh`

## Validation
- rebased onto current `upstream/main`
- `bash -n scripts/notarize-macos.sh`
- `zig build bench -- --json` with Zig `0.15.2`
- `python3 scripts/run-bench-json.py /tmp/codedb-bench.json` with Zig `0.15.2`
- inspected failed Actions job `24218531644` and confirmed the failure was the fork PR comment step, not benchmark execution

## Notes
- `zig build test` on macOS still hits the existing `tests.test.perf regression: indexing 200 files under 200ms`; that is separate from the failing GitHub `bench` job addressed here
- no generated files, lockfiles, or benchmark artifacts are committed
