### PR TITLE
fix: add statx fallback for WSL1 / older kernels

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,134 @@
+/// WSL1 compatibility layer.
+///
+/// Zig 0.15's `File.stat()` and `Dir.statFile()` use the `statx` syscall on
+/// Linux with no fallback when `ENOSYS` is returned. WSL1 runs kernel 4.4
+/// which predates `statx` (added in 4.11), so every stat call fails with
+/// `error.Unexpected`.
+///
+/// This module detects the situation at startup and provides drop-in
+/// replacements that go through `fstat`/`fstatat64` instead.
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const linux = std.os.linux;
+const fs = std.fs;
+
+/// Cached result of the runtime statx probe.
+var statx_supported: enum(u8) { unknown = 0, yes = 1, no = 2 } = .unknown;
+
+/// Probe once whether the running kernel supports `statx`.
+fn hasStatx() bool {
+    // Fast path: already probed.
+    const cached = @atomicLoad(@TypeOf(statx_supported), &statx_supported, .acquire);
+    if (cached == .yes) return true;
+    if (cached == .no) return false;
+
+    // Probe: call statx on stdin with an empty mask. On kernels that
+    // support it this is a cheap no-op; on WSL1 it returns ENOSYS.
+    var stx = std.mem.zeroes(linux.Statx);
+    const rc = linux.statx(
+        // Use AT.FDCWD (-100) with path "." as a safe, always-valid probe target
+        linux.AT.FDCWD,
+        ".",
+        0,
+        0,
+        &stx,
+    );
+    const supported: bool = linux.E.init(rc) != .NOSYS;
+    @atomicStore(@TypeOf(statx_supported), &statx_supported, if (supported) .yes else .no, .release);
+    return supported;
+}
+
+/// Stat result matching the fields codedb actually uses (size, mtime).
+pub const Stat = struct {
+    size: u64,
+    mtime: i128,
+    kind: fs.File.Kind,
+};
+
+/// `File.stat()` replacement that falls back to `fstat` on WSL1.
+pub fn fileStat(file: fs.File) fs.File.StatError!Stat {
+    if (comptime builtin.os.tag != .linux) {
+        const st = try file.stat();
+        return .{ .size = st.size, .mtime = st.mtime, .kind = st.kind };
+    }
+
+    if (hasStatx()) {
+        const st = try file.stat();
+        return .{ .size = st.size, .mtime = st.mtime, .kind = st.kind };
+    }
+
+    // Fallback: use posix.fstat which calls the fstat64 syscall directly.
+    const st = try posix.fstat(file.handle);
+    return .{
+        .size = @intCast(st.size),
+        .mtime = @as(i128, st.mtime().sec) * std.time.ns_per_s + st.mtime().nsec,
+        .kind = fileTypeFromMode(st.mode),
+    };
+}
+
+/// `Dir.statFile()` replacement that falls back to `fstatat` on WSL1.
+pub fn dirStatFile(dir: fs.Dir, sub_path: []const u8) (fs.File.OpenError || fs.File.StatError || posix.FStatAtError)!Stat {
+    if (comptime builtin.os.tag != .linux) {
+        const st = try dir.statFile(sub_path);
+        return .{ .size = st.size, .mtime = st.mtime, .kind = st.kind };
+    }
+
+    if (hasStatx()) {
+        const st = try dir.statFile(sub_path);
+        return .{ .size = st.size, .mtime = st.mtime, .kind = st.kind };
+    }
+
+    // Fallback: use posix.fstatat which calls fstatat64 directly.
+    const st = try posix.fstatat(dir.fd, sub_path, 0);
+    return .{
+        .size = @intCast(st.size),
+        .mtime = @as(i128, st.mtime().sec) * std.time.ns_per_s + st.mtime().nsec,
+        .kind = fileTypeFromMode(st.mode),
+    };
+}
+
+/// `Dir.makePath()` replacement. On WSL1 the stdlib's `makePath` fails
+/// because it calls `statFile` (which uses statx) when the directory
+/// already exists.  We implement a simple recursive mkdir that tolerates
+/// EEXIST without needing stat.
+pub fn makePath(dir: fs.Dir, sub_path: []const u8) !void {
+    if (comptime builtin.os.tag != .linux) {
+        return dir.makePath(sub_path);
+    }
+
+    if (hasStatx()) {
+        return dir.makePath(sub_path);
+    }
+
+    // Simple iterative mkdir: split path by '/' and create each component.
+    // Tolerate EEXIST (component already exists).
+    var it = try fs.path.componentIterator(sub_path);
+    var component = it.first() orelse return;
+    while (true) {
+        dir.makeDir(component.path) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            error.FileNotFound => {
+                // Parent doesn't exist yet — should not happen with forward iteration
+                // from first component, but handle gracefully.
+                return err;
+            },
+            else => return err,
+        };
+        component = it.next() orelse return;
+    }
+}
+
+fn fileTypeFromMode(mode: u32) fs.File.Kind {
+    const file_type = mode & 0o170000;
+    return switch (file_type) {
+        0o040000 => .directory,
+        0o100000 => .file,
+        0o120000 => .sym_link,
+        0o010000 => .named_pipe,
+        0o140000 => .unix_domain_socket,
+        0o060000 => .block_device,
+        0o020000 => .character_device,
+        else => .unknown,
+    };
+}

--- a/src/index.zig
+++ b/src/index.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 
 // ── Inverted word index ─────────────────────────────────────
 // Maps word → list of (path, line) hits. O(1) word lookup.
@@ -1380,7 +1381,7 @@ pub fn readFrequencyTable(dir_path: []const u8, allocator: std.mem.Allocator) !?
     };
     defer file.close();
     const expected_size = 256 * 256 * @sizeOf(u16);
-    const stat = try file.stat();
+    const stat = try compat.fileStat(file);
     if (stat.size != expected_size) return null;
     const result = try allocator.create([256][256]u16);
     errdefer allocator.destroy(result);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const Store = @import("store.zig").Store;
 const AgentRegistry = @import("agent.zig").AgentRegistry;
 const Explorer = @import("explore.zig").Explorer;
@@ -559,7 +560,7 @@ fn getDataDir(allocator: std.mem.Allocator, abs_root: []const u8) ![]u8 {
     };
     defer allocator.free(home);
     const dir = try std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash });
-    std.fs.cwd().makePath(dir) catch |err| {
+    compat.makePath(std.fs.cwd(), dir) catch |err| {
         std.log.warn("could not create data dir {s}: {}", .{ dir, err });
     };
     return dir;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -22,6 +22,7 @@
 //     META    (6): JSON {file_count, total_bytes, indexed_at, format_version}
 
 const std = @import("std");
+const compat = @import("compat.zig");
 const Explorer = @import("explore.zig").Explorer;
 const git_mod = @import("git.zig");
 
@@ -281,7 +282,7 @@ pub fn readSectionBytes(path: []const u8, section_id: SectionId, allocator: std.
     defer file.close();
 
     // Validate section fits within file
-    const stat = try file.stat();
+    const stat = try compat.fileStat(file);
     if (entry.offset + entry.length > stat.size) return null;
 
     try file.seekTo(entry.offset);
@@ -394,7 +395,7 @@ pub fn loadSnapshotValidated(
     defer content_file.close();
 
     // Validate content section fits within actual file size (issue-40: truncation detection)
-    const file_stat = content_file.stat() catch return false;
+    const file_stat = compat.fileStat(content_file) catch return false;
     const file_size = file_stat.size;
     if (content_entry.offset + content_entry.length > file_size) return false;
 
@@ -439,7 +440,7 @@ pub fn loadSnapshotValidated(
         if (snap_mtime > 0) blk: {
             const df = std.fs.cwd().openFile(path_buf, .{}) catch break :blk;
             defer df.close();
-            const ds = df.stat() catch break :blk;
+            const ds = compat.fileStat(df) catch break :blk;
             if (ds.mtime <= snap_mtime) break :blk;
             disk_content = df.readToEndAlloc(allocator, 16 * 1024 * 1024) catch break :blk;
         }
@@ -616,7 +617,7 @@ pub fn writeSnapshotDual(
 
     const dir_path = std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash }) catch return;
     defer allocator.free(dir_path);
-    std.fs.cwd().makePath(dir_path) catch {};
+    compat.makePath(std.fs.cwd(), dir_path) catch {};
 
     const proj_txt = std.fmt.allocPrint(allocator, "{s}/project.txt", .{dir_path}) catch return;
     defer allocator.free(proj_txt);

--- a/src/store.zig
+++ b/src/store.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const AgentId = @import("agent.zig").AgentId;
 const version = @import("version.zig");
 const Version = version.Version;
@@ -42,10 +43,10 @@ pub const Store = struct {
     pub fn openDataLog(self: *Store, path: []const u8) !void {
         // Extract parent dir and ensure it exists
         if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| {
-            std.fs.cwd().makePath(path[0..sep]) catch {};
+            compat.makePath(std.fs.cwd(), path[0..sep]) catch {};
         }
         self.data_log = try std.fs.cwd().createFile(path, .{ .read = true, .truncate = false });
-        const stat = try self.data_log.?.stat();
+        const stat = try compat.fileStat(self.data_log.?);
         self.data_log_pos = stat.size;
     }
 
@@ -86,7 +87,7 @@ pub const Store = struct {
                 defer if (locked) log.unlock();
 
                 // Re-stat to get current end position (another process may have appended)
-                const stat = log.stat() catch return error.Unexpected;
+                const stat = compat.fileStat(log) catch return error.Unexpected;
                 self.data_log_pos = stat.size;
 
                 data_offset = self.data_log_pos;

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const compat = @import("compat.zig");
 const explore = @import("explore.zig");
 const index = @import("index.zig");
 
@@ -158,7 +159,7 @@ pub const Telemetry = struct {
         if (!self.enabled or self.path_len == 0) return;
         const path = self.path_buf[0..self.path_len];
 
-        const stat = std.fs.cwd().statFile(path) catch return;
+        const stat = compat.dirStatFile(std.fs.cwd(), path) catch return;
         if (stat.size == 0) return;
 
         // Use argv-based exec (no shell interpolation) to avoid injection

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const Store = @import("store.zig").Store;
 const Explorer = @import("explore.zig").Explorer;
 
@@ -244,7 +245,7 @@ pub fn initialScan(store: *Store, explorer: *Explorer, root: []const u8, allocat
     var file_count: usize = 0;
 
     while (try walker.next()) |entry| {
-        const stat = dir.statFile(entry.path) catch continue;
+        const stat = compat.dirStatFile(dir, entry.path) catch continue;
         _ = try store.recordSnapshot(entry.path, stat.size, 0);
         file_count += 1;
         // Auto-skip trigram indexing beyond file count cap to prevent OOM
@@ -258,7 +259,7 @@ fn indexFileOutline(explorer: *Explorer, dir: std.fs.Dir, path: []const u8, allo
     if (shouldSkipFile(path)) return;
     const file = try dir.openFile(path, .{});
     defer file.close();
-    const stat = try file.stat();
+    const stat = try compat.fileStat(file);
     if (stat.size > 512 * 1024) return;
     const content = try file.readToEndAlloc(allocator, 512 * 1024);
     defer allocator.free(content);
@@ -301,7 +302,7 @@ pub fn incrementalLoop(store: *Store, explorer: *Explorer, queue: *EventQueue, r
         var walker = FilteredWalker.init(dir, tmp) catch return;
         defer walker.deinit();
         while (walker.next() catch null) |entry| {
-            const stat = dir.statFile(entry.path) catch continue;
+            const stat = compat.dirStatFile(dir, entry.path) catch continue;
             const mtime: i64 = @intCast(@divTrunc(stat.mtime, std.time.ns_per_ms));
             const duped = backing.dupe(u8, entry.path) catch continue;
             known.put(duped, .{ .mtime = mtime, .size = stat.size, .hash = 0, .seen = false }) catch backing.free(duped);
@@ -364,7 +365,7 @@ fn incrementalDiff(store: *Store, explorer: *Explorer, queue: *EventQueue, known
     defer walker.deinit();
 
     while (try walker.next()) |entry| {
-        const stat = dir.statFile(entry.path) catch continue;
+        const stat = compat.dirStatFile(dir, entry.path) catch continue;
         const mtime: i64 = @intCast(@divTrunc(stat.mtime, std.time.ns_per_ms));
 
         if (known.getEntry(entry.path)) |known_entry| {
@@ -495,7 +496,7 @@ fn indexFileContent(explorer: *Explorer, dir: std.fs.Dir, path: []const u8, allo
     if (shouldSkipFile(path)) return;
     const file = try dir.openFile(path, .{});
     defer file.close();
-    const stat = try file.stat();
+    const stat = try compat.fileStat(file);
     // Skip files over 512KB (likely minified bundles or generated)
     if (stat.size > 512 * 1024) return;
     const content = try file.readToEndAlloc(allocator, 512 * 1024);
@@ -552,7 +553,7 @@ fn drainNotifyFile(store: *Store, explorer: *Explorer, queue: *EventQueue, known
         indexFileContent(explorer, dir, rel, alloc, false) catch continue;
 
         // Update known-file state so incrementalDiff doesn't double-process
-        const stat = dir.statFile(rel) catch continue;
+        const stat = compat.dirStatFile(dir, rel) catch continue;
         const mtime: i64 = @intCast(@divTrunc(stat.mtime, std.time.ns_per_ms));
         const hash = hashFile(dir, rel, stat.size) catch continue;
         if (known.getPtr(rel)) |existing| {


### PR DESCRIPTION
## Summary

- Add `src/compat.zig` — a WSL1 compatibility layer that falls back to `fstat`/`fstatat64` when `statx` is unavailable
- Replace all `File.stat()`, `Dir.statFile()`, and `Dir.makePath()` calls in the codebase with compat wrappers

## Problem

codedb doesn't work on WSL1 (kernel 4.4) or any Linux kernel older than 4.11. Zig 0.15's stdlib `File.stat()` and `Dir.statFile()` use the `statx` syscall directly on Linux ([File.zig#L563-L585](https://github.com/ziglang/zig/blob/0.15.0/lib/std/fs/File.zig#L563-L585), [Dir.zig#L2698-L2718](https://github.com/ziglang/zig/blob/0.15.0/lib/std/fs/Dir.zig#L2698-L2718)) with no fallback when `ENOSYS` is returned. The `ENOSYS` errno hits the catch-all `else` branch and becomes `error.Unexpected`.

This causes:
1. **Data dir creation fails** — `Dir.makePath()` internally calls `statFile()` to check if path components exist, which always errors
2. **Data log init fails** — `store.openDataLog()` calls `file.stat()` to get the file size
3. **Zero files indexed** — `dir.statFile(entry.path) catch continue` in the scan loop skips every file

Symptoms: `warning: could not create data dir ... error.Unexpected`, `warning: could not open data log ... error.Unexpected`, and `0 files` in tree/status output.

## Solution

`src/compat.zig` probes `statx` once at startup (cached via atomic):
- If `statx` works → delegates to stdlib (zero overhead, single atomic load)
- If `statx` returns `ENOSYS` → falls back to `posix.fstat()` / `posix.fstatat()` which use the classic `fstat64`/`fstatat64` syscalls (available since Linux 2.6)

Provides three drop-in functions:
- `compat.fileStat(file)` → replaces `file.stat()`
- `compat.dirStatFile(dir, path)` → replaces `dir.statFile(path)`
- `compat.makePath(dir, path)` → replaces `dir.makePath(path)` (uses iterative mkdir + tolerate EEXIST, avoiding the statFile call)

On non-Linux platforms, all functions delegate directly to the stdlib.

## Test plan

- [x] Verified `statx` returns `ENOSYS` on WSL1 kernel 4.4.0-26100-Microsoft
- [x] Tested on small directory (2 files): tree, search, outline, find all work
- [x] Tested on large repo (12,700+ C# files): full index completes, MCP server works
- [x] No data dir or data log warnings after patch
- [x] Cross-compiled from Windows Zig 0.15.0 targeting x86_64-linux (Zig itself can't run on WSL1 due to the same statx issue)

## Note on building

Zig 0.15 itself uses `statx` internally (for loading `build.zig.zon`, etc.), so it cannot run natively on WSL1. To build this on WSL1, cross-compile using the Windows Zig distribution:

```bash
cmd.exe /c "path\to\zig.exe build -Dtarget=x86_64-linux"
```