### PR TITLE
fix: mmap_overlay fail-safe on allocation pressure

### DIFF
--- a/src/index.zig
+++ b/src/index.zig
@@ -1377,22 +1377,30 @@ pub const AnyTrigramIndex = union(enum) {
             .heap => |*h| h.candidates(query, allocator),
             .mmap => |*m| m.candidates(query, allocator),
             .mmap_overlay => |*mo| blk: {
-                // Query both, merge results (overlay may have newer files)
                 const base = mo.base.candidates(query, allocator);
                 const over = mo.overlay.candidates(query, allocator);
                 if (base == null and over == null) break :blk null;
                 if (base == null) break :blk over;
                 if (over == null) break :blk base;
-                // Merge and dedup
+                // Merge and dedup — return null on alloc failure (triggers full scan fallback)
                 var merged = std.StringHashMap(void).init(allocator);
                 defer merged.deinit();
-                for (base.?) |p| merged.put(p, {}) catch {};
-                for (over.?) |p| merged.put(p, {}) catch {};
+                for (base.?) |p| merged.put(p, {}) catch {
+                    allocator.free(base.?);
+                    allocator.free(over.?);
+                    break :blk null;
+                };
+                for (over.?) |p| merged.put(p, {}) catch {
+                    allocator.free(base.?);
+                    allocator.free(over.?);
+                    break :blk null;
+                };
                 allocator.free(base.?);
                 allocator.free(over.?);
                 var result: std.ArrayList([]const u8) = .{};
+                result.ensureTotalCapacity(allocator, merged.count()) catch break :blk null;
                 var it = merged.keyIterator();
-                while (it.next()) |k| result.append(allocator, k.*) catch {};
+                while (it.next()) |k| result.appendAssumeCapacity(k.*);
                 break :blk result.toOwnedSlice(allocator) catch null;
             },
         };
@@ -1410,13 +1418,22 @@ pub const AnyTrigramIndex = union(enum) {
                 if (over == null) break :blk base;
                 var merged = std.StringHashMap(void).init(allocator);
                 defer merged.deinit();
-                for (base.?) |p| merged.put(p, {}) catch {};
-                for (over.?) |p| merged.put(p, {}) catch {};
+                for (base.?) |p| merged.put(p, {}) catch {
+                    allocator.free(base.?);
+                    allocator.free(over.?);
+                    break :blk null;
+                };
+                for (over.?) |p| merged.put(p, {}) catch {
+                    allocator.free(base.?);
+                    allocator.free(over.?);
+                    break :blk null;
+                };
                 allocator.free(base.?);
                 allocator.free(over.?);
                 var result: std.ArrayList([]const u8) = .{};
+                result.ensureTotalCapacity(allocator, merged.count()) catch break :blk null;
                 var it = merged.keyIterator();
-                while (it.next()) |k| result.append(allocator, k.*) catch {};
+                while (it.next()) |k| result.appendAssumeCapacity(k.*);
                 break :blk result.toOwnedSlice(allocator) catch null;
             },
         };


### PR DESCRIPTION
## Problem
Codex stop-gate flagged: `mmap_overlay` merge path swallowed allocation errors with `catch {}`, silently dropping candidates. `searchContent` treats candidate lists as authoritative, so dropped candidates become false negatives — not just degraded ranking.

## Fix
Both `candidates()` and `candidatesRegex()` now return `null` on any allocation failure in the merge path. This triggers the full scan fallback in `searchContent`, which is safe (slower but correct).

Also pre-allocates result array with `ensureTotalCapacity` + `appendAssumeCapacity` to avoid per-element alloc failures.

## Test plan
- [x] All tests pass (zero leaks)
- [x] Pre-push benchmarks pass