### PR TITLE
fix(release): sync release_info.zig with build.zig.zon (0.2.578)

### DIFF
--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.59";
+pub const semver = "0.2.578";


### PR DESCRIPTION
## Summary
- `src/release_info.zig` reported `0.2.59` while `build.zig.zon` was bumped to `0.2.578` in 1654be7. The auto-updater in `src/update.zig` compares the running binary against `release_info.semver`, so a 0.2.578 binary identified itself as 0.2.59 — `codedb update` treated every published release as a major upgrade and may have allowed downgrades.
- Syncs the constant to `0.2.578`. Single-line change; no other files touched.

Addresses the P2 review Codex left on [#293](https://github.com/justrach/codedb/pull/293).

## Test plan
- [x] `zig build test --summary all` → 387/387 tests passed
- [ ] Sanity-check on a fresh build that `codedb --version` now reports `0.2.578` and `codedb update` no longer loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)