### PR TITLE
fix(mcp): hint regex=true when codedb_search query has regex metachars

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2370,7 +2370,7 @@ fn mcpGenerateSummary(
     // codedb_snapshot, codedb_status: label + timer is enough
 }
 
-fn mcpGenerateGuidance(
+pub fn mcpGenerateGuidance(
     alloc: std.mem.Allocator,
     tool_name: []const u8,
     args: *const std.json.ObjectMap,
@@ -2392,7 +2392,18 @@ fn mcpGenerateGuidance(
     } else if (eql(tool_name, "codedb_symbol")) {
         buf.appendSlice(alloc, MCP_DIM ++ MCP_ARROW ++ "next: codedb_edit to modify this symbol" ++ MCP_RESET) catch {};
     } else if (eql(tool_name, "codedb_search")) {
-        if (!getBool(args, "scope")) {
+        const has_regex_meta = blk: {
+            if (getBool(args, "regex")) break :blk false;
+            const q = getStr(args, "query") orelse break :blk false;
+            for (q) |c| switch (c) {
+                '|', '(', ')', '[', ']', '?', '+', '*', '^', '$' => break :blk true,
+                else => {},
+            };
+            break :blk false;
+        };
+        if (has_regex_meta) {
+            buf.appendSlice(alloc, MCP_DIM ++ MCP_ARROW ++ "hint: query has regex metachars but regex=false; matched as literal — pass regex=true for OR/grouping" ++ MCP_RESET) catch {};
+        } else if (!getBool(args, "scope")) {
             buf.appendSlice(alloc, MCP_DIM ++ MCP_ARROW ++ "next: add scope=true to see enclosing functions" ++ MCP_RESET) catch {};
         }
     } else if (eql(tool_name, "codedb_word")) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6811,3 +6811,65 @@ test "search: BM25 ranks higher-frequency line first" {
     try testing.expect(results[0].score >= results[1].score);
     try testing.expectEqual(@as(u32, 2), results[0].line_num);
 }
+
+// ── Issue #290/#292: special-char queries must not crash MCP server ──
+
+test "issue-290: searchContent with hyphen query does not crash" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    try explorer.indexFile("a.zig", "const x = \"test-case\";\n");
+    const results = try explorer.searchContent("test-case", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+}
+
+test "issue-292: searchContent with pipe query does not crash" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    try explorer.indexFile("a.zig", "const x = \"timestamp|activity|filter\";\n");
+    const results = try explorer.searchContent("timestamp|activity|filter", testing.allocator, 5);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+}
+
+test "issue-292: codedb_search guidance hints regex=true on metachar query" {
+    const args_json = "{\"query\":\"timestamp|activity|filter\"}";
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, false, &buf);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") != null);
+}
+
+test "issue-292: codedb_search guidance does not warn when regex=true is set" {
+    const args_json = "{\"query\":\"timestamp|activity\",\"regex\":true}";
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, false, &buf);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") == null);
+}
+
+test "issue-290: codedb_search guidance does not warn on plain hyphen" {
+    const args_json = "{\"query\":\"test-case\"}";
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, false, &buf);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") == null);
+}


### PR DESCRIPTION
## Summary
Closes [#290](https://github.com/justrach/codedb/issues/290) and [#292](https://github.com/justrach/codedb/issues/292).

Both were reported against codedb 0.2.571. After the 0.16 migration + perf passes (0.2.572 → 0.2.578) I could not reproduce the server-level crash from either the CLI or a direct MCP JSON-RPC `tools/call` invocation against a real repo. Rather than chase a crash that no longer reproduces on current main, this PR does two things:

1. **Regression tests.** Add `Explorer`-level tests at [src/tests.zig:6817](src/tests.zig:6817) that run the two offending queries (`test-case` and `timestamp|activity|filter`) through `searchContent` with `regex=false`. They lock in the current non-crashing behavior so any future regression fails CI immediately.

2. **Address the actual UX gap behind #292.** When `query` contains regex metachars (`|`, parens, brackets, `?+*`, `^`, `$`) and `regex=false`, the search quietly runs as a literal substring match and returns nothing — exactly the failure mode the reporter described (`"the expected behaviour should be it returns the result but sends a friendly reminder that if it wants to actually do an OR search it must set regex=true"`). Swap the generic `scope=true` guidance for a targeted hint in that case so callers get steered toward `regex=true`.

Implementation: [src/mcp.zig:2394](src/mcp.zig:2394) — `mcpGenerateGuidance` gets a small metachar check before the existing `scope=true` nudge.

## Test plan
- [x] `zig build test` — **393/393 pass** (388 baseline + 5 new)
  - `issue-290: searchContent with hyphen query does not crash`
  - `issue-292: searchContent with pipe query does not crash`
  - `issue-292: codedb_search guidance hints regex=true on metachar query`
  - `issue-292: codedb_search guidance does not warn when regex=true is set`
  - `issue-290: codedb_search guidance does not warn on plain hyphen`
- [x] Verified end-to-end: `echo '{...tools/call codedb_search query=timestamp|activity|filter}' | codedb mcp` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)