### PR TITLE
fix(index): bound searchPrefix allocation by max_results

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1311,7 +1311,7 @@ pub fn parseContentForIndexing(allocator: std.mem.Allocator, path: []const u8, c
         // Activates when Tier 0 found nothing and query is ≥3 chars, catching partial
         // identifier queries like "searchC" that match "searchContent" in the word index.
         if (result_list.items.len == 0 and query.len >= 3) {
-            const prefix_hits = try self.word_index.searchPrefix(query, allocator);
+            const prefix_hits = try self.word_index.searchPrefix(query, allocator, max_results);
             defer allocator.free(prefix_hits);
             for (prefix_hits) |hit| {
                 const hit_path = self.word_index.hitPath(hit);

--- a/src/index.zig
+++ b/src/index.zig
@@ -267,9 +267,9 @@ pub const WordIndex = struct {
     /// Collect all hits for index keys that begin with `prefix_raw` (normalized internally to
     /// lowercase). Only keys strictly longer than the normalized prefix are considered —
     /// exact-match keys are already handled by Tier 0 (`search`).
-    /// Results are deduplicated by (doc_id, line_num) and returned as an owned slice.
-    pub fn searchPrefix(self: *WordIndex, prefix_raw: []const u8, allocator: std.mem.Allocator) ![]const WordHit {
-        if (prefix_raw.len == 0) return try allocator.alloc(WordHit, 0);
+    /// Results are deduplicated by (doc_id, line_num), capped at `max_results`, and returned as an owned slice.
+    pub fn searchPrefix(self: *WordIndex, prefix_raw: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const WordHit {
+        if (prefix_raw.len == 0 or max_results == 0) return try allocator.alloc(WordHit, 0);
         var buf: [512]u8 = undefined;
         const prefix = if (prefix_raw.len <= buf.len) blk: {
             for (prefix_raw, 0..) |c, i| buf[i] = normalizeChar(c);
@@ -278,19 +278,24 @@ pub const WordIndex = struct {
 
         var result: std.ArrayList(WordHit) = .empty;
         errdefer result.deinit(allocator);
+        try result.ensureTotalCapacity(allocator, max_results);
         const DedupKey = struct { doc_id: u32, line_num: u32 };
         var seen = std.AutoHashMap(DedupKey, void).init(allocator);
         defer seen.deinit();
+        try seen.ensureTotalCapacity(@intCast(max_results));
 
         var key_iter = self.index.keyIterator();
-        while (key_iter.next()) |k| {
+        outer: while (key_iter.next()) |k| {
             if (k.len <= prefix.len) continue; // strictly longer: exact match is Tier 0
             if (!std.mem.startsWith(u8, k.*, prefix)) continue;
             const hits = self.index.get(k.*) orelse continue;
             for (hits.items) |hit| {
                 const dk = DedupKey{ .doc_id = hit.doc_id, .line_num = hit.line_num };
                 const gop = try seen.getOrPut(dk);
-                if (!gop.found_existing) try result.append(allocator, hit);
+                if (!gop.found_existing) {
+                    result.appendAssumeCapacity(hit);
+                    if (result.items.len >= max_results) break :outer;
+                }
             }
         }
         return result.toOwnedSlice(allocator);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6722,7 +6722,7 @@ test "word-index: searchPrefix finds extensions of a prefix" {
     try wi.indexFile("a.zig", "fn searchContent() void {} fn searchConfig() void {}");
 
     // "searchco" is a strict prefix of "searchcontent" and "searchconfig"
-    const hits = try wi.searchPrefix("searchco", a);
+    const hits = try wi.searchPrefix("searchco", a, 32);
     try testing.expect(hits.len >= 1);
 }
 
@@ -6735,15 +6735,35 @@ test "word-index: searchPrefix skips exact match (Tier 0 responsibility)" {
     try wi.indexFile("a.zig", "fn searchContent() void {}");
 
     // Exact key "search" exists (sub-token). searchPrefix should return 0 for exact key.
-    const hits_exact = try wi.searchPrefix("search", a);
+    const hits_exact = try wi.searchPrefix("search", a, 32);
     // "search" itself is in the index. Only keys STRICTLY longer are returned.
     // "searchcontent" is longer, so we expect ≥1 result.
     try testing.expect(hits_exact.len >= 1);
 
     // The hits must come from keys other than "search" itself.
     // Verify by checking "searchc..." style prefix:
-    const hits_prefix = try wi.searchPrefix("searchco", a);
+    const hits_prefix = try wi.searchPrefix("searchco", a, 32);
     try testing.expect(hits_prefix.len >= 1);
+}
+
+test "word-index: searchPrefix respects max_results cap" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var wi = WordIndex.init(a);
+
+    // Index many distinct files producing many keys that share the "fooBar" prefix.
+    var i: usize = 0;
+    while (i < 50) : (i += 1) {
+        const path = try std.fmt.allocPrint(a, "f{d}.zig", .{i});
+        const content = try std.fmt.allocPrint(a, "fn fooBar{d}() void {{}}\n", .{i});
+        try wi.indexFile(path, content);
+    }
+
+    const cap: usize = 5;
+    const hits = try wi.searchPrefix("foobar", a, cap);
+    try testing.expect(hits.len <= cap);
+    try testing.expect(hits.len > 0);
 }
 
 test "integration: Tier 0.5 prefix expansion finds partial identifier" {


### PR DESCRIPTION
## Summary
- Add `max_results: usize` parameter to `WordIndex.searchPrefix` (src/index.zig:271) so the prefix-key scan stops once the cap is reached, instead of collecting every deduplicated hit and relying on the caller to truncate.
- Pre-size the result list and dedup map to the cap, switch the append to `appendAssumeCapacity`, and break out of both the inner `hits` loop and outer `keyIterator` once `result.items.len >= max_results`.
- Update the only caller, Tier 0.5 in `Explorer.searchContent` (src/explore.zig:1314), to pass the user-requested `max_results`.

Addresses Codex's P2 review on [#293](https://github.com/justrach/codedb/pull/293): on large indexes a broad 3-char prefix could allocate a huge hit set before the post-call truncation in `searchContent`, causing latency spikes / OOM despite a small caller limit.

## Test plan
- [x] `zig build test` — 388/388 pass (387 baseline + 1 new `word-index: searchPrefix respects max_results cap`).
- [x] New test indexes 50 distinct files with the `fooBar` prefix and asserts `searchPrefix("foobar", a, 5)` returns at most 5 hits.
- [x] Existing two `searchPrefix` tests updated to pass an explicit cap (32) and continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)