### PR TITLE
fix(snapshot): truncate oversized symbol detail instead of panicking

### DIFF
--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -209,10 +209,20 @@ pub fn writeSnapshot(
 
                 if (sym.detail) |detail| {
                     try writer.writeByte(1);
+                    // Snapshot format length-prefixes `detail` with u16, so any
+                    // detail >64KB can't be round-tripped. Minified JS / bundled
+                    // monorepos (e.g. nodejs/node, vercel/next.js) produce
+                    // "symbols" whose detail holds a multi-kilobyte inline body
+                    // and overflows u16. Truncate rather than crash the snapshot.
+                    const max_detail: usize = std.math.maxInt(u16);
+                    const clipped = if (detail.len > max_detail) detail[0..max_detail] else detail;
+                    if (detail.len > max_detail) {
+                        std.log.warn("snapshot: truncating symbol detail from {d}B to {d}B (u16 length-prefix limit)", .{ detail.len, max_detail });
+                    }
                     var detail_len_buf: [2]u8 = undefined;
-                    std.mem.writeInt(u16, &detail_len_buf, @intCast(detail.len), .little);
+                    std.mem.writeInt(u16, &detail_len_buf, @intCast(clipped.len), .little);
                     try writer.writeAll(&detail_len_buf);
-                    try writer.writeAll(detail);
+                    try writer.writeAll(clipped);
                 } else {
                     try writer.writeByte(0);
                 }


### PR DESCRIPTION
## Summary
\`writeSnapshot\` at \`snapshot.zig:213\` crashes when a symbol's \`detail\` field exceeds **65,535 bytes** (u16 length-prefix limit). Truncate with a \`std.log.warn\` instead of panicking.

## Repro
- Clone \`vercel/next.js\` and run \`codedb snapshot\`:
  \`\`\`
  thread panic: integer does not fit in destination type
  /.../snapshot.zig:213:60: writeSnapshot
      std.mem.writeInt(u16, &detail_len_buf, @intCast(detail.len), .little);
                                             ^
  \`\`\`
- Same bug kills \`nodejs/node\`.
- Minified JS / bundled monorepos produce synthetic "symbols" whose detail holds a multi-kilobyte inline body. Observed \`detail.len\` values up to **290,774 bytes** during the next.js reproducer.

## Fix
Single-site clamp in \`writeSnapshot\`:

\`\`\`zig
const max_detail: usize = std.math.maxInt(u16);
const clipped = if (detail.len > max_detail) detail[0..max_detail] else detail;
if (detail.len > max_detail) {
    std.log.warn("snapshot: truncating symbol detail from {d}B to {d}B (u16 length-prefix limit)", .{ detail.len, max_detail });
}
\`\`\`

No format-version bump needed — the reader at L644 already caps \`readSectionString\` at \`std.math.maxInt(u16)\`, so the truncated payload round-trips fine.

## Scope kept minimal
The same u16 length-prefix pattern also applies to \`sym.name\` (L196), imports (L186), and OUTLINE_STATE path (L167). Those haven't crashed in practice, and truncating \`name\` would break symbol identity; skipping them properly needs a bigger refactor. Filed as a follow-up concern, not included here.

## Test plan
- [x] Local \`zig build\` clean
- [x] \`codedb snapshot\` on vercel/next.js clone: **176 ms, 26,530 files, 21 MB, 12 warnings**, previously crashed at 71 s
- [ ] Re-ingest \`nodejs/node\` and \`vercel/next.js\` through codedb-cloud once binary is redeployed there
- [ ] No regressions on already-working repos (react, godot, llvm, torvalds/linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)