### PR TITLE
feat(mcp): expose scan state via codedb_status (issue #207)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -583,6 +583,7 @@ fn mainImpl() !void {
 
         const git_head = git_mod.getGitHead(abs_root, allocator) catch null;
         const startup_t0 = cio.milliTimestamp();
+        mcp_server.setScanState(.loading_snapshot);
         const snapshot_loaded = blk: {
             const snap_head = snapshot_mod.readSnapshotGitHead(io, "codedb.snapshot") orelse {
                 if (git_head != null) break :blk false;
@@ -612,17 +613,19 @@ fn mainImpl() !void {
         queue.* = watcher.EventQueue{};
         var scan_thread: ?std.Thread = null;
         if (!snapshot_loaded) {
+            mcp_server.setScanState(.walking);
             scan_thread = try std.Thread.spawn(.{}, scanBg, .{ io, &store, &explorer, root, allocator, &scan_done, &shutdown, data_dir, abs_root, &telem, startup_t0 });
         } else {
             const startup_time_ms: u64 = @intCast(@max(cio.milliTimestamp() - startup_t0, 0));
             loadTrigramFromDiskIfPresent(io, &explorer, data_dir, allocator);
             telem.recordCodebaseStats(&explorer, startup_time_ms);
+            mcp_server.setScanState(.ready);
         }
 
         const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, &store, &explorer, queue, root, &shutdown, &scan_done });
         const idle_thread = try std.Thread.spawn(.{}, idleWatchdog, .{&shutdown});
 
-        std.log.info("codedb mcp: root={s} files={d} data={s}", .{ abs_root, store.currentSeq(), data_dir });
+        std.log.info("codedb mcp: root={s} files={d} data={s} scan={s}", .{ abs_root, store.currentSeq(), data_dir, mcp_server.getScanState().name() });
 
         mcp_server.run(io, allocator, &store, &explorer, &agents, abs_root, &telem);
 
@@ -821,6 +824,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
         break :blk std.mem.eql(u8, &a, &b);
     };
 
+    mcp_server.setScanState(.walking);
     watcher.initialScan(io, store, explorer, root, allocator, heads_match) catch |err| {
         std.log.warn("background scan failed: {}", .{err});
     };
@@ -828,8 +832,10 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
     // Phase gate: bail if shutting down after initial scan
     if (shutdown.load(.acquire)) {
         scan_done.store(true, .release);
+        mcp_server.setScanState(.ready);
         return;
     }
+    mcp_server.setScanState(.indexing);
     persistWordIndexToDisk(io, explorer, data_dir, git_head);
 
     if (heads_match) {
@@ -841,6 +847,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
                 explorer.trigram_index = .{ .mmap = loaded };
                 explorer.mu.unlock();
                 scan_done.store(true, .release);
+                mcp_server.setScanState(.ready);
                 if (shutdown.load(.acquire)) return;
                 telem.recordCodebaseStats(explorer, @intCast(@max(cio.milliTimestamp() - startup_t0, 0)));
                 snapshot_mod.writeSnapshotDual(io, explorer, abs_root, "codedb.snapshot", allocator) catch |err| {
@@ -862,6 +869,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
                 explorer.trigram_index = .{ .heap = loaded };
                 explorer.mu.unlock();
                 scan_done.store(true, .release);
+                mcp_server.setScanState(.ready);
                 if (shutdown.load(.acquire)) return;
                 telem.recordCodebaseStats(explorer, @intCast(@max(cio.milliTimestamp() - startup_t0, 0)));
                 snapshot_mod.writeSnapshotDual(io, explorer, abs_root, "codedb.snapshot", allocator) catch |err| {
@@ -881,6 +889,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
     // Phase gate: bail before disk write if shutting down
     if (shutdown.load(.acquire)) {
         scan_done.store(true, .release);
+        mcp_server.setScanState(.ready);
         return;
     }
 
@@ -891,6 +900,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
     // Phase gate: bail before mmap swap if shutting down
     if (shutdown.load(.acquire)) {
         scan_done.store(true, .release);
+        mcp_server.setScanState(.ready);
         return;
     }
 
@@ -908,6 +918,7 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
     }
 
     scan_done.store(true, .release);
+    mcp_server.setScanState(.ready);
 
     if (shutdown.load(.acquire)) return;
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -385,6 +385,39 @@ pub var last_activity: std.atomic.Value(i64) = std.atomic.Value(i64).init(0);
 /// Claude Code restarts MCP servers on demand, so this is safe.
 pub const idle_timeout_ms: i64 = 10 * 60 * 1000; // 10 minutes — allows long debugging sessions; stdin EOF is detected by the watchdog poll
 
+// ── Serve-first scan state (issue #207) ─────────────────────────────────────
+//
+// MCP serves immediately on startup; the file walk + index build runs in a
+// background thread. Tools that query the explorer during this window may see
+// partial results, so we expose the current scan phase via codedb_status so
+// callers can decide whether to retry or proceed with what's available.
+
+pub const ScanState = enum(u8) {
+    loading_snapshot = 0,
+    walking = 1,
+    indexing = 2,
+    ready = 3,
+
+    pub fn name(self: ScanState) []const u8 {
+        return switch (self) {
+            .loading_snapshot => "loading_snapshot",
+            .walking => "walking",
+            .indexing => "indexing",
+            .ready => "ready",
+        };
+    }
+};
+
+var scan_state_atomic: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(ScanState.ready));
+
+pub fn setScanState(s: ScanState) void {
+    scan_state_atomic.store(@intFromEnum(s), .release);
+}
+
+pub fn getScanState() ScanState {
+    return @enumFromInt(scan_state_atomic.load(.acquire));
+}
+
 // ── Session state for MCP protocol ──────────────────────────────────────────
 
 const Session = struct {
@@ -1183,6 +1216,7 @@ fn handleStatus(alloc: std.mem.Allocator, out: *std.ArrayList(u8), store: *Store
         \\  contents_cached: {d}
         \\  trigram_index: {s} ({d} files)
         \\  index_memory: {d}KB
+        \\  scan: {s}
         \\
     , .{
         store.currentSeq(),
@@ -1192,6 +1226,7 @@ fn handleStatus(alloc: std.mem.Allocator, out: *std.ArrayList(u8), store: *Store
         trigram_type,
         trigram_files,
         index_bytes / 1024,
+        getScanState().name(),
     }) catch {};
 }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6873,3 +6873,29 @@ test "issue-290: codedb_search guidance does not warn on plain hyphen" {
     mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, false, &buf);
     try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") == null);
 }
+
+// ── Issue #207: serve-first scan state ─────────────────────────────────────
+
+test "issue-207: ScanState round-trips through atomic" {
+    const initial = mcp_mod.getScanState();
+    defer mcp_mod.setScanState(initial);
+
+    mcp_mod.setScanState(.loading_snapshot);
+    try testing.expectEqual(mcp_mod.ScanState.loading_snapshot, mcp_mod.getScanState());
+
+    mcp_mod.setScanState(.walking);
+    try testing.expectEqual(mcp_mod.ScanState.walking, mcp_mod.getScanState());
+
+    mcp_mod.setScanState(.indexing);
+    try testing.expectEqual(mcp_mod.ScanState.indexing, mcp_mod.getScanState());
+
+    mcp_mod.setScanState(.ready);
+    try testing.expectEqual(mcp_mod.ScanState.ready, mcp_mod.getScanState());
+}
+
+test "issue-207: ScanState.name covers all states" {
+    try testing.expectEqualStrings("loading_snapshot", mcp_mod.ScanState.loading_snapshot.name());
+    try testing.expectEqualStrings("walking", mcp_mod.ScanState.walking.name());
+    try testing.expectEqualStrings("indexing", mcp_mod.ScanState.indexing.name());
+    try testing.expectEqualStrings("ready", mcp_mod.ScanState.ready.name());
+}


### PR DESCRIPTION
## Summary
Closes [#207](https://github.com/justrach/codedb/issues/207).

The MCP server already serves immediately on startup — `scanBg` runs in a background thread spawned at [src/main.zig:616](src/main.zig:616), and `mcp_server.run` is called right after spawn. What was missing was **client visibility into where the scan is**: on a 5K-file repo the cold scan takes ~42s, and during that window tools could return partial results with no signal that a retry would yield more.

## Changes

**`src/mcp.zig`** — add `ScanState` enum + atomic backing:
```zig
pub const ScanState = enum(u8) { loading_snapshot, walking, indexing, ready };
pub fn setScanState(s: ScanState) void;
pub fn getScanState() ScanState;
```
Backed by `std.atomic.Value(u8)` — release/acquire ordering, no locks.

**`src/main.zig`** — wire transitions through the existing startup + `scanBg` phases:
- `loading_snapshot` while reading `codedb.snapshot`
- `walking` while `watcher.initialScan` collects files + builds outlines
- `indexing` while trigram/word indexes build, get persisted, and swap to mmap
- `ready` once everything is up (also set on early return / shutdown bail-out paths so the state never gets stuck mid-phase)

**`src/mcp.zig` (handleStatus)** — append one line `scan: <state>` to `codedb_status` output. Existing fields unchanged.

**`src/main.zig`** — startup log now reads `codedb mcp: root=X files=N data=Z scan=walking` so operators see the state on launch.

## Manual verification
```
$ codedb mcp
info: codedb mcp: root=/tmp/repo files=0 data=... scan=walking
{...}codedb_status → "scan: walking" ... transitions to "ready" ...
```

## Test plan
- [x] `zig build test` — **395/395 pass** (393 baseline + 2 new)
  - `issue-207: ScanState round-trips through atomic`
  - `issue-207: ScanState.name covers all states`
- [x] End-to-end: launched `codedb mcp` against a fresh repo, observed `scan=walking` in startup log and `scan: walking` in `codedb_status` output until background scan completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)