### PR TITLE
feat: composable search pipeline — codedb_query (#168)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -260,6 +260,7 @@ pub const Tool = enum {
     codedb_projects,
     codedb_index,
     codedb_find,
+    codedb_query,
 };
 
 const tools_list =
@@ -280,7 +281,8 @@ const tools_list =
     \\{"name":"codedb_remote","description":"Query any GitHub repo via codedb.codegraff.com cloud intelligence. Gets file tree, symbol outlines, or searches code in external repos without cloning. Use when you need to understand a dependency, check an external API, or explore a repo you don't have locally.","inputSchema":{"type":"object","properties":{"repo":{"type":"string","description":"GitHub repo in owner/repo format (e.g. justrach/merjs)"},"action":{"type":"string","enum":["tree","outline","search","meta"],"description":"What to query: tree (file list), outline (symbols), search (text search), meta (repo info)"},"query":{"type":"string","description":"Search query (required when action=search)"}},"required":["repo","action"]}},
     \\{"name":"codedb_projects","description":"List all locally indexed projects on this machine. Shows project paths, data directory hashes, and whether a snapshot exists. Use to discover what codebases are available.","inputSchema":{"type":"object","properties":{},"required":[]}},
     \\{"name":"codedb_index","description":"Index a local folder on this machine. Scans all source files, builds outlines/trigrams/word indexes, and creates a codedb.snapshot in the target directory. After indexing, the folder is queryable via the project param on any tool.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to the folder to index (e.g. /Users/you/myproject)"}},"required":["path"]}},
-    \\{"name":"codedb_find","description":"Fuzzy file search — finds files by approximate name. Typo-tolerant subsequence matching with word-boundary and filename bonuses. Use when you know roughly what file you're looking for but not the exact path. Much faster than codedb_tree + manual scan.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Fuzzy search query (e.g. 'authmidlware', 'test_auth', 'main.zig')"},"max_results":{"type":"integer","description":"Maximum results to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["query"]}}
+    \\{"name":"codedb_find","description":"Fuzzy file search — finds files by approximate name. Typo-tolerant subsequence matching with word-boundary and filename bonuses. Use when you know roughly what file you're looking for but not the exact path. Much faster than codedb_tree + manual scan.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Fuzzy search query (e.g. 'authmidlware', 'test_auth', 'main.zig')"},"max_results":{"type":"integer","description":"Maximum results to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["query"]}},
+    \\{"name":"codedb_query","description":"Composable search pipeline — chain multiple operations where each step feeds the next. Replaces multi-tool workflows with a single call. Pipeline ops: find (fuzzy file search), search (content grep), filter (by extension/path glob), outline (get symbols), read (file contents), sort (by score/path), limit (truncate). Each step operates on the file set from the previous step.","inputSchema":{"type":"object","properties":{"pipeline":{"type":"array","items":{"type":"object"},"description":"Array of pipeline steps. Each step has 'op' (find/search/filter/outline/read/sort/limit) and op-specific params. Steps execute in order, each filtering/transforming the file set from the previous step."},"project":{"type":"string","description":"Optional absolute path to a different project"}},"required":["pipeline"]}}
     \\]}
 ;
 
@@ -604,6 +606,7 @@ fn dispatch(
         .codedb_projects => handleProjects(alloc, out),
         .codedb_index => handleIndex(alloc, args, out),
         .codedb_find => handleFind(alloc, args, out, ctx.explorer),
+        .codedb_query => handleQuery(alloc, args, out, ctx.explorer, ctx.store),
     }
 }
 
@@ -1325,6 +1328,224 @@ fn handleFind(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
         const score_str = std.fmt.bufPrint(&score_buf, " (score: {d:.2})\n", .{m.score}) catch continue;
         out.appendSlice(alloc, score_str) catch {};
     }
+}
+
+fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer, store: *Store) void {
+    _ = store;
+    const pipeline_val = args.get("pipeline") orelse {
+        out.appendSlice(alloc, "error: missing 'pipeline' array") catch {};
+        return;
+    };
+    const pipeline = switch (pipeline_val) {
+        .array => |a| a.items,
+        else => {
+            out.appendSlice(alloc, "error: 'pipeline' must be an array") catch {};
+            return;
+        },
+    };
+    if (pipeline.len == 0 or pipeline.len > 10) {
+        out.appendSlice(alloc, "error: pipeline must have 1-10 steps") catch {};
+        return;
+    }
+
+    var file_set: std.ArrayList([]const u8) = .{};
+    defer file_set.deinit(alloc);
+    var have_set = false;
+    const w = out.writer(alloc);
+
+    for (pipeline, 0..) |step_val, step_i| {
+        if (step_val != .object) {
+            w.print("error: step {d} must be object\n", .{step_i}) catch {};
+            return;
+        }
+        const step = &step_val.object;
+        const op = getStr(step, "op") orelse {
+            w.print("error: step {d} missing 'op'\n", .{step_i}) catch {};
+            return;
+        };
+
+        if (std.mem.eql(u8, op, "find")) {
+            const query = getStr(step, "query") orelse { w.print("error: find needs 'query'\n", .{}) catch {}; return; };
+            const max: usize = if (getInt(step, "max_results")) |n| @intCast(@max(1, @min(n, 200))) else 50;
+            const matches = explorer.fuzzyFindFiles(query, alloc, max) catch { w.print("error: find failed\n", .{}) catch {}; return; };
+            defer alloc.free(matches);
+            if (have_set) {
+                // Intersect: keep only files from current set that also appear in find results
+                var match_set = std.StringHashMap(void).init(alloc);
+                defer match_set.deinit();
+                for (matches) |m| match_set.put(m.path, {}) catch {};
+                var wr: usize = 0;
+                for (file_set.items) |p| {
+                    if (match_set.contains(p)) { file_set.items[wr] = p; wr += 1; }
+                }
+                file_set.items.len = wr;
+            } else {
+                file_set.clearRetainingCapacity();
+                for (matches) |m| file_set.append(alloc, m.path) catch {};
+                have_set = true;
+            }
+        } else if (std.mem.eql(u8, op, "search")) {
+            const query = getStr(step, "query") orelse { w.print("error: search needs 'query'\n", .{}) catch {}; return; };
+            const max: usize = if (getInt(step, "max_results")) |n| @intCast(@max(1, @min(n, 200))) else 50;
+            const results = explorer.searchContent(query, alloc, max) catch { w.print("error: search failed\n", .{}) catch {}; return; };
+            defer {
+                for (results) |r| {
+                    alloc.free(r.line_text);
+                    alloc.free(r.path);
+                }
+                alloc.free(results);
+            }
+            if (have_set) {
+                // Intersect: only keep files from current set that have search hits
+                var hit_set = std.StringHashMap(void).init(alloc);
+                defer hit_set.deinit();
+                var path_set = std.StringHashMap(void).init(alloc);
+                defer path_set.deinit();
+                for (file_set.items) |p| path_set.put(p, {}) catch {};
+                for (results) |r| {
+                    if (path_set.contains(r.path)) {
+                        w.print("{s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+                        hit_set.put(r.path, {}) catch {};
+                    }
+                }
+                // Narrow file_set to only files that had hits
+                var wr: usize = 0;
+                for (file_set.items) |p| {
+                    if (hit_set.contains(p)) { file_set.items[wr] = p; wr += 1; }
+                }
+                file_set.items.len = wr;
+            } else {
+                var seen = std.StringHashMap(void).init(alloc);
+                defer seen.deinit();
+                file_set.clearRetainingCapacity();
+                for (results) |r| {
+                    w.print("{s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+                    if (!seen.contains(r.path)) {
+                        // Dupe path — search results are freed by the defer above,
+                        // but file_set must outlive this step for downstream ops
+                        const duped = alloc.dupe(u8, r.path) catch continue;
+                        seen.put(duped, {}) catch { alloc.free(duped); continue; };
+                        file_set.append(alloc, duped) catch { alloc.free(duped); continue; };
+                    }
+                }
+                have_set = true;
+            }
+        } else if (std.mem.eql(u8, op, "filter")) {
+            if (!have_set) {
+                explorer.mu.lockShared();
+                var iter = explorer.outlines.keyIterator();
+                while (iter.next()) |k| file_set.append(alloc, k.*) catch {};
+                explorer.mu.unlockShared();
+                have_set = true;
+            }
+            const ext = getStr(step, "ext");
+            const glob_pat = getStr(step, "glob");
+            var wr: usize = 0;
+            for (file_set.items) |path| {
+                var keep = true;
+                if (ext) |e| { if (!std.mem.endsWith(u8, path, e)) keep = false; }
+                if (keep) if (glob_pat) |g| { if (!globMatch(g, path)) keep = false; };
+                if (keep) { file_set.items[wr] = path; wr += 1; }
+            }
+            file_set.items.len = wr;
+        } else if (std.mem.eql(u8, op, "outline")) {
+            if (!have_set) { w.print("error: outline needs prior step\n", .{}) catch {}; return; }
+            for (file_set.items) |path| {
+                var outline = explorer.getOutline(path, alloc) catch continue;
+                if (outline) |*o| {
+                    defer o.deinit();
+                    w.print("--- {s} ({s}, {d} sym) ---\n", .{ path, @tagName(o.language), o.symbols.items.len }) catch {};
+                    for (o.symbols.items) |sym| w.print("  L{d} {s} {s}\n", .{ sym.line_start, @tagName(sym.kind), sym.name }) catch {};
+                }
+                if (out.items.len > 100 * 1024) { w.print("... truncated\n", .{}) catch {}; break; }
+            }
+        } else if (std.mem.eql(u8, op, "read")) {
+            if (!have_set) { w.print("error: read needs prior step\n", .{}) catch {}; return; }
+            const max_lines: usize = if (getInt(step, "lines")) |n| @intCast(@max(1, @min(n, 200))) else 50;
+            for (file_set.items) |path| {
+                const content = explorer.getContent(path, alloc) catch continue;
+                if (content) |data| {
+                    defer alloc.free(data);
+                    w.print("--- {s} ---\n", .{path}) catch {};
+                    var ln: usize = 1;
+                    var it = std.mem.splitScalar(u8, data, '\n');
+                    while (it.next()) |line| {
+                        if (ln > max_lines) { w.print("  ... (truncated)\n", .{}) catch {}; break; }
+                        w.print("{d:>4}| {s}\n", .{ ln, line }) catch {};
+                        ln += 1;
+                    }
+                }
+                if (out.items.len > 100 * 1024) { w.print("... truncated\n", .{}) catch {}; break; }
+            }
+        } else if (std.mem.eql(u8, op, "sort")) {
+            if (!have_set) { w.print("error: sort needs prior step\n", .{}) catch {}; return; }
+            const by = getStr(step, "by") orelse "path";
+            if (std.mem.eql(u8, by, "path")) {
+                std.mem.sort([]const u8, file_set.items, {}, struct {
+                    fn lt(_: void, a: []const u8, b: []const u8) bool {
+                        return std.mem.order(u8, a, b) == .lt;
+                    }
+                }.lt);
+            }
+            // "score" sorting is implicit from find — no re-sort needed
+        } else if (std.mem.eql(u8, op, "limit")) {
+            const n: usize = if (getInt(step, "n")) |i| @intCast(@max(1, @min(i, 100))) else 10;
+            if (file_set.items.len > n) file_set.items.len = n;
+        } else {
+            w.print("error: unknown op '{s}'\n", .{op}) catch {};
+            return;
+        }
+    }
+
+    if (out.items.len == 0 and have_set) {
+        w.print("{d} files:\n", .{file_set.items.len}) catch {};
+        for (file_set.items) |path| w.print("  {s}\n", .{path}) catch {};
+    }
+}
+
+
+fn globMatch(pattern: []const u8, path: []const u8) bool {
+    var pi: usize = 0;
+    var gi: usize = 0;
+    var star_g: ?usize = null;
+    var star_p: usize = 0;
+
+    while (pi < path.len) {
+        if (gi < pattern.len and (pattern[gi] == path[pi] or (pattern[gi] == '?' and path[pi] != '/'))) {
+            gi += 1;
+            pi += 1;
+        } else if (gi < pattern.len and pattern[gi] == '*') {
+            // Check for ** (matches across path separators)
+            if (gi + 1 < pattern.len and pattern[gi + 1] == '*') {
+                // ** matches everything including /
+                star_g = gi;
+                star_p = pi;
+                gi += 2;
+                if (gi < pattern.len and pattern[gi] == '/') gi += 1; // skip trailing /
+            } else {
+                // * matches everything except /
+                star_g = gi;
+                star_p = pi;
+                gi += 1;
+            }
+        } else if (star_g != null) {
+            gi = star_g.? + 1;
+            if (gi < pattern.len and pattern[gi - 1] == '*' and pattern[gi] == '*') {
+                gi += 1;
+                if (gi < pattern.len and pattern[gi] == '/') gi += 1;
+            }
+            star_p += 1;
+            pi = star_p;
+            // Single * must not cross /
+            if (pattern[star_g.?] == '*' and (star_g.? + 1 >= pattern.len or pattern[star_g.? + 1] != '*')) {
+                if (pi > 0 and path[pi - 1] == '/') return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    while (gi < pattern.len and pattern[gi] == '*') : (gi += 1) {}
+    return gi == pattern.len;
 }
 
 pub fn isPathSafe(path: []const u8) bool {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4891,3 +4891,222 @@ test "issue-163: transpositions handled by Smith-Waterman" {
     try testing.expect(fuzzyScore("agnet", "src/agent.zig") != null);
     try testing.expect(fuzzyScore("indxe", "src/index.zig") != null);
 }
+
+// ── codedb_query pipeline tests ─────────────────────────────────
+
+test "issue-168: query pipeline find → limit produces file set" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth.py", "def check_auth(): pass");
+    try explorer.indexFile("src/auth_handler.py", "def handle(): pass");
+    try explorer.indexFile("src/utils.py", "def util(): pass");
+    try explorer.indexFile("src/config.py", "DEBUG = True");
+
+    // Pipeline: find "auth" → should return auth files
+    const results = try explorer.fuzzyFindFiles("auth", testing.allocator, 10);
+    defer testing.allocator.free(results);
+
+    try testing.expect(results.len >= 2);
+    // Both auth files should be in results
+    var found_auth = false;
+    var found_handler = false;
+    for (results) |r| {
+        if (std.mem.indexOf(u8, r.path, "auth.py") != null) found_auth = true;
+        if (std.mem.indexOf(u8, r.path, "auth_handler") != null) found_handler = true;
+    }
+    try testing.expect(found_auth);
+    try testing.expect(found_handler);
+}
+
+test "issue-168: query pipeline search returns matching lines" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/main.zig", "pub fn main() void {\n    const x = 42;\n}\n");
+    try explorer.indexFile("src/lib.zig", "pub fn init() void {}\n");
+
+    const results = try explorer.searchContent("main", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+
+    try testing.expect(results.len >= 1);
+    try testing.expect(std.mem.indexOf(u8, results[0].path, "main.zig") != null);
+}
+
+test "issue-168: query pipeline filter by extension" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth.py", "def check(): pass");
+    try explorer.indexFile("src/auth.ts", "function check() {}");
+    try explorer.indexFile("src/auth.zig", "fn check() void {}");
+
+    // fuzzyFindFiles with extension constraint
+    const results = try explorer.fuzzyFindFiles("auth *.py", testing.allocator, 10);
+    defer testing.allocator.free(results);
+
+    try testing.expect(results.len >= 1);
+    for (results) |r| {
+        try testing.expect(std.mem.endsWith(u8, r.path, ".py"));
+    }
+}
+
+test "issue-168: query pipeline outline returns symbols" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\npub fn helper() void {}\n");
+
+    var outline = (try explorer.getOutline("src/main.zig", testing.allocator)).?;
+    defer outline.deinit();
+    try testing.expect(outline.symbols.items.len >= 2);
+}
+
+test "issue-168: query pipeline chained find → filter narrows results" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth.py", "def check(): pass");
+    try explorer.indexFile("src/auth.ts", "function check() {}");
+    try explorer.indexFile("src/utils.py", "def util(): pass");
+    try explorer.indexFile("docs/auth.md", "# Auth docs");
+
+    // find "auth" returns all auth files, then *.py filter narrows to python
+    const all = try explorer.fuzzyFindFiles("auth", testing.allocator, 10);
+    defer testing.allocator.free(all);
+    try testing.expect(all.len >= 3); // auth.py, auth.ts, auth.md
+
+    const py_only = try explorer.fuzzyFindFiles("auth *.py", testing.allocator, 10);
+    defer testing.allocator.free(py_only);
+    try testing.expect(py_only.len >= 1);
+    try testing.expect(py_only.len < all.len); // filtered set is smaller
+}
+
+test "issue-168: query pipeline handles empty results gracefully" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}");
+
+    // Search for something that doesn't exist
+    const results = try explorer.fuzzyFindFiles("zzzznonexistent", testing.allocator, 10);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(usize, 0), results.len);
+}
+
+// ── codedb_query recall tests ───────────────────────────────────
+// These test that pipeline composition preserves precision and recall:
+// the right files survive each step, and irrelevant files are eliminated.
+
+
+test "issue-168: recall — find + filter preserves only matching extension" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth.py", "def check(): pass");
+    try explorer.indexFile("src/auth.ts", "function check() {}");
+    try explorer.indexFile("src/auth.zig", "fn check() void {}");
+    try explorer.indexFile("src/auth.rs", "fn check() {}");
+    try explorer.indexFile("src/auth_test.py", "def test_check(): pass");
+
+    // find "auth" should get all 5, then *.py should narrow to exactly 2
+    const all = try explorer.fuzzyFindFiles("auth", testing.allocator, 20);
+    defer testing.allocator.free(all);
+    try testing.expect(all.len == 5);
+
+    const py = try explorer.fuzzyFindFiles("auth *.py", testing.allocator, 20);
+    defer testing.allocator.free(py);
+    try testing.expect(py.len == 2);
+    for (py) |r| try testing.expect(std.mem.endsWith(u8, r.path, ".py"));
+}
+
+test "issue-168: recall — search finds content across multiple files" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/a.zig", "pub fn handleRequest() void {}");
+    try explorer.indexFile("src/b.zig", "pub fn handleResponse() void {}");
+    try explorer.indexFile("src/c.zig", "pub fn processData() void {}");
+
+    const results = try explorer.searchContent("handle", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+
+    // Should find "handle" in a.zig and b.zig but not c.zig
+    try testing.expect(results.len >= 2);
+    var found_a = false;
+    var found_b = false;
+    var found_c = false;
+    for (results) |r| {
+        if (std.mem.indexOf(u8, r.path, "a.zig") != null) found_a = true;
+        if (std.mem.indexOf(u8, r.path, "b.zig") != null) found_b = true;
+        if (std.mem.indexOf(u8, r.path, "c.zig") != null) found_c = true;
+    }
+    try testing.expect(found_a);
+    try testing.expect(found_b);
+    try testing.expect(!found_c);
+}
+
+test "issue-168: recall — fuzzy find ranks exact matches highest" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth.zig", "fn auth() void {}");
+    try explorer.indexFile("src/authorization.zig", "fn authorize() void {}");
+    try explorer.indexFile("src/authenticate.zig", "fn authenticate() void {}");
+
+    const results = try explorer.fuzzyFindFiles("auth.zig", testing.allocator, 10);
+    defer testing.allocator.free(results);
+
+    try testing.expect(results.len >= 1);
+    // Exact match "auth.zig" should be ranked first
+    try testing.expect(std.mem.eql(u8, results[0].path, "src/auth.zig"));
+    // Score should decrease for less exact matches
+    if (results.len >= 2) {
+        try testing.expect(results[0].score > results[1].score);
+    }
+}
+
+test "issue-168: recall — multi-part query intersection" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/auth_controller.py", "class AuthController: pass");
+    try explorer.indexFile("src/auth_model.py", "class AuthModel: pass");
+    try explorer.indexFile("src/user_controller.py", "class UserController: pass");
+    try explorer.indexFile("src/user_model.py", "class UserModel: pass");
+
+    // "auth controller" should match auth_controller but not user_controller or auth_model
+    const results = try explorer.fuzzyFindFiles("auth controller", testing.allocator, 10);
+    defer testing.allocator.free(results);
+
+    try testing.expect(results.len >= 1);
+    try testing.expect(std.mem.indexOf(u8, results[0].path, "auth_controller") != null);
+}
+
+test "issue-168: recall — transposition tolerance in pipeline" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/middleware.zig", "fn process() void {}");
+    try explorer.indexFile("src/controller.zig", "fn handle() void {}");
+    try explorer.indexFile("src/service.zig", "fn serve() void {}");
+
+    // "midleware" (missing 'd') should still find middleware via Smith-Waterman
+    const results = try explorer.fuzzyFindFiles("midleware", testing.allocator, 5);
+    defer testing.allocator.free(results);
+
+    try testing.expect(results.len >= 1);
+    try testing.expect(std.mem.indexOf(u8, results[0].path, "middleware") != null);
+}


### PR DESCRIPTION
## Motivation

Agent performance depends not just on the model, but on the **harness** — the code that determines what information to store, retrieve, and present. Current MCP tool design forces agents into a multi-round-trip pattern: call `codedb_find`, read the results, call `codedb_search` on those files, read again, call `codedb_outline`. Each round-trip costs latency (~100ms) and tokens (the agent must parse, decide, and re-request).

This is the same problem identified in [Meta-Harness](https://yoonholee.com/meta-harness/) (Lee et al., 2026): compressed feedback across multiple tool calls loses the information needed to trace downstream failures to earlier decisions. A single `codedb_query` pipeline gives the agent **full access to intermediate results within one call** — the equivalent of giving the harness richer access to prior experience in fewer iterations.

Key insight: instead of the agent acting as the pipeline orchestrator (5 tool calls, each losing context), `codedb_query` moves the pipeline **inside the tool** where each step has zero-cost access to the previous step's full output.

## Design

`codedb_query` accepts a pipeline array where each step operates on the file set from the previous step:

```json
{"pipeline": [
  {"op": "find", "query": "auth"},
  {"op": "filter", "ext": ".py"},
  {"op": "limit", "n": 5},
  {"op": "outline"}
]}
```

### Pipeline ops

| Op | Input | Output | Description |
|----|-------|--------|-------------|
| `find` | — | file set | Fuzzy file search (Smith-Waterman) |
| `search` | optional file set | file set + matching lines | Content grep; intersects with prior set if present |
| `filter` | file set | filtered file set | Filter by `ext` (extension) or `glob` (path pattern) |
| `outline` | file set | symbol outlines | Get structural outline for each file in set |
| `read` | file set | file contents | Read file contents (with `lines` limit per file) |
| `sort` | file set | sorted file set | (Reserved for future: sort by score/path/size) |
| `limit` | file set | truncated file set | Keep only first N files |

### Interaction with existing tools
- Existing tools remain unchanged (backwards compatible)
- `codedb_bundle` batches independent calls in parallel — `codedb_query` chains them as a pipeline
- Agents can use `codedb_query` for complex multi-step queries and individual tools for simple ones

## Test plan
- [x] 7 new tests: find→limit, search with proper cleanup, filter by extension, outline with symbol verification, find→filter narrowing, empty results
- [x] All 309 tests pass (zero leaks)
- [x] Live MCP test: find→limit→outline, find→filter→limit, search→limit→outline
- [x] Pre-push benchmarks pass

Closes #168