### PR TITLE
docs: align MCP timeout wording with issue-148

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 | Auto-registration in Claude, Codex, Gemini, Cursor     |                                          |
 | Polling file watcher with filtered directory walker    |                                          |
 | Portable snapshot for instant MCP startup              |                                          |
-| Singleton MCP with PID lock + 2min idle timeout        |                                          |
+| Singleton MCP with PID lock + 10min idle timeout       |                                          |
 | Sensitive file blocking (.env, credentials, keys)      |                                          |
 | Codesigned + notarized macOS binaries                  |                                          |
 | SHA256 checksum verification in installer              |                                          |

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -289,7 +289,7 @@ pub var last_activity: std.atomic.Value(i64) = std.atomic.Value(i64).init(0);
 
 /// How long (ms) the server may sit idle before auto-exiting.
 /// Claude Code restarts MCP servers on demand, so this is safe.
-pub const idle_timeout_ms: i64 = 10 * 60 * 1000; // 10 minutes — allows long debugging sessions; stdin EOF exits immediately
+pub const idle_timeout_ms: i64 = 10 * 60 * 1000; // 10 minutes — allows long debugging sessions; stdin EOF is detected by the watchdog poll
 
 // ── Session state for MCP protocol ──────────────────────────────────────────
 

--- a/website/app/update.zig
+++ b/website/app/update.zig
@@ -197,7 +197,7 @@ const html =
     \\      <div class="change-card"><div class="tag tag-perf">performance</div><h3>Batch-accumulate trigrams</h3><p>Local HashMap per file, bulk-insert to global index. Skip whitespace-only trigrams (12% of occurrences).</p></div>
     \\      <div class="change-card"><div class="tag tag-perf">performance</div><h3>Memory optimization</h3><p>Release file contents after indexing. Zero-copy ContentRef for search. 47% less memory at 40k files.</p></div>
     \\      <div class="change-card"><div class="tag tag-fix">fix</div><h3>Python &amp; TypeScript parsers</h3><p>Triple-quote docstrings, block comments, import alias handling. Fixed dependency matching for Python imports.</p></div>
-    \\      <div class="change-card"><div class="tag tag-fix">fix</div><h3>MCP reliability</h3><p>2-minute idle timeout. Singleton PID lock. Fixed crash on exit (duplicate thread join). Linux /bin/bash update.</p></div>
+    \\      <div class="change-card"><div class="tag tag-fix">fix</div><h3>MCP reliability</h3><p>10-minute idle timeout. Faster disconnect exit via stdin polling. Singleton PID lock. Fixed crash on exit (duplicate thread join). Linux /bin/bash update.</p></div>
     \\      <div class="change-card"><div class="tag tag-doc">docs</div><h3>16 MCP tools documented</h3><p>Added codedb_bundle, codedb_remote, codedb_projects, codedb_index. CLI commands table in README.</p></div>
     \\    </div>
     \\  </div>


### PR DESCRIPTION
## Summary
- update README timeout wording to 10 minutes
- update website release copy to mention the longer timeout and stdin polling
- soften the `src/mcp.zig` comment so it matches the actual watchdog behavior

## Notes
- stacked on top of #148
- `socials/` is gitignored in this repo, so that local note was not included in the PR

Refs #231