### PR TITLE
fix: Python docstring detection and snapshot JSON injection (#179)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -529,13 +529,21 @@ fn parseOutlineWithParser(parser: *Explorer, path: []const u8, content: []const 
         var trimmed = std.mem.trim(u8, line, " \t");
 
         if (outline.language == .python) {
-            const triple_count = std.mem.count(u8, trimmed, "\"\"\"") + std.mem.count(u8, trimmed, "'''");
+            const has_dq = std.mem.indexOf(u8, trimmed, "\"\"\"");
+            const has_sq = std.mem.indexOf(u8, trimmed, "'''");
+            const has_triple = has_dq != null or has_sq != null;
             if (in_py_docstring) {
-                if (triple_count > 0) in_py_docstring = false;
+                if (has_triple) in_py_docstring = false;
                 continue;
             }
-            if (triple_count >= 2) continue;
-            if (triple_count == 1) {
+            if (has_triple) {
+                // Check if triple quote appears twice (single-line docstring like """text""")
+                const marker = if (has_dq != null) "\"\"\"" else "'''";
+                const first_pos = if (has_dq) |p| p else has_sq.?;
+                if (std.mem.indexOf(u8, trimmed[first_pos + 3 ..], marker) != null) {
+                    // Opens and closes on same line — skip as a single-line docstring
+                    continue;
+                }
                 in_py_docstring = true;
                 continue;
             }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -119,10 +119,11 @@ pub fn writeSnapshot(
             if (!first) try writer.writeByte(',');
             first = false;
             const outline = entry.value_ptr;
+            try writer.writeAll("{\"path\":\"");
+            try writeJsonEscaped(writer, entry.key_ptr.*);
             try writer.print(
-                \\{{"path":"{s}","language":"{s}","line_count":{d},"byte_size":{d},"symbol_count":{d}}}
+                \\","language":"{s}","line_count":{d},"byte_size":{d},"symbol_count":{d}}}
             , .{
-                entry.key_ptr.*,
                 @tagName(outline.language),
                 outline.line_count,
                 outline.byte_size,
@@ -973,4 +974,23 @@ pub fn writeSnapshotDual(
     } else |_| {}
 
     writeSnapshot(explorer, root_path, secondary, allocator) catch {};
+}
+
+fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            else => if (c < 0x20) {
+                const hex = "0123456789abcdef";
+                const esc = [6]u8{ '\\', 'u', '0', '0', hex[c >> 4], hex[c & 0x0f] };
+                try writer.writeAll(&esc);
+            } else {
+                try writer.writeByte(c);
+            },
+        }
+    }
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6045,3 +6045,50 @@ test "issue-215: detectLanguage handles .r and .R" {
     try testing.expectEqual(Language.r, explore.detectLanguage("script.r"));
     try testing.expectEqual(Language.r, explore.detectLanguage("analysis.R"));
 }
+
+test "issue-179: Python inline docstring does not leak symbols" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("mod.py",
+        \\def real_func():
+        \\    """This docstring contains def fake(): pass"""
+        \\    return 1
+    );
+
+    const real = try explorer.findAllSymbols("real_func", alloc);
+    defer alloc.free(real);
+    try testing.expect(real.len == 1);
+
+    const fake = try explorer.findAllSymbols("fake", alloc);
+    defer alloc.free(fake);
+    try testing.expectEqual(@as(usize, 0), fake.len);
+}
+
+test "issue-179: Python multi-line docstring with def inside" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("doc.py",
+        \\def outer():
+        \\    """
+        \\    Example:
+        \\        def inner_example():
+        \\            pass
+        \\    """
+        \\    return True
+    );
+
+    const outer = try explorer.findAllSymbols("outer", alloc);
+    defer alloc.free(outer);
+    try testing.expect(outer.len == 1);
+
+    const inner = try explorer.findAllSymbols("inner_example", alloc);
+    defer alloc.free(inner);
+    try testing.expectEqual(@as(usize, 0), inner.len);
+}
+


### PR DESCRIPTION
## Summary

From the 8 bugs in #179, 4 were already fixed in prior commits. This PR fixes the remaining 2 actionable ones:

- **Python docstring detection** — replaced naive `std.mem.count` triple-quote check with position-aware `std.mem.indexOf` logic. Now correctly handles: inline docstrings (`"""text"""`), opening docstrings with text after (`"""starts here`), and multi-line docstrings containing `def`/`class` lines that shouldn't be indexed as symbols
- **Snapshot JSON injection** — replaced raw `{s}` path interpolation in `snapshot.zig` with `writeJsonEscaped()`. Files with `"`, `\`, or control characters in paths no longer corrupt the snapshot cache

### Already fixed (no changes needed):
- C/C++ block comment exclusion — `.c`/`.cpp` already in the language check
- u16 file count truncation — already using `u32`
- ANSI escape strip — already parsing full CSI sequences
- Telemetry data race — `call_count` already `std.atomic.Value(u32)` with `fetchAdd`

### Not addressed (larger scope):
- Global mutable `active_pair_freq` — needs architectural change
- HTTP unbounded threads — needs thread pool, separate issue

## Test plan

- [x] All existing tests pass
- [x] New test: inline docstring `"""text"""` does not leak fake symbols
- [x] New test: multi-line docstring containing `def` does not produce phantom symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)