### PR TITLE
fix: block home directory indexing to prevent 17GB RAM spike (#174)

### DIFF
--- a/src/root_policy.zig
+++ b/src/root_policy.zig
@@ -11,15 +11,39 @@ pub fn isIndexableRoot(path: []const u8) bool {
     if (isExactOrChild(path, "/private/tmp")) return false;
     if (isExactOrChild(path, "/tmp")) return false;
     if (isExactOrChild(path, "/var/tmp")) return false;
+
+    // Block home directory itself (not subdirectories) — prevents 17GB RAM spike (#174)
+    if (std.posix.getenv("HOME")) |home| {
+        if (home.len > 0 and std.mem.eql(u8, path, home)) return false;
+    }
+    // Also block common home patterns directly
+    if (std.mem.eql(u8, path, "/root")) return false;
+    if (std.mem.startsWith(u8, path, "/home/") or std.mem.startsWith(u8, path, "/Users/")) {
+        // /home/user or /Users/user (no deeper path component) = home dir
+        const rest = if (std.mem.startsWith(u8, path, "/home/")) path[6..] else path[7..];
+        if (std.mem.indexOfScalar(u8, rest, '/') == null and rest.len > 0) return false;
+    }
+
     return true;
 }
 
 const testing = std.testing;
 
-test "issue-80: root / is denied" {
-    try testing.expect(!isIndexableRoot("/"));
+test "issue-80: normal paths are allowed" {
+    try testing.expect(isIndexableRoot("/Users/dev/project"));
+    try testing.expect(isIndexableRoot("/home/user/code"));
+    try testing.expect(isIndexableRoot("/home/user/code/subdir"));
 }
 
+test "issue-174: home directory itself is denied" {
+    try testing.expect(!isIndexableRoot("/root"));
+    try testing.expect(!isIndexableRoot("/home/user"));
+    try testing.expect(!isIndexableRoot("/Users/dev"));
+    // But subdirectories are allowed
+    try testing.expect(isIndexableRoot("/home/user/projects"));
+    try testing.expect(isIndexableRoot("/Users/dev/code"));
+    try testing.expect(isIndexableRoot("/root/projects"));
+}
 test "issue-80: empty path is denied" {
     try testing.expect(!isIndexableRoot(""));
 }
@@ -29,7 +53,3 @@ test "issue-80: /tmp is denied" {
     try testing.expect(!isIndexableRoot("/tmp/foo"));
 }
 
-test "issue-80: normal paths are allowed" {
-    try testing.expect(isIndexableRoot("/Users/dev/project"));
-    try testing.expect(isIndexableRoot("/home/user/code"));
-}


### PR DESCRIPTION
## Problem
When Claude Code starts in `~`, codedb recursively indexes the entire home directory causing ~17GB RAM spikes (#174).

## Fix
`root_policy.zig` now blocks:
- `$HOME` (via env var)
- `/root`
- `/home/<user>` (exact match only)
- `/Users/<user>` (exact match only)

Subdirectories like `/home/user/project` are still allowed.

## Test
```
$ codedb /Users/rachpradhan tree
✗ refusing to index temporary root: /Users/rachpradhan

$ codedb /Users/rachpradhan/codedb2 tree
✓ loaded snapshot  84 files  ⚡ 0ns
```

Closes #174