### PR TITLE
fix: releaseContents reclaims HashMap bucket memory (#187)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -171,7 +171,7 @@ pub const Explorer = struct {
         while (content_iter.next()) |entry| {
             self.allocator.free(entry.value_ptr.*);
         }
-        self.contents.clearRetainingCapacity();
+        self.contents.clearAndFree();
     }
 
     pub fn releaseSecondaryIndexes(self: *Explorer) void {


### PR DESCRIPTION
## Problem
`releaseContents` used `clearRetainingCapacity` which frees values but keeps the HashMap bucket array allocated (~160KB for 10k files).

## Fix
Use `clearAndFree` to release everything.

## Memory audit
Codex-verified audit of all allocation paths. Findings:
- #185: readFromDisk double-dupes paths (deferred — needs ownership refactor)
- #186: MmapTrigramIndex heap allocation for file_table (~660KB, low priority)
- **#187: clearRetainingCapacity → clearAndFree (this PR)**
- #188: Closed — mmap is already tried first in all paths

Closes #187