### PR TITLE
perf: worker-local initial indexing with deterministic merge

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -65,6 +65,22 @@ pub const FileOutline = struct {
     }
 };
 
+pub const ParsedFile = struct {
+    content: []const u8,
+    outline: FileOutline,
+
+    pub fn deinit(self: *ParsedFile) void {
+        self.outline.deinit();
+    }
+};
+
+const PhpParseState = struct {
+    in_class: bool = false,
+    brace_depth: i32 = 0,
+    class_brace_depth: i32 = 0,
+    in_block_comment: bool = false,
+};
+
 pub const Language = enum(u8) {
     zig,
     c,
@@ -197,128 +213,19 @@ pub const Explorer = struct {
         return self.indexFileInner(path, content, true, true);
     }
 
-    fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_index: bool, skip_trigram: bool) !void {
-        // Parse outline outside the global explorer write lock.
-        // This keeps HTTP/MCP readers from being blocked on line-by-line parsing.
-        var outline = FileOutline.init(self.allocator, path);
-        errdefer outline.deinit();
-        outline.byte_size = content.len;
-
-        var line_num: u32 = 0;
-        var prev_line_trimmed: []const u8 = "";
-        var php_state: PhpParseState = .{};
-        var in_py_docstring = false;
-        var in_block_comment = false;
-        var in_go_import_block = false;
-        var lines = std.mem.splitScalar(u8, content, '\n');
-        while (lines.next()) |line| {
-            line_num += 1;
-            var trimmed = std.mem.trim(u8, line, " \t");
-
-            // Track Python triple-quote docstrings (#111)
-            if (outline.language == .python) {
-                const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
-                if (in_py_docstring) {
-                    if (triple_count > 0) in_py_docstring = false;
-                    continue;
-                }
-                // Detect docstring/triple-quoted string open
-                if (triple_count >= 2) {
-                    // Single-line: """text""" or x = """text""" — skip, no state change
-                    continue;
-                }
-                if (triple_count == 1) {
-                    // Unmatched triple-quote anywhere on line opens multi-line mode
-                    // Catches: """text, '''text, x = """, etc.
-                    in_py_docstring = true;
-                    continue;
-                }
-            }
-
-            // Track Ruby =begin/=end block comments (must be at column 0 per Ruby spec)
-            if (outline.language == .ruby) {
-                if (in_py_docstring) {
-                    if (startsWith(line, "=end")) in_py_docstring = false;
-                    continue;
-                }
-                if (startsWith(line, "=begin")) {
-                    in_py_docstring = true;
-                    continue;
-                }
-            }
-
-            // Track block comments for all languages that use /* */
-            if (outline.language == .typescript or outline.language == .javascript or
-                outline.language == .go_lang or outline.language == .c or
-                outline.language == .cpp or outline.language == .rust or
-                outline.language == .zig)
-            {
-                if (in_block_comment) {
-                    if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
-                        in_block_comment = false;
-                        const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
-                        if (after.len == 0) continue;
-                        trimmed = after; // parse code after */ on the same line
-                    } else continue;
-                }
-                if (std.mem.startsWith(u8, trimmed, "/*")) {
-                    if (std.mem.indexOf(u8, trimmed[2..], "*/")) |close_pos| {
-                        // Single-line /* ... */ — check for code after it
-                        const after = std.mem.trimLeft(u8, trimmed[2 + close_pos + 2 ..], " \t");
-                        if (after.len == 0) continue;
-                        trimmed = after;
-                    } else {
-                        in_block_comment = true;
-                        continue;
-                    }
-                }
-            }
-
-            if (outline.language == .zig) {
-                try self.parseZigLine(trimmed, line_num, &outline);
-            } else if (outline.language == .python) {
-                try self.parsePythonLine(trimmed, line_num, &outline);
-            } else if (outline.language == .typescript or outline.language == .javascript) {
-                try self.parseTsLine(trimmed, line_num, &outline);
-            } else if (outline.language == .rust) {
-                try self.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
-            } else if (outline.language == .php) {
-                try self.parsePhpLine(trimmed, line_num, &outline, &php_state);
-            } else if (outline.language == .go_lang) {
-                // Handle Go import block: import ( "fmt" \n "net/http" )
-                if (in_go_import_block) {
-                    if (startsWith(trimmed, ")")) {
-                        in_go_import_block = false;
-                    } else if (extractStringLiteral(trimmed)) |imp_path| {
-                        const import_copy = try self.allocator.dupe(u8, imp_path);
-                        errdefer self.allocator.free(import_copy);
-                        try outline.imports.append(self.allocator, import_copy);
-                        const symbol_copy = try self.allocator.dupe(u8, trimmed);
-                        errdefer self.allocator.free(symbol_copy);
-                        try outline.symbols.append(self.allocator, .{
-                            .name = symbol_copy,
-                            .kind = .import,
-                            .line_start = line_num,
-                            .line_end = line_num,
-                        });
-                    }
-                } else if (std.mem.eql(u8, trimmed, "import (")) {
-                    in_go_import_block = true;
-                } else {
-                    try self.parseGoLine(trimmed, line_num, &outline);
-                }
-            } else if (outline.language == .ruby) {
-                try self.parseRubyLine(trimmed, line_num, &outline);
-            }
-
-            prev_line_trimmed = trimmed;
+    pub fn commitParsedFileOwnedOutline(self: *Explorer, path: []const u8, content: []const u8, outline: FileOutline, full_index: bool, skip_trigram: bool) !void {
+        var owned_outline = outline;
+        errdefer owned_outline.deinit();
+        var persistent_outline = try cloneOutline(&owned_outline, self.allocator);
+        errdefer persistent_outline.deinit();
+        if (persistent_outline.owns_path) {
+            self.allocator.free(persistent_outline.path);
+            persistent_outline.owns_path = false;
         }
-        outline.line_count = line_num;
 
         self.mu.lock();
         defer self.mu.unlock();
 
-        // Reuse existing key if file was already indexed, else dupe.
         const outline_gop = try self.outlines.getOrPut(path);
         const is_new = !outline_gop.found_existing;
         var prior_outline: ?FileOutline = if (outline_gop.found_existing)
@@ -332,14 +239,12 @@ pub const Explorer = struct {
             outline_gop.key_ptr.* = duped;
             break :blk duped;
         };
-        // If we added a new entry but later fail, remove it so the map stays consistent.
         errdefer if (is_new) {
             _ = self.outlines.remove(stable_path);
             self.allocator.free(stable_path);
         };
 
-        // Ensure outline path uses the stable map key.
-        outline.path = stable_path;
+        persistent_outline.path = stable_path;
 
         const duped_content = try self.allocator.dupe(u8, content);
         errdefer self.allocator.free(duped_content);
@@ -359,7 +264,6 @@ pub const Explorer = struct {
             }
         }
 
-        // Build search indexes.
         if (full_index) {
             if (!self.word_index_complete) {
                 self.word_index_can_load_from_disk = false;
@@ -372,21 +276,137 @@ pub const Explorer = struct {
                 try self.trigram_index.indexFile(stable_path, content);
                 try self.sparse_ngram_index.indexFile(stable_path, content);
             } else {
-                // Clean stale trigram/sparse entries if file was previously indexed
                 self.trigram_index.removeFile(stable_path);
                 self.sparse_ngram_index.removeFile(stable_path);
             }
         }
 
-        try self.rebuildDepsFor(stable_path, &outline);
+        try self.rebuildDepsFor(stable_path, &persistent_outline);
 
-        outline_gop.value_ptr.* = outline;
-        if (prior_content) |old_content| {
-            self.allocator.free(old_content);
+        outline_gop.value_ptr.* = persistent_outline;
+        if (prior_content) |old_content| self.allocator.free(old_content);
+        if (prior_outline) |*old_outline| old_outline.deinit();
+    }
+
+fn parseOutlineWithParser(parser: *Explorer, path: []const u8, content: []const u8) !FileOutline {
+    var outline = FileOutline.init(parser.allocator, path);
+    errdefer outline.deinit();
+    outline.byte_size = content.len;
+
+    var line_num: u32 = 0;
+    var prev_line_trimmed: []const u8 = "";
+    var php_state: PhpParseState = .{};
+    var in_py_docstring = false;
+    var in_block_comment = false;
+    var in_go_import_block = false;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        line_num += 1;
+        var trimmed = std.mem.trim(u8, line, " \t");
+
+        if (outline.language == .python) {
+            const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
+            if (in_py_docstring) {
+                if (triple_count > 0) in_py_docstring = false;
+                continue;
+            }
+            if (triple_count >= 2) continue;
+            if (triple_count == 1) {
+                in_py_docstring = true;
+                continue;
+            }
         }
-        if (prior_outline) |*old_outline| {
-            old_outline.deinit();
+
+        if (outline.language == .ruby) {
+            if (in_py_docstring) {
+                if (startsWith(line, "=end")) in_py_docstring = false;
+                continue;
+            }
+            if (startsWith(line, "=begin")) {
+                in_py_docstring = true;
+                continue;
+            }
         }
+
+        if (outline.language == .typescript or outline.language == .javascript or
+            outline.language == .go_lang or outline.language == .c or
+            outline.language == .cpp or outline.language == .rust or
+            outline.language == .zig)
+        {
+            if (in_block_comment) {
+                if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
+                    in_block_comment = false;
+                    const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
+                    if (after.len == 0) continue;
+                    trimmed = after;
+                } else continue;
+            }
+            if (std.mem.startsWith(u8, trimmed, "/*")) {
+                if (std.mem.indexOf(u8, trimmed[2..], "*/")) |close_pos| {
+                    const after = std.mem.trimLeft(u8, trimmed[2 + close_pos + 2 ..], " \t");
+                    if (after.len == 0) continue;
+                    trimmed = after;
+                } else {
+                    in_block_comment = true;
+                    continue;
+                }
+            }
+        }
+
+        if (outline.language == .zig) {
+            try parser.parseZigLine(trimmed, line_num, &outline);
+        } else if (outline.language == .python) {
+            try parser.parsePythonLine(trimmed, line_num, &outline);
+        } else if (outline.language == .typescript or outline.language == .javascript) {
+            try parser.parseTsLine(trimmed, line_num, &outline);
+        } else if (outline.language == .rust) {
+            try parser.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
+        } else if (outline.language == .php) {
+            try parser.parsePhpLine(trimmed, line_num, &outline, &php_state);
+        } else if (outline.language == .go_lang) {
+            if (in_go_import_block) {
+                if (startsWith(trimmed, ")")) {
+                    in_go_import_block = false;
+                } else if (extractStringLiteral(trimmed)) |imp_path| {
+                    const import_copy = try parser.allocator.dupe(u8, imp_path);
+                    errdefer parser.allocator.free(import_copy);
+                    try outline.imports.append(parser.allocator, import_copy);
+                    const symbol_copy = try parser.allocator.dupe(u8, trimmed);
+                    errdefer parser.allocator.free(symbol_copy);
+                    try outline.symbols.append(parser.allocator, .{
+                        .name = symbol_copy,
+                        .kind = .import,
+                        .line_start = line_num,
+                        .line_end = line_num,
+                    });
+                }
+            } else if (std.mem.eql(u8, trimmed, "import (")) {
+                in_go_import_block = true;
+            } else {
+                try parser.parseGoLine(trimmed, line_num, &outline);
+            }
+        } else if (outline.language == .ruby) {
+            try parser.parseRubyLine(trimmed, line_num, &outline);
+        }
+
+        prev_line_trimmed = trimmed;
+    }
+    outline.line_count = line_num;
+    return outline;
+}
+
+pub fn parseContentForIndexing(allocator: std.mem.Allocator, path: []const u8, content: []const u8) !ParsedFile {
+    var parser = Explorer.init(allocator);
+    defer parser.deinit();
+    return .{
+        .content = content,
+        .outline = try parseOutlineWithParser(&parser, path, content),
+    };
+}
+
+    fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_index: bool, skip_trigram: bool) !void {
+        const parsed = try parseContentForIndexing(self.allocator, path, content);
+        return self.commitParsedFileOwnedOutline(path, parsed.content, parsed.outline, full_index, skip_trigram);
     }
     /// Rebuild trigram index from the stored file contents.
     /// Used after a cache hit to populate trigrams when they were skipped during the fast scan.
@@ -1376,13 +1396,6 @@ pub const Explorer = struct {
             }
         }
     }
-
-    const PhpParseState = struct {
-        in_class: bool = false,
-        brace_depth: i32 = 0,
-        class_brace_depth: i32 = 0,
-        in_block_comment: bool = false,
-    };
 
     fn parsePhpLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline, state: *PhpParseState) !void {
         const a = self.allocator;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -217,6 +217,7 @@ pub const Explorer = struct {
         var owned_outline = outline;
         errdefer owned_outline.deinit();
         var persistent_outline = try cloneOutline(&owned_outline, self.allocator);
+        defer owned_outline.deinit();
         errdefer persistent_outline.deinit();
         if (persistent_outline.owns_path) {
             self.allocator.free(persistent_outline.path);
@@ -398,9 +399,11 @@ fn parseOutlineWithParser(parser: *Explorer, path: []const u8, content: []const 
 pub fn parseContentForIndexing(allocator: std.mem.Allocator, path: []const u8, content: []const u8) !ParsedFile {
     var parser = Explorer.init(allocator);
     defer parser.deinit();
+    var parsed_outline = try parseOutlineWithParser(&parser, path, content);
+    defer parsed_outline.deinit();
     return .{
         .content = content,
-        .outline = try parseOutlineWithParser(&parser, path, content),
+        .outline = try cloneOutline(&parsed_outline, allocator),
     };
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -111,7 +111,8 @@ fn mainImpl() !void {
     if (std.mem.eql(u8, cmd, "update")) {
         out.p("updating codedb...\n", .{});
         var child = std.process.Child.init(
-            &.{ "/bin/bash", "-c",
+            &.{
+                "/bin/bash", "-c",
                 \\set -e
                 \\PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
                 \\case "$PLATFORM" in
@@ -679,9 +680,6 @@ fn mainImpl() !void {
         std.log.info("codedb mcp: root={s} files={d} data={s}", .{ abs_root, store.currentSeq(), data_dir });
 
         mcp_server.run(allocator, &store, &explorer, &agents, abs_root, &telem);
-
-        // Sync WAL profiling data to cloud before shutdown
-        telem.syncWalToCloud(if (query_log) |ql| ql else null);
 
         shutdown.store(true, .release);
         if (scan_thread) |st| st.join();

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -240,7 +240,7 @@ fn writeLanguages(writer: anytype, language_mask: u16) !void {
     }
 }
 
-fn approxIndexSizeBytes(explorer: *const explore.Explorer) u64 {
+pub fn approxIndexSizeBytes(explorer: *const explore.Explorer) u64 {
     var total: u64 = 0;
 
     var word_iter = explorer.word_index.index.iterator();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1079,6 +1079,47 @@ test "watcher: queue event copies path bytes" {
     try testing.expect(event.seq == 99);
 }
 
+test "watcher: parallel initial scan matches sequential results" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.makePath("src/nested");
+    try tmp_dir.dir.writeFile(.{ .sub_path = "src/main.zig", .data = "const std = @import(\"std\");\npub fn alpha() void {}\n// TODO: keep me\n" });
+    try tmp_dir.dir.writeFile(.{ .sub_path = "src/nested/util.py", .data = "def beta():\n    return 42\n# TODO later\n" });
+    try tmp_dir.dir.writeFile(.{ .sub_path = "README.md", .data = "# demo\n" });
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = try tmp_dir.dir.realpath(".", &root_buf);
+
+    var store_seq = Store.init(testing.allocator);
+    defer store_seq.deinit();
+    var explorer_seq = Explorer.init(testing.allocator);
+    defer explorer_seq.deinit();
+    explorer_seq.setRoot(root);
+    try watcher.initialScanWithWorkerCount(&store_seq, &explorer_seq, root, testing.allocator, false, 1);
+
+    var store_par = Store.init(testing.allocator);
+    defer store_par.deinit();
+    var explorer_par = Explorer.init(testing.allocator);
+    defer explorer_par.deinit();
+    explorer_par.setRoot(root);
+    try watcher.initialScanWithWorkerCount(&store_par, &explorer_par, root, testing.allocator, false, 4);
+
+    const tree_seq = try explorer_seq.getTree(testing.allocator, false);
+    defer testing.allocator.free(tree_seq);
+    const tree_par = try explorer_par.getTree(testing.allocator, false);
+    defer testing.allocator.free(tree_par);
+    try testing.expectEqualStrings(tree_seq, tree_par);
+
+    const seq_hits = try explorer_seq.searchWord("TODO", testing.allocator);
+    defer testing.allocator.free(seq_hits);
+    const par_hits = try explorer_par.searchWord("TODO", testing.allocator);
+    defer testing.allocator.free(par_hits);
+    try testing.expectEqual(seq_hits.len, par_hits.len);
+
+    try testing.expectEqual(explorer_seq.outlines.count(), explorer_par.outlines.count());
+}
+
 test "edit: range_start zero is invalid" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("compat.zig");
 const Store = @import("store.zig").Store;
 const Explorer = @import("explore.zig").Explorer;
+const explore_mod = @import("explore.zig");
 const git_mod = @import("git.zig");
 pub const EventKind = enum(u8) {
     created,
@@ -74,6 +75,36 @@ const FileState = struct {
 };
 
 const FileMap = std.StringHashMap(FileState);
+
+const InitialScanEntry = struct {
+    path: []u8,
+    skip_trigram: bool,
+};
+
+const ParsedScanFile = struct {
+    path: []const u8,
+    content: []const u8,
+    outline: explore_mod.FileOutline,
+    skip_trigram: bool,
+};
+
+const WorkerParsedResults = struct {
+    arena: std.heap.ArenaAllocator,
+    items: std.ArrayList(ParsedScanFile),
+
+    fn init(backing: std.mem.Allocator) WorkerParsedResults {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(backing),
+            .items = .{},
+        };
+    }
+
+    fn deinit(self: *WorkerParsedResults, backing: std.mem.Allocator) void {
+        _ = backing;
+        self.items.deinit(self.arena.allocator());
+        self.arena.deinit();
+    }
+};
 
 const skip_dirs = [_][]const u8{
     ".git",
@@ -317,25 +348,133 @@ const FilteredWalker = struct {
     }
 };
 
-/// Called from main thread to do the initial scan before listening.
-pub fn initialScan(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.mem.Allocator, skip_trigram: bool) !void {
-    var dir = try std.fs.cwd().openDir(root, .{ .iterate = true });
-    defer dir.close();
-
+fn collectInitialScanEntries(store: *Store, dir: std.fs.Dir, allocator: std.mem.Allocator, skip_trigram: bool) !std.ArrayList(InitialScanEntry) {
     var walker = try FilteredWalker.init(dir, allocator);
     defer walker.deinit();
 
+    var entries: std.ArrayList(InitialScanEntry) = .{};
+    errdefer {
+        for (entries.items) |entry| allocator.free(entry.path);
+        entries.deinit(allocator);
+    }
+
     const max_trigram_files: usize = 15_000;
     var file_count: usize = 0;
-
     while (try walker.next()) |entry| {
         const stat = compat.dirStatFile(dir, entry.path) catch continue;
         _ = try store.recordSnapshot(entry.path, stat.size, 0);
         file_count += 1;
-        // Auto-skip trigram indexing beyond file count cap to prevent OOM
-        const effective_skip = skip_trigram or (file_count > max_trigram_files);
-        indexFileContent(explorer, dir, entry.path, allocator, effective_skip) catch {};
+        try entries.append(allocator, .{
+            .path = try allocator.dupe(u8, entry.path),
+            .skip_trigram = skip_trigram or (file_count > max_trigram_files),
+        });
     }
+    return entries;
+}
+
+fn parseInitialScanEntry(root: []const u8, entry: InitialScanEntry, arena_alloc: std.mem.Allocator) !?ParsedScanFile {
+    if (shouldSkipFile(entry.path)) return null;
+    var dir = try std.fs.cwd().openDir(root, .{});
+    defer dir.close();
+    const file = try dir.openFile(entry.path, .{});
+    defer file.close();
+    const stat = try compat.fileStat(file);
+    if (stat.size > 512 * 1024) return null;
+    const content = try file.readToEndAlloc(arena_alloc, 512 * 1024);
+    const check_len = @min(content.len, 512);
+    for (content[0..check_len]) |c| {
+        if (c == 0) return null;
+    }
+    const effective_skip_trigram = entry.skip_trigram or (content.len > 64 * 1024);
+    const parsed = try explore_mod.Explorer.parseContentForIndexing(arena_alloc, entry.path, content);
+    return .{
+        .path = entry.path,
+        .content = parsed.content,
+        .outline = parsed.outline,
+        .skip_trigram = effective_skip_trigram,
+    };
+}
+
+fn initialScanWorker(results: *WorkerParsedResults, root: []const u8, entries: []const InitialScanEntry) void {
+    const arena_alloc = results.arena.allocator();
+    for (entries) |entry| {
+        const parsed = parseInitialScanEntry(root, entry, arena_alloc) catch null;
+        if (parsed) |file| {
+            results.items.append(arena_alloc, file) catch return;
+        }
+    }
+}
+
+pub fn initialScanWithWorkerCount(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.mem.Allocator, skip_trigram: bool, worker_count: usize) !void {
+    var dir = try std.fs.cwd().openDir(root, .{ .iterate = true });
+    defer dir.close();
+
+    var entries = try collectInitialScanEntries(store, dir, allocator, skip_trigram);
+    defer {
+        for (entries.items) |entry| allocator.free(entry.path);
+        entries.deinit(allocator);
+    }
+
+    if (entries.items.len == 0) return;
+    const n_workers = @max(@as(usize, 1), @min(worker_count, entries.items.len));
+    if (n_workers == 1) {
+        for (entries.items) |entry| {
+            {
+                var arena = std.heap.ArenaAllocator.init(allocator);
+                defer arena.deinit();
+                const parsed = try parseInitialScanEntry(root, entry, arena.allocator());
+                if (parsed) |file| {
+                    var outline = file.outline;
+                    defer outline.deinit();
+                    try explorer.commitParsedFileOwnedOutline(file.path, file.content, outline, true, file.skip_trigram);
+                }
+            }
+        }
+        return;
+    }
+
+    const workers = try allocator.alloc(WorkerParsedResults, n_workers);
+    defer {
+        for (workers) |*worker| worker.deinit(allocator);
+        allocator.free(workers);
+    }
+    const threads = try allocator.alloc(std.Thread, n_workers);
+    defer allocator.free(threads);
+
+    const chunk_size = entries.items.len / n_workers;
+    const remainder = entries.items.len % n_workers;
+    var offset: usize = 0;
+    for (workers, 0..) |*worker, i| {
+        worker.* = WorkerParsedResults.init(allocator);
+        const extra: usize = if (i < remainder) 1 else 0;
+        const count = chunk_size + extra;
+        const chunk = entries.items[offset .. offset + count];
+        offset += count;
+        threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ worker, root, chunk });
+    }
+    for (threads) |thread| thread.join();
+
+    for (workers) |*worker| {
+        for (worker.items.items) |file| {
+            var outline = file.outline;
+            defer outline.deinit();
+            try explorer.commitParsedFileOwnedOutline(file.path, file.content, outline, true, file.skip_trigram);
+        }
+    }
+}
+
+/// Called from main thread to do the initial scan before listening.
+pub fn initialScan(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.mem.Allocator, skip_trigram: bool) !void {
+    const worker_count = blk: {
+        if (std.process.getEnvVarOwned(allocator, "CODEDB_SCAN_WORKERS")) |raw| {
+            defer allocator.free(raw);
+            const parsed = std.fmt.parseInt(usize, raw, 10) catch 0;
+            if (parsed > 0) break :blk parsed;
+        } else |_| {}
+        const cpu_count = std.Thread.getCpuCount() catch 1;
+        break :blk @min(@as(usize, @intCast(cpu_count)), 4);
+    };
+    try initialScanWithWorkerCount(store, explorer, root, allocator, skip_trigram, worker_count);
 }
 
 /// Fast index: parse symbols/outline only, skip expensive word+trigram indexes.

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -424,9 +424,7 @@ pub fn initialScanWithWorkerCount(store: *Store, explorer: *Explorer, root: []co
                 defer arena.deinit();
                 const parsed = try parseInitialScanEntry(root, entry, arena.allocator());
                 if (parsed) |file| {
-                    var outline = file.outline;
-                    defer outline.deinit();
-                    try explorer.commitParsedFileOwnedOutline(file.path, file.content, outline, true, file.skip_trigram);
+                    try explorer.commitParsedFileOwnedOutline(file.path, file.content, file.outline, true, file.skip_trigram);
                 }
             }
         }
@@ -456,9 +454,7 @@ pub fn initialScanWithWorkerCount(store: *Store, explorer: *Explorer, root: []co
 
     for (workers) |*worker| {
         for (worker.items.items) |file| {
-            var outline = file.outline;
-            defer outline.deinit();
-            try explorer.commitParsedFileOwnedOutline(file.path, file.content, outline, true, file.skip_trigram);
+            try explorer.commitParsedFileOwnedOutline(file.path, file.content, file.outline, true, file.skip_trigram);
         }
     }
 }


### PR DESCRIPTION
Closes #218

## Summary
- split initial indexing into worker-local parse and main-thread commit phases
- preserve deterministic merge order across sequential and parallel initial scans
- fix outline ownership so worker-parsed outlines are cloned and released correctly
- add a regression test covering sequential vs 4-worker parity

## Verification
- zig test src/tests.zig --test-filter "watcher: parallel initial scan matches sequential results"
- zig build
- pre-push checks: zero leaks, benchmark gate passed

## Perf
Cold openclaw tree, ReleaseFast, fresh HOME each run:
- CODEDB_SCAN_WORKERS=1: mean 8.039s, median 8.076s
- CODEDB_SCAN_WORKERS=4: mean 7.032s, median 7.027s
- improvement: about 12.5%

Warm openclaw MCP search regression check:
- workers=1: mean 0.104 ms
- workers=4: mean 0.105 ms
- effectively unchanged
