### PR TITLE
fix: restore help CLI build and exit behavior

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -73,9 +73,13 @@ fn mainImpl() !void {
         root = ".";
         cmd = "--version";
         cmd_args_start = 2;
-    } else if (args.len >= 2 and std.mem.eql(u8, args[1], "--help")) {
+    } else if (args.len >= 2 and
+        (std.mem.eql(u8, args[1], "--help") or
+            std.mem.eql(u8, args[1], "-h") or
+            std.mem.eql(u8, args[1], "help")))
+    {
         root = ".";
-        cmd = "--help";
+        cmd = args[1];
         cmd_args_start = 2;
     } else if (args.len < 2) {
         printUsage(out, s);
@@ -111,7 +115,8 @@ fn mainImpl() !void {
     if (std.mem.eql(u8, cmd, "update")) {
         out.p("updating codedb...\n", .{});
         var child = std.process.Child.init(
-            &.{ "/bin/bash", "-c",
+            &.{
+                "/bin/bash", "-c",
                 \\set -e
                 \\PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
                 \\case "$PLATFORM" in

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -181,6 +181,11 @@ pub const Telemetry = struct {
         } else |_| {}
     }
 
+    pub fn syncWalToCloud(self: *Telemetry, wal_path: ?[]const u8) void {
+        _ = wal_path;
+        self.syncToCloud();
+    }
+
     fn formatEvent(self: *Telemetry, ev: *const Event) !usize {
         var fbs = std.io.fixedBufferStream(&self.buf);
         const w = fbs.writer();
@@ -240,7 +245,7 @@ fn writeLanguages(writer: anytype, language_mask: u16) !void {
     }
 }
 
-fn approxIndexSizeBytes(explorer: *const explore.Explorer) u64 {
+pub fn approxIndexSizeBytes(explorer: *const explore.Explorer) u64 {
     var total: u64 = 0;
 
     var word_iter = explorer.word_index.index.iterator();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4690,27 +4690,53 @@ test "issue-151: Go block comments skipped" {
 }
 
 test "issue-150: --help prints usage" {
+    const build = try std.process.Child.run(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "zig", "build" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(build.stdout);
+    defer testing.allocator.free(build.stderr);
+
+    try testing.expect(build.term == .Exited);
+    try testing.expect(build.term.Exited == 0);
+
     const result = try std.process.Child.run(.{
         .allocator = testing.allocator,
-        .argv = &.{ "zig", "build", "run", "--", "--help" },
+        .argv = &.{ "./zig-out/bin/codedb", "--help" },
         .max_output_bytes = 8192,
     });
     defer testing.allocator.free(result.stdout);
     defer testing.allocator.free(result.stderr);
 
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited == 0);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
         std.mem.indexOf(u8, result.stderr, "usage:") != null);
 }
 
 test "issue-150: -h prints usage" {
+    const build = try std.process.Child.run(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "zig", "build" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(build.stdout);
+    defer testing.allocator.free(build.stderr);
+
+    try testing.expect(build.term == .Exited);
+    try testing.expect(build.term.Exited == 0);
+
     const result = try std.process.Child.run(.{
         .allocator = testing.allocator,
-        .argv = &.{ "zig", "build", "run", "--", "-h" },
+        .argv = &.{ "./zig-out/bin/codedb", "-h" },
         .max_output_bytes = 8192,
     });
     defer testing.allocator.free(result.stdout);
     defer testing.allocator.free(result.stderr);
 
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited == 0);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
         std.mem.indexOf(u8, result.stderr, "usage:") != null);
 }
@@ -5221,7 +5247,6 @@ test "issue-168: query pipeline handles empty results gracefully" {
 // ── codedb_query recall tests ───────────────────────────────────
 // These test that pipeline composition preserves precision and recall:
 // the right files survive each step, and irrelevant files are eliminated.
-
 
 test "issue-168: recall — find + filter preserves only matching extension" {
     var explorer = Explorer.init(testing.allocator);


### PR DESCRIPTION
## Summary
- restore the telemetry API surface that `main.zig` and `mcp.zig` already reference so the CLI executable builds again
- route `-h` and `help` through the same early help path as `--help`, which makes all help entrypoints exit successfully
- strengthen the `issue-150` tests to assert a zero exit status and run the built binary directly instead of nesting `zig build run` inside the test harness

## Verification
- `zig test src/tests.zig --test-filter 'issue-150:'`
- `zig build run -- --help`
- `zig build run -- -h`
- `zig build test`
