### PR TITLE
feat: add first-pass Svelte language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 > **Alpha software — API is stabilizing but may change**
 >
 > codedb works and is used daily in production AI workflows, but:
-> - **Language support** — Zig, Python, TypeScript/JavaScript, Rust, PHP, C# (more planned)
+> - **Language support** — Zig, C/C++, Python, TypeScript/JavaScript, Svelte, Rust, Go, PHP, Ruby
 > - **No auth** — HTTP server binds to localhost only
 > - **Snapshot format** may change between versions
 > - **MCP protocol** is JSON-RPC 2.0 over stdio (stable)

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -79,6 +79,7 @@ pub const Language = enum(u8) {
     markdown,
     json,
     yaml,
+    svelte,
     unknown,
 };
 
@@ -96,6 +97,7 @@ pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".md")) return .markdown;
     if (std.mem.endsWith(u8, path, ".json")) return .json;
     if (std.mem.endsWith(u8, path, ".yaml") or std.mem.endsWith(u8, path, ".yml")) return .yaml;
+    if (std.mem.endsWith(u8, path, ".svelte")) return .svelte;
     return .unknown;
 }
 
@@ -210,6 +212,7 @@ pub const Explorer = struct {
         var in_py_docstring = false;
         var in_block_comment = false;
         var in_go_import_block = false;
+        var in_svelte_script = false;
         var lines = std.mem.splitScalar(u8, content, '\n');
         while (lines.next()) |line| {
             line_num += 1;
@@ -251,7 +254,7 @@ pub const Explorer = struct {
             if (outline.language == .typescript or outline.language == .javascript or
                 outline.language == .go_lang or outline.language == .c or
                 outline.language == .cpp or outline.language == .rust or
-                outline.language == .zig)
+                outline.language == .zig or outline.language == .svelte)
             {
                 if (in_block_comment) {
                     if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
@@ -309,6 +312,8 @@ pub const Explorer = struct {
                 }
             } else if (outline.language == .ruby) {
                 try self.parseRubyLine(trimmed, line_num, &outline);
+            } else if (outline.language == .svelte) {
+                try self.parseSvelteLine(trimmed, line_num, &outline, &in_svelte_script);
             }
 
             prev_line_trimmed = trimmed;
@@ -1719,6 +1724,53 @@ pub const Explorer = struct {
         }
     }
 
+    fn parseSvelteLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline, in_script: *bool) !void {
+        var script_line = line;
+
+        if (!in_script.*) {
+            const open_pos = std.mem.indexOf(u8, line, "<script") orelse return;
+            const open_tag = line[open_pos..];
+            const tag_end = std.mem.indexOfScalar(u8, open_tag, '>') orelse {
+                in_script.* = true;
+                return;
+            };
+            in_script.* = true;
+            script_line = std.mem.trimLeft(u8, open_tag[tag_end + 1 ..], " \t");
+        }
+
+        if (std.mem.indexOf(u8, script_line, "</script>")) |close_pos| {
+            const before_close = std.mem.trim(u8, script_line[0..close_pos], " \t");
+            if (before_close.len != 0) try self.parseSvelteScriptLine(before_close, line_num, outline);
+            in_script.* = false;
+            return;
+        }
+
+        const trimmed = std.mem.trim(u8, script_line, " \t");
+        if (trimmed.len == 0) return;
+        try self.parseSvelteScriptLine(trimmed, line_num, outline);
+    }
+
+    fn parseSvelteScriptLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        if (startsWith(line, "export let ") or startsWith(line, "let ") or startsWith(line, "var ")) {
+            const trimmed = skipKeywords(line);
+            if (extractIdent(trimmed)) |name| {
+                const name_copy = try a.dupe(u8, name);
+                errdefer a.free(name_copy);
+                const detail_copy = try a.dupe(u8, line);
+                errdefer a.free(detail_copy);
+                try outline.symbols.append(a, .{
+                    .name = name_copy,
+                    .kind = .variable,
+                    .line_start = line_num,
+                    .line_end = line_num,
+                    .detail = detail_copy,
+                });
+            }
+        }
+        try self.parseTsLine(line, line_num, outline);
+    }
+
     fn rebuildDepsFor(self: *Explorer, path: []const u8, outline: *FileOutline) !void {
         var deps: std.ArrayList([]const u8) = .{};
         errdefer deps.deinit(self.allocator);
@@ -1957,7 +2009,7 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
     return switch (language) {
         .zig, .rust, .go_lang => std.mem.startsWith(u8, trimmed, "//"),
         .python, .ruby => std.mem.startsWith(u8, trimmed, "#"),
-        .javascript, .typescript, .c, .cpp => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .javascript, .typescript, .c, .cpp, .svelte => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
         else => false,
     };
 }
@@ -2430,15 +2482,15 @@ fn isWordBoundary(path: []const u8, pi: usize) bool {
 
 fn isSpecialEntryPoint(filename: []const u8) bool {
     const specials = [_][]const u8{
-        "main.zig",     "lib.zig",     "root.zig",
-        "main.rs",      "lib.rs",      "mod.rs",
-        "main.go",      "main.c",      "main.cpp",
-        "index.ts",     "index.tsx",   "index.js",
-        "index.jsx",    "index.mjs",   "index.cjs",
-        "index.vue",    "index.php",   "main.rb",
-        "index.rb",     "__init__.py", "__main__.py",
-        "Makefile",     "build.zig",   "Cargo.toml",
-        "package.json",
+        "main.zig",    "lib.zig",      "root.zig",
+        "main.rs",     "lib.rs",       "mod.rs",
+        "main.go",     "main.c",       "main.cpp",
+        "index.ts",    "index.tsx",    "index.js",
+        "index.jsx",   "index.mjs",    "index.cjs",
+        "index.vue",   "index.svelte", "index.php",
+        "main.rb",     "index.rb",     "__init__.py",
+        "__main__.py", "Makefile",     "build.zig",
+        "Cargo.toml",  "package.json",
     };
     for (specials) |s| {
         if (std.mem.eql(u8, filename, s)) return true;

--- a/src/style.zig
+++ b/src/style.zig
@@ -19,6 +19,7 @@ pub const Style = struct {
         if (std.mem.eql(u8, lang, "zig")) return self.yellow;
         if (std.mem.eql(u8, lang, "typescript")) return self.blue;
         if (std.mem.eql(u8, lang, "javascript")) return self.yellow;
+        if (std.mem.eql(u8, lang, "svelte")) return self.orange;
         if (std.mem.eql(u8, lang, "go_lang")) return self.cyan;
         if (std.mem.eql(u8, lang, "rust")) return self.orange;
         if (std.mem.eql(u8, lang, "python")) return self.blue;
@@ -103,8 +104,8 @@ pub fn formatDuration(buf: []u8, ns: i128) []const u8 {
 /// Return a color scaled to elapsed duration.
 pub fn durationColor(s: Style, ns: i128) []const u8 {
     const abs_ns: u128 = if (ns < 0) @intCast(-ns) else @intCast(ns);
-    if (abs_ns < 10_000_000) return s.cyan;    // <10ms  → cyan ⚡
-    if (abs_ns < 100_000_000) return s.green;  // <100ms → green
+    if (abs_ns < 10_000_000) return s.cyan; // <10ms  → cyan ⚡
+    if (abs_ns < 100_000_000) return s.green; // <100ms → green
     if (abs_ns < 1_000_000_000) return s.blue; // <1s    → blue
-    return s.yellow;                            // 1s+    → yellow
+    return s.yellow; // 1s+    → yellow
 }

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -225,9 +225,12 @@ fn writeLanguages(writer: anytype, language_mask: u16) !void {
         "typescript",
         "rust",
         "go_lang",
+        "php",
+        "ruby",
         "markdown",
         "json",
         "yaml",
+        "svelte",
         "unknown",
     };
     var first = true;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1679,6 +1679,7 @@ test "isCommentOrBlank: detects language-specific comments" {
     try testing.expect(isCommentOrBlank("  # python comment", .python));
     try testing.expect(isCommentOrBlank("  /* c comment */", .c));
     try testing.expect(isCommentOrBlank("  * continuation", .javascript));
+    try testing.expect(isCommentOrBlank("  // svelte script comment", .svelte));
     try testing.expect(isCommentOrBlank("   ", .zig));
     try testing.expect(isCommentOrBlank("", .zig));
     try testing.expect(!isCommentOrBlank("  const x = 1;", .zig));
@@ -1773,6 +1774,7 @@ test "detectLanguage: public access and correct detection" {
     try testing.expect(explore.detectLanguage("src/main.zig") == .zig);
     try testing.expect(explore.detectLanguage("app.py") == .python);
     try testing.expect(explore.detectLanguage("index.ts") == .typescript);
+    try testing.expect(explore.detectLanguage("App.svelte") == .svelte);
     try testing.expect(explore.detectLanguage("style.css") == .unknown);
 }
 
@@ -2018,6 +2020,7 @@ test "detectLanguage: all supported extensions" {
     try testing.expect(explore.detectLanguage("comp.jsx") == .javascript);
     try testing.expect(explore.detectLanguage("app.ts") == .typescript);
     try testing.expect(explore.detectLanguage("comp.tsx") == .typescript);
+    try testing.expect(explore.detectLanguage("Component.svelte") == .svelte);
     try testing.expect(explore.detectLanguage("main.rs") == .rust);
     try testing.expect(explore.detectLanguage("main.go") == .go_lang);
     try testing.expect(explore.detectLanguage("README.md") == .markdown);
@@ -3688,6 +3691,9 @@ test "issue-59: telemetry writes session, tool, and codebase stats ndjson" {
     defer explorer.deinit();
     try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
     try explorer.indexFile("src/lib.py", "def run():\n    return 1\n");
+    try explorer.indexFile("src/app.php", "<?php\nfunction run() {}\n");
+    try explorer.indexFile("src/lib.rb", "def run\nend\n");
+    try explorer.indexFile("src/App.svelte", "<script>export let name = \"world\";</script>\n");
 
     telem.recordCodebaseStats(&explorer, 42);
     telem.flush();
@@ -3703,7 +3709,70 @@ test "issue-59: telemetry writes session, tool, and codebase stats ndjson" {
     try testing.expect(std.mem.indexOf(u8, contents, "\"tool\":\"codedb_status\"") != null);
     try testing.expect(std.mem.indexOf(u8, contents, "\"event_type\":\"codebase_stats\"") != null);
     try testing.expect(std.mem.indexOf(u8, contents, "\"startup_time_ms\":42") != null);
-    try testing.expect(std.mem.indexOf(u8, contents, "\"languages\":[\"zig\",\"python\"]") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"languages\":[\"zig\",\"python\",\"php\",\"ruby\",\"svelte\"]") != null);
+}
+
+test "Svelte: parse script blocks and ignore template markup" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("Component.svelte",
+        \\<script lang="ts">
+        \\  import { onMount } from "svelte";
+        \\  export let name = "world";
+        \\  const count = 0;
+        \\  function greet() {
+        \\    return name;
+        \\  }
+        \\</script>
+        \\
+        \\<button on:click={greet}>{name}</button>
+        \\{#if name}
+        \\  <Child value={name} />
+        \\{/if}
+    );
+
+    var outline = (try explorer.getOutline("Component.svelte", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+
+    var found_import = false;
+    var found_prop = false;
+    var found_const = false;
+    var found_function = false;
+    var found_template_noise = false;
+    for (outline.symbols.items) |sym| {
+        if (sym.kind == .import and std.mem.eql(u8, sym.name, "import { onMount } from \"svelte\";")) found_import = true;
+        if (sym.kind == .variable and std.mem.eql(u8, sym.name, "name")) found_prop = true;
+        if (sym.kind == .constant and std.mem.eql(u8, sym.name, "count")) found_const = true;
+        if (sym.kind == .function and std.mem.eql(u8, sym.name, "greet")) found_function = true;
+        if (std.mem.eql(u8, sym.name, "button") or std.mem.eql(u8, sym.name, "Child")) found_template_noise = true;
+    }
+
+    try testing.expect(found_import);
+    try testing.expect(found_prop);
+    try testing.expect(found_const);
+    try testing.expect(found_function);
+    try testing.expect(!found_template_noise);
+    try testing.expect(outline.imports.items.len == 1);
+    try testing.expectEqualStrings("svelte", outline.imports.items[0]);
+}
+
+test "Svelte: inline script tag on one line is parsed" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("Inline.svelte",
+        \\<script>const ready = true;</script>
+        \\<div>{ready}</div>
+    );
+
+    var outline = (try explorer.getOutline("Inline.svelte", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    try testing.expect(outline.symbols.items.len == 1);
+    try testing.expect(outline.symbols.items[0].kind == .constant);
+    try testing.expectEqualStrings("ready", outline.symbols.items[0].name);
 }
 
 test "issue-60: telemetry disabled path is a no-op" {
@@ -5221,7 +5290,6 @@ test "issue-168: query pipeline handles empty results gracefully" {
 // ── codedb_query recall tests ───────────────────────────────────
 // These test that pipeline composition preserves precision and recall:
 // the right files survive each step, and irrelevant files are eliminated.
-
 
 test "issue-168: recall — find + filter preserves only matching extension" {
     var explorer = Explorer.init(testing.allocator);


### PR DESCRIPTION
## Summary
- add `.svelte` language detection and a Svelte parser wrapper that only extracts symbols from `<script>` blocks
- surface Svelte in language styling and special-entrypoint ranking
- fix telemetry language-name ordering so existing `php` and `ruby` bits stay aligned while adding `svelte`
- add targeted tests for Svelte parsing, inline `<script>` handling, detectLanguage coverage, and telemetry output

## Verification
- `zig test src/tests.zig --test-filter 'Svelte:'`
- `zig test src/tests.zig --test-filter 'issue-59: telemetry writes session, tool, and codebase stats ndjson'`
- `zig test src/tests.zig --test-filter 'detectLanguage:'`
- `zig test src/tests.zig --test-filter 'isCommentOrBlank: detects language-specific comments'`

## Notes
- `zig build test` still fails on `origin/main` because the pre-existing `issue-150` help-output tests are red in a clean baseline worktree as well.
