### PR TITLE
fix: harden self-update and scope nuke cleanup

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,8 @@ const snapshot_mod = @import("snapshot.zig");
 const telemetry = @import("telemetry.zig");
 const root_policy = @import("root_policy.zig");
 const nuke_mod = @import("nuke.zig");
+const update_mod = @import("update.zig");
+const release_info = @import("release_info.zig");
 
 /// Thin wrapper: format + write to a File via allocator.
 const Out = struct {
@@ -100,7 +102,7 @@ fn mainImpl() !void {
 
     // Handle --version early (no root needed)
     if (std.mem.eql(u8, cmd, "--version") or std.mem.eql(u8, cmd, "-v") or std.mem.eql(u8, cmd, "version")) {
-        out.p("codedb 0.2.56\n", .{});
+        out.p("codedb {s}\n", .{release_info.semver});
         return;
     }
 
@@ -110,48 +112,9 @@ fn mainImpl() !void {
         return;
     }
 
-    // Handle update command — direct binary download from GitHub releases.
-    // The CDN install script has issues with set -euo pipefail on macOS,
-    // so we download the binary directly and replace in-place.
+    // Handle update command early — before root resolution so it works from anywhere.
     if (std.mem.eql(u8, cmd, "update")) {
-        out.p("updating codedb...\n", .{});
-        var child = std.process.Child.init(
-            &.{
-                "/bin/bash", "-c",
-                \\set -e
-                \\PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
-                \\case "$PLATFORM" in
-                \\  darwin-arm64) BIN="codedb-darwin-arm64" ;;
-                \\  darwin-x86_64) BIN="codedb-darwin-x86_64" ;;
-                \\  linux-x86_64) BIN="codedb-linux-x86_64" ;;
-                \\  linux-aarch64) BIN="codedb-linux-aarch64" ;;
-                \\  *) echo "unsupported platform: $PLATFORM" >&2; exit 1 ;;
-                \\esac
-                \\VERSION=$(curl -fsSL https://api.github.com/repos/justrach/codedb/releases/latest 2>/dev/null | grep -oE '"tag_name"\s*:\s*"v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
-                \\if [ -z "$VERSION" ]; then
-                \\  VERSION=$(curl -fsSL https://codedb.codegraff.com/latest.json | grep -oE '"version"\s*:\s*"[^"]*"' | cut -d'"' -f4)
-                \\fi
-                \\if [ -z "$VERSION" ]; then
-                \\  echo "failed to determine latest version" >&2
-                \\  exit 1
-                \\fi
-                \\echo "  latest: v${VERSION}"
-                \\TMP=$(mktemp)
-                \\curl -fsSL "https://github.com/justrach/codedb/releases/download/v${VERSION}/${BIN}" -o "$TMP"
-                \\SELF=$(which codedb 2>/dev/null || echo "$HOME/bin/codedb")
-                \\chmod +x "$TMP"
-                \\mv -f "$TMP" "$SELF"
-                \\echo "  updated: $($SELF --version)"
-            },
-            allocator,
-        );
-        child.stdin_behavior = .Inherit;
-        child.stdout_behavior = .Inherit;
-        child.stderr_behavior = .Inherit;
-        _ = child.spawnAndWait() catch {
-            out.p("update failed\n", .{});
-            std.process.exit(1);
-        };
+        update_mod.run(stdout, s, allocator);
         return;
     }
 
@@ -732,10 +695,6 @@ fn printUsage(out: Out, s: sty.Style) void {
         \\    {s}find{s}    {s}<name>{s}         find where a symbol is defined
         \\    {s}search{s}  {s}<query>{s}        full-text search (trigram, case-insensitive)
         \\    {s}word{s}    {s}<identifier>{s}   exact word lookup via inverted index
-        \\    {s}hot{s}                       recently modified files
-        \\    {s}serve{s}                     HTTP daemon on :7719
-        \\    {s}mcp{s}                       JSON-RPC/MCP server over stdio
-        \\    {s}nuke{s}                      uninstall codedb, clear caches, and deregister integrations
         \\
     , .{
         s.bold, s.reset,
@@ -750,6 +709,16 @@ fn printUsage(out: Out, s: sty.Style) void {
         s.dim,  s.reset,
         s.cyan, s.reset,
         s.dim,  s.reset,
+    });
+    out.p(
+        \\    {s}hot{s}                       recently modified files
+        \\    {s}serve{s}                     HTTP daemon on :7719
+        \\    {s}mcp{s}                       JSON-RPC/MCP server over stdio
+        \\    {s}update{s}                    self-update to the latest verified release
+        \\    {s}nuke{s}                      uninstall codedb, clear caches, and deregister integrations
+        \\
+    , .{
+        s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -19,6 +19,7 @@ const snapshot_mod = @import("snapshot.zig");
 const telemetry_mod = @import("telemetry.zig");
 const git_mod = @import("git.zig");
 const root_policy = @import("root_policy.zig");
+const release_info = @import("release_info.zig");
 // ── Project cache ────────────────────────────────────────────────────────────
 
 const ProjectCtx = struct {
@@ -493,9 +494,11 @@ fn handleInitialize(s: *Session, root: *const std.json.ObjectMap, id: ?std.json.
             s.client_name = name;
         }
     }
-    writeResult(s.alloc, s.stdout, id,
-        \\{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"codedb","version":"0.2.56"}}
-    );
+    const init_result = std.fmt.allocPrint(s.alloc,
+        \\{{"protocolVersion":"2025-06-18","capabilities":{{"tools":{{"listChanged":false}}}},"serverInfo":{{"name":"codedb","version":"{s}"}}}}
+    , .{release_info.semver}) catch return;
+    defer s.alloc.free(init_result);
+    writeResult(s.alloc, s.stdout, id, init_result);
 }
 
 fn requestRoots(s: *Session) void {

--- a/src/nuke.zig
+++ b/src/nuke.zig
@@ -27,11 +27,13 @@ pub fn run(stdout: std.fs.File, s: sty.Style, allocator: std.mem.Allocator) void
         std.process.exit(1);
     };
     defer allocator.free(home);
+    const self_exe = std.fs.selfExePathAlloc(allocator) catch null;
+    defer if (self_exe) |path| allocator.free(path);
 
     var stats = NukeStats{};
 
     const self_pid = std.c.getpid();
-    stats.killed_processes = killOtherCodedbProcesses(allocator, self_pid);
+    stats.killed_processes = killOtherCodedbProcesses(allocator, self_pid, self_exe);
     stats.integrations_removed = deregisterInstalledIntegrations(allocator, home);
     stats.snapshots_removed = removeRegisteredSnapshots(allocator, home);
 
@@ -39,7 +41,7 @@ pub fn run(stdout: std.fs.File, s: sty.Style, allocator: std.mem.Allocator) void
         stats.snapshots_removed += 1;
     }
 
-    stats.binaries_removed = removeInstalledBinaries(allocator, home);
+    stats.binaries_removed = removeInstalledBinaries(home, self_exe);
 
     const codedb_dir = std.fmt.allocPrint(allocator, "{s}/.codedb", .{home}) catch {
         out.p("{s}\xe2\x9c\x97{s} failed to allocate uninstall paths\n", .{ s.red, s.reset });
@@ -66,7 +68,8 @@ pub fn run(stdout: std.fs.File, s: sty.Style, allocator: std.mem.Allocator) void
     out.p("\n  to reinstall: {s}curl -fsSL https://codedb.codegraff.com/install.sh | bash{s}\n", .{ s.cyan, s.reset });
 }
 
-fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t) usize {
+fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t, self_exe: ?[]const u8) usize {
+    const executable_path = self_exe orelse return 0;
     var killed: usize = 0;
     var pid_buf: [32]u8 = undefined;
     const self_pid_str = std.fmt.bufPrint(&pid_buf, "{d}", .{self_pid}) catch "0";
@@ -84,6 +87,9 @@ fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t)
         const trimmed = std.mem.trim(u8, pid_line, " \t\r\n");
         if (trimmed.len == 0) continue;
         if (std.mem.eql(u8, trimmed, self_pid_str)) continue;
+        const command_line = readProcessCommandLine(allocator, trimmed) orelse continue;
+        defer allocator.free(command_line);
+        if (!commandTargetsBinary(command_line, executable_path)) continue;
         const kill_result = std.process.Child.run(.{
             .allocator = allocator,
             .argv = &.{ "kill", trimmed },
@@ -97,6 +103,43 @@ fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t)
     }
 
     return killed;
+}
+
+fn readProcessCommandLine(allocator: std.mem.Allocator, pid: []const u8) ?[]u8 {
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "ps", "-p", pid, "-o", "args=" },
+        .max_output_bytes = 4096,
+    }) catch return null;
+    defer allocator.free(result.stderr);
+
+    if (result.term != .Exited or result.term.Exited != 0) {
+        allocator.free(result.stdout);
+        return null;
+    }
+
+    return result.stdout;
+}
+
+pub fn commandTargetsBinary(command_line: []const u8, executable_path: []const u8) bool {
+    if (std.mem.indexOf(u8, command_line, executable_path) != null) return true;
+
+    const command_exe = commandExecutablePath(command_line) orelse return false;
+    return std.mem.eql(u8, normalizeExecutablePath(command_exe), normalizeExecutablePath(executable_path));
+}
+
+fn commandExecutablePath(command_line: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, command_line, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const exe_end = std.mem.indexOfScalar(u8, trimmed, ' ') orelse trimmed.len;
+    return trimmed[0..exe_end];
+}
+
+fn normalizeExecutablePath(path: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, path, "/private/")) {
+        return path["/private".len..];
+    }
+    return path;
 }
 
 fn removeRegisteredSnapshots(allocator: std.mem.Allocator, home: []const u8) usize {
@@ -148,24 +191,21 @@ fn deregisterInstalledIntegrations(allocator: std.mem.Allocator, home: []const u
     return removed;
 }
 
-fn removeInstalledBinaries(allocator: std.mem.Allocator, home: []const u8) usize {
+fn removeInstalledBinaries(home: []const u8, self_exe: ?[]const u8) usize {
     var removed: usize = 0;
-
-    const self_exe = std.fs.selfExePathAlloc(allocator) catch null;
-    defer if (self_exe) |path| allocator.free(path);
 
     if (self_exe) |path| {
         if (deleteFileIfExists(path)) removed += 1;
     }
 
-    const home_bin = std.fmt.allocPrint(allocator, "{s}/bin/codedb", .{home}) catch return removed;
-    defer allocator.free(home_bin);
+    var home_bin_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home_bin = std.fmt.bufPrint(&home_bin_buf, "{s}/bin/codedb", .{home}) catch return removed;
     if (self_exe == null or !std.mem.eql(u8, self_exe.?, home_bin)) {
         if (deleteFileIfExists(home_bin)) removed += 1;
     }
 
-    const home_bin_exe = std.fmt.allocPrint(allocator, "{s}/bin/codedb.exe", .{home}) catch return removed;
-    defer allocator.free(home_bin_exe);
+    var home_bin_exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home_bin_exe = std.fmt.bufPrint(&home_bin_exe_buf, "{s}/bin/codedb.exe", .{home}) catch return removed;
     if ((self_exe == null or !std.mem.eql(u8, self_exe.?, home_bin_exe)) and !std.mem.eql(u8, home_bin, home_bin_exe)) {
         if (deleteFileIfExists(home_bin_exe)) removed += 1;
     }

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,0 +1,1 @@
+pub const semver = "0.2.56";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -32,6 +32,7 @@ const SymbolKind = explore.SymbolKind;
 const mcp_mod = @import("mcp.zig");
 const main_mod = @import("main.zig");
 const nuke_mod = @import("nuke.zig");
+const update_mod = @import("update.zig");
 const snapshot_mod = @import("snapshot.zig");
 const telemetry_mod = @import("telemetry.zig");
 // ── Store tests ─────────────────────────────────────────────
@@ -4756,6 +4757,10 @@ test "issue-150: --help prints usage" {
     try testing.expect(result.term.Exited == 0);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
         std.mem.indexOf(u8, result.stderr, "usage:") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "update") != null or
+        std.mem.indexOf(u8, result.stderr, "update") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "nuke") != null or
+        std.mem.indexOf(u8, result.stderr, "nuke") != null);
 }
 
 test "issue-150: -h prints usage" {
@@ -4782,6 +4787,50 @@ test "issue-150: -h prints usage" {
     try testing.expect(result.term.Exited == 0);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
         std.mem.indexOf(u8, result.stderr, "usage:") != null);
+}
+
+test "update: compareVersions orders semantic versions" {
+    try testing.expect(try update_mod.compareVersions("0.2.55", "0.2.56") == .lt);
+    try testing.expect(try update_mod.compareVersions("0.2.56", "0.2.56") == .eq);
+    try testing.expect(try update_mod.compareVersions("v0.2.57", "0.2.56") == .gt);
+    try testing.expect(try update_mod.compareVersions("0.2.56", "0.2.56.0") == .eq);
+}
+
+test "update: checksumForBinary parses release manifest" {
+    const manifest =
+        \\7be38140d090b2e23723c8cde02be150171c818daa16b18c520b44cc1e078add  codedb-darwin-arm64
+        \\76bc7b81bc9fd211aa2c1ac59d1d26e8c80bc211ab560de2dc998ea9e04ec471  codedb-darwin-x86_64
+        \\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  *codedb-linux-arm64
+    ;
+
+    try testing.expectEqualStrings(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        update_mod.checksumForBinary(manifest, "codedb-linux-arm64") orelse return error.TestUnexpectedResult,
+    );
+    try testing.expect(update_mod.checksumForBinary(manifest, "codedb-linux-x86_64") == null);
+}
+
+test "update: asset names match published release naming" {
+    try testing.expectEqualStrings("codedb-darwin-arm64", update_mod.assetNameForTarget(.macos, .aarch64).?);
+    try testing.expectEqualStrings("codedb-darwin-x86_64", update_mod.assetNameForTarget(.macos, .x86_64).?);
+    try testing.expectEqualStrings("codedb-linux-arm64", update_mod.assetNameForTarget(.linux, .aarch64).?);
+    try testing.expectEqualStrings("codedb-linux-x86_64", update_mod.assetNameForTarget(.linux, .x86_64).?);
+    try testing.expect(update_mod.assetNameForTarget(.windows, .x86_64) == null);
+}
+
+test "nuke: commandTargetsBinary only matches the current install path" {
+    try testing.expect(nuke_mod.commandTargetsBinary(
+        "/tmp/codedb-test/bin/codedb serve",
+        "/tmp/codedb-test/bin/codedb",
+    ));
+    try testing.expect(nuke_mod.commandTargetsBinary(
+        "/var/folders/example/codedb serve",
+        "/private/var/folders/example/codedb",
+    ));
+    try testing.expect(!nuke_mod.commandTargetsBinary(
+        "/Users/rachpradhan/bin/codedb --mcp",
+        "/tmp/codedb-test/bin/codedb",
+    ));
 }
 
 test "nuke: removeJsonMcpServerEntry drops only codedb integration" {

--- a/src/update.zig
+++ b/src/update.zig
@@ -1,0 +1,296 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const sty = @import("style.zig");
+const release_info = @import("release_info.zig");
+
+const github_repo = "justrach/codedb";
+const default_base_url = "https://codedb.codegraff.com";
+const user_agent = "codedb-update";
+
+const Out = struct {
+    file: std.fs.File,
+    alloc: std.mem.Allocator,
+
+    fn p(self: Out, comptime fmt: []const u8, args: anytype) void {
+        const str = std.fmt.allocPrint(self.alloc, fmt, args) catch return;
+        defer self.alloc.free(str);
+        self.file.writeAll(str) catch {};
+    }
+};
+
+const VersionSource = enum {
+    env,
+    github,
+    fallback,
+};
+
+const ResolvedVersion = struct {
+    value: []u8,
+    source: VersionSource,
+};
+
+pub fn run(stdout: std.fs.File, s: sty.Style, allocator: std.mem.Allocator) void {
+    const out = Out{ .file = stdout, .alloc = allocator };
+
+    const resolved = resolveTargetVersion(allocator) catch |err| {
+        out.p("{s}✗{s} failed to resolve update target: {s}\n", .{ s.red, s.reset, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer allocator.free(resolved.value);
+
+    const version_order = compareVersions(release_info.semver, resolved.value) catch |err| {
+        out.p("{s}✗{s} invalid release version: {s}\n", .{ s.red, s.reset, @errorName(err) });
+        std.process.exit(1);
+    };
+
+    switch (version_order) {
+        .eq => {
+            out.p("codedb {s} is already up to date\n", .{release_info.semver});
+            return;
+        },
+        .gt => {
+            out.p("{s}✗{s} refusing to replace codedb {s} with older release {s}\n", .{ s.red, s.reset, release_info.semver, resolved.value });
+            std.process.exit(1);
+        },
+        .lt => {},
+    }
+
+    const asset_name = assetNameForTarget(builtin.os.tag, builtin.cpu.arch) orelse {
+        out.p("{s}✗{s} self-update is unsupported on this platform\n", .{ s.red, s.reset });
+        std.process.exit(1);
+    };
+
+    out.p("updating codedb {s} -> {s}\n", .{ release_info.semver, resolved.value });
+    out.p("  source: {s}\n", .{switch (resolved.source) {
+        .env => "CODEDB_VERSION",
+        .github => "github releases",
+        .fallback => "codedb.codegraff.com/latest.json",
+    }});
+    out.p("  asset:  {s}\n", .{asset_name});
+
+    const manifest = fetchChecksumsManifest(allocator, resolved.value) catch |err| {
+        out.p("{s}✗{s} failed to download checksums for v{s}: {s}\n", .{ s.red, s.reset, resolved.value, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer allocator.free(manifest);
+
+    const expected_hash = checksumForBinary(manifest, asset_name) orelse {
+        out.p("{s}✗{s} release v{s} is missing a checksum for {s}\n", .{ s.red, s.reset, resolved.value, asset_name });
+        std.process.exit(1);
+    };
+
+    const self_path = std.fs.selfExePathAlloc(allocator) catch |err| {
+        out.p("{s}✗{s} cannot locate current executable: {s}\n", .{ s.red, s.reset, @errorName(err) });
+        std.process.exit(1);
+    };
+    defer allocator.free(self_path);
+
+    downloadAndReplaceBinary(allocator, resolved.value, asset_name, self_path, expected_hash) catch |err| {
+        out.p("{s}✗{s} update failed: {s}\n", .{ s.red, s.reset, @errorName(err) });
+        std.process.exit(1);
+    };
+
+    out.p("{s}✓{s} updated to codedb {s}\n", .{ s.green, s.reset, resolved.value });
+}
+
+pub fn assetNameForTarget(os_tag: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) ?[]const u8 {
+    return switch (os_tag) {
+        .macos => switch (arch) {
+            .aarch64 => "codedb-darwin-arm64",
+            .x86_64 => "codedb-darwin-x86_64",
+            else => null,
+        },
+        .linux => switch (arch) {
+            .aarch64 => "codedb-linux-arm64",
+            .x86_64 => "codedb-linux-x86_64",
+            else => null,
+        },
+        else => null,
+    };
+}
+
+pub fn compareVersions(current: []const u8, target: []const u8) !std.math.Order {
+    var current_it = std.mem.splitScalar(u8, trimVersionPrefix(current), '.');
+    var target_it = std.mem.splitScalar(u8, trimVersionPrefix(target), '.');
+
+    while (true) {
+        const current_part = current_it.next();
+        const target_part = target_it.next();
+
+        if (current_part == null and target_part == null) return .eq;
+
+        const current_num = if (current_part) |part| try parseVersionPart(part) else 0;
+        const target_num = if (target_part) |part| try parseVersionPart(part) else 0;
+
+        if (current_num < target_num) return .lt;
+        if (current_num > target_num) return .gt;
+    }
+}
+
+pub fn checksumForBinary(manifest: []const u8, binary_name: []const u8) ?[]const u8 {
+    var lines = std.mem.splitScalar(u8, manifest, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+
+        const hash_end = std.mem.indexOfAny(u8, line, " \t") orelse continue;
+        const hash = line[0..hash_end];
+        var name = std.mem.trimLeft(u8, line[hash_end..], " \t");
+        if (name.len == 0) continue;
+        if (name[0] == '*') name = name[1..];
+        if (std.mem.eql(u8, name, binary_name)) return hash;
+    }
+
+    return null;
+}
+
+fn resolveTargetVersion(allocator: std.mem.Allocator) !ResolvedVersion {
+    const explicit = std.process.getEnvVarOwned(allocator, "CODEDB_VERSION") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    if (explicit) |value| {
+        return .{ .value = value, .source = .env };
+    }
+
+    if (fetchLatestVersionFromGitHub(allocator) catch null) |value| {
+        return .{ .value = value, .source = .github };
+    }
+
+    if (fetchLatestVersionFromFallback(allocator) catch null) |value| {
+        return .{ .value = value, .source = .fallback };
+    }
+
+    return error.CouldNotResolveLatestVersion;
+}
+
+fn fetchLatestVersionFromGitHub(allocator: std.mem.Allocator) !?[]u8 {
+    const response = fetchUrlToMemory(allocator, "https://api.github.com/repos/" ++ github_repo ++ "/releases/latest", 1 * 1024 * 1024) catch return null;
+    defer allocator.free(response);
+    return parseJsonStringField(allocator, response, "tag_name", true);
+}
+
+fn fetchLatestVersionFromFallback(allocator: std.mem.Allocator) !?[]u8 {
+    const base_url = try getBaseUrl(allocator);
+    defer if (base_url.owned) allocator.free(base_url.value);
+
+    const url = try std.fmt.allocPrint(allocator, "{s}/latest.json", .{base_url.value});
+    defer allocator.free(url);
+
+    const response = fetchUrlToMemory(allocator, url, 256 * 1024) catch return null;
+    defer allocator.free(response);
+    return parseJsonStringField(allocator, response, "version", false);
+}
+
+fn fetchChecksumsManifest(allocator: std.mem.Allocator, version: []const u8) ![]u8 {
+    const url = try std.fmt.allocPrint(allocator, "https://github.com/{s}/releases/download/v{s}/checksums.sha256", .{ github_repo, version });
+    defer allocator.free(url);
+    return fetchUrlToMemory(allocator, url, 256 * 1024);
+}
+
+fn fetchUrlToMemory(allocator: std.mem.Allocator, url: []const u8, max_output_bytes: usize) ![]u8 {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "curl", "-fsSL", "-A", user_agent, url },
+        .max_output_bytes = max_output_bytes,
+    });
+    defer allocator.free(result.stderr);
+
+    if (result.term != .Exited or result.term.Exited != 0) {
+        allocator.free(result.stdout);
+        return error.CurlFailed;
+    }
+
+    return result.stdout;
+}
+
+fn parseJsonStringField(allocator: std.mem.Allocator, json_text: []const u8, field_name: []const u8, trim_v_prefix: bool) !?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_text, .{}) catch return null;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return null;
+    const field = parsed.value.object.get(field_name) orelse return null;
+    if (field != .string) return null;
+
+    const value = if (trim_v_prefix) trimVersionPrefix(field.string) else field.string;
+    if (value.len == 0) return null;
+    return try allocator.dupe(u8, value);
+}
+
+fn getBaseUrl(allocator: std.mem.Allocator) !struct { value: []const u8, owned: bool } {
+    const env_value = std.process.getEnvVarOwned(allocator, "CODEDB_URL") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    if (env_value) |value| {
+        return .{ .value = value, .owned = true };
+    }
+    return .{ .value = default_base_url, .owned = false };
+}
+
+fn trimVersionPrefix(value: []const u8) []const u8 {
+    return std.mem.trimLeft(u8, value, "vV");
+}
+
+fn parseVersionPart(part: []const u8) !u64 {
+    const trimmed = std.mem.trim(u8, part, " \t\r\n");
+    if (trimmed.len == 0) return error.InvalidVersion;
+    return std.fmt.parseInt(u64, trimmed, 10);
+}
+
+fn downloadAndReplaceBinary(allocator: std.mem.Allocator, version: []const u8, asset_name: []const u8, dest_path: []const u8, expected_hash: []const u8) !void {
+    const url = try std.fmt.allocPrint(allocator, "https://github.com/{s}/releases/download/v{s}/{s}", .{ github_repo, version, asset_name });
+    defer allocator.free(url);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp.{d}", .{ dest_path, std.time.nanoTimestamp() });
+    defer allocator.free(tmp_path);
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+
+    try downloadToFile(allocator, url, tmp_path);
+
+    const actual_hash = try sha256FileHex(allocator, tmp_path);
+    defer allocator.free(actual_hash);
+    if (!std.ascii.eqlIgnoreCase(actual_hash, expected_hash)) {
+        return error.ChecksumMismatch;
+    }
+
+    {
+        var tmp_file = try std.fs.openFileAbsolute(tmp_path, .{ .mode = .read_write });
+        defer tmp_file.close();
+        try tmp_file.chmod(0o755);
+    }
+
+    try std.fs.renameAbsolute(tmp_path, dest_path);
+}
+
+fn downloadToFile(allocator: std.mem.Allocator, url: []const u8, dest_path: []const u8) !void {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "curl", "-fsSL", "-A", user_agent, url, "-o", dest_path },
+        .max_output_bytes = 16 * 1024,
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    if (result.term != .Exited or result.term.Exited != 0) {
+        return error.DownloadFailed;
+    }
+}
+
+fn sha256FileHex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var file = try std.fs.openFileAbsolute(path, .{});
+    defer file.close();
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var buf: [16 * 1024]u8 = undefined;
+    while (true) {
+        const read_len = try file.read(&buf);
+        if (read_len == 0) break;
+        hasher.update(buf[0..read_len]);
+    }
+
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    hasher.final(&digest);
+    const digest_hex = std.fmt.bytesToHex(digest, .lower);
+    return allocator.dupe(u8, &digest_hex);
+}


### PR DESCRIPTION
## Summary
- replace the inline shell updater with a dedicated self-update module that resolves the latest release via GitHub first, verifies `checksums.sha256`, and no-ops when already current
- centralize the release version string and expose `codedb update` in CLI help
- scope `codedb nuke` process termination to the same executable path so uninstalling one install does not kill unrelated codedb sessions
- add targeted tests for update version ordering, checksum parsing, asset naming, help output, and nuke process matching

## Verification
- `zig build`
- `zig build test -- --test-filter "issue-150:"`
- `zig build test -- --test-filter "update:"`
- `zig build test -- --test-filter "nuke:"`
- `CODEDB_VERSION=0.2.56 ./zig-out/bin/codedb update`
- isolated temp-HOME smoke test for `codedb nuke` covering snapshot/config/binary removal and a same-install dummy `serve` process