### PR TITLE
fix: 5 bugs from issue #179

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -212,7 +212,7 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
         line_num += 1;
-        const trimmed = std.mem.trim(u8, line, " \t");
+        var trimmed = std.mem.trim(u8, line, " \t");
 
         // Track Python triple-quote docstrings (#111)
         if (outline.language == .python) {
@@ -221,8 +221,14 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
                 if (triple_count > 0) in_py_docstring = false;
                 continue;
             }
-            // Only skip if the line is JUST a docstring opener (no code before it)
-            if (triple_count == 1 and (std.mem.eql(u8, trimmed, "\"\"\"") or std.mem.eql(u8, trimmed, "'''"))) {
+            // Detect docstring/triple-quoted string open
+            if (triple_count >= 2) {
+                // Single-line: """text""" or x = """text""" — skip, no state change
+                continue;
+            }
+            if (triple_count == 1) {
+                // Unmatched triple-quote anywhere on line opens multi-line mode
+                // Catches: """text, '''text, x = """, etc.
                 in_py_docstring = true;
                 continue;
             }
@@ -237,14 +243,18 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
             if (startsWith(line, "=begin")) { in_py_docstring = true; continue; }
         }
 
-        // Track JS/TS block comments (#113)
-        if (outline.language == .typescript or outline.language == .javascript or outline.language == .go_lang) {
+        // Track block comments for all languages that use /* */
+        if (outline.language == .typescript or outline.language == .javascript or
+            outline.language == .go_lang or outline.language == .c or
+            outline.language == .cpp or outline.language == .rust or
+            outline.language == .zig)
+        {
             if (in_block_comment) {
                 if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
                     in_block_comment = false;
-                    // If there's code after */, don't skip — fall through to parse it
                     const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
                     if (after.len == 0) continue;
+                    trimmed = after; // parse code after */ on the same line
                 } else continue;
             }
             if (std.mem.startsWith(u8, trimmed, "/*")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -323,7 +323,7 @@ fn mainImpl() !void {
 
             if (heads_match) {
                 // Verify file count then load trigram from disk via mmap
-                const current_count = @as(u16, @intCast(@min(explorer.outlines.count(), std.math.maxInt(u16))));
+                const current_count = @as(u32, @intCast(explorer.outlines.count()));
                 if (disk_hdr != null and current_count == disk_hdr.?.file_count) {
                     if (MmapTrigramIndex.initFromDisk(data_dir, allocator)) |loaded| {
                         explorer.mu.lock();
@@ -785,7 +785,7 @@ fn scanBg(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.m
     }
 
     if (heads_match) {
-        const current_count = @as(u16, @intCast(@min(explorer.outlines.count(), std.math.maxInt(u16))));
+        const current_count = @as(u32, @intCast(explorer.outlines.count()));
         if (disk_hdr != null and current_count == disk_hdr.?.file_count) {
             if (MmapTrigramIndex.initFromDisk(data_dir, allocator)) |loaded| {
                 explorer.mu.lock();

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1350,12 +1350,27 @@ fn handleIndex(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
     out.appendSlice(alloc, abs_path) catch {};
     if (result.stdout.len > 0) {
         out.appendSlice(alloc, "\n") catch {};
-        // Strip ANSI color codes from stdout for clean MCP output
-        for (result.stdout) |c| {
-            if (c == 0x1b) {
-                // Skip ESC sequences — handled below
+        // Strip ANSI escape sequences
+        var i: usize = 0;
+        while (i < result.stdout.len) {
+            if (result.stdout[i] == 0x1b) {
+                i += 1;
+                if (i < result.stdout.len and result.stdout[i] == '[') {
+                    // CSI sequence: skip until final byte (0x40-0x7E per ECMA-48)
+                    i += 1;
+                    while (i < result.stdout.len) {
+                        const ch = result.stdout[i];
+                        i += 1;
+                        if (ch >= 0x40 and ch <= 0x7E) break;
+                    }
+                } else if (i < result.stdout.len) {
+                    // Fe sequence (ESC + one byte) — skip
+                    i += 1;
+                }
+                // Lone ESC at end — already skipped by i += 1 above
             } else {
-                out.append(alloc, c) catch {};
+                out.append(alloc, result.stdout[i]) catch {};
+                i += 1;
             }
         }
     }

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -82,15 +82,13 @@ pub const Telemetry = struct {
         if ((next + 1) -% tail > RING_SIZE) {
             self.tail.store((next + 1) -% RING_SIZE, .monotonic);
         }
+        self.call_count += 1;
+        const should_flush = self.call_count % 3 == 0;
+        const should_sync = self.call_count % 10 == 0;
         self.write_lock.unlock();
 
-        self.call_count += 1;
-        if (self.call_count % 3 == 0) {
-            self.flush();
-        }
-        if (self.call_count % 10 == 0) {
-            self.syncToCloud();
-        }
+        if (should_flush) self.flush();
+        if (should_sync) self.syncToCloud();
     }
 
     pub fn recordSessionStart(self: *Telemetry) void {
@@ -159,10 +157,13 @@ pub const Telemetry = struct {
         if (!self.enabled or self.path_len == 0) return;
         const path = self.path_buf[0..self.path_len];
 
+        // Hold lock during file I/O to prevent flush() from writing while we upload+truncate
+        self.write_lock.lock();
+        defer self.write_lock.unlock();
+
         const stat = compat.dirStatFile(std.fs.cwd(), path) catch return;
         if (stat.size == 0) return;
 
-        // Use argv-based exec (no shell interpolation) to avoid injection
         var data_arg_buf: [std.fs.max_path_bytes + 1]u8 = undefined;
         const data_arg = std.fmt.bufPrint(&data_arg_buf, "@{s}", .{path}) catch return;
 
@@ -175,7 +176,6 @@ pub const Telemetry = struct {
         child.stderr_behavior = .Ignore;
         _ = child.spawnAndWait() catch return;
 
-        // Truncate the file after successful sync
         if (std.fs.cwd().createFile(path, .{ .truncate = true })) |f| {
             f.close();
         } else |_| {}


### PR DESCRIPTION
## Fixes

1. **u16 file count → u32** — mmap cache comparison was truncating to 65K, breaking instant startup for large repos
2. **ANSI strip rewrite** — full ECMA-48 CSI parsing (0x40-0x7E terminators), handles `ESC[?25l`, `ESC[200~`, Fe sequences, lone ESC
3. **Block comments for C/C++/Rust/Zig** — was only tracking `/* */` for JS/TS/Go, causing phantom symbols from commented-out code
4. **Python docstring detection** — now catches `"""text`, `x = """`, `'''text` anywhere on line, not just bare `"""` lines
5. **Telemetry data race** — `call_count` moved inside `write_lock`, flush/sync decisions computed inside lock but executed outside

## Codex review
- Round 1: found ANSI terminator range bug + Python docstring column-0 issue
- Round 2: both fixed

## Remaining from #179
- Snapshot JSON injection (needs `writeJsonEscaped` in binary snapshot path)
- Global `active_pair_freq` race (needs atomic or mutex)  
- Unbounded HTTP threads (needs thread pool)

## Test plan
- [x] All tests pass (zero leaks)
- [x] Pre-push benchmarks pass