### PR TITLE
fix: release ProjectCache contents after snapshot load

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -124,6 +124,12 @@ const ProjectCache = struct {
             }
         }
 
+        const fc = new_entry.explorer.outlines.count();
+        if (fc > 1000 or std.process.hasEnvVarConstant("CODEDB_LOW_MEMORY")) {
+            new_entry.explorer.releaseContents();
+            new_entry.explorer.releaseSecondaryIndexes();
+        }
+
         // Find free slot or evict LRU
         var target_slot: usize = 0;
         var found_free = false;


### PR DESCRIPTION
Fixes #210

## Problem
`ProjectCache.get()` in `src/mcp.zig` loads snapshots for non-default repos but never calls `releaseContents()` or `releaseSecondaryIndexes()` on the cached `Explorer`. This retains raw file contents in memory for the lifetime of each cache entry. On a ~22K file repo, this causes ~4.5GB RSS from a single cached project.

## Solution
After `loadSnapshot` succeeds, release file contents that are not needed for query serving (the snapshot provides outlines + trigram index + word index, which is sufficient for all MCP query tools). Mirrors the identical pattern already used by the primary explorer in `main.zig` `scanBg()`.

## Testing
The fix mirrors the existing `main.zig` pattern exactly (`fc > 1000 or CODEDB_LOW_MEMORY`). Verified by code inspection that `releaseContents` and `releaseSecondaryIndexes` are safe to call after snapshot load — the snapshot contains outlines and indexes sufficient for all query tools.