### PR TITLE
[codex] perf: speed up warm snapshot reopen

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -120,6 +120,8 @@ pub const Explorer = struct {
     allocator: std.mem.Allocator,
     word_index_complete: bool = true,
     word_index_can_load_from_disk: bool = false,
+    word_index_generation: u64 = 0,
+    word_index_persisted_generation: u64 = 0,
     mu: std.Thread.RwLock = .{},
     root_dir: ?std.fs.Dir = null,
 
@@ -360,6 +362,9 @@ pub const Explorer = struct {
                 self.word_index_can_load_from_disk = false;
             }
             try self.word_index.indexFile(stable_path, content);
+            if (self.word_index_complete) {
+                self.word_index_generation +%= 1;
+            }
             if (!skip_trigram) {
                 try self.trigram_index.indexFile(stable_path, content);
                 try self.sparse_ngram_index.indexFile(stable_path, content);
@@ -417,6 +422,7 @@ pub const Explorer = struct {
         while (iter.next()) |entry| {
             try self.word_index.indexFile(entry.key_ptr.*, entry.value_ptr.*);
         }
+        self.word_index_generation +%= 1;
         self.word_index_complete = true;
         self.word_index_can_load_from_disk = false;
     }
@@ -450,13 +456,37 @@ pub const Explorer = struct {
         return self.word_index_complete;
     }
 
+    pub fn wordIndexNeedsPersist(self: *Explorer) bool {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        return self.word_index_complete and self.word_index_generation != self.word_index_persisted_generation;
+    }
+
+    pub fn wordIndexGenerationToPersist(self: *Explorer) ?u64 {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        if (!self.word_index_complete) return null;
+        if (self.word_index_generation == self.word_index_persisted_generation) return null;
+        return self.word_index_generation;
+    }
+
+    pub fn markWordIndexPersisted(self: *Explorer, generation: u64) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        if (self.word_index_complete and self.word_index_generation == generation) {
+            self.word_index_persisted_generation = generation;
+        }
+    }
+
     pub fn replaceWordIndex(self: *Explorer, word_index: WordIndex) void {
         self.mu.lock();
         defer self.mu.unlock();
         self.word_index.deinit();
         self.word_index = word_index;
+        self.word_index_generation +%= 1;
         self.word_index_complete = true;
         self.word_index_can_load_from_disk = false;
+        self.word_index_persisted_generation = self.word_index_generation;
     }
 
     pub fn removeFile(self: *Explorer, path: []const u8) void {
@@ -464,6 +494,8 @@ pub const Explorer = struct {
         defer self.mu.unlock();
         if (!self.word_index_complete) {
             self.word_index_can_load_from_disk = false;
+        } else {
+            self.word_index_generation +%= 1;
         }
         if (self.dep_graph.getPtr(path)) |deps| {
             deps.deinit(self.allocator);

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -7,7 +7,6 @@ const MmapTrigramIndex = idx.MmapTrigramIndex;
 const AnyTrigramIndex = idx.AnyTrigramIndex;
 const SparseNgramIndex = idx.SparseNgramIndex;
 
-
 pub const SymbolKind = enum(u8) {
     function,
     struct_def,
@@ -119,6 +118,8 @@ pub const Explorer = struct {
     trigram_index: AnyTrigramIndex,
     sparse_ngram_index: SparseNgramIndex,
     allocator: std.mem.Allocator,
+    word_index_complete: bool = true,
+    word_index_can_load_from_disk: bool = false,
     mu: std.Thread.RwLock = .{},
     root_dir: ?std.fs.Dir = null,
 
@@ -136,7 +137,6 @@ pub const Explorer = struct {
             .allocator = allocator,
         };
     }
-
 
     pub fn deinit(self: *Explorer) void {
         var iter = self.outlines.iterator();
@@ -195,190 +195,191 @@ pub const Explorer = struct {
         return self.indexFileInner(path, content, true, true);
     }
 
+    fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_index: bool, skip_trigram: bool) !void {
+        // Parse outline outside the global explorer write lock.
+        // This keeps HTTP/MCP readers from being blocked on line-by-line parsing.
+        var outline = FileOutline.init(self.allocator, path);
+        errdefer outline.deinit();
+        outline.byte_size = content.len;
 
-fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_index: bool, skip_trigram: bool) !void {
-    // Parse outline outside the global explorer write lock.
-    // This keeps HTTP/MCP readers from being blocked on line-by-line parsing.
-    var outline = FileOutline.init(self.allocator, path);
-    errdefer outline.deinit();
-    outline.byte_size = content.len;
+        var line_num: u32 = 0;
+        var prev_line_trimmed: []const u8 = "";
+        var php_state: PhpParseState = .{};
+        var in_py_docstring = false;
+        var in_block_comment = false;
+        var in_go_import_block = false;
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            line_num += 1;
+            var trimmed = std.mem.trim(u8, line, " \t");
 
-    var line_num: u32 = 0;
-    var prev_line_trimmed: []const u8 = "";
-    var php_state: PhpParseState = .{};
-    var in_py_docstring = false;
-    var in_block_comment = false;
-    var in_go_import_block = false;
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        line_num += 1;
-        var trimmed = std.mem.trim(u8, line, " \t");
-
-        // Track Python triple-quote docstrings (#111)
-        if (outline.language == .python) {
-            const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
-            if (in_py_docstring) {
-                if (triple_count > 0) in_py_docstring = false;
-                continue;
-            }
-            // Detect docstring/triple-quoted string open
-            if (triple_count >= 2) {
-                // Single-line: """text""" or x = """text""" — skip, no state change
-                continue;
-            }
-            if (triple_count == 1) {
-                // Unmatched triple-quote anywhere on line opens multi-line mode
-                // Catches: """text, '''text, x = """, etc.
-                in_py_docstring = true;
-                continue;
-            }
-        }
-
-        // Track Ruby =begin/=end block comments (must be at column 0 per Ruby spec)
-        if (outline.language == .ruby) {
-            if (in_py_docstring) {
-                if (startsWith(line, "=end")) in_py_docstring = false;
-                continue;
-            }
-            if (startsWith(line, "=begin")) { in_py_docstring = true; continue; }
-        }
-
-        // Track block comments for all languages that use /* */
-        if (outline.language == .typescript or outline.language == .javascript or
-            outline.language == .go_lang or outline.language == .c or
-            outline.language == .cpp or outline.language == .rust or
-            outline.language == .zig)
-        {
-            if (in_block_comment) {
-                if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
-                    in_block_comment = false;
-                    const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
-                    if (after.len == 0) continue;
-                    trimmed = after; // parse code after */ on the same line
-                } else continue;
-            }
-            if (std.mem.startsWith(u8, trimmed, "/*")) {
-                if (std.mem.indexOf(u8, trimmed[2..], "*/")) |close_pos| {
-                    // Single-line /* ... */ — check for code after it
-                    const after = std.mem.trimLeft(u8, trimmed[2 + close_pos + 2 ..], " \t");
-                    if (after.len == 0) continue;
-                    trimmed = after;
-                } else {
-                    in_block_comment = true;
+            // Track Python triple-quote docstrings (#111)
+            if (outline.language == .python) {
+                const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
+                if (in_py_docstring) {
+                    if (triple_count > 0) in_py_docstring = false;
+                    continue;
+                }
+                // Detect docstring/triple-quoted string open
+                if (triple_count >= 2) {
+                    // Single-line: """text""" or x = """text""" — skip, no state change
+                    continue;
+                }
+                if (triple_count == 1) {
+                    // Unmatched triple-quote anywhere on line opens multi-line mode
+                    // Catches: """text, '''text, x = """, etc.
+                    in_py_docstring = true;
                     continue;
                 }
             }
-        }
 
-        if (outline.language == .zig) {
-            try self.parseZigLine(trimmed, line_num, &outline);
-        } else if (outline.language == .python) {
-            try self.parsePythonLine(trimmed, line_num, &outline);
-        } else if (outline.language == .typescript or outline.language == .javascript) {
-            try self.parseTsLine(trimmed, line_num, &outline);
-        } else if (outline.language == .rust) {
-            try self.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
-        } else if (outline.language == .php) {
-            try self.parsePhpLine(trimmed, line_num, &outline, &php_state);
-        } else if (outline.language == .go_lang) {
-            // Handle Go import block: import ( "fmt" \n "net/http" )
-            if (in_go_import_block) {
-                if (startsWith(trimmed, ")")) {
-                    in_go_import_block = false;
-                } else if (extractStringLiteral(trimmed)) |imp_path| {
-                    const import_copy = try self.allocator.dupe(u8, imp_path);
-                    errdefer self.allocator.free(import_copy);
-                    try outline.imports.append(self.allocator, import_copy);
-                    const symbol_copy = try self.allocator.dupe(u8, trimmed);
-                    errdefer self.allocator.free(symbol_copy);
-                    try outline.symbols.append(self.allocator, .{
-                        .name = symbol_copy,
-                        .kind = .import,
-                        .line_start = line_num,
-                        .line_end = line_num,
-                    });
+            // Track Ruby =begin/=end block comments (must be at column 0 per Ruby spec)
+            if (outline.language == .ruby) {
+                if (in_py_docstring) {
+                    if (startsWith(line, "=end")) in_py_docstring = false;
+                    continue;
                 }
-            } else if (std.mem.eql(u8, trimmed, "import (")) {
-                in_go_import_block = true;
-            } else {
-                try self.parseGoLine(trimmed, line_num, &outline);
+                if (startsWith(line, "=begin")) { in_py_docstring = true; continue; }
             }
-        } else if (outline.language == .ruby) {
-            try self.parseRubyLine(trimmed, line_num, &outline);
+
+            // Track block comments for all languages that use /* */
+            if (outline.language == .typescript or outline.language == .javascript or
+                outline.language == .go_lang or outline.language == .c or
+                outline.language == .cpp or outline.language == .rust or
+                outline.language == .zig)
+            {
+                if (in_block_comment) {
+                    if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
+                        in_block_comment = false;
+                        const after = std.mem.trimLeft(u8, trimmed[close_pos + 2 ..], " \t");
+                        if (after.len == 0) continue;
+                        trimmed = after; // parse code after */ on the same line
+                    } else continue;
+                }
+                if (std.mem.startsWith(u8, trimmed, "/*")) {
+                    if (std.mem.indexOf(u8, trimmed[2..], "*/")) |close_pos| {
+                        // Single-line /* ... */ — check for code after it
+                        const after = std.mem.trimLeft(u8, trimmed[2 + close_pos + 2 ..], " \t");
+                        if (after.len == 0) continue;
+                        trimmed = after;
+                    } else {
+                        in_block_comment = true;
+                        continue;
+                    }
+                }
+            }
+
+            if (outline.language == .zig) {
+                try self.parseZigLine(trimmed, line_num, &outline);
+            } else if (outline.language == .python) {
+                try self.parsePythonLine(trimmed, line_num, &outline);
+            } else if (outline.language == .typescript or outline.language == .javascript) {
+                try self.parseTsLine(trimmed, line_num, &outline);
+            } else if (outline.language == .rust) {
+                try self.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
+            } else if (outline.language == .php) {
+                try self.parsePhpLine(trimmed, line_num, &outline, &php_state);
+            } else if (outline.language == .go_lang) {
+                // Handle Go import block: import ( "fmt" \n "net/http" )
+                if (in_go_import_block) {
+                    if (startsWith(trimmed, ")")) {
+                        in_go_import_block = false;
+                    } else if (extractStringLiteral(trimmed)) |imp_path| {
+                        const import_copy = try self.allocator.dupe(u8, imp_path);
+                        errdefer self.allocator.free(import_copy);
+                        try outline.imports.append(self.allocator, import_copy);
+                        const symbol_copy = try self.allocator.dupe(u8, trimmed);
+                        errdefer self.allocator.free(symbol_copy);
+                        try outline.symbols.append(self.allocator, .{
+                            .name = symbol_copy,
+                            .kind = .import,
+                            .line_start = line_num,
+                            .line_end = line_num,
+                        });
+                    }
+                } else if (std.mem.eql(u8, trimmed, "import (")) {
+                    in_go_import_block = true;
+                } else {
+                    try self.parseGoLine(trimmed, line_num, &outline);
+                }
+            } else if (outline.language == .ruby) {
+                try self.parseRubyLine(trimmed, line_num, &outline);
+            }
+
+            prev_line_trimmed = trimmed;
         }
+        outline.line_count = line_num;
 
-        prev_line_trimmed = trimmed;
-    }
-    outline.line_count = line_num;
+        self.mu.lock();
+        defer self.mu.unlock();
 
-    self.mu.lock();
-    defer self.mu.unlock();
+        // Reuse existing key if file was already indexed, else dupe.
+        const outline_gop = try self.outlines.getOrPut(path);
+        const is_new = !outline_gop.found_existing;
+        var prior_outline: ?FileOutline = if (outline_gop.found_existing)
+            outline_gop.value_ptr.*
+        else
+            null;
+        const stable_path = if (outline_gop.found_existing) blk: {
+            break :blk outline_gop.key_ptr.*;
+        } else blk: {
+            const duped = try self.allocator.dupe(u8, path);
+            outline_gop.key_ptr.* = duped;
+            break :blk duped;
+        };
+        // If we added a new entry but later fail, remove it so the map stays consistent.
+        errdefer if (is_new) {
+            _ = self.outlines.remove(stable_path);
+            self.allocator.free(stable_path);
+        };
 
-    // Reuse existing key if file was already indexed, else dupe.
-    const outline_gop = try self.outlines.getOrPut(path);
-    const is_new = !outline_gop.found_existing;
-    var prior_outline: ?FileOutline = if (outline_gop.found_existing)
-        outline_gop.value_ptr.*
-    else
-        null;
-    const stable_path = if (outline_gop.found_existing) blk: {
-        break :blk outline_gop.key_ptr.*;
-    } else blk: {
-        const duped = try self.allocator.dupe(u8, path);
-        outline_gop.key_ptr.* = duped;
-        break :blk duped;
-    };
-    // If we added a new entry but later fail, remove it so the map stays consistent.
-    errdefer if (is_new) {
-        _ = self.outlines.remove(stable_path);
-        self.allocator.free(stable_path);
-    };
+        // Ensure outline path uses the stable map key.
+        outline.path = stable_path;
 
-    // Ensure outline path uses the stable map key.
-    outline.path = stable_path;
-
-    const duped_content = try self.allocator.dupe(u8, content);
-    errdefer self.allocator.free(duped_content);
-    const content_gop = try self.contents.getOrPut(stable_path);
-    var prior_content: ?[]const u8 = null;
-    if (content_gop.found_existing) {
-        prior_content = content_gop.value_ptr.*;
-    } else {
-        content_gop.key_ptr.* = stable_path;
-    }
-    content_gop.value_ptr.* = duped_content;
-    errdefer {
+        const duped_content = try self.allocator.dupe(u8, content);
+        errdefer self.allocator.free(duped_content);
+        const content_gop = try self.contents.getOrPut(stable_path);
+        var prior_content: ?[]const u8 = null;
         if (content_gop.found_existing) {
-            content_gop.value_ptr.* = prior_content.?;
+            prior_content = content_gop.value_ptr.*;
         } else {
-            _ = self.contents.remove(stable_path);
+            content_gop.key_ptr.* = stable_path;
+        }
+        content_gop.value_ptr.* = duped_content;
+        errdefer {
+            if (content_gop.found_existing) {
+                content_gop.value_ptr.* = prior_content.?;
+            } else {
+                _ = self.contents.remove(stable_path);
+            }
+        }
+
+        // Build search indexes.
+        if (full_index) {
+            if (!self.word_index_complete) {
+                self.word_index_can_load_from_disk = false;
+            }
+            try self.word_index.indexFile(stable_path, content);
+            if (!skip_trigram) {
+                try self.trigram_index.indexFile(stable_path, content);
+                try self.sparse_ngram_index.indexFile(stable_path, content);
+            } else {
+                // Clean stale trigram/sparse entries if file was previously indexed
+                self.trigram_index.removeFile(stable_path);
+                self.sparse_ngram_index.removeFile(stable_path);
+            }
+        }
+
+        try self.rebuildDepsFor(stable_path, &outline);
+
+        outline_gop.value_ptr.* = outline;
+        if (prior_content) |old_content| {
+            self.allocator.free(old_content);
+        }
+        if (prior_outline) |*old_outline| {
+            old_outline.deinit();
         }
     }
-
-    // Build search indexes.
-    if (full_index) {
-        try self.word_index.indexFile(stable_path, content);
-        if (!skip_trigram) {
-            try self.trigram_index.indexFile(stable_path, content);
-            try self.sparse_ngram_index.indexFile(stable_path, content);
-        } else {
-            // Clean stale trigram/sparse entries if file was previously indexed
-            self.trigram_index.removeFile(stable_path);
-            self.sparse_ngram_index.removeFile(stable_path);
-        }
-    }
-
-
-    try self.rebuildDepsFor(stable_path, &outline);
-
-    outline_gop.value_ptr.* = outline;
-    if (prior_content) |old_content| {
-        self.allocator.free(old_content);
-    }
-    if (prior_outline) |*old_outline| {
-        old_outline.deinit();
-    }
-}
     /// Rebuild trigram index from the stored file contents.
     /// Used after a cache hit to populate trigrams when they were skipped during the fast scan.
     pub fn rebuildTrigrams(self: *Explorer) !void {
@@ -403,10 +404,67 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
         }
     }
 
+    /// Rebuild the inverted word index from stored contents.
+    /// Used after fast snapshot restore, which intentionally avoids per-file tokenization.
+    pub fn rebuildWordIndex(self: *Explorer) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        self.word_index.deinit();
+        self.word_index = WordIndex.init(self.allocator);
+
+        var iter = self.contents.iterator();
+        while (iter.next()) |entry| {
+            try self.word_index.indexFile(entry.key_ptr.*, entry.value_ptr.*);
+        }
+        self.word_index_complete = true;
+        self.word_index_can_load_from_disk = false;
+    }
+
+    pub fn markWordIndexIncomplete(self: *Explorer, can_load_from_disk: bool) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.word_index.deinit();
+        self.word_index = WordIndex.init(self.allocator);
+        self.word_index_complete = false;
+        self.word_index_can_load_from_disk = can_load_from_disk;
+    }
+
+    pub fn disableWordIndexDiskLoad(self: *Explorer) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        if (!self.word_index_complete) {
+            self.word_index_can_load_from_disk = false;
+        }
+    }
+
+    pub fn wordIndexCanLoadFromDisk(self: *Explorer) bool {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        return !self.word_index_complete and self.word_index_can_load_from_disk;
+    }
+
+    pub fn wordIndexIsComplete(self: *Explorer) bool {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        return self.word_index_complete;
+    }
+
+    pub fn replaceWordIndex(self: *Explorer, word_index: WordIndex) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.word_index.deinit();
+        self.word_index = word_index;
+        self.word_index_complete = true;
+        self.word_index_can_load_from_disk = false;
+    }
 
     pub fn removeFile(self: *Explorer, path: []const u8) void {
         self.mu.lock();
         defer self.mu.unlock();
+        if (!self.word_index_complete) {
+            self.word_index_can_load_from_disk = false;
+        }
         if (self.dep_graph.getPtr(path)) |deps| {
             deps.deinit(self.allocator);
             _ = self.dep_graph.remove(path);
@@ -445,7 +503,7 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
 
     const ContentRef = struct {
         data: []const u8,
-        owned: bool,  // true = caller must free; false = borrowed from cache
+        owned: bool, // true = caller must free; false = borrowed from cache
         allocator: std.mem.Allocator,
 
         fn deinit(self: ContentRef) void {
@@ -465,100 +523,105 @@ fn indexFileInner(self: *Explorer, path: []const u8, content: []const u8, full_i
         return .{ .data = data, .owned = true, .allocator = allocator };
     }
 
-fn cloneOutline(src: *const FileOutline, allocator: std.mem.Allocator) !FileOutline {
-    const copied_path = try allocator.dupe(u8, src.path);
-    // No errdefer here: dst.deinit() below handles freeing copied_path via owns_path.
+    fn cloneOutline(src: *const FileOutline, allocator: std.mem.Allocator) !FileOutline {
+        const copied_path = try allocator.dupe(u8, src.path);
+        // No errdefer here: dst.deinit() below handles freeing copied_path via owns_path.
 
-    var dst = FileOutline.init(allocator, copied_path);
-    dst.owns_path = true;
-    errdefer dst.deinit();
-    dst.line_count = src.line_count;
-    dst.byte_size = src.byte_size;
-    for (src.symbols.items) |sym| {
-        const copied_name = try allocator.dupe(u8, sym.name);
-        errdefer allocator.free(copied_name);
+        var dst = FileOutline.init(allocator, copied_path);
+        dst.owns_path = true;
+        errdefer dst.deinit();
+        dst.line_count = src.line_count;
+        dst.byte_size = src.byte_size;
+        for (src.symbols.items) |sym| {
+            const copied_name = try allocator.dupe(u8, sym.name);
+            errdefer allocator.free(copied_name);
 
-        const copied_detail = if (sym.detail) |d| blk: {
-            const detail = try allocator.dupe(u8, d);
-            break :blk detail;
-        } else null;
-        errdefer if (copied_detail) |d| allocator.free(d);
+            const copied_detail = if (sym.detail) |d| blk: {
+                const detail = try allocator.dupe(u8, d);
+                break :blk detail;
+            } else null;
+            errdefer if (copied_detail) |d| allocator.free(d);
 
-        try dst.symbols.append(allocator, .{
-            .name = copied_name,
-            .kind = sym.kind,
-            .line_start = sym.line_start,
-            .line_end = sym.line_end,
-            .detail = copied_detail,
-        });
-    }
-    for (src.imports.items) |imp| {
-        const copied_import = try allocator.dupe(u8, imp);
-        errdefer allocator.free(copied_import);
-        try dst.imports.append(allocator, copied_import);
-    }
-
-    return dst;
-}
-
-pub fn getTree(self: *Explorer, allocator: std.mem.Allocator, use_color: bool) ![]u8 {
-    const s = @import("style.zig").style(use_color);
-
-    self.mu.lockShared();
-    defer self.mu.unlockShared();
-
-    var buf: std.ArrayList(u8) = .{};
-    errdefer buf.deinit(allocator);
-    const writer = buf.writer(allocator);
-
-    var paths: std.ArrayList([]const u8) = .{};
-    defer paths.deinit(allocator);
-
-    var iter = self.outlines.iterator();
-    while (iter.next()) |entry| {
-        try paths.append(allocator, entry.key_ptr.*);
-    }
-
-    std.mem.sort([]const u8, paths.items, {}, struct {
-        fn lessThan(_: void, a: []const u8, b: []const u8) bool {
-            return std.mem.order(u8, a, b) == .lt;
+            try dst.symbols.append(allocator, .{
+                .name = copied_name,
+                .kind = sym.kind,
+                .line_start = sym.line_start,
+                .line_end = sym.line_end,
+                .detail = copied_detail,
+            });
         }
-    }.lessThan);
+        for (src.imports.items) |imp| {
+            const copied_import = try allocator.dupe(u8, imp);
+            errdefer allocator.free(copied_import);
+            try dst.imports.append(allocator, copied_import);
+        }
 
-    var seen_dirs = std.StringHashMap(void).init(allocator);
-    defer seen_dirs.deinit();
+        return dst;
+    }
 
-    for (paths.items) |path| {
-        const outline = self.outlines.get(path) orelse continue;
+    pub fn getTree(self: *Explorer, allocator: std.mem.Allocator, use_color: bool) ![]u8 {
+        const s = @import("style.zig").style(use_color);
 
-        // Emit directory nodes we haven't seen yet
-        var prefix_end: usize = 0;
-        while (std.mem.indexOfScalarPos(u8, path, prefix_end, '/')) |sep| {
-            const dir = path[0 .. sep + 1];
-            if (!seen_dirs.contains(dir)) {
-                try seen_dirs.put(dir, {});
-                const depth = std.mem.count(u8, dir[0..sep], "/");
-                for (0..depth) |_| try writer.writeAll("  ");
-                const dir_name = path[if (depth > 0) std.mem.lastIndexOfScalar(u8, dir[0..sep], '/').? + 1 else 0 .. sep];
-                try writer.print("{s}{s}/{s}\n", .{ s.bold, dir_name, s.reset });
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+
+        var buf: std.ArrayList(u8) = .{};
+        errdefer buf.deinit(allocator);
+        const writer = buf.writer(allocator);
+
+        var paths: std.ArrayList([]const u8) = .{};
+        defer paths.deinit(allocator);
+
+        var iter = self.outlines.iterator();
+        while (iter.next()) |entry| {
+            try paths.append(allocator, entry.key_ptr.*);
+        }
+
+        std.mem.sort([]const u8, paths.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
             }
-            prefix_end = sep + 1;
+        }.lessThan);
+
+        var seen_dirs = std.StringHashMap(void).init(allocator);
+        defer seen_dirs.deinit();
+
+        for (paths.items) |path| {
+            const outline = self.outlines.get(path) orelse continue;
+
+            // Emit directory nodes we haven't seen yet
+            var prefix_end: usize = 0;
+            while (std.mem.indexOfScalarPos(u8, path, prefix_end, '/')) |sep| {
+                const dir = path[0 .. sep + 1];
+                if (!seen_dirs.contains(dir)) {
+                    try seen_dirs.put(dir, {});
+                    const depth = std.mem.count(u8, dir[0..sep], "/");
+                    for (0..depth) |_| try writer.writeAll("  ");
+                    const dir_name = path[if (depth > 0) std.mem.lastIndexOfScalar(u8, dir[0..sep], '/').? + 1 else 0..sep];
+                    try writer.print("{s}{s}/{s}\n", .{ s.bold, dir_name, s.reset });
+                }
+                prefix_end = sep + 1;
+            }
+
+            // Emit file leaf
+            const depth = std.mem.count(u8, path, "/");
+            for (0..depth) |_| try writer.writeAll("  ");
+            const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
+            const lang = @tagName(outline.language);
+            try writer.print("{s}  {s}{s}{s}  {s}{d}L  {d} sym{s}\n", .{
+                basename,
+                s.langColor(lang),
+                lang,
+                s.reset,
+                s.dim,
+                outline.line_count,
+                outline.symbols.items.len,
+                s.reset,
+            });
         }
 
-        // Emit file leaf
-        const depth = std.mem.count(u8, path, "/");
-        for (0..depth) |_| try writer.writeAll("  ");
-        const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
-        const lang = @tagName(outline.language);
-        try writer.print("{s}  {s}{s}{s}  {s}{d}L  {d} sym{s}\n", .{
-            basename,
-            s.langColor(lang), lang, s.reset,
-            s.dim, outline.line_count, outline.symbols.items.len, s.reset,
-        });
+        return buf.toOwnedSlice(allocator);
     }
-
-    return buf.toOwnedSlice(allocator);
-}
 
     pub fn findSymbol(self: *Explorer, name: []const u8, allocator: std.mem.Allocator) !?struct { path: []const u8, symbol: Symbol } {
         self.mu.lockShared();
@@ -685,7 +748,6 @@ pub fn getTree(self: *Explorer, allocator: std.mem.Allocator, use_color: bool) !
         return result_list.toOwnedSlice(allocator);
     }
 
-
     /// Search file contents using a regex pattern with trigram acceleration.
     /// Decomposes the regex to extract literal trigrams for candidate filtering,
     /// then does actual regex matching on candidates.
@@ -744,9 +806,15 @@ pub fn getTree(self: *Explorer, allocator: std.mem.Allocator, use_color: bool) !
         return result_list.toOwnedSlice(allocator);
     }
 
-
     /// Search for a word using the inverted word index. O(1) lookup.
     pub fn searchWord(self: *Explorer, word: []const u8, allocator: std.mem.Allocator) ![]const idx.WordHit {
+        self.mu.lockShared();
+        const needs_rebuild = !self.word_index_complete and self.contents.count() > 0;
+        self.mu.unlockShared();
+        if (needs_rebuild) {
+            try self.rebuildWordIndex();
+        }
+
         self.mu.lockShared();
         defer self.mu.unlockShared();
         return self.word_index.searchDeduped(word, allocator);
@@ -872,36 +940,6 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
             try path_list.append(allocator, path_copy);
         }
     }
-
-    // Query store seqs without holding explorer lock.
-    const Entry = struct { path: []u8, seq: u64 };
-    var entries: std.ArrayList(Entry) = .{};
-    defer entries.deinit(allocator);
-    {
-        store.mu.lock();
-        defer store.mu.unlock();
-        for (path_list.items) |path| {
-            const seq = store.getLatestSeqUnlocked(path);
-            try entries.append(allocator, .{ .path = path, .seq = seq });
-        }
-    }
-
-    std.mem.sort(Entry, entries.items, {}, struct {
-        fn cmp(_: void, a: Entry, b: Entry) bool {
-            return a.seq > b.seq;
-        }
-    }.cmp);
-
-    const count = @min(limit, entries.items.len);
-    const paths = try allocator.alloc([]const u8, count);
-    for (entries.items[0..count], 0..) |e, i| {
-        paths[i] = e.path;
-    }
-    for (entries.items[count..]) |e| {
-        allocator.free(e.path);
-    }
-    return paths;
-}
     // ── Language parsers ──────────────────────────────────────
 
     fn parseZigLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
@@ -1484,7 +1522,7 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
             if (rest.len > 0 and rest[0] == '(') {
                 // Skip past receiver: find ") "
                 if (std.mem.indexOf(u8, rest, ") ")) |close| {
-                    name_start = rest[close + 2..];
+                    name_start = rest[close + 2 ..];
                 }
             }
             if (extractIdent(name_start)) |name| {
@@ -1615,26 +1653,26 @@ pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator,
         }
     }
 
-fn rebuildDepsFor(self: *Explorer, path: []const u8, outline: *FileOutline) !void {
-    var deps: std.ArrayList([]const u8) = .{};
-    errdefer deps.deinit(self.allocator);
+    fn rebuildDepsFor(self: *Explorer, path: []const u8, outline: *FileOutline) !void {
+        var deps: std.ArrayList([]const u8) = .{};
+        errdefer deps.deinit(self.allocator);
 
-    for (outline.imports.items) |imp| {
-        // Skip imports with path traversal sequences
-        if (std.mem.indexOf(u8, imp, "..") != null) continue;
-        try deps.append(self.allocator, imp);
-    }
+        for (outline.imports.items) |imp| {
+            // Skip imports with path traversal sequences
+            if (std.mem.indexOf(u8, imp, "..") != null) continue;
+            try deps.append(self.allocator, imp);
+        }
 
-    const gop = try self.dep_graph.getOrPut(path);
-    if (gop.found_existing) {
-        var old = gop.value_ptr.*;
-        gop.value_ptr.* = deps;
-        old.deinit(self.allocator);
-    } else {
-        gop.key_ptr.* = path;
-        gop.value_ptr.* = deps;
+        const gop = try self.dep_graph.getOrPut(path);
+        if (gop.found_existing) {
+            var old = gop.value_ptr.*;
+            gop.value_ptr.* = deps;
+            old.deinit(self.allocator);
+        } else {
+            gop.key_ptr.* = path;
+            gop.value_ptr.* = deps;
+        }
     }
-}
 
     /// Return the source body for a symbol given its file path and line range.
     /// Caller owns the returned slice.
@@ -1910,12 +1948,34 @@ pub fn regexMatch(haystack: []const u8, pattern: []const u8) bool {
     var in_bracket = false;
     while (i < pattern.len) {
         const c = pattern[i];
-        if (c == '\\' and i + 1 < pattern.len) { i += 2; continue; }
-        if (c == '[') { in_bracket = true; i += 1; continue; }
-        if (c == ']') { in_bracket = false; i += 1; continue; }
-        if (in_bracket) { i += 1; continue; }
-        if (c == '(') { depth += 1; i += 1; continue; }
-        if (c == ')') { if (depth > 0) depth -= 1; i += 1; continue; }
+        if (c == '\\' and i + 1 < pattern.len) {
+            i += 2;
+            continue;
+        }
+        if (c == '[') {
+            in_bracket = true;
+            i += 1;
+            continue;
+        }
+        if (c == ']') {
+            in_bracket = false;
+            i += 1;
+            continue;
+        }
+        if (in_bracket) {
+            i += 1;
+            continue;
+        }
+        if (c == '(') {
+            depth += 1;
+            i += 1;
+            continue;
+        }
+        if (c == ')') {
+            if (depth > 0) depth -= 1;
+            i += 1;
+            continue;
+        }
         if (c == '|' and depth == 0) {
             if (regexMatchSingle(haystack, pattern[prev..i])) return true;
             prev = i + 1;
@@ -1978,7 +2038,9 @@ fn matchHere(haystack: []const u8, pattern: []const u8, pos: usize) bool {
                     continue;
                 }
                 if (group_content[i] == '(') d += 1;
-                if (group_content[i] == ')') { if (d > 0) d -= 1; }
+                if (group_content[i] == ')') {
+                    if (d > 0) d -= 1;
+                }
                 if (group_content[i] == '|' and d == 0) {
                     // Try this branch
                     if (matchGroupBranch(haystack, group_content[branch_start..i], after_group, h)) return true;
@@ -2072,8 +2134,8 @@ fn matchBranchThenRest(haystack: []const u8, branch: []const u8, rest: []const u
     var buf: [4096]u8 = undefined;
     if (branch.len + rest.len > buf.len) return false;
     @memcpy(buf[0..branch.len], branch);
-    @memcpy(buf[branch.len..branch.len + rest.len], rest);
-    return matchHere(haystack, buf[0..branch.len + rest.len], pos);
+    @memcpy(buf[branch.len .. branch.len + rest.len], rest);
+    return matchHere(haystack, buf[0 .. branch.len + rest.len], pos);
 }
 
 /// Match a quantified element (greedy).
@@ -2180,7 +2242,6 @@ fn matchElement(c: u8, pattern: []const u8, start: usize, end: usize) bool {
     // Literal
     return c == pattern[start];
 }
-
 
 fn indexOfCaseInsensitive(haystack: []const u8, needle: []const u8) ?usize {
     if (needle.len == 0) return 0;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -241,7 +241,10 @@ pub const Explorer = struct {
                     if (startsWith(line, "=end")) in_py_docstring = false;
                     continue;
                 }
-                if (startsWith(line, "=begin")) { in_py_docstring = true; continue; }
+                if (startsWith(line, "=begin")) {
+                    in_py_docstring = true;
+                    continue;
+                }
             }
 
             // Track block comments for all languages that use /* */
@@ -928,50 +931,81 @@ pub const Explorer = struct {
         };
     }
 
-pub fn getImportedBy(self: *Explorer, path: []const u8, allocator: std.mem.Allocator) ![]const []const u8 {
-    self.mu.lockShared();
-    defer self.mu.unlockShared();
-
-    // Extract basename for matching against raw import strings
-    // e.g., "src/store.zig" -> "store.zig"
-    const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
-
-    var result: std.ArrayList([]const u8) = .{};
-    errdefer {
-        for (result.items) |p| allocator.free(p);
-        result.deinit(allocator);
-    }
-
-    var iter = self.dep_graph.iterator();
-    while (iter.next()) |entry| {
-        for (entry.value_ptr.items) |dep| {
-            if (std.mem.eql(u8, dep, path) or std.mem.eql(u8, dep, basename)) {
-                const dep_path = try allocator.dupe(u8, entry.key_ptr.*);
-                try result.append(allocator, dep_path);
-                break;
-            }
-        }
-    }
-    return result.toOwnedSlice(allocator);
-}
-
-pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator, limit: usize) ![]const []const u8 {
-    // Collect stable path copies under explorer lock.
-    var path_list: std.ArrayList([]u8) = .{};
-    errdefer {
-        for (path_list.items) |path| allocator.free(path);
-        path_list.deinit(allocator);
-    }
-    defer path_list.deinit(allocator);
-    {
+    pub fn getImportedBy(self: *Explorer, path: []const u8, allocator: std.mem.Allocator) ![]const []const u8 {
         self.mu.lockShared();
         defer self.mu.unlockShared();
-        var iter = self.outlines.iterator();
-        while (iter.next()) |kv| {
-            const path_copy = try allocator.dupe(u8, kv.key_ptr.*);
-            try path_list.append(allocator, path_copy);
+
+        // Extract basename for matching against raw import strings
+        // e.g., "src/store.zig" -> "store.zig"
+        const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
+
+        var result: std.ArrayList([]const u8) = .{};
+        errdefer {
+            for (result.items) |p| allocator.free(p);
+            result.deinit(allocator);
         }
+
+        var iter = self.dep_graph.iterator();
+        while (iter.next()) |entry| {
+            for (entry.value_ptr.items) |dep| {
+                if (std.mem.eql(u8, dep, path) or std.mem.eql(u8, dep, basename)) {
+                    const dep_path = try allocator.dupe(u8, entry.key_ptr.*);
+                    try result.append(allocator, dep_path);
+                    break;
+                }
+            }
+        }
+        return result.toOwnedSlice(allocator);
     }
+
+    pub fn getHotFiles(self: *Explorer, store: *Store, allocator: std.mem.Allocator, limit: usize) ![]const []const u8 {
+        // Collect stable path copies under explorer lock.
+        var path_list: std.ArrayList([]u8) = .{};
+        errdefer {
+            for (path_list.items) |path| allocator.free(path);
+            path_list.deinit(allocator);
+        }
+        defer path_list.deinit(allocator);
+        {
+            self.mu.lockShared();
+            defer self.mu.unlockShared();
+            var iter = self.outlines.iterator();
+            while (iter.next()) |kv| {
+                const path_copy = try allocator.dupe(u8, kv.key_ptr.*);
+                try path_list.append(allocator, path_copy);
+            }
+        }
+
+        // Query store seqs without holding explorer lock.
+        const Entry = struct { path: []u8, seq: u64 };
+        var entries: std.ArrayList(Entry) = .{};
+        defer entries.deinit(allocator);
+        {
+            store.mu.lock();
+            defer store.mu.unlock();
+            for (path_list.items) |path| {
+                const seq = store.getLatestSeqUnlocked(path);
+                try entries.append(allocator, .{ .path = path, .seq = seq });
+            }
+        }
+
+        std.mem.sort(Entry, entries.items, {}, struct {
+            fn cmp(_: void, a: Entry, b: Entry) bool {
+                return a.seq > b.seq;
+            }
+        }.cmp);
+
+        const count = @min(limit, entries.items.len);
+        const paths = try allocator.alloc([]const u8, count);
+        for (entries.items[0..count], 0..) |e, i| {
+            paths[i] = e.path;
+        }
+        for (entries.items[count..]) |e| {
+            allocator.free(e.path);
+        }
+        return paths;
+    }
+
     // ── Language parsers ──────────────────────────────────────
 
     fn parseZigLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
@@ -2396,14 +2430,15 @@ fn isWordBoundary(path: []const u8, pi: usize) bool {
 
 fn isSpecialEntryPoint(filename: []const u8) bool {
     const specials = [_][]const u8{
-        "main.zig", "lib.zig", "root.zig",
-        "main.rs", "lib.rs", "mod.rs",
-        "main.go", "main.c", "main.cpp",
-        "index.ts", "index.tsx", "index.js", "index.jsx",
-        "index.mjs", "index.cjs", "index.vue",
-        "index.php", "main.rb", "index.rb",
-        "__init__.py", "__main__.py",
-        "Makefile", "build.zig", "Cargo.toml", "package.json",
+        "main.zig",     "lib.zig",     "root.zig",
+        "main.rs",      "lib.rs",      "mod.rs",
+        "main.go",      "main.c",      "main.cpp",
+        "index.ts",     "index.tsx",   "index.js",
+        "index.jsx",    "index.mjs",   "index.cjs",
+        "index.vue",    "index.php",   "main.rb",
+        "index.rb",     "__init__.py", "__main__.py",
+        "Makefile",     "build.zig",   "Cargo.toml",
+        "package.json",
     };
     for (specials) |s| {
         if (std.mem.eql(u8, filename, s)) return true;

--- a/src/index.zig
+++ b/src/index.zig
@@ -12,7 +12,8 @@ pub const WordHit = struct {
 pub const WordIndex = struct {
     /// word → hits
     index: std.StringHashMap(std.ArrayList(WordHit)),
-    /// path → set of words contributed (for efficient re-index cleanup)
+    /// path → set of words contributed (for efficient re-index cleanup).
+    /// WordIndex owns these path keys.
     file_words: std.StringHashMap(std.StringHashMap(void)),
     allocator: std.mem.Allocator,
 
@@ -36,6 +37,7 @@ pub const WordIndex = struct {
         // Free per-file word sets
         var fw_iter = self.file_words.iterator();
         while (fw_iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
             entry.value_ptr.deinit();
         }
         self.file_words.deinit();
@@ -43,7 +45,13 @@ pub const WordIndex = struct {
 
     /// Remove all index entries for a file (call before re-indexing).
     pub fn removeFile(self: *WordIndex, path: []const u8) void {
-        const words_set = self.file_words.getPtr(path) orelse return;
+        const removed = self.file_words.fetchRemove(path) orelse return;
+        const stable_path = removed.key;
+        var words_set = removed.value;
+        defer {
+            words_set.deinit();
+            self.allocator.free(stable_path);
+        }
 
         // For each word this file contributed, remove hits with this path.
         // Prune empty buckets so churn does not leak key/list entries.
@@ -53,7 +61,7 @@ pub const WordIndex = struct {
                 const hits = entry.value_ptr;
                 var i: usize = 0;
                 while (i < hits.items.len) {
-                    if (std.mem.eql(u8, hits.items[i].path, path)) {
+                    if (std.mem.eql(u8, hits.items[i].path, stable_path)) {
                         _ = hits.swapRemove(i);
                     } else {
                         i += 1;
@@ -67,16 +75,15 @@ pub const WordIndex = struct {
                 }
             }
         }
-
-        words_set.deinit();
-        _ = self.file_words.remove(path);
     }
-
 
     /// Index a file's content — tokenizes into words and records hits.
     pub fn indexFile(self: *WordIndex, path: []const u8, content: []const u8) !void {
         // Clean up old entries first
         self.removeFile(path);
+
+        const stable_path = try self.allocator.dupe(u8, path);
+        errdefer self.allocator.free(stable_path);
 
         var words_set = std.StringHashMap(void).init(self.allocator);
         errdefer words_set.deinit();
@@ -108,7 +115,7 @@ pub const WordIndex = struct {
                 }
 
                 try gop.value_ptr.append(self.allocator, .{
-                    .path = path,
+                    .path = stable_path,
                     .line_num = line_num,
                 });
 
@@ -121,7 +128,7 @@ pub const WordIndex = struct {
             }
         }
 
-        try self.file_words.put(path, words_set);
+        try self.file_words.put(stable_path, words_set);
     }
 
     /// Look up all hits for a word. O(1) lookup + O(hits) iteration.
@@ -134,33 +141,264 @@ pub const WordIndex = struct {
 
     /// Look up hits, returning results allocated by the caller.
     /// Deduplicates by (path, line_num).
-pub fn searchDeduped(self: *WordIndex, word: []const u8, allocator: std.mem.Allocator) ![]const WordHit {
-    const hits = self.search(word);
-    if (hits.len == 0) return try allocator.alloc(WordHit, 0);
-    if (hits.len == 1) {
-        var out = try allocator.alloc(WordHit, 1);
-        out[0] = hits[0];
-        return out;
-    }
-
-    const DedupKey = struct { path_ptr: usize, line_num: u32 };
-    var seen = std.AutoHashMap(DedupKey, void).init(allocator);
-    defer seen.deinit();
-    try seen.ensureTotalCapacity(@intCast(hits.len));
-
-    var result: std.ArrayList(WordHit) = .{};
-    errdefer result.deinit(allocator);
-    try result.ensureTotalCapacity(allocator, hits.len);
-
-    for (hits) |hit| {
-        const key = DedupKey{ .path_ptr = @intFromPtr(hit.path.ptr), .line_num = hit.line_num };
-        const gop = try seen.getOrPut(key);
-        if (!gop.found_existing) {
-            result.appendAssumeCapacity(hit);
+    pub fn searchDeduped(self: *WordIndex, word: []const u8, allocator: std.mem.Allocator) ![]const WordHit {
+        const hits = self.search(word);
+        if (hits.len == 0) return try allocator.alloc(WordHit, 0);
+        if (hits.len == 1) {
+            var out = try allocator.alloc(WordHit, 1);
+            out[0] = hits[0];
+            return out;
         }
+
+        const DedupKey = struct { path_ptr: usize, line_num: u32 };
+        var seen = std.AutoHashMap(DedupKey, void).init(allocator);
+        defer seen.deinit();
+        try seen.ensureTotalCapacity(@intCast(hits.len));
+
+        var result: std.ArrayList(WordHit) = .{};
+        errdefer result.deinit(allocator);
+        try result.ensureTotalCapacity(allocator, hits.len);
+
+        for (hits) |hit| {
+            const key = DedupKey{ .path_ptr = @intFromPtr(hit.path.ptr), .line_num = hit.line_num };
+            const gop = try seen.getOrPut(key);
+            if (!gop.found_existing) {
+                result.appendAssumeCapacity(hit);
+            }
+        }
+        return result.toOwnedSlice(allocator);
     }
-    return result.toOwnedSlice(allocator);
-}
+
+    pub fn fileCount(self: *WordIndex) u32 {
+        return @intCast(self.file_words.count());
+    }
+
+    pub const DiskHeader = struct {
+        file_count: u32,
+        git_head: ?[40]u8,
+    };
+
+    const DISK_MAGIC = [4]u8{ 'C', 'D', 'B', 'W' };
+    const DISK_FORMAT_VERSION: u16 = 1;
+
+    pub fn writeToDisk(self: *WordIndex, dir_path: []const u8, git_head: ?[40]u8) !void {
+        var file_table: std.ArrayList([]const u8) = .{};
+        defer file_table.deinit(self.allocator);
+        var disk_path_to_id = std.StringHashMap(u32).init(self.allocator);
+        defer disk_path_to_id.deinit();
+
+        var file_iter = self.file_words.iterator();
+        while (file_iter.next()) |entry| {
+            const path = entry.key_ptr.*;
+            if (path.len > std.math.maxInt(u16)) return error.NameTooLong;
+            const id: u32 = @intCast(file_table.items.len);
+            try file_table.append(self.allocator, path);
+            try disk_path_to_id.put(path, id);
+        }
+
+        var words_sorted: std.ArrayList([]const u8) = .{};
+        defer words_sorted.deinit(self.allocator);
+        try words_sorted.ensureTotalCapacity(self.allocator, self.index.count());
+        var word_iter = self.index.keyIterator();
+        while (word_iter.next()) |word_ptr| {
+            if (word_ptr.*.len > std.math.maxInt(u16)) return error.NameTooLong;
+            words_sorted.appendAssumeCapacity(word_ptr.*);
+        }
+        std.mem.sort([]const u8, words_sorted.items, {}, struct {
+            fn lt(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lt);
+
+        const rand_suffix = std.crypto.random.int(u64);
+        const tmp_path = try std.fmt.allocPrint(self.allocator, "{s}/word.index.{x}.tmp", .{ dir_path, rand_suffix });
+        defer self.allocator.free(tmp_path);
+        const final_path = try std.fmt.allocPrint(self.allocator, "{s}/word.index", .{dir_path});
+        defer self.allocator.free(final_path);
+
+        const file = try std.fs.cwd().createFile(tmp_path, .{});
+        defer file.close();
+
+        var file_buf: [256 * 1024]u8 = undefined;
+        var writer = file.writer(&file_buf);
+
+        var header_buf: [51]u8 = [_]u8{0} ** 51;
+        @memcpy(header_buf[0..4], &DISK_MAGIC);
+        std.mem.writeInt(u16, header_buf[4..6], DISK_FORMAT_VERSION, .little);
+        std.mem.writeInt(u32, header_buf[6..10], @intCast(file_table.items.len), .little);
+        if (git_head) |head| {
+            header_buf[10] = 40;
+            @memcpy(header_buf[11..51], &head);
+        }
+        try writer.interface.writeAll(&header_buf);
+
+        for (file_table.items) |path| {
+            var pl_buf: [2]u8 = undefined;
+            std.mem.writeInt(u16, &pl_buf, @intCast(path.len), .little);
+            try writer.interface.writeAll(&pl_buf);
+            try writer.interface.writeAll(path);
+        }
+
+        var wc_buf: [4]u8 = undefined;
+        std.mem.writeInt(u32, &wc_buf, @intCast(words_sorted.items.len), .little);
+        try writer.interface.writeAll(&wc_buf);
+
+        for (words_sorted.items) |word| {
+            const hits = self.index.get(word) orelse return error.InvalidData;
+            var wl_buf: [2]u8 = undefined;
+            std.mem.writeInt(u16, &wl_buf, @intCast(word.len), .little);
+            try writer.interface.writeAll(&wl_buf);
+            try writer.interface.writeAll(word);
+
+            var hc_buf: [4]u8 = undefined;
+            std.mem.writeInt(u32, &hc_buf, @intCast(hits.items.len), .little);
+            try writer.interface.writeAll(&hc_buf);
+            for (hits.items) |hit| {
+                const file_id = disk_path_to_id.get(hit.path) orelse return error.InvalidData;
+                var hit_buf: [8]u8 = undefined;
+                std.mem.writeInt(u32, hit_buf[0..4], file_id, .little);
+                std.mem.writeInt(u32, hit_buf[4..8], hit.line_num, .little);
+                try writer.interface.writeAll(&hit_buf);
+            }
+        }
+        try writer.interface.flush();
+
+        try std.fs.cwd().rename(tmp_path, final_path);
+    }
+
+    pub fn readFromDisk(dir_path: []const u8, allocator: std.mem.Allocator) ?WordIndex {
+        return readFromDiskInner(dir_path, allocator) catch null;
+    }
+
+    fn readFromDiskInner(dir_path: []const u8, allocator: std.mem.Allocator) !?WordIndex {
+        const index_path = try std.fmt.allocPrint(allocator, "{s}/word.index", .{dir_path});
+        defer allocator.free(index_path);
+
+        const data = std.fs.cwd().readFileAlloc(allocator, index_path, 512 * 1024 * 1024) catch return null;
+        defer allocator.free(data);
+
+        if (data.len < 51) return null;
+        if (!std.mem.eql(u8, data[0..4], &DISK_MAGIC)) return null;
+        const version = std.mem.readInt(u16, data[4..6], .little);
+        if (version < 1 or version > DISK_FORMAT_VERSION) return null;
+        const file_count = std.mem.readInt(u32, data[6..10], .little);
+
+        var file_paths = try allocator.alloc([]u8, file_count);
+        defer allocator.free(file_paths);
+        var used_paths = try allocator.alloc(bool, file_count);
+        defer allocator.free(used_paths);
+        @memset(used_paths, false);
+        var parsed_files: u32 = 0;
+        defer {
+            for (0..parsed_files) |i| {
+                if (!used_paths[i]) allocator.free(file_paths[i]);
+            }
+        }
+
+        var pos: usize = 51;
+        for (0..file_count) |i| {
+            if (pos + 2 > data.len) return null;
+            const path_len = std.mem.readInt(u16, data[pos..][0..2], .little);
+            pos += 2;
+            if (path_len == 0 or pos + path_len > data.len) return null;
+            file_paths[i] = try allocator.dupe(u8, data[pos .. pos + path_len]);
+            pos += path_len;
+            parsed_files += 1;
+        }
+
+        if (pos + 4 > data.len) return null;
+        const word_count = std.mem.readInt(u32, data[pos..][0..4], .little);
+        pos += 4;
+
+        var result = WordIndex.init(allocator);
+        errdefer result.deinit();
+
+        for (0..word_count) |_| {
+            if (pos + 2 > data.len) return null;
+            const word_len = std.mem.readInt(u16, data[pos..][0..2], .little);
+            pos += 2;
+            if (word_len == 0 or pos + word_len > data.len) return null;
+            const word = try allocator.dupe(u8, data[pos .. pos + word_len]);
+            pos += word_len;
+            errdefer allocator.free(word);
+
+            if (pos + 4 > data.len) return null;
+            const hit_count = std.mem.readInt(u32, data[pos..][0..4], .little);
+            pos += 4;
+
+            var hits: std.ArrayList(WordHit) = .{};
+            errdefer hits.deinit(allocator);
+            try hits.ensureTotalCapacity(allocator, hit_count);
+
+            var last_file_id: ?u32 = null;
+            for (0..hit_count) |_| {
+                if (pos + 8 > data.len) return null;
+                const file_id = std.mem.readInt(u32, data[pos..][0..4], .little);
+                pos += 4;
+                if (file_id >= file_count) return null;
+                const line_num = std.mem.readInt(u32, data[pos..][0..4], .little);
+                pos += 4;
+
+                const stable_path = file_paths[file_id];
+                hits.appendAssumeCapacity(.{
+                    .path = stable_path,
+                    .line_num = line_num,
+                });
+
+                if (last_file_id == null or last_file_id.? != file_id) {
+                    const fw_gop = try result.file_words.getOrPut(stable_path);
+                    if (!fw_gop.found_existing) {
+                        fw_gop.key_ptr.* = stable_path;
+                        fw_gop.value_ptr.* = std.StringHashMap(void).init(allocator);
+                        used_paths[file_id] = true;
+                    }
+                    const wgop = try fw_gop.value_ptr.getOrPut(word);
+                    if (!wgop.found_existing) wgop.key_ptr.* = word;
+                    last_file_id = file_id;
+                }
+            }
+
+            const gop = try result.index.getOrPut(word);
+            if (gop.found_existing) return error.InvalidData;
+            gop.key_ptr.* = word;
+            gop.value_ptr.* = hits;
+        }
+
+        if (pos != data.len) return null;
+        return result;
+    }
+
+    pub fn readDiskHeader(dir_path: []const u8, allocator: std.mem.Allocator) !?DiskHeader {
+        const index_path = try std.fmt.allocPrint(allocator, "{s}/word.index", .{dir_path});
+        defer allocator.free(index_path);
+
+        const file = std.fs.cwd().openFile(index_path, .{}) catch return null;
+        defer file.close();
+
+        var buf: [51]u8 = undefined;
+        const n = file.readAll(&buf) catch return null;
+        if (n < 51) return null;
+        if (!std.mem.eql(u8, buf[0..4], &DISK_MAGIC)) return null;
+        const version = std.mem.readInt(u16, buf[4..6], .little);
+        if (version < 1 or version > DISK_FORMAT_VERSION) return null;
+
+        const file_count = std.mem.readInt(u32, buf[6..10], .little);
+        var git_head: ?[40]u8 = null;
+        if (buf[10] == 40) {
+            var head: [40]u8 = undefined;
+            @memcpy(&head, buf[11..51]);
+            git_head = head;
+        }
+        return DiskHeader{
+            .file_count = file_count,
+            .git_head = git_head,
+        };
+    }
+
+    pub fn readGitHead(dir_path: []const u8, allocator: std.mem.Allocator) !?[40]u8 {
+        const header = try readDiskHeader(dir_path, allocator) orelse return null;
+        return header.git_head;
+    }
 };
 
 // ── Trigram index ───────────────────────────────────────────
@@ -173,7 +411,6 @@ pub const Trigram = u24;
 pub fn packTrigram(a: u8, b: u8, c: u8) Trigram {
     return @as(Trigram, a) << 16 | @as(Trigram, b) << 8 | @as(Trigram, c);
 }
-
 
 pub const PostingMask = struct {
     next_mask: u8 = 0, // bloom filter of chars following this trigram
@@ -216,7 +453,11 @@ pub const PostingList = struct {
         while (lo < hi) {
             const mid = lo + (hi - lo) / 2;
             if (items[mid].doc_id == doc_id) return PostingMask{ .next_mask = items[mid].next_mask, .loc_mask = items[mid].loc_mask };
-            if (items[mid].doc_id < doc_id) { lo = mid + 1; } else { hi = mid; }
+            if (items[mid].doc_id < doc_id) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
         }
         return null;
     }
@@ -228,7 +469,11 @@ pub const PostingList = struct {
         while (lo < hi) {
             const mid = lo + (hi - lo) / 2;
             if (items[mid].doc_id == doc_id) return true;
-            if (items[mid].doc_id < doc_id) { lo = mid + 1; } else { hi = mid; }
+            if (items[mid].doc_id < doc_id) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
         }
         return false;
     }
@@ -240,7 +485,11 @@ pub const PostingList = struct {
         while (lo < hi) {
             const mid = lo + (hi - lo) / 2;
             if (items[mid].doc_id == doc_id) return &self.items.items[mid];
-            if (items[mid].doc_id < doc_id) { lo = mid + 1; } else { hi = mid; }
+            if (items[mid].doc_id < doc_id) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
         }
         // Insert at sorted position
         try self.items.insert(allocator, lo, .{ .doc_id = doc_id });
@@ -393,118 +642,116 @@ pub const TrigramIndex = struct {
         try self.file_trigrams.put(path, tri_list);
     }
 
-
     /// Find candidate files that contain ALL trigrams from the query.
-pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.Allocator) ?[]const []const u8 {
-    if (query.len < 3) return null;
+    pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.Allocator) ?[]const []const u8 {
+        if (query.len < 3) return null;
 
-    const tri_count = query.len - 2;
+        const tri_count = query.len - 2;
 
-    var unique = std.AutoHashMap(Trigram, void).init(allocator);
-    defer unique.deinit();
-    unique.ensureTotalCapacity(@intCast(tri_count)) catch return null;
-    for (0..tri_count) |i| {
-        const tri = packTrigram(
-            normalizeChar(query[i]),
-            normalizeChar(query[i + 1]),
-            normalizeChar(query[i + 2]),
-        );
-        _ = unique.getOrPut(tri) catch return null;
-    }
+        var unique = std.AutoHashMap(Trigram, void).init(allocator);
+        defer unique.deinit();
+        unique.ensureTotalCapacity(@intCast(tri_count)) catch return null;
+        for (0..tri_count) |i| {
+            const tri = packTrigram(
+                normalizeChar(query[i]),
+                normalizeChar(query[i + 1]),
+                normalizeChar(query[i + 2]),
+            );
+            _ = unique.getOrPut(tri) catch return null;
+        }
 
-    var sets: std.ArrayList(*PostingList) = .{};
-    defer sets.deinit(allocator);
-    sets.ensureTotalCapacity(allocator, unique.count()) catch return null;
+        var sets: std.ArrayList(*PostingList) = .{};
+        defer sets.deinit(allocator);
+        sets.ensureTotalCapacity(allocator, unique.count()) catch return null;
 
-    var tri_iter = unique.keyIterator();
-    while (tri_iter.next()) |tri_ptr| {
-        const posting_list = self.index.getPtr(tri_ptr.*) orelse {
+        var tri_iter = unique.keyIterator();
+        while (tri_iter.next()) |tri_ptr| {
+            const posting_list = self.index.getPtr(tri_ptr.*) orelse {
+                return allocator.alloc([]const u8, 0) catch null;
+            };
+            sets.appendAssumeCapacity(posting_list);
+        }
+
+        if (sets.items.len == 0) {
             return allocator.alloc([]const u8, 0) catch null;
+        }
+
+        // Sort posting lists by size (smallest first) for efficient intersection
+        std.mem.sort(*PostingList, sets.items, {}, struct {
+            fn lt(_: void, a: *PostingList, b: *PostingList) bool {
+                return a.items.items.len < b.items.items.len;
+            }
+        }.lt);
+
+        // Sorted merge intersection: start with smallest list's doc_ids
+        var result_ids: std.ArrayList(u32) = .{};
+        defer result_ids.deinit(allocator);
+
+        // Seed with doc_ids from smallest posting list
+        result_ids.ensureTotalCapacity(allocator, sets.items[0].items.items.len) catch return null;
+        for (sets.items[0].items.items) |p| {
+            result_ids.appendAssumeCapacity(p.doc_id);
+        }
+
+        // Intersect with each subsequent list (both sorted → merge O(n+m))
+        for (sets.items[1..]) |set| {
+            var write: usize = 0;
+            var si: usize = 0;
+            const set_items = set.items.items;
+            for (result_ids.items) |id| {
+                // Advance set pointer to >= id
+                while (si < set_items.len and set_items[si].doc_id < id) : (si += 1) {}
+                if (si < set_items.len and set_items[si].doc_id == id) {
+                    result_ids.items[write] = id;
+                    write += 1;
+                    si += 1;
+                }
+            }
+            result_ids.items.len = write;
+            if (write == 0) break; // early exit if intersection is empty
+        }
+
+        var result: std.ArrayList([]const u8) = .{};
+        errdefer result.deinit(allocator);
+        result.ensureTotalCapacity(allocator, result_ids.items.len) catch return null;
+
+        next_cand: for (result_ids.items) |doc_id| {
+            // Bloom-filter check for consecutive trigram pairs
+            if (tri_count >= 2) {
+                for (0..tri_count - 1) |j| {
+                    const tri_a = packTrigram(
+                        normalizeChar(query[j]),
+                        normalizeChar(query[j + 1]),
+                        normalizeChar(query[j + 2]),
+                    );
+                    const tri_b = packTrigram(
+                        normalizeChar(query[j + 1]),
+                        normalizeChar(query[j + 2]),
+                        normalizeChar(query[j + 3]),
+                    );
+                    const list_a = self.index.getPtr(tri_a) orelse continue;
+                    const list_b = self.index.getPtr(tri_b) orelse continue;
+                    const mask_a = list_a.getByDocId(doc_id) orelse continue;
+                    const mask_b = list_b.getByDocId(doc_id) orelse continue;
+
+                    const next_bit: u8 = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8);
+                    if ((mask_a.next_mask & next_bit) == 0) continue :next_cand;
+
+                    const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
+                    if ((rotated & mask_b.loc_mask) == 0) continue :next_cand;
+                }
+            }
+
+            if (doc_id < self.id_to_path.items.len) {
+                result.appendAssumeCapacity(self.id_to_path.items[doc_id]);
+            }
+        }
+
+        return result.toOwnedSlice(allocator) catch {
+            result.deinit(allocator);
+            return null;
         };
-        sets.appendAssumeCapacity(posting_list);
     }
-
-    if (sets.items.len == 0) {
-        return allocator.alloc([]const u8, 0) catch null;
-    }
-
-    // Sort posting lists by size (smallest first) for efficient intersection
-    std.mem.sort(*PostingList, sets.items, {}, struct {
-        fn lt(_: void, a: *PostingList, b: *PostingList) bool {
-            return a.items.items.len < b.items.items.len;
-        }
-    }.lt);
-
-    // Sorted merge intersection: start with smallest list's doc_ids
-    var result_ids: std.ArrayList(u32) = .{};
-    defer result_ids.deinit(allocator);
-
-    // Seed with doc_ids from smallest posting list
-    result_ids.ensureTotalCapacity(allocator, sets.items[0].items.items.len) catch return null;
-    for (sets.items[0].items.items) |p| {
-        result_ids.appendAssumeCapacity(p.doc_id);
-    }
-
-    // Intersect with each subsequent list (both sorted → merge O(n+m))
-    for (sets.items[1..]) |set| {
-        var write: usize = 0;
-        var si: usize = 0;
-        const set_items = set.items.items;
-        for (result_ids.items) |id| {
-            // Advance set pointer to >= id
-            while (si < set_items.len and set_items[si].doc_id < id) : (si += 1) {}
-            if (si < set_items.len and set_items[si].doc_id == id) {
-                result_ids.items[write] = id;
-                write += 1;
-                si += 1;
-            }
-        }
-        result_ids.items.len = write;
-        if (write == 0) break; // early exit if intersection is empty
-    }
-
-    var result: std.ArrayList([]const u8) = .{};
-    errdefer result.deinit(allocator);
-    result.ensureTotalCapacity(allocator, result_ids.items.len) catch return null;
-
-    next_cand: for (result_ids.items) |doc_id| {
-        // Bloom-filter check for consecutive trigram pairs
-        if (tri_count >= 2) {
-            for (0..tri_count - 1) |j| {
-                const tri_a = packTrigram(
-                    normalizeChar(query[j]),
-                    normalizeChar(query[j + 1]),
-                    normalizeChar(query[j + 2]),
-                );
-                const tri_b = packTrigram(
-                    normalizeChar(query[j + 1]),
-                    normalizeChar(query[j + 2]),
-                    normalizeChar(query[j + 3]),
-                );
-                const list_a = self.index.getPtr(tri_a) orelse continue;
-                const list_b = self.index.getPtr(tri_b) orelse continue;
-                const mask_a = list_a.getByDocId(doc_id) orelse continue;
-                const mask_b = list_b.getByDocId(doc_id) orelse continue;
-
-                const next_bit: u8 = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8);
-                if ((mask_a.next_mask & next_bit) == 0) continue :next_cand;
-
-                const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
-                if ((rotated & mask_b.loc_mask) == 0) continue :next_cand;
-            }
-        }
-
-        if (doc_id < self.id_to_path.items.len) {
-            result.appendAssumeCapacity(self.id_to_path.items[doc_id]);
-        }
-    }
-
-    return result.toOwnedSlice(allocator) catch {
-        result.deinit(allocator);
-        return null;
-    };
-}
-
 
     pub fn candidatesRegex(self: *TrigramIndex, query: *const RegexQuery, allocator: std.mem.Allocator) ?[]const []const u8 {
         if (query.and_trigrams.len == 0 and query.or_groups.len == 0) return null;
@@ -875,7 +1122,10 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
                 if (result.file_trigrams.getPtr(path)) |tri_list| {
                     var found = false;
                     for (tri_list.items) |existing| {
-                        if (existing == tri) { found = true; break; }
+                        if (existing == tri) {
+                            found = true;
+                            break;
+                        }
                     }
                     if (!found) try tri_list.append(allocator, tri);
                 }
@@ -943,9 +1193,7 @@ pub fn candidates(self: *TrigramIndex, query: []const u8, allocator: std.mem.All
         const header = try readDiskHeader(dir_path, allocator) orelse return null;
         return header.git_head;
     }
-
 };
-
 
 // ── mmap-backed trigram index ───────────────────────────────
 // Zero-copy: binary search on mmap'd lookup table, read postings directly.
@@ -1532,11 +1780,30 @@ pub fn decomposeRegex(pattern: []const u8, allocator: std.mem.Allocator) !RegexQ
                 i += 2;
                 continue;
             }
-            if (c == '[') { in_bracket = true; i += 1; continue; }
-            if (c == ']') { in_bracket = false; i += 1; continue; }
-            if (in_bracket) { i += 1; continue; }
-            if (c == '(') { depth += 1; i += 1; continue; }
-            if (c == ')') { if (depth > 0) depth -= 1; i += 1; continue; }
+            if (c == '[') {
+                in_bracket = true;
+                i += 1;
+                continue;
+            }
+            if (c == ']') {
+                in_bracket = false;
+                i += 1;
+                continue;
+            }
+            if (in_bracket) {
+                i += 1;
+                continue;
+            }
+            if (c == '(') {
+                depth += 1;
+                i += 1;
+                continue;
+            }
+            if (c == ')') {
+                if (depth > 0) depth -= 1;
+                i += 1;
+                continue;
+            }
             if (c == '|' and depth == 0) {
                 try top_pipes.append(allocator, i);
             }
@@ -1729,7 +1996,6 @@ fn flushLiterals(
     literals.clearRetainingCapacity();
 }
 
-
 // ── Tokenizer ───────────────────────────────────────────────
 
 pub const WordTokenizer = struct {
@@ -1769,42 +2035,70 @@ pub const MAX_NGRAM_LEN: usize = 16;
 /// Rare pairs   → HIGH weight (they become n-gram boundaries).
 /// All unspecified pairs default to 0xFE00 (rare = high weight).
 pub const default_pair_freq: [256][256]u16 = blk: {
-
     var table: [256][256]u16 = .{.{0xFE00} ** 256} ** 256;
     // English bigrams (lowercase) — common in identifiers and prose
-    table['t']['h'] = 0x1000; table['h']['e'] = 0x1000;
-    table['i']['n'] = 0x1000; table['e']['r'] = 0x1000;
-    table['a']['n'] = 0x1000; table['r']['e'] = 0x1000;
-    table['o']['n'] = 0x1000; table['e']['n'] = 0x1000;
-    table['s']['t'] = 0x1000; table['e']['s'] = 0x1000;
-    table['a']['t'] = 0x1000; table['i']['o'] = 0x1000;
-    table['t']['e'] = 0x1000; table['o']['r'] = 0x1000;
-    table['t']['i'] = 0x1000; table['a']['r'] = 0x1000;
-    table['a']['l'] = 0x1000; table['l']['e'] = 0x1000;
-    table['n']['t'] = 0x1000; table['e']['d'] = 0x1000;
-    table['n']['d'] = 0x1000; table['o']['u'] = 0x1000;
-    table['e']['a'] = 0x1000; table['f']['o'] = 0x1000;
+    table['t']['h'] = 0x1000;
+    table['h']['e'] = 0x1000;
+    table['i']['n'] = 0x1000;
+    table['e']['r'] = 0x1000;
+    table['a']['n'] = 0x1000;
+    table['r']['e'] = 0x1000;
+    table['o']['n'] = 0x1000;
+    table['e']['n'] = 0x1000;
+    table['s']['t'] = 0x1000;
+    table['e']['s'] = 0x1000;
+    table['a']['t'] = 0x1000;
+    table['i']['o'] = 0x1000;
+    table['t']['e'] = 0x1000;
+    table['o']['r'] = 0x1000;
+    table['t']['i'] = 0x1000;
+    table['a']['r'] = 0x1000;
+    table['a']['l'] = 0x1000;
+    table['l']['e'] = 0x1000;
+    table['n']['t'] = 0x1000;
+    table['e']['d'] = 0x1000;
+    table['n']['d'] = 0x1000;
+    table['o']['u'] = 0x1000;
+    table['e']['a'] = 0x1000;
+    table['f']['o'] = 0x1000;
     // Common code keyword fragments
-    table['f']['n'] = 0x1000; table['i']['f'] = 0x1000;
-    table['r']['n'] = 0x1000; table['t']['u'] = 0x1000;
-    table['p']['u'] = 0x1000; table['b']['l'] = 0x1000;
-    table['c']['o'] = 0x1000; table['n']['s'] = 0x1000;
-    table['t']['r'] = 0x1000; table['u']['e'] = 0x1000;
+    table['f']['n'] = 0x1000;
+    table['i']['f'] = 0x1000;
+    table['r']['n'] = 0x1000;
+    table['t']['u'] = 0x1000;
+    table['p']['u'] = 0x1000;
+    table['b']['l'] = 0x1000;
+    table['c']['o'] = 0x1000;
+    table['n']['s'] = 0x1000;
+    table['t']['r'] = 0x1000;
+    table['u']['e'] = 0x1000;
     // Common operator / punctuation pairs
-    table['('][')'] = 0x0800; table['{']['}'] = 0x0800;
-    table['['][']'] = 0x0800; table['/']['/'] = 0x0800;
-    table['-']['>'] = 0x0800; table['=']['>'] = 0x0800;
-    table[':'][':'] = 0x0800; table['!']['='] = 0x0800;
-    table['=']['='] = 0x0800; table['<']['='] = 0x0800;
-    table['>']['='] = 0x0800; table['&']['&'] = 0x0800;
+    table['('][')'] = 0x0800;
+    table['{']['}'] = 0x0800;
+    table['['][']'] = 0x0800;
+    table['/']['/'] = 0x0800;
+    table['-']['>'] = 0x0800;
+    table['=']['>'] = 0x0800;
+    table[':'][':'] = 0x0800;
+    table['!']['='] = 0x0800;
+    table['=']['='] = 0x0800;
+    table['<']['='] = 0x0800;
+    table['>']['='] = 0x0800;
+    table['&']['&'] = 0x0800;
     table['|']['|'] = 0x0800;
     // Whitespace / structural pairs
-    table[' '][' '] = 0x0800; table['\t'][' '] = 0x0800;
-    table[' ']['('] = 0x0800; table[' ']['{'] = 0x0800;
-    table[';'][' '] = 0x0800; table[':'][' '] = 0x0800;
-    table['='][' '] = 0x0800; table[' ']['='] = 0x0800;
-    table[','][' '] = 0x0800; table['.']['.'] = 0x0800;
-    table['\n'][' '] = 0x0800; table['\n']['\t'] = 0x0800;
+    table[' '][' '] = 0x0800;
+    table['\t'][' '] = 0x0800;
+    table[' ']['('] = 0x0800;
+    table[' ']['{'] = 0x0800;
+    table[';'][' '] = 0x0800;
+    table[':'][' '] = 0x0800;
+    table['='][' '] = 0x0800;
+    table[' ']['='] = 0x0800;
+    table[','][' '] = 0x0800;
+    table['.']['.'] = 0x0800;
+    table['\n'][' '] = 0x0800;
+    table['\n']['\t'] = 0x0800;
     break :blk table;
 };
 
@@ -1812,7 +2106,6 @@ pub const default_pair_freq: [256][256]u16 = blk: {
 /// per-project table.  Swap only before indexing starts (not thread-safe).
 pub var active_pair_freq: *const [256][256]u16 = &default_pair_freq;
 var loaded_freq_table: [256][256]u16 = undefined;
-
 
 /// Deterministic weight for a character pair, used to place content-defined
 /// boundaries between n-grams.  Frequency-weighted: common source-code pairs
@@ -1950,7 +2243,7 @@ pub fn readFrequencyTable(dir_path: []const u8, allocator: std.mem.Allocator) !?
 
 /// A single sparse n-gram extracted from a string.
 pub const SparseNgram = struct {
-    hash: u64,  // Wyhash of the normalized (lowercased) n-gram bytes
+    hash: u64, // Wyhash of the normalized (lowercased) n-gram bytes
     pos: usize, // byte offset in the source string
     len: usize, // byte length of the n-gram
 };
@@ -2034,7 +2327,6 @@ pub fn extractSparseNgrams(content: []const u8, allocator: std.mem.Allocator) ![
                 // every byte in the span is covered.
                 try result.append(allocator, makeNgram(content, ngram_end - MIN_LEN, MIN_LEN));
             }
-
         }
     }
 
@@ -2188,4 +2480,3 @@ pub const SparseNgramIndex = struct {
         return @intCast(self.file_ngrams.count());
     }
 };
-

--- a/src/main.zig
+++ b/src/main.zig
@@ -764,13 +764,16 @@ fn loadWordIndexFromDiskIfPresent(
 }
 
 fn persistWordIndexToDisk(explorer: *Explorer, data_dir: []const u8, git_head: ?[40]u8) void {
-    if (!explorer.wordIndexIsComplete()) return;
+    const generation = explorer.wordIndexGenerationToPersist() orelse return;
 
     explorer.mu.lockShared();
-    defer explorer.mu.unlockShared();
     explorer.word_index.writeToDisk(data_dir, git_head) catch |err| {
+        explorer.mu.unlockShared();
         std.log.warn("could not persist word index: {}", .{err});
+        return;
     };
+    explorer.mu.unlockShared();
+    explorer.markWordIndexPersisted(generation);
 }
 
 fn saveProjectInfo(allocator: std.mem.Allocator, data_dir: []const u8, abs_root: []const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -717,11 +717,16 @@ fn loadTrigramFromDiskIfPresent(explorer: *Explorer, data_dir: []const u8, alloc
     explorer.mu.unlockShared();
     if (already_loaded) return;
 
-    if (TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+    if (MmapTrigramIndex.initFromDisk(data_dir, allocator)) |loaded| {
         explorer.mu.lock();
         defer explorer.mu.unlock();
         explorer.trigram_index.deinit();
-        explorer.trigram_index = loaded;
+        explorer.trigram_index = .{ .mmap = loaded };
+    } else if (TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.mu.lock();
+        defer explorer.mu.unlock();
+        explorer.trigram_index.deinit();
+        explorer.trigram_index = .{ .heap = loaded };
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const git_mod = @import("git.zig");
 const TrigramIndex = @import("index.zig").TrigramIndex;
 const MmapTrigramIndex = @import("index.zig").MmapTrigramIndex;
 const AnyTrigramIndex = @import("index.zig").AnyTrigramIndex;
+const WordIndex = @import("index.zig").WordIndex;
 const index_mod = @import("index.zig");
 const snapshot_mod = @import("snapshot.zig");
 const telemetry = @import("telemetry.zig");
@@ -275,6 +276,7 @@ fn mainImpl() !void {
 
         // Try loading from codedb.snapshot if it exists and git HEAD matches.
         const snapshot_path = "codedb.snapshot";
+        const snapshot_t0 = std.time.nanoTimestamp();
         const snapshot_loaded = blk: {
             const snap_head = snapshot_mod.readSnapshotGitHead(snapshot_path) orelse {
                 // No git HEAD in snapshot (non-git project or missing) — load if current project also has no git
@@ -285,17 +287,21 @@ fn mainImpl() !void {
             if (!std.mem.eql(u8, &snap_head, &cur_head)) break :blk false;
             break :blk snapshot_mod.loadSnapshot(snapshot_path, &explorer, &store, allocator);
         };
+        const snapshot_elapsed = std.time.nanoTimestamp() - snapshot_t0;
 
         if (snapshot_loaded) {
-            const t_scan = std.time.nanoTimestamp();
+            if (std.mem.eql(u8, cmd, "search")) {
+                loadTrigramFromDiskIfPresent(&explorer, data_dir, allocator);
+            } else if (std.mem.eql(u8, cmd, "word")) {
+                loadWordIndexFromDiskIfPresent(&explorer, data_dir, git_head, allocator);
+            }
             var dur_buf: [64]u8 = undefined;
-            const scan_elapsed = std.time.nanoTimestamp() - t_scan;
             out.p("{s}\xe2\x9c\x93{s} {s}loaded snapshot{s}  {s}{d} files{s}  {s}{s}{s}\n", .{
-                s.green,                                    s.reset,
-                s.bold,                                     s.reset,
-                s.dim,                                      explorer.outlines.count(),
-                s.reset,                                    sty.durationColor(s, scan_elapsed),
-                sty.formatDuration(&dur_buf, scan_elapsed), s.reset,
+                s.green,                                        s.reset,
+                s.bold,                                         s.reset,
+                s.dim,                                          explorer.outlines.count(),
+                s.reset,                                        sty.durationColor(s, snapshot_elapsed),
+                sty.formatDuration(&dur_buf, snapshot_elapsed), s.reset,
             });
         } else {
             const disk_hdr = TrigramIndex.readDiskHeader(data_dir, allocator) catch null;
@@ -566,6 +572,15 @@ fn mainImpl() !void {
             out.p("{s}\xe2\x9c\x97{s} snapshot failed: {}\n", .{ s.red, s.reset, err });
             std.process.exit(1);
         };
+        const git_head = git_mod.getGitHead(abs_root, allocator) catch null;
+        loadWordIndexFromDiskIfPresent(&explorer, data_dir, git_head, allocator);
+        if (!explorer.wordIndexIsComplete()) {
+            explorer.rebuildWordIndex() catch |err| {
+                out.p("{s}\xe2\x9c\x97{s} word index rebuild failed: {}\n", .{ s.red, s.reset, err });
+                std.process.exit(1);
+            };
+        }
+        persistWordIndexToDisk(&explorer, data_dir, git_head);
         const elapsed = std.time.nanoTimestamp() - t0;
         var dur_buf: [64]u8 = undefined;
         out.p("{s}\xe2\x9c\x93{s} {s}snapshot{s}  {s}{s}{s}  {s}{d} files{s}  {s}{s}{s}\n", .{
@@ -610,6 +625,7 @@ fn mainImpl() !void {
         if (query_log) |ql| mcp_server.setQueryLogPath(ql);
 
         const git_head = git_mod.getGitHead(abs_root, allocator) catch null;
+        const startup_t0 = std.time.milliTimestamp();
         const snapshot_loaded = blk: {
             const snap_head = snapshot_mod.readSnapshotGitHead("codedb.snapshot") orelse {
                 if (git_head != null) break :blk false;
@@ -638,11 +654,11 @@ fn mainImpl() !void {
         defer allocator.destroy(queue);
         queue.* = watcher.EventQueue{};
         var scan_thread: ?std.Thread = null;
-        const startup_t0 = std.time.milliTimestamp();
         if (!snapshot_loaded) {
             scan_thread = try std.Thread.spawn(.{}, scanBg, .{ &store, &explorer, root, allocator, &scan_done, &shutdown, data_dir, abs_root, &telem, startup_t0 });
         } else {
             const startup_time_ms: u64 = @intCast(@max(std.time.milliTimestamp() - startup_t0, 0));
+            loadTrigramFromDiskIfPresent(&explorer, data_dir, allocator);
             telem.recordCodebaseStats(&explorer, startup_time_ms);
         }
 
@@ -693,6 +709,68 @@ fn getDataDir(allocator: std.mem.Allocator, abs_root: []const u8) ![]u8 {
         std.log.warn("could not create data dir {s}: {}", .{ dir, err });
     };
     return dir;
+}
+
+fn loadTrigramFromDiskIfPresent(explorer: *Explorer, data_dir: []const u8, allocator: std.mem.Allocator) void {
+    explorer.mu.lockShared();
+    const already_loaded = explorer.trigram_index.fileCount() > 0;
+    explorer.mu.unlockShared();
+    if (already_loaded) return;
+
+    if (TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.mu.lock();
+        defer explorer.mu.unlock();
+        explorer.trigram_index.deinit();
+        explorer.trigram_index = loaded;
+    }
+}
+
+fn loadWordIndexFromDiskIfPresent(
+    explorer: *Explorer,
+    data_dir: []const u8,
+    current_git_head: ?[40]u8,
+    allocator: std.mem.Allocator,
+) void {
+    if (!explorer.wordIndexCanLoadFromDisk()) return;
+
+    const header = WordIndex.readDiskHeader(data_dir, allocator) catch null orelse {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    };
+
+    explorer.mu.lockShared();
+    const current_count = @as(u32, @intCast(explorer.outlines.count()));
+    explorer.mu.unlockShared();
+    if (header.file_count != current_count) {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    }
+
+    const heads_match = blk: {
+        if (current_git_head == null and header.git_head == null) break :blk true;
+        if (current_git_head == null or header.git_head == null) break :blk false;
+        break :blk std.mem.eql(u8, &current_git_head.?, &header.git_head.?);
+    };
+    if (!heads_match) {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    }
+
+    if (WordIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.replaceWordIndex(loaded);
+    } else {
+        explorer.disableWordIndexDiskLoad();
+    }
+}
+
+fn persistWordIndexToDisk(explorer: *Explorer, data_dir: []const u8, git_head: ?[40]u8) void {
+    if (!explorer.wordIndexIsComplete()) return;
+
+    explorer.mu.lockShared();
+    defer explorer.mu.unlockShared();
+    explorer.word_index.writeToDisk(data_dir, git_head) catch |err| {
+        std.log.warn("could not persist word index: {}", .{err});
+    };
 }
 
 fn saveProjectInfo(allocator: std.mem.Allocator, data_dir: []const u8, abs_root: []const u8) !void {
@@ -783,6 +861,7 @@ fn scanBg(store: *Store, explorer: *Explorer, root: []const u8, allocator: std.m
         scan_done.store(true, .release);
         return;
     }
+    persistWordIndexToDisk(explorer, data_dir, git_head);
 
     if (heads_match) {
         const current_count = @as(u32, @intCast(explorer.outlines.count()));

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -17,6 +17,7 @@ const edit_mod = @import("edit.zig");
 const idx = @import("index.zig");
 const snapshot_mod = @import("snapshot.zig");
 const telemetry_mod = @import("telemetry.zig");
+const git_mod = @import("git.zig");
 const root_policy = @import("root_policy.zig");
 // ── Project cache ────────────────────────────────────────────────────────────
 
@@ -24,6 +25,73 @@ const ProjectCtx = struct {
     explorer: *Explorer,
     store: *Store,
 };
+
+fn getProjectDataDir(allocator: std.mem.Allocator, project_path: []const u8) ?[]u8 {
+    const hash = std.hash.Wyhash.hash(0, project_path);
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch {
+        return std.fmt.allocPrint(allocator, "{s}/.codedb", .{project_path}) catch null;
+    };
+    defer allocator.free(home);
+
+    return std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash }) catch null;
+}
+
+fn loadProjectTrigramFromDiskIfPresent(explorer: *Explorer, project_path: []const u8, allocator: std.mem.Allocator) void {
+    explorer.mu.lockShared();
+    const already_loaded = explorer.trigram_index.fileCount() > 0;
+    explorer.mu.unlockShared();
+    if (already_loaded) return;
+
+    const data_dir = getProjectDataDir(allocator, project_path) orelse return;
+    defer allocator.free(data_dir);
+
+    if (idx.TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.mu.lock();
+        defer explorer.mu.unlock();
+        explorer.trigram_index.deinit();
+        explorer.trigram_index = loaded;
+    }
+}
+
+fn loadProjectWordIndexFromDiskIfPresent(explorer: *Explorer, project_path: []const u8, allocator: std.mem.Allocator) void {
+    if (!explorer.wordIndexCanLoadFromDisk()) return;
+
+    const data_dir = getProjectDataDir(allocator, project_path) orelse {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    };
+    defer allocator.free(data_dir);
+
+    const header = idx.WordIndex.readDiskHeader(data_dir, allocator) catch null orelse {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    };
+
+    explorer.mu.lockShared();
+    const current_count = @as(u32, @intCast(explorer.outlines.count()));
+    explorer.mu.unlockShared();
+    if (header.file_count != current_count) {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    }
+
+    const current_git_head = git_mod.getGitHead(project_path, allocator) catch null;
+    const heads_match = blk: {
+        if (current_git_head == null and header.git_head == null) break :blk true;
+        if (current_git_head == null or header.git_head == null) break :blk false;
+        break :blk std.mem.eql(u8, &current_git_head.?, &header.git_head.?);
+    };
+    if (!heads_match) {
+        explorer.disableWordIndexDiskLoad();
+        return;
+    }
+
+    if (idx.WordIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.replaceWordIndex(loaded);
+    } else {
+        explorer.disableWordIndexDiskLoad();
+    }
+}
 
 const ProjectCache = struct {
     const MAX_CACHED = 5;
@@ -123,6 +191,8 @@ const ProjectCache = struct {
                 return error.SnapshotLoadFailed;
             }
         }
+
+        loadProjectTrigramFromDiskIfPresent(&new_entry.explorer, p, self.alloc);
 
         // Find free slot or evict LRU
         var target_slot: usize = 0;
@@ -611,6 +681,11 @@ fn dispatch(
         out.appendSlice(alloc, @errorName(err)) catch {};
         return;
     };
+
+    if (tool == .codedb_word) {
+        const effective_project = project_path orelse cache.default_path;
+        loadProjectWordIndexFromDiskIfPresent(ctx.explorer, effective_project, alloc);
+    }
 
     switch (tool) {
         .codedb_tree => handleTree(alloc, out, ctx.explorer),
@@ -1146,7 +1221,10 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
     const valid_actions = [_][]const u8{ "tree", "outline", "search", "meta" };
     var action_valid = false;
     for (valid_actions) |va| {
-        if (std.mem.eql(u8, action, va)) { action_valid = true; break; }
+        if (std.mem.eql(u8, action, va)) {
+            action_valid = true;
+            break;
+        }
     }
     if (!action_valid) {
         out.appendSlice(alloc, "error: invalid action, must be one of: tree, outline, search, meta") catch {};

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -45,11 +45,16 @@ fn loadProjectTrigramFromDiskIfPresent(explorer: *Explorer, project_path: []cons
     const data_dir = getProjectDataDir(allocator, project_path) orelse return;
     defer allocator.free(data_dir);
 
-    if (idx.TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+    if (idx.MmapTrigramIndex.initFromDisk(data_dir, allocator)) |loaded| {
         explorer.mu.lock();
         defer explorer.mu.unlock();
         explorer.trigram_index.deinit();
-        explorer.trigram_index = loaded;
+        explorer.trigram_index = .{ .mmap = loaded };
+    } else if (idx.TrigramIndex.readFromDisk(data_dir, allocator)) |loaded| {
+        explorer.mu.lock();
+        defer explorer.mu.unlock();
+        explorer.trigram_index.deinit();
+        explorer.trigram_index = .{ .heap = loaded };
     }
 }
 

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -16,18 +16,25 @@
 //     length: u64    (byte length)
 //   Sections:
 //     TREE    (1): JSON array of {path, language, line_count, byte_size, symbol_count}
-//     OUTLINE (2): JSON object mapping path → [{name, kind, line, detail}]
+//     OUTLINE (2): legacy JSON object mapping path → [{name, kind, line, detail}]
 //     CONTENT (3): for each file: path_len(u16) + path + content_len(u32) + content
 //     FREQ    (5): 256×256×u16 LE frequency table
 //     META    (6): JSON {file_count, total_bytes, indexed_at, format_version}
+//     OUTLINE_STATE (7): binary per-file outline/import metadata for fast warm restore
 
 const std = @import("std");
 const compat = @import("compat.zig");
-const Explorer = @import("explore.zig").Explorer;
+const explore_mod = @import("explore.zig");
+const Explorer = explore_mod.Explorer;
+const FileOutline = explore_mod.FileOutline;
+const Symbol = explore_mod.Symbol;
+const SymbolKind = explore_mod.SymbolKind;
+const Language = explore_mod.Language;
+const Store = @import("store.zig").Store;
 const git_mod = @import("git.zig");
 
 const MAGIC = [4]u8{ 'C', 'D', 'B', 0x01 };
-const FORMAT_VERSION: u16 = 1;
+const FORMAT_VERSION: u16 = 2;
 
 pub const SectionId = enum(u32) {
     tree = 1,
@@ -35,6 +42,7 @@ pub const SectionId = enum(u32) {
     content = 3,
     freq_table = 5,
     meta = 6,
+    outline_state = 7,
 };
 
 const SectionEntry = struct {
@@ -126,35 +134,88 @@ pub fn writeSnapshot(
         try sections.append(allocator, .{ .id = @intFromEnum(SectionId.tree), .offset = offset, .length = buf.items.len });
     }
 
-    // ── Section: OUTLINE ──
+    // ── Section: OUTLINE_STATE ──
     {
         const offset = try file.getPos();
         var buf: std.ArrayList(u8) = .{};
         defer buf.deinit(allocator);
         const writer = buf.writer(allocator);
-        try writer.writeByte('{');
-        var first = true;
+
+        var file_count_buf: [4]u8 = undefined;
+        var file_count: u32 = 0;
+        var count_iter = explorer.outlines.keyIterator();
+        while (count_iter.next()) |key_ptr| {
+            if (!isSensitivePath(key_ptr.*)) file_count += 1;
+        }
+        std.mem.writeInt(u32, &file_count_buf, file_count, .little);
+        try writer.writeAll(&file_count_buf);
+
         var iter = explorer.outlines.iterator();
         while (iter.next()) |entry| {
             if (isSensitivePath(entry.key_ptr.*)) continue;
-            if (!first) try writer.writeByte(',');
-            first = false;
-            try writer.print("\"{s}\":[", .{entry.key_ptr.*});
-            for (entry.value_ptr.symbols.items, 0..) |sym, si| {
-                if (si > 0) try writer.writeByte(',');
-                try writer.print(
-                    \\{{"name":"{s}","kind":"{s}","line":{d}
-                , .{ sym.name, @tagName(sym.kind), sym.line_start });
-                if (sym.detail) |d| {
-                    try writer.print(",\"detail\":\"{s}\"", .{d});
-                }
-                try writer.writeByte('}');
+
+            const path = entry.key_ptr.*;
+            const outline = entry.value_ptr;
+
+            var path_len_buf: [2]u8 = undefined;
+            std.mem.writeInt(u16, &path_len_buf, @intCast(path.len), .little);
+            try writer.writeAll(&path_len_buf);
+            try writer.writeAll(path);
+
+            try writer.writeByte(@intFromEnum(outline.language));
+
+            var line_count_buf: [4]u8 = undefined;
+            std.mem.writeInt(u32, &line_count_buf, outline.line_count, .little);
+            try writer.writeAll(&line_count_buf);
+
+            var byte_size_buf: [8]u8 = undefined;
+            std.mem.writeInt(u64, &byte_size_buf, outline.byte_size, .little);
+            try writer.writeAll(&byte_size_buf);
+
+            var import_count_buf: [4]u8 = undefined;
+            std.mem.writeInt(u32, &import_count_buf, @intCast(outline.imports.items.len), .little);
+            try writer.writeAll(&import_count_buf);
+            for (outline.imports.items) |imp| {
+                var import_len_buf: [2]u8 = undefined;
+                std.mem.writeInt(u16, &import_len_buf, @intCast(imp.len), .little);
+                try writer.writeAll(&import_len_buf);
+                try writer.writeAll(imp);
             }
-            try writer.writeByte(']');
+
+            var symbol_count_buf: [4]u8 = undefined;
+            std.mem.writeInt(u32, &symbol_count_buf, @intCast(outline.symbols.items.len), .little);
+            try writer.writeAll(&symbol_count_buf);
+            for (outline.symbols.items) |sym| {
+                var name_len_buf: [2]u8 = undefined;
+                std.mem.writeInt(u16, &name_len_buf, @intCast(sym.name.len), .little);
+                try writer.writeAll(&name_len_buf);
+                try writer.writeAll(sym.name);
+
+                try writer.writeByte(@intFromEnum(sym.kind));
+
+                var line_start_buf: [4]u8 = undefined;
+                std.mem.writeInt(u32, &line_start_buf, sym.line_start, .little);
+                try writer.writeAll(&line_start_buf);
+
+                var line_end_buf: [4]u8 = undefined;
+                std.mem.writeInt(u32, &line_end_buf, sym.line_end, .little);
+                try writer.writeAll(&line_end_buf);
+
+                if (sym.detail) |detail| {
+                    try writer.writeByte(1);
+                    var detail_len_buf: [2]u8 = undefined;
+                    std.mem.writeInt(u16, &detail_len_buf, @intCast(detail.len), .little);
+                    try writer.writeAll(&detail_len_buf);
+                    try writer.writeAll(detail);
+                } else {
+                    try writer.writeByte(0);
+                }
+            }
         }
-        try writer.writeByte('}');
+
         try file.writeAll(buf.items);
-        try sections.append(allocator, .{ .id = @intFromEnum(SectionId.outline), .offset = offset, .length = buf.items.len });
+        const end = try file.getPos();
+        try sections.append(allocator, .{ .id = @intFromEnum(SectionId.outline_state), .offset = offset, .length = end - offset });
     }
 
     // ── Section: CONTENT ──
@@ -339,7 +400,7 @@ pub fn loadSnapshotValidated(
     snapshot_path: []const u8,
     expected_root: ?[]const u8,
     explorer: *Explorer,
-    store: *@import("store.zig").Store,
+    store: *Store,
     allocator: std.mem.Allocator,
 ) bool {
     // Clean up stale temp files from previous crashed writers
@@ -386,6 +447,10 @@ pub fn loadSnapshotValidated(
             // No root_hash in snapshot — reject if caller requires validation
             return false;
         }
+    }
+
+    if (sections.get(@intFromEnum(SectionId.outline_state)) != null) {
+        return loadSnapshotFast(snapshot_path, expected_file_count, explorer, store, allocator) catch false;
     }
 
     // Load CONTENT section — this is the core data
@@ -497,7 +562,294 @@ pub fn loadSnapshotValidated(
     return true;
 }
 
+fn deinitOutlineStateMap(map: *std.StringHashMap(FileOutline), allocator: std.mem.Allocator) void {
+    var iter = map.iterator();
+    while (iter.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+        entry.value_ptr.deinit();
+    }
+    map.deinit();
+}
 
+fn readSectionInt(comptime T: type, buf: []const u8, cursor: *usize) !T {
+    const size = @sizeOf(T);
+    if (cursor.* + size > buf.len) return error.InvalidData;
+    const value = std.mem.readInt(T, buf[cursor.*..][0..size], .little);
+    cursor.* += size;
+    return value;
+}
+
+fn readSectionByte(buf: []const u8, cursor: *usize) !u8 {
+    if (cursor.* >= buf.len) return error.InvalidData;
+    const value = buf[cursor.*];
+    cursor.* += 1;
+    return value;
+}
+
+fn readSectionString(buf: []const u8, cursor: *usize, allocator: std.mem.Allocator, max_len: usize) ![]u8 {
+    const len = try readSectionInt(u16, buf, cursor);
+    if (len > max_len) return error.InvalidData;
+    if (cursor.* + len > buf.len) return error.InvalidData;
+    const out = try allocator.dupe(u8, buf[cursor.* .. cursor.* + len]);
+    cursor.* += len;
+    return out;
+}
+
+fn loadOutlineStateMap(snapshot_path: []const u8, allocator: std.mem.Allocator) !std.StringHashMap(FileOutline) {
+    const bytes = (try readSectionBytes(snapshot_path, .outline_state, allocator)) orelse return error.InvalidData;
+    defer allocator.free(bytes);
+
+    var result = std.StringHashMap(FileOutline).init(allocator);
+    errdefer deinitOutlineStateMap(&result, allocator);
+
+    var cursor: usize = 0;
+    const file_count = try readSectionInt(u32, bytes, &cursor);
+    for (0..file_count) |_| {
+        const path = try readSectionString(bytes, &cursor, allocator, 4096);
+        if (path.len == 0) return error.InvalidData;
+        errdefer allocator.free(path);
+
+        var outline = FileOutline.init(allocator, path);
+        errdefer outline.deinit();
+
+        const language_raw = try readSectionByte(bytes, &cursor);
+        outline.language = std.meta.intToEnum(Language, language_raw) catch return error.InvalidData;
+        outline.line_count = try readSectionInt(u32, bytes, &cursor);
+        outline.byte_size = try readSectionInt(u64, bytes, &cursor);
+
+        const import_count = try readSectionInt(u32, bytes, &cursor);
+        for (0..import_count) |_| {
+            const imp = try readSectionString(bytes, &cursor, allocator, 4096);
+            errdefer allocator.free(imp);
+            try outline.imports.append(allocator, imp);
+        }
+
+        const symbol_count = try readSectionInt(u32, bytes, &cursor);
+        for (0..symbol_count) |_| {
+            const name = try readSectionString(bytes, &cursor, allocator, 4096);
+            if (name.len == 0) return error.InvalidData;
+            errdefer allocator.free(name);
+
+            const kind_raw = try readSectionByte(bytes, &cursor);
+            const kind = std.meta.intToEnum(SymbolKind, kind_raw) catch return error.InvalidData;
+            const line_start = try readSectionInt(u32, bytes, &cursor);
+            const line_end = try readSectionInt(u32, bytes, &cursor);
+            const has_detail = try readSectionByte(bytes, &cursor);
+            const detail = switch (has_detail) {
+                0 => null,
+                1 => try readSectionString(bytes, &cursor, allocator, 4096),
+                else => return error.InvalidData,
+            };
+            errdefer if (detail) |d| allocator.free(d);
+
+            try outline.symbols.append(allocator, Symbol{
+                .name = name,
+                .kind = kind,
+                .line_start = line_start,
+                .line_end = line_end,
+                .detail = detail,
+            });
+        }
+
+        try result.put(path, outline);
+    }
+
+    if (cursor != bytes.len) return error.InvalidData;
+    return result;
+}
+
+fn rebuildDepsFromOutline(explorer: *Explorer, path: []const u8, outline: *const FileOutline, allocator: std.mem.Allocator) !void {
+    var deps: std.ArrayList([]const u8) = .{};
+    errdefer deps.deinit(allocator);
+
+    for (outline.imports.items) |imp| {
+        if (std.mem.indexOf(u8, imp, "..") != null) continue;
+        try deps.append(allocator, imp);
+    }
+
+    try explorer.dep_graph.put(path, deps);
+}
+
+fn insertRestoredFile(
+    explorer: *Explorer,
+    path: []const u8,
+    content: []const u8,
+    outline: FileOutline,
+    allocator: std.mem.Allocator,
+) !void {
+    var restored_outline = outline;
+    restored_outline.path = path;
+
+    const outline_gop = try explorer.outlines.getOrPut(path);
+    if (outline_gop.found_existing) return error.InvalidData;
+    outline_gop.key_ptr.* = path;
+    outline_gop.value_ptr.* = restored_outline;
+
+    const content_gop = try explorer.contents.getOrPut(path);
+    if (content_gop.found_existing) return error.InvalidData;
+    content_gop.key_ptr.* = path;
+    content_gop.value_ptr.* = content;
+
+    try rebuildDepsFromOutline(explorer, path, &restored_outline, allocator);
+}
+
+fn loadSnapshotFast(
+    snapshot_path: []const u8,
+    expected_file_count: ?u32,
+    explorer: *Explorer,
+    store: *Store,
+    allocator: std.mem.Allocator,
+) !bool {
+    var outline_states = try loadOutlineStateMap(snapshot_path, allocator);
+    defer deinitOutlineStateMap(&outline_states, allocator);
+
+    var sections = (try readSections(snapshot_path, allocator)) orelse return false;
+    defer sections.deinit();
+
+    const content_entry = sections.get(@intFromEnum(SectionId.content)) orelse return false;
+    const content_file = std.fs.cwd().openFile(snapshot_path, .{}) catch return false;
+    defer content_file.close();
+
+    const file_stat = compat.fileStat(content_file) catch return false;
+    if (content_entry.offset + content_entry.length > file_stat.size) return false;
+    try content_file.seekTo(content_entry.offset);
+
+    const snap_mtime: i128 = file_stat.mtime;
+    var bytes_read: u64 = 0;
+    var file_count: u32 = 0;
+    var word_index_can_load_from_disk = true;
+    while (bytes_read < content_entry.length) {
+        var pl_buf: [2]u8 = undefined;
+        const pln = content_file.readAll(&pl_buf) catch return false;
+        if (pln != 2) break;
+        const path_len = std.mem.readInt(u16, &pl_buf, .little);
+        if (path_len == 0 or path_len > 4096) break;
+        bytes_read += 2;
+
+        const path_buf = allocator.alloc(u8, path_len) catch return false;
+        const prn = content_file.readAll(path_buf) catch return false;
+        if (prn != path_len) {
+            allocator.free(path_buf);
+            break;
+        }
+        bytes_read += path_len;
+
+        var cl_buf: [4]u8 = undefined;
+        const cln = content_file.readAll(&cl_buf) catch return false;
+        if (cln != 4) {
+            allocator.free(path_buf);
+            break;
+        }
+        const content_len = std.mem.readInt(u32, &cl_buf, .little);
+        if (content_len > 64 * 1024 * 1024) {
+            allocator.free(path_buf);
+            break;
+        }
+        bytes_read += 4;
+
+        const content = allocator.alloc(u8, content_len) catch return false;
+        const crn = content_file.readAll(content) catch return false;
+        if (crn != content_len) {
+            allocator.free(path_buf);
+            allocator.free(content);
+            break;
+        }
+        bytes_read += content_len;
+
+        var disk_content: ?[]u8 = null;
+        if (snap_mtime > 0) blk: {
+            const df = std.fs.cwd().openFile(path_buf, .{}) catch break :blk;
+            defer df.close();
+            const ds = compat.fileStat(df) catch break :blk;
+            if (ds.mtime <= snap_mtime) break :blk;
+            disk_content = df.readToEndAlloc(allocator, 16 * 1024 * 1024) catch break :blk;
+        }
+        defer if (disk_content) |dc| allocator.free(dc);
+
+        if (disk_content) |dc| {
+            word_index_can_load_from_disk = false;
+            if (outline_states.fetchRemove(path_buf)) |removed| {
+                allocator.free(removed.key);
+                var stale_outline = removed.value;
+                stale_outline.deinit();
+            }
+
+            explorer.indexFileOutlineOnly(path_buf, dc) catch {
+                allocator.free(path_buf);
+                allocator.free(content);
+                continue;
+            };
+            const hash = std.hash.Wyhash.hash(0, dc);
+            _ = store.recordSnapshot(path_buf, dc.len, hash) catch {};
+            allocator.free(path_buf);
+            allocator.free(content);
+        } else if (outline_states.fetchRemove(path_buf)) |removed| {
+            allocator.free(path_buf);
+            insertRestoredFile(explorer, removed.key, content, removed.value, allocator) catch {
+                allocator.free(removed.key);
+                var bad_outline = removed.value;
+                bad_outline.deinit();
+                allocator.free(content);
+                continue;
+            };
+            const hash = std.hash.Wyhash.hash(0, content);
+            _ = store.recordSnapshot(removed.key, content.len, hash) catch {};
+        } else {
+            word_index_can_load_from_disk = false;
+            explorer.indexFileOutlineOnly(path_buf, content) catch {
+                allocator.free(path_buf);
+                allocator.free(content);
+                continue;
+            };
+            const hash = std.hash.Wyhash.hash(0, content);
+            _ = store.recordSnapshot(path_buf, content.len, hash) catch {};
+            allocator.free(path_buf);
+            allocator.free(content);
+        }
+
+        file_count += 1;
+    }
+
+    if (expected_file_count) |expected| {
+        if (file_count != expected) return false;
+    } else if (file_count == 0) {
+        return false;
+    }
+
+    if (outline_states.count() != 0) return false;
+
+    explorer.markWordIndexIncomplete(word_index_can_load_from_disk);
+
+    if (sections.get(@intFromEnum(SectionId.freq_table))) |freq_entry| {
+        if (freq_entry.length == 256 * 256 * 2) {
+            const index_mod = @import("index.zig");
+            const ft = allocator.create([256][256]u16) catch return file_count > 0;
+            const freq_file = std.fs.cwd().openFile(snapshot_path, .{}) catch return file_count > 0;
+            defer freq_file.close();
+            freq_file.seekTo(freq_entry.offset) catch {
+                allocator.destroy(ft);
+                return file_count > 0;
+            };
+            var row_buf: [256 * 2]u8 = undefined;
+            for (0..256) |a| {
+                if (freq_file.readAll(&row_buf) catch {
+                    allocator.destroy(ft);
+                    return file_count > 0;
+                } != 512) {
+                    allocator.destroy(ft);
+                    return file_count > 0;
+                }
+                for (0..256) |b| {
+                    ft[a][b] = std.mem.readInt(u16, row_buf[b * 2 ..][0..2], .little);
+                }
+            }
+            index_mod.setFrequencyTable(ft);
+            allocator.destroy(ft);
+        }
+    }
+
+    return true;
+}
 
 fn parseJsonU32(json: []const u8, key: []const u8) ?u32 {
     const val = parseJsonU64(json, key) orelse return null;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3389,6 +3389,7 @@ test "issue-220: snapshot fast load restores outlines and lazily rebuilds word i
     try testing.expectEqual(@as(usize, 0), exp2.word_index.index.count());
     try testing.expect(exp2.wordIndexCanLoadFromDisk());
     try testing.expect(!exp2.wordIndexIsComplete());
+    try testing.expect(!exp2.wordIndexNeedsPersist());
 
     const deps = try exp2.getImportedBy("src/store.zig", testing.allocator);
     defer {
@@ -3403,6 +3404,7 @@ test "issue-220: snapshot fast load restores outlines and lazily rebuilds word i
     try testing.expect(hits.len >= 1);
     try testing.expect(exp2.word_index.index.count() > 0);
     try testing.expect(exp2.wordIndexIsComplete());
+    try testing.expect(exp2.wordIndexNeedsPersist());
 }
 
 test "issue-220: partial word index state rebuilds before search" {
@@ -3443,6 +3445,31 @@ test "issue-220: partial word index state rebuilds before search" {
     try testing.expectEqual(@as(usize, 1), gamma_hits.len);
     try testing.expect(std.mem.eql(u8, gamma_hits[0].path, "src/b.zig"));
     try testing.expect(exp2.wordIndexIsComplete());
+    try testing.expect(exp2.wordIndexNeedsPersist());
+}
+
+test "issue-220: word index persistence tracking skips redundant rewrites" {
+    var exp = Explorer.init(testing.allocator);
+    defer exp.deinit();
+
+    try exp.indexFile("src/a.zig", "pub const Alpha = 1;\n");
+    try testing.expect(exp.wordIndexIsComplete());
+    try testing.expect(exp.wordIndexNeedsPersist());
+
+    const first_gen = exp.wordIndexGenerationToPersist() orelse return error.TestUnexpectedResult;
+    exp.markWordIndexPersisted(first_gen);
+    try testing.expect(!exp.wordIndexNeedsPersist());
+    try testing.expect(exp.wordIndexGenerationToPersist() == null);
+
+    try exp.indexFile("src/a.zig", "pub const Beta = 2;\n");
+    try testing.expect(exp.wordIndexNeedsPersist());
+
+    const second_gen = exp.wordIndexGenerationToPersist() orelse return error.TestUnexpectedResult;
+    try testing.expect(second_gen != first_gen);
+    exp.markWordIndexPersisted(first_gen);
+    try testing.expect(exp.wordIndexNeedsPersist());
+    exp.markWordIndexPersisted(second_gen);
+    try testing.expect(!exp.wordIndexNeedsPersist());
 }
 
 // ── Snapshot non-git tests ───────────────────────────────────

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2866,6 +2866,51 @@ test "perf regression: bloom filter reduces scan work" {
 
 // ── Disk persistence tests ──────────────────────────────────
 
+test "disk word index: round-trip write and read preserves hits" {
+    const alloc = testing.allocator;
+    var wi = WordIndex.init(alloc);
+    defer wi.deinit();
+
+    try wi.indexFile("src/main.zig", "const Store = @import(\"store.zig\").Store;\npub fn main() void {}\n");
+    try wi.indexFile("src/store.zig", "pub const Store = struct {};\npub fn open() void {}\n");
+
+    const hits_before = try wi.searchDeduped("Store", alloc);
+    defer alloc.free(hits_before);
+    try testing.expectEqual(@as(usize, 2), hits_before.len);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &path_buf);
+
+    const fake_head = "0123456789abcdef0123456789abcdef01234567".*;
+    try wi.writeToDisk(dir_path, fake_head);
+
+    const header = try WordIndex.readDiskHeader(dir_path, alloc);
+    try testing.expect(header != null);
+    try testing.expectEqual(@as(u32, 2), header.?.file_count);
+    try testing.expect(header.?.git_head != null);
+    try testing.expectEqualSlices(u8, &fake_head, &header.?.git_head.?);
+
+    const loaded = WordIndex.readFromDisk(dir_path, alloc);
+    try testing.expect(loaded != null);
+    var loaded_wi = loaded.?;
+    defer loaded_wi.deinit();
+
+    const hits_after = try loaded_wi.searchDeduped("Store", alloc);
+    defer alloc.free(hits_after);
+    try testing.expectEqual(hits_before.len, hits_after.len);
+
+    var found_main = false;
+    var found_store = false;
+    for (hits_after) |hit| {
+        if (std.mem.eql(u8, hit.path, "src/main.zig")) found_main = true;
+        if (std.mem.eql(u8, hit.path, "src/store.zig")) found_store = true;
+    }
+    try testing.expect(found_main);
+    try testing.expect(found_store);
+}
+
 test "disk index: round-trip write and read preserves candidates" {
     const alloc = testing.allocator;
     var ti = TrigramIndex.init(alloc);
@@ -3311,6 +3356,93 @@ test "issue-46: empty-repo snapshot rejected on load" {
     const loaded = snapshot_mod.loadSnapshot(snap_path, &exp2, &store, testing.allocator);
     // Valid empty-repo snapshot should be accepted; currently returns false (bug: file_count == 0)
     try testing.expect(loaded);
+}
+
+test "issue-220: snapshot fast load restores outlines and lazily rebuilds word index" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var exp = Explorer.init(aa);
+    try exp.indexFile("src/store.zig", "pub const Store = struct {};\n");
+    try exp.indexFile("src/main.zig", "const Store = @import(\"store.zig\").Store;\npub fn main() void {}\n");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &path_buf);
+
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/fast.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(&exp, dir_path, snap_path, testing.allocator);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    var exp2 = Explorer.init(arena2.allocator());
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    const loaded = snapshot_mod.loadSnapshot(snap_path, &exp2, &store, arena2.allocator());
+    try testing.expect(loaded);
+    try testing.expectEqual(@as(usize, 2), exp2.outlines.count());
+    try testing.expectEqual(@as(u32, 0), exp2.trigram_index.fileCount());
+    try testing.expectEqual(@as(usize, 0), exp2.word_index.index.count());
+    try testing.expect(exp2.wordIndexCanLoadFromDisk());
+    try testing.expect(!exp2.wordIndexIsComplete());
+
+    const deps = try exp2.getImportedBy("src/store.zig", testing.allocator);
+    defer {
+        for (deps) |dep| testing.allocator.free(dep);
+        testing.allocator.free(deps);
+    }
+    try testing.expectEqual(@as(usize, 1), deps.len);
+    try testing.expect(std.mem.eql(u8, deps[0], "src/main.zig"));
+
+    const hits = try exp2.searchWord("Store", testing.allocator);
+    defer testing.allocator.free(hits);
+    try testing.expect(hits.len >= 1);
+    try testing.expect(exp2.word_index.index.count() > 0);
+    try testing.expect(exp2.wordIndexIsComplete());
+}
+
+test "issue-220: partial word index state rebuilds before search" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &path_buf);
+
+    var exp = Explorer.init(testing.allocator);
+    defer exp.deinit();
+    try exp.indexFile("src/a.zig", "pub const Alpha = 1;\n");
+    try exp.indexFile("src/b.zig", "pub const Beta = 2;\n");
+
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/partial.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(&exp, dir_path, snap_path, testing.allocator);
+
+    var exp2 = Explorer.init(testing.allocator);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    try testing.expect(snapshot_mod.loadSnapshot(snap_path, &exp2, &store, testing.allocator));
+    try testing.expect(exp2.wordIndexCanLoadFromDisk());
+    try testing.expect(!exp2.wordIndexIsComplete());
+
+    try exp2.indexFileSkipTrigram("src/b.zig", "pub const Gamma = 3;\n");
+    try testing.expect(!exp2.wordIndexCanLoadFromDisk());
+    try testing.expect(!exp2.wordIndexIsComplete());
+
+    const alpha_hits = try exp2.searchWord("Alpha", testing.allocator);
+    defer testing.allocator.free(alpha_hits);
+    try testing.expectEqual(@as(usize, 1), alpha_hits.len);
+    try testing.expect(std.mem.eql(u8, alpha_hits[0].path, "src/a.zig"));
+
+    const gamma_hits = try exp2.searchWord("Gamma", testing.allocator);
+    defer testing.allocator.free(gamma_hits);
+    try testing.expectEqual(@as(usize, 1), gamma_hits.len);
+    try testing.expect(std.mem.eql(u8, gamma_hits[0].path, "src/b.zig"));
+    try testing.expect(exp2.wordIndexIsComplete());
 }
 
 // ── Snapshot non-git tests ───────────────────────────────────
@@ -4529,7 +4661,6 @@ test "issue-151: Go block comments skipped" {
     }
     try testing.expect(func_count == 1); // only realFunc
 }
-
 
 test "issue-150: --help prints usage" {
     const result = try std.process.Child.run(.{


### PR DESCRIPTION
## Summary
- restore snapshot outlines/state directly instead of reparsing every file on warm reopen
- reuse persisted trigram sidecars for CLI and MCP loads, and lazily rebuild/persist the word index
- skip redundant `word.index` rewrites and align the clean `main`-based branch with `AnyTrigramIndex`

## Why
Warm snapshot startup was still spending seconds rebuilding indexes after loading `codedb.snapshot`. This keeps cold indexing effectively flat while making warm CLI and MCP startup dramatically faster.

## Benchmarks
All numbers below are `ReleaseFast` and measured against `v0.2.54` on the same machine. The broader benchmark appendix was added post-merge while preparing the `0.2.55` release.

### Data Shape: Large Repo CLI (`openclaw`)

| Benchmark | 0.2.55 | 0.2.54 | Delta |
| --- | ---: | ---: | ---: |
| cold `tree` | `5.32s` | `5.29s` | `+0.6%` |
| `snapshot` | `6.53s` | `6.25s` | `+4.6%` |
| warm `tree` | `0.26s` | `6.16s` | `23.7x faster` |
| warm `search workspace` | `0.24s` | `6.14s` | `25.6x faster` |
| warm `word session` | `0.61s` | `5.99s` | `9.9x faster` |

### Data Shape: MCP First Secondary-Project Call (`openclaw`)

| Tool | 0.2.55 | 0.2.54 | Delta |
| --- | ---: | ---: | ---: |
| `codedb_tree` | `0.076s` | `5.289s` | `69.6x faster` |
| `codedb_search` | `0.067s` | `5.278s` | `78.8x faster` |
| `codedb_word` | `0.285s` | `5.312s` | `18.6x faster` |

### Data Shape: Peak RSS (`openclaw`)

| Benchmark | 0.2.55 | 0.2.54 |
| --- | ---: | ---: |
| cold `tree` | `3478.8MB` | `3478.1MB` |
| warm `tree` | `192.6MB` | `3314.0MB` |
| warm `search` | `193.3MB` | `3312.9MB` |
| warm `word` | `677.1MB` | `3313.3MB` |

### Data Shape: Small-Corpus Sanity (`codedb/src`)

| Benchmark | 0.2.55 | 0.2.54 |
| --- | ---: | ---: |
| cold `tree` | `0.045s` | `0.040s` |
| warm `tree` | `0.010s` | `0.030s` |
| warm `search` | `0.010s` | `0.030s` |
| warm `word` | `0.010s` | `0.030s` |

### Workload-Shaping Note

The release also includes WAL profiling and hashed cloud sync from [#198](https://github.com/justrach/codedb/pull/198) and [#199](https://github.com/justrach/codedb/pull/199), so production query/open patterns can be aggregated without sending raw query strings or file paths off-machine.

## Validation
- `SDKROOT=$(xcrun --show-sdk-path) zig build test`
- `SDKROOT=$(xcrun --show-sdk-path) zig build -Doptimize=ReleaseFast`
- `SDKROOT=$(xcrun --show-sdk-path) zig build run -- --help`

Closes #220.
