### PR TITLE
Sync main with release/0.2.579 (api.wiki.codes MCP, 1h MCP timeout, C parser, extension parsers, bench/snapshot perf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | Auto-registration in Claude, Codex, Gemini, Cursor     |                                          |
 | Polling file watcher with filtered directory walker    |                                          |
 | Portable snapshot for instant MCP startup              |                                          |
-| Singleton MCP with PID lock + 10min idle timeout       |                                          |
+| Singleton MCP with PID lock + 1h idle timeout          |                                          |
 | Sensitive file blocking (.env, credentials, keys)      |                                          |
 | Codesigned + notarized macOS binaries                  |                                          |
 | SHA256 checksum verification in installer              |                                          |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@
 > **Alpha software — API is stabilizing but may change**
 >
 > codedb works and is used daily in production AI workflows, but:
-> - **Language support** — Zig, Python, TypeScript/JavaScript, Rust, Go, PHP, Ruby, HCL, R, Dart/Flutter
+> - **Parser support** — Zig, C/C++, Python, TypeScript/JavaScript, Rust, Go, PHP, Ruby, HCL, R, Dart/Flutter
+> - **Language detection** — also tags Java, Kotlin, Svelte, Vue, Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen files in trees/snapshots
 > - **No auth** — HTTP server binds to localhost only
 > - **Snapshot format** may change between versions
 > - **MCP protocol** is JSON-RPC 2.0 over stdio (stable)

--- a/README.md
+++ b/README.md
@@ -138,25 +138,30 @@ codedb hot                            # recently modified files
 
 ### `codedb_remote` — Cloud Intelligence
 
-Query any public GitHub repo without cloning it. Powered by `codedb.codegraff.com`.
+Query any public GitHub repo without cloning it. The default backend uses `codedb.codegraff.com`; `backend="wiki"` uses `api.wiki.codes` for code intelligence plus dependency/security artifacts.
 
 ```
-# Get the file tree of an external repo
+# Get the file tree of an external repo via the default backend
 codedb_remote repo="vercel/next.js" action="tree"
 
 # Search for code in a dependency
 codedb_remote repo="justrach/merjs" action="search" query="handleRequest"
 
-# Get symbol outlines
-codedb_remote repo="justrach/merjs" action="outline"
+# Exact symbol lookup through api.wiki.codes
+codedb_remote repo="justrach/codedb" backend="wiki" action="symbol" query="buildSnapshot"
 
-# Get repo metadata
-codedb_remote repo="justrach/merjs" action="meta"
+# Check dependency CVE evidence; scope can be runtime or all
+codedb_remote repo="axios/axios" backend="wiki" action="cves" scope="runtime"
+
+# Raw wiki slugs are accepted for repos that are indexed that way
+codedb_remote repo="chromium" backend="wiki" action="policy"
 ```
 
-**Actions:** `tree`, `outline`, `search`, `meta`
+**Default actions:** `tree`, `outline`, `search`, `meta`
 
-**Note:** This tool calls `codedb.codegraff.com` via HTTPS. No API key required. The service must be available for this tool to work.
+**Wiki actions:** `tree`, `outline`, `search`, `symbol`, `policy`, `deps`, `score`, `cves`, `commits`, `branches`, `dep-history`
+
+**Note:** This tool calls remote HTTPS services. No API key required. The selected service must be available for this tool to work.
 
 ### CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 >
 > codedb works and is used daily in production AI workflows, but:
 > - **Parser support** — Zig, C/C++, Python, TypeScript/JavaScript, Rust, Go, PHP, Ruby, HCL, R, Dart/Flutter
-> - **Language detection** — also tags Java, Kotlin, Svelte, Vue, Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen files in trees/snapshots
+> - **Lightweight outline support** — Java, Kotlin, Svelte, Vue, Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen
 > - **No auth** — HTTP server binds to localhost only
 > - **Snapshot format** may change between versions
 > - **MCP protocol** is JSON-RPC 2.0 over stdio (stable)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ JSON-RPC 2.0 over stdio with Content-Length framing. Implements the Model Contex
 | `codedb_status` | Index status |
 | `codedb_snapshot` | Full snapshot |
 | `codedb_bundle` | Batch multiple queries (max 20 ops) |
-| `codedb_remote` | Query GitHub repos via codedb.codegraff.com |
+| `codedb_remote` | Query GitHub repos via codedb.codegraff.com or api.wiki.codes |
 | `codedb_projects` | List locally indexed projects |
 | `codedb_index` | Index a local folder |
 **Safety:** path validation, oversized message handling (drains >1MB lines instead of killing the loop).

--- a/scripts/compare-bench.py
+++ b/scripts/compare-bench.py
@@ -28,18 +28,28 @@ def pct_change(base_ns: int, head_ns: int) -> float:
     return ((head_ns - base_ns) / base_ns) * 100.0
 
 
-def render_markdown(rows: list[tuple[str, int, int, float]], threshold_pct: float) -> str:
+def status_for(delta_pct: float, abs_delta_ns: int, threshold_pct: float, min_abs_ns: int) -> str:
+    if delta_pct <= threshold_pct:
+        return "OK"
+    if abs_delta_ns <= min_abs_ns:
+        return "NOISE"
+    return "FAIL"
+
+
+def render_markdown(rows: list[tuple[str, int, int, float, int]], threshold_pct: float, min_abs_ns: int) -> str:
     lines = [
         "## Benchmark Regression Report",
         "",
-        f"Threshold: {threshold_pct:.2f}%",
+        f"Thresholds: {threshold_pct:.2f}% and {min_abs_ns:,} ns absolute delta",
         "",
-        "| Tool | Base (ns) | Head (ns) | Delta | Status |",
-        "| --- | ---: | ---: | ---: | --- |",
+        "`NOISE` means the percentage threshold was exceeded, but the absolute delta was too small to fail CI.",
+        "",
+        "| Tool | Base (ns) | Head (ns) | Delta | Abs Delta (ns) | Status |",
+        "| --- | ---: | ---: | ---: | ---: | --- |",
     ]
-    for tool, base_ns, head_ns, delta in rows:
-        status = "FAIL" if delta > threshold_pct else "OK"
-        lines.append(f"| `{tool}` | {base_ns} | {head_ns} | {delta:+.2f}% | {status} |")
+    for tool, base_ns, head_ns, delta, abs_delta in rows:
+        status = status_for(delta, abs_delta, threshold_pct, min_abs_ns)
+        lines.append(f"| `{tool}` | {base_ns} | {head_ns} | {delta:+.2f}% | {abs_delta:+d} | {status} |")
     return "\n".join(lines) + "\n"
 
 
@@ -57,7 +67,7 @@ def main() -> int:
         return 1
     common = sorted(set(base) & set(head))
 
-    rows: list[tuple[str, int, int, float]] = []
+    rows: list[tuple[str, int, int, float, int]] = []
     failures: list[str] = []
 
     for tool in common:
@@ -65,13 +75,13 @@ def main() -> int:
         head_ns = int(head[tool]["avg_latency_ns"])
         delta = pct_change(base_ns, head_ns)
         abs_delta = head_ns - base_ns
-        rows.append((tool, base_ns, head_ns, delta))
+        rows.append((tool, base_ns, head_ns, delta, abs_delta))
         # Only flag as regression if BOTH percentage AND absolute delta exceed thresholds
         # This prevents false positives on fast tools where CI noise dominates
         if delta > args.threshold_pct and abs_delta > args.min_abs_ns:
-            failures.append(f"{tool} regressed by {delta:.2f}%")
+            failures.append(f"{tool} regressed by {delta:.2f}% ({abs_delta:+d} ns)")
 
-    report = render_markdown(rows, args.threshold_pct)
+    report = render_markdown(rows, args.threshold_pct, args.min_abs_ns)
     sys.stdout.write(report)
 
     if args.markdown_out:

--- a/scripts/test_compare_bench.py
+++ b/scripts/test_compare_bench.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("compare-bench.py")
+spec = importlib.util.spec_from_file_location("compare_bench", SCRIPT)
+assert spec is not None
+compare_bench = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(compare_bench)
+
+
+class CompareBenchTests(unittest.TestCase):
+    def test_small_absolute_regression_is_noise(self) -> None:
+        self.assertEqual(compare_bench.status_for(22.54, 11_399, 10.0, 50_000), "NOISE")
+
+    def test_large_absolute_regression_fails(self) -> None:
+        self.assertEqual(compare_bench.status_for(12.0, 75_000, 10.0, 50_000), "FAIL")
+
+    def test_report_explains_noise_status(self) -> None:
+        report = compare_bench.render_markdown(
+            [("codedb_read", 50_580, 61_979, 22.54, 11_399)],
+            10.0,
+            50_000,
+        )
+        self.assertIn("50,000 ns absolute delta", report)
+        self.assertIn("| `codedb_read` | 50580 | 61979 | +22.54% | +11399 | NOISE |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -105,7 +105,10 @@ pub const Language = enum(u8) {
 pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".zig")) return .zig;
     if (std.mem.endsWith(u8, path, ".c") or std.mem.endsWith(u8, path, ".h")) return .c;
-    if (std.mem.endsWith(u8, path, ".cpp") or std.mem.endsWith(u8, path, ".hpp")) return .cpp;
+    if (std.mem.endsWith(u8, path, ".cpp") or std.mem.endsWith(u8, path, ".hpp") or
+        std.mem.endsWith(u8, path, ".cc") or std.mem.endsWith(u8, path, ".hh") or
+        std.mem.endsWith(u8, path, ".cxx") or std.mem.endsWith(u8, path, ".hxx"))
+        return .cpp;
     if (std.mem.endsWith(u8, path, ".py")) return .python;
     if (std.mem.endsWith(u8, path, ".js") or std.mem.endsWith(u8, path, ".jsx")) return .javascript;
     if (std.mem.endsWith(u8, path, ".ts") or std.mem.endsWith(u8, path, ".tsx")) return .typescript;
@@ -862,6 +865,8 @@ pub const Explorer = struct {
                 try parser.parsePythonLine(trimmed, line_num, &outline);
             } else if (outline.language == .typescript or outline.language == .javascript) {
                 try parser.parseTsLine(trimmed, line_num, &outline);
+            } else if (outline.language == .c or outline.language == .cpp) {
+                try parser.parseCLine(trimmed, line_num, &outline);
             } else if (outline.language == .rust) {
                 try parser.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
             } else if (outline.language == .php) {
@@ -1869,6 +1874,39 @@ pub const Explorer = struct {
                 errdefer a.free(import_copy);
                 try outline.imports.append(a, import_copy);
             }
+        }
+    }
+
+    fn parseCLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "#include")) {
+            if (extractCIncludePath(line)) |path| {
+                const import_copy = try a.dupe(u8, path);
+                errdefer a.free(import_copy);
+                try outline.imports.append(a, import_copy);
+            }
+            try appendOutlineSymbol(a, outline, line, .import, line_num, line);
+            return;
+        }
+
+        if (startsWith(line, "#define")) {
+            const rest = std.mem.trimStart(u8, line["#define".len..], " \t");
+            if (extractIdent(rest)) |name| {
+                try appendOutlineSymbol(a, outline, name, .macro_def, line_num, line);
+            }
+            return;
+        }
+
+        if (parseCNamedType(line)) |type_sym| {
+            try appendOutlineSymbol(a, outline, type_sym.name, type_sym.kind, line_num, line);
+            return;
+        }
+
+        if (extractCFunctionName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
         }
     }
 
@@ -3535,6 +3573,27 @@ fn startsWith(haystack: []const u8, needle: []const u8) bool {
     return std.mem.startsWith(u8, haystack, needle);
 }
 
+fn appendOutlineSymbol(
+    allocator: std.mem.Allocator,
+    outline: *FileOutline,
+    name: []const u8,
+    kind: SymbolKind,
+    line_num: u32,
+    detail: []const u8,
+) !void {
+    const name_copy = try allocator.dupe(u8, name);
+    errdefer allocator.free(name_copy);
+    const detail_copy = try allocator.dupe(u8, detail);
+    errdefer allocator.free(detail_copy);
+    try outline.symbols.append(allocator, .{
+        .name = name_copy,
+        .kind = kind,
+        .line_start = line_num,
+        .line_end = line_num,
+        .detail = detail_copy,
+    });
+}
+
 fn extractIdent(s: []const u8) ?[]const u8 {
     const max_ident_len: usize = 256;
     var end: usize = 0;
@@ -3547,7 +3606,13 @@ fn extractIdent(s: []const u8) ?[]const u8 {
     return if (end > 0) s[0..end] else null;
 }
 
-fn extractLastIdent(s: []const u8) ?[]const u8 {
+const IdentSpan = struct {
+    text: []const u8,
+    start: usize,
+    end: usize,
+};
+
+fn extractLastIdentSpan(s: []const u8) ?IdentSpan {
     if (s.len == 0) return null;
 
     var end = s.len;
@@ -3564,7 +3629,148 @@ fn extractLastIdent(s: []const u8) ?[]const u8 {
         if (!(std.ascii.isAlphanumeric(ch) or ch == '_')) break;
         start -= 1;
     }
-    return s[start..end];
+    return .{ .text = s[start..end], .start = start, .end = end };
+}
+
+fn extractLastIdent(s: []const u8) ?[]const u8 {
+    return if (extractLastIdentSpan(s)) |span| span.text else null;
+}
+
+fn stripLineComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "//")) return "";
+    if (std.mem.indexOf(u8, trimmed, "//")) |pos| {
+        return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    }
+    return trimmed;
+}
+
+fn extractCIncludePath(line: []const u8) ?[]const u8 {
+    const rest = std.mem.trimStart(u8, line["#include".len..], " \t");
+    if (rest.len >= 2 and rest[0] == '<') {
+        if (std.mem.indexOfScalar(u8, rest[1..], '>')) |end| {
+            if (end == 0) return null;
+            return rest[1 .. end + 1];
+        }
+    }
+    return extractStringLiteral(rest);
+}
+
+const CTypeSymbol = struct {
+    name: []const u8,
+    kind: SymbolKind,
+};
+
+fn parseCNamedType(line: []const u8) ?CTypeSymbol {
+    const stripped = stripCAttributesPrefix(line);
+    if (startsWith(stripped, "typedef ")) {
+        const rest = std.mem.trimStart(u8, stripped["typedef ".len..], " \t");
+        if (parseCBraceType(rest)) |sym| return sym;
+        if (std.mem.indexOf(u8, rest, "(*") != null) return null;
+        if (std.mem.indexOfScalar(u8, rest, ';')) |semi| {
+            const before_semi = rest[0..semi];
+            if (extractLastIdent(before_semi)) |name| {
+                if (!isCKeyword(name)) return .{ .name = name, .kind = .type_alias };
+            }
+        }
+        return null;
+    }
+    return parseCBraceType(stripped);
+}
+
+fn parseCBraceType(line: []const u8) ?CTypeSymbol {
+    if (std.mem.indexOfScalar(u8, line, '{') == null) return null;
+    if (startsWith(line, "struct ")) {
+        return parseCTypeAfterKeyword(line["struct ".len..], .struct_def);
+    }
+    if (startsWith(line, "enum ")) {
+        return parseCTypeAfterKeyword(line["enum ".len..], .enum_def);
+    }
+    if (startsWith(line, "union ")) {
+        return parseCTypeAfterKeyword(line["union ".len..], .union_def);
+    }
+    return null;
+}
+
+fn parseCTypeAfterKeyword(rest: []const u8, kind: SymbolKind) ?CTypeSymbol {
+    const trimmed = std.mem.trimStart(u8, rest, " \t");
+    if (trimmed.len == 0 or trimmed[0] == '{') return null;
+    if (extractIdent(trimmed)) |name| {
+        if (!isCKeyword(name)) return .{ .name = name, .kind = kind };
+    }
+    return null;
+}
+
+fn extractCFunctionName(line: []const u8) ?[]const u8 {
+    const stripped = stripCAttributesPrefix(line);
+    if (stripped.len == 0 or stripped[0] == '#') return null;
+    if (startsWith(stripped, "typedef ")) return null;
+    if (std.mem.indexOfScalar(u8, stripped, ';') != null) return null;
+
+    const search_end = std.mem.indexOfScalar(u8, stripped, '{') orelse stripped.len;
+    if (search_end == 0) return null;
+    const signature = std.mem.trimEnd(u8, stripped[0..search_end], " \t");
+    const open_paren = std.mem.lastIndexOfScalar(u8, signature, '(') orelse return null;
+    if (std.mem.indexOfScalar(u8, signature[open_paren..], ')') == null) return null;
+    if (std.mem.indexOf(u8, signature, "(*") != null) return null;
+
+    const before_paren = std.mem.trimEnd(u8, signature[0..open_paren], " \t");
+    const span = extractLastIdentSpan(before_paren) orelse return null;
+    const name = span.text;
+    if (isCKeyword(name)) return null;
+
+    const before_name = std.mem.trim(u8, before_paren[0..span.start], " \t*(&");
+    if (before_name.len == 0) return null;
+    if (hasCAssignmentBeforeName(before_name)) return null;
+    if (isCForbiddenFunctionPrefix(before_name)) return null;
+    if (std.mem.endsWith(u8, before_name, ".") or std.mem.endsWith(u8, before_name, "->")) return null;
+
+    return name;
+}
+
+fn stripCAttributesPrefix(line: []const u8) []const u8 {
+    var rest = std.mem.trimStart(u8, line, " \t");
+    while (startsWith(rest, "__attribute__((")) {
+        if (std.mem.indexOf(u8, rest, "))")) |end| {
+            rest = std.mem.trimStart(u8, rest[end + 2 ..], " \t");
+        } else break;
+    }
+    return rest;
+}
+
+fn hasCAssignmentBeforeName(prefix: []const u8) bool {
+    for (prefix, 0..) |ch, i| {
+        if (ch != '=') continue;
+        const prev = if (i > 0) prefix[i - 1] else 0;
+        const next = if (i + 1 < prefix.len) prefix[i + 1] else 0;
+        if (prev == '=' or prev == '!' or prev == '<' or prev == '>' or next == '=') continue;
+        return true;
+    }
+    return false;
+}
+
+fn isCForbiddenFunctionPrefix(prefix: []const u8) bool {
+    const first = extractIdent(std.mem.trimStart(u8, prefix, " \t*(&")) orelse return false;
+    return std.mem.eql(u8, first, "return") or
+        std.mem.eql(u8, first, "case") or
+        std.mem.eql(u8, first, "sizeof") or
+        std.mem.eql(u8, first, "if") or
+        std.mem.eql(u8, first, "for") or
+        std.mem.eql(u8, first, "while") or
+        std.mem.eql(u8, first, "switch");
+}
+
+fn isCKeyword(s: []const u8) bool {
+    const keywords = [_][]const u8{
+        "if",       "for",      "while",  "switch", "return",   "sizeof",
+        "case",     "do",       "else",   "struct", "enum",     "union",
+        "typedef",  "static",   "extern", "inline", "const",    "volatile",
+        "register", "restrict", "auto",   "break",  "continue",
+    };
+    for (keywords) |kw| {
+        if (std.mem.eql(u8, s, kw)) return true;
+    }
+    return false;
 }
 
 fn firstIndexOfAny(s: []const u8, chars: []const u8) ?usize {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1256,7 +1256,33 @@ pub const Explorer = struct {
         var result_list: std.ArrayList(SymbolResult) = .empty;
         errdefer result_list.deinit(allocator);
 
-        // Scan outlines for all symbols by name (catches all kinds including imports).
+        // O(1) lookup via symbol_index (all kinds are indexed).
+        if (self.symbol_index.get(name)) |locs| {
+            for (locs.items) |loc| {
+                var detail: ?[]const u8 = null;
+                if (self.outlines.getPtr(loc.path)) |outline| {
+                    for (outline.symbols.items) |sym| {
+                        if (sym.line_start == loc.line_start and std.mem.eql(u8, sym.name, name)) {
+                            detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null;
+                            break;
+                        }
+                    }
+                }
+                try result_list.append(allocator, .{
+                    .path = try allocator.dupe(u8, loc.path),
+                    .symbol = .{
+                        .name = try allocator.dupe(u8, name),
+                        .kind = loc.kind,
+                        .line_start = loc.line_start,
+                        .line_end = loc.line_end,
+                        .detail = detail,
+                    },
+                });
+            }
+            return result_list.toOwnedSlice(allocator);
+        }
+
+        // Fallback: scan outlines (kept for safety; with complete indexing above this is rare).
         var iter = self.outlines.iterator();
         while (iter.next()) |entry| {
             for (entry.value_ptr.symbols.items) |sym| {
@@ -2684,7 +2710,6 @@ pub const Explorer = struct {
     fn rebuildSymbolIndexFor(self: *Explorer, path: []const u8, outline: *FileOutline) void {
         self.removeSymbolIndexFor(path);
         for (outline.symbols.items) |sym| {
-            if (sym.kind == .import or sym.kind == .comment_block) continue;
             const gop = self.symbol_index.getOrPut(sym.name) catch continue;
             if (!gop.found_existing) {
                 gop.value_ptr.* = std.ArrayList(SymbolLocation).empty;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2159,7 +2159,7 @@ pub const Explorer = struct {
         const line = stripLineComment(raw_line);
         if (line.len == 0) return;
 
-        if (startsWith(line, "#include")) {
+        if (startsWith(line, "#include") or startsWith(line, "#import")) {
             if (extractCIncludePath(line)) |path| {
                 const import_copy = try a.dupe(u8, path);
                 errdefer a.free(import_copy);
@@ -2174,6 +2174,16 @@ pub const Explorer = struct {
             if (extractIdent(rest)) |name| {
                 try appendOutlineSymbol(a, outline, name, .macro_def, line_num, line);
             }
+            return;
+        }
+
+        if (parseObjCType(line)) |type_sym| {
+            try appendOutlineSymbol(a, outline, type_sym.name, type_sym.kind, line_num, line);
+            return;
+        }
+
+        if (extractObjCMethodName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
             return;
         }
 
@@ -4144,7 +4154,13 @@ fn stripLineComment(raw_line: []const u8) []const u8 {
 }
 
 fn extractCIncludePath(line: []const u8) ?[]const u8 {
-    const rest = std.mem.trimStart(u8, line["#include".len..], " \t");
+    const keyword = if (startsWith(line, "#include"))
+        "#include"
+    else if (startsWith(line, "#import"))
+        "#import"
+    else
+        return null;
+    const rest = std.mem.trimStart(u8, line[keyword.len..], " \t");
     if (rest.len >= 2 and rest[0] == '<') {
         if (std.mem.indexOfScalar(u8, rest[1..], '>')) |end| {
             if (end == 0) return null;
@@ -4178,6 +4194,9 @@ fn parseCNamedType(line: []const u8) ?CTypeSymbol {
 
 fn parseCBraceType(line: []const u8) ?CTypeSymbol {
     if (std.mem.indexOfScalar(u8, line, '{') == null) return null;
+    if (startsWith(line, "class ")) {
+        return parseCTypeAfterKeyword(line["class ".len..], .class_def);
+    }
     if (startsWith(line, "struct ")) {
         return parseCTypeAfterKeyword(line["struct ".len..], .struct_def);
     }
@@ -4197,6 +4216,26 @@ fn parseCTypeAfterKeyword(rest: []const u8, kind: SymbolKind) ?CTypeSymbol {
         if (!isCKeyword(name)) return .{ .name = name, .kind = kind };
     }
     return null;
+}
+
+fn parseObjCType(line: []const u8) ?CTypeSymbol {
+    if (startsWith(line, "@interface ")) {
+        return parseCTypeAfterKeyword(line["@interface ".len..], .class_def);
+    }
+    if (startsWith(line, "@implementation ")) {
+        return parseCTypeAfterKeyword(line["@implementation ".len..], .class_def);
+    }
+    if (startsWith(line, "@protocol ")) {
+        return parseCTypeAfterKeyword(line["@protocol ".len..], .interface_def);
+    }
+    return null;
+}
+
+fn extractObjCMethodName(line: []const u8) ?[]const u8 {
+    if (!startsWith(line, "- (") and !startsWith(line, "+ (")) return null;
+    const close = std.mem.indexOfScalar(u8, line, ')') orelse return null;
+    const rest = std.mem.trimStart(u8, line[close + 1 ..], " \t*");
+    return extractIdent(rest);
 }
 
 fn extractCFunctionName(line: []const u8) ?[]const u8 {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1256,7 +1256,19 @@ pub const Explorer = struct {
         var result_list: std.ArrayList(SymbolResult) = .empty;
         errdefer result_list.deinit(allocator);
 
-        // O(1) lookup via symbol_index (all kinds are indexed).
+        // Track (path, line_start) pairs already appended. symbol_index can be
+        // incomplete after fast-snapshot restore (outlines are populated before
+        // rebuildSymbolIndexFor runs on every file), so we must still fall
+        // through to the outline scan — and dedupe against what the index
+        // already supplied. Keys are "<path>:<line>" allocated from the caller
+        // allocator, freed at end of call.
+        var seen = std.StringHashMap(void).init(allocator);
+        defer {
+            var sit = seen.keyIterator();
+            while (sit.next()) |k| allocator.free(k.*);
+            seen.deinit();
+        }
+
         if (self.symbol_index.get(name)) |locs| {
             for (locs.items) |loc| {
                 var detail: ?[]const u8 = null;
@@ -1278,26 +1290,29 @@ pub const Explorer = struct {
                         .detail = detail,
                     },
                 });
+                const key = try std.fmt.allocPrint(allocator, "{s}:{d}", .{ loc.path, loc.line_start });
+                seen.put(key, {}) catch allocator.free(key);
             }
-            return result_list.toOwnedSlice(allocator);
         }
 
-        // Fallback: scan outlines (kept for safety; with complete indexing above this is rare).
+        // Safety scan: append any outline symbols the index missed.
         var iter = self.outlines.iterator();
         while (iter.next()) |entry| {
             for (entry.value_ptr.symbols.items) |sym| {
-                if (std.mem.eql(u8, sym.name, name)) {
-                    try result_list.append(allocator, .{
-                        .path = try allocator.dupe(u8, entry.key_ptr.*),
-                        .symbol = .{
-                            .name = try allocator.dupe(u8, sym.name),
-                            .kind = sym.kind,
-                            .line_start = sym.line_start,
-                            .line_end = sym.line_end,
-                            .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
-                        },
-                    });
-                }
+                if (!std.mem.eql(u8, sym.name, name)) continue;
+                var key_buf: [std.fs.max_path_bytes + 32]u8 = undefined;
+                const key = std.fmt.bufPrint(&key_buf, "{s}:{d}", .{ entry.key_ptr.*, sym.line_start }) catch continue;
+                if (seen.contains(key)) continue;
+                try result_list.append(allocator, .{
+                    .path = try allocator.dupe(u8, entry.key_ptr.*),
+                    .symbol = .{
+                        .name = try allocator.dupe(u8, sym.name),
+                        .kind = sym.kind,
+                        .line_start = sym.line_start,
+                        .line_end = sym.line_end,
+                        .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
+                    },
+                });
             }
         }
         return result_list.toOwnedSlice(allocator);

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -641,7 +641,12 @@ pub const Explorer = struct {
             outline.language == .cpp or outline.language == .typescript or
             outline.language == .javascript or outline.language == .rust or
             outline.language == .go_lang or outline.language == .php or
-            outline.language == .dart;
+            outline.language == .dart or outline.language == .java or
+            outline.language == .kotlin or outline.language == .svelte or
+            outline.language == .vue or outline.language == .astro or
+            outline.language == .css or outline.language == .scss or
+            outline.language == .protobuf or outline.language == .mlir or
+            outline.language == .tablegen;
 
         for (outline.symbols.items) |*sym| {
             // Skip single-line kinds
@@ -866,7 +871,12 @@ pub const Explorer = struct {
                 outline.language == .go_lang or outline.language == .c or
                 outline.language == .cpp or outline.language == .rust or
                 outline.language == .zig or outline.language == .hcl or
-                outline.language == .dart)
+                outline.language == .dart or outline.language == .java or
+                outline.language == .kotlin or outline.language == .svelte or
+                outline.language == .vue or outline.language == .astro or
+                outline.language == .css or outline.language == .scss or
+                outline.language == .protobuf or outline.language == .mlir or
+                outline.language == .tablegen)
             {
                 if (in_block_comment) {
                     if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
@@ -930,6 +940,28 @@ pub const Explorer = struct {
                 try parser.parseHclLine(trimmed, line_num, &outline);
             } else if (outline.language == .r) {
                 try parser.parseRLine(trimmed, line_num, &outline);
+            } else if (outline.language == .java) {
+                try parser.parseJavaLine(trimmed, line_num, &outline);
+            } else if (outline.language == .kotlin) {
+                try parser.parseKotlinLine(trimmed, line_num, &outline);
+            } else if (outline.language == .svelte or outline.language == .vue or outline.language == .astro) {
+                try parser.parseComponentLine(trimmed, line_num, &outline);
+            } else if (outline.language == .shell) {
+                try parser.parseShellLine(trimmed, line_num, &outline);
+            } else if (outline.language == .css or outline.language == .scss) {
+                try parser.parseStyleLine(trimmed, line_num, &outline);
+            } else if (outline.language == .sql) {
+                try parser.parseSqlLine(trimmed, line_num, &outline);
+            } else if (outline.language == .protobuf) {
+                try parser.parseProtoLine(trimmed, line_num, &outline);
+            } else if (outline.language == .fortran) {
+                try parser.parseFortranLine(trimmed, line_num, &outline);
+            } else if (outline.language == .llvm_ir) {
+                try parser.parseLlvmIrLine(trimmed, line_num, &outline);
+            } else if (outline.language == .mlir) {
+                try parser.parseMlirLine(trimmed, line_num, &outline);
+            } else if (outline.language == .tablegen) {
+                try parser.parseTableGenLine(trimmed, line_num, &outline);
             }
 
             prev_line_trimmed = trimmed;
@@ -1872,8 +1904,19 @@ pub const Explorer = struct {
     }
     fn parseTsLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
         const a = self.allocator;
-        if (containsAny(line, &.{ "function ", "const ", "export function ", "export const " })) {
-            const kind: SymbolKind = if (std.mem.indexOf(u8, line, "function") != null) .function else .constant;
+        if (containsAny(line, &.{ "function ", "const ", "let ", "var ", "class ", "interface ", "enum ", "type " })) {
+            const kind: SymbolKind = if (std.mem.indexOf(u8, line, "function") != null)
+                .function
+            else if (std.mem.indexOf(u8, line, "class ") != null)
+                .class_def
+            else if (std.mem.indexOf(u8, line, "interface ") != null)
+                .interface_def
+            else if (std.mem.indexOf(u8, line, "enum ") != null)
+                .enum_def
+            else if (std.mem.indexOf(u8, line, "type ") != null)
+                .type_alias
+            else
+                .constant;
             const trimmed = skipKeywords(line);
             if (extractIdent(trimmed)) |name| {
                 const name_copy = try a.dupe(u8, name);
@@ -1903,6 +1946,211 @@ pub const Explorer = struct {
                 errdefer a.free(import_copy);
                 try outline.imports.append(a, import_copy);
             }
+        }
+    }
+
+    fn parseJavaLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0 or startsWith(line, "@")) return;
+
+        if (parseDelimitedImport(line, "import ", ";")) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+
+        if (extractIdentAfterKeyword(line, "record ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "interface ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "enum ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractJvmMethodName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
+        }
+    }
+
+    fn parseKotlinLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0 or startsWith(line, "@")) return;
+
+        if (parseDelimitedImport(line, "import ", "")) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+
+        if (extractIdentAfterKeyword(line, "enum class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "interface ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "object ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "fun ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "val ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "var ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        }
+    }
+
+    fn parseComponentLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "<!--") or startsWith(line, "<script") or startsWith(line, "</script") or
+            startsWith(line, "<style") or startsWith(line, "</style"))
+            return;
+        if (startsWith(line, ".") or startsWith(line, "#") or startsWith(line, "@keyframes") or startsWith(line, "$") or startsWith(line, "--")) {
+            try self.parseStyleLine(line, line_num, outline);
+            return;
+        }
+        try self.parseTsLine(line, line_num, outline);
+    }
+
+    fn parseShellLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "#")) return;
+
+        if (startsWith(line, "source ")) {
+            const imp = firstShellWord(line["source ".len..]) orelse return;
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+        if (startsWith(line, ". ")) {
+            const imp = firstShellWord(line[2..]) orelse return;
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+        if (extractIdentAfterKeyword(line, "function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+            return;
+        }
+        if (std.mem.indexOf(u8, line, "()")) |pos| {
+            const before = std.mem.trim(u8, line[0..pos], " \t");
+            if (extractIdent(before)) |name| {
+                if (name.len == before.len) try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+            }
+            return;
+        }
+        if (parseShellAssignment(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        }
+    }
+
+    fn parseStyleLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "/*") or startsWith(line, "*")) return;
+
+        if (extractIdentAfterKeyword(line, "@keyframes ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "@mixin ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "@function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (parseCssVariable(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (parseCssSelector(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        }
+    }
+
+    fn parseSqlLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripSqlLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (parseSqlCreate(line)) |sym| {
+            try appendOutlineSymbol(a, outline, sym.name, sym.kind, line_num, line);
+        }
+    }
+
+    fn parseProtoLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "import ")) {
+            if (extractStringLiteral(line)) |imp| try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "message ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "enum ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "service ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "rpc ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
+        }
+    }
+
+    fn parseFortranLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripFortranComment(raw_line);
+        if (line.len == 0) return;
+
+        if (parseFortranUse(line)) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "module ")) |name| {
+            if (!startsWithIgnoreCase(line, "module procedure ")) try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "program ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "subroutine ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (parseFortranTypeName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+        }
+    }
+
+    fn parseLlvmIrLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, ";")) return;
+
+        if (startsWith(line, "define ") or startsWith(line, "declare ")) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (line[0] == '@') {
+            if (extractLlvmGlobalName(line)) |name| try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        } else if (line[0] == '%' and std.mem.indexOf(u8, line, " = type") != null) {
+            if (extractLlvmGlobalName(line)) |name| try appendOutlineSymbol(a, outline, name, .type_alias, line_num, line);
+        }
+    }
+
+    fn parseMlirLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (std.mem.indexOf(u8, line, "module @") != null) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (std.mem.indexOf(u8, line, "func") != null and std.mem.indexOfScalar(u8, line, '@') != null) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        }
+    }
+
+    fn parseTableGenLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "include ")) {
+            if (extractStringLiteral(line)) |imp| try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "defm ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "def ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "multiclass ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "let ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
         }
     }
 
@@ -3629,6 +3877,19 @@ fn appendOutlineSymbol(
     });
 }
 
+fn appendImportSymbol(
+    allocator: std.mem.Allocator,
+    outline: *FileOutline,
+    import_path: []const u8,
+    line_num: u32,
+    detail: []const u8,
+) !void {
+    try appendOutlineSymbol(allocator, outline, import_path, .import, line_num, detail);
+    const import_copy = try allocator.dupe(u8, import_path);
+    errdefer allocator.free(import_copy);
+    try outline.imports.append(allocator, import_copy);
+}
+
 fn extractIdent(s: []const u8) ?[]const u8 {
     const max_ident_len: usize = 256;
     var end: usize = 0;
@@ -3637,6 +3898,208 @@ fn extractIdent(s: []const u8) ?[]const u8 {
         if (std.ascii.isAlphanumeric(ch) or ch == '_') {
             end += 1;
         } else break;
+    }
+    return if (end > 0) s[0..end] else null;
+}
+
+fn isIdentChar(ch: u8) bool {
+    return std.ascii.isAlphanumeric(ch) or ch == '_';
+}
+
+fn extractIdentAfterKeyword(line: []const u8, keyword: []const u8) ?[]const u8 {
+    var start: usize = 0;
+    while (std.mem.indexOfPos(u8, line, start, keyword)) |pos| {
+        if (pos > 0 and isIdentChar(line[pos - 1])) {
+            start = pos + 1;
+            continue;
+        }
+        return extractIdent(std.mem.trimStart(u8, line[pos + keyword.len ..], " \t"));
+    }
+    return null;
+}
+
+fn extractIdentAfterKeywordIgnoreCase(line: []const u8, keyword: []const u8) ?[]const u8 {
+    if (indexOfCaseInsensitive(line, keyword)) |pos| {
+        if (pos > 0 and isIdentChar(line[pos - 1])) return null;
+        return extractIdent(std.mem.trimStart(u8, line[pos + keyword.len ..], " \t"));
+    }
+    return null;
+}
+
+fn startsWithIgnoreCase(s: []const u8, prefix: []const u8) bool {
+    if (s.len < prefix.len) return false;
+    for (prefix, 0..) |p, i| {
+        if (std.ascii.toLower(s[i]) != std.ascii.toLower(p)) return false;
+    }
+    return true;
+}
+
+fn parseDelimitedImport(line: []const u8, prefix: []const u8, delimiter: []const u8) ?[]const u8 {
+    if (!startsWith(line, prefix)) return null;
+    var body = std.mem.trim(u8, line[prefix.len..], " \t;");
+    if (startsWith(body, "static ")) body = std.mem.trimStart(u8, body["static ".len..], " \t");
+    if (delimiter.len > 0) {
+        if (std.mem.indexOf(u8, body, delimiter)) |end| body = body[0..end];
+    }
+    body = std.mem.trim(u8, body, " \t;");
+    return if (body.len > 0) body else null;
+}
+
+fn extractJvmMethodName(line: []const u8) ?[]const u8 {
+    if (startsWith(line, "import ") or startsWith(line, "package ") or startsWith(line, "return ") or
+        startsWith(line, "throw ") or startsWith(line, "new "))
+        return null;
+    if (std.mem.indexOf(u8, line, " class ") != null or std.mem.indexOf(u8, line, " interface ") != null or
+        std.mem.indexOf(u8, line, " enum ") != null or std.mem.indexOf(u8, line, " record ") != null)
+        return null;
+    const open = std.mem.lastIndexOfScalar(u8, line, '(') orelse return null;
+    if (std.mem.indexOfScalar(u8, line[open..], ')') == null) return null;
+    const before = std.mem.trimEnd(u8, line[0..open], " \t");
+    const span = extractLastIdentSpan(before) orelse return null;
+    const name = span.text;
+    if (isControlKeyword(name)) return null;
+    const before_name = std.mem.trim(u8, before[0..span.start], " \t");
+    if (before_name.len == 0) return null;
+    if (std.mem.endsWith(u8, before_name, ".") or std.mem.endsWith(u8, before_name, "->") or
+        std.mem.endsWith(u8, before_name, "="))
+        return null;
+    return name;
+}
+
+fn isControlKeyword(name: []const u8) bool {
+    const keywords = [_][]const u8{ "if", "for", "while", "switch", "catch", "return", "throw", "new", "when" };
+    for (keywords) |kw| {
+        if (std.mem.eql(u8, name, kw)) return true;
+    }
+    return false;
+}
+
+fn firstShellWord(s: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trimStart(u8, s, " \t");
+    if (trimmed.len == 0) return null;
+    var end: usize = 0;
+    while (end < trimmed.len and trimmed[end] != ' ' and trimmed[end] != '\t' and trimmed[end] != ';') : (end += 1) {}
+    return if (end > 0) trimmed[0..end] else null;
+}
+
+fn parseShellAssignment(line: []const u8) ?[]const u8 {
+    const eq = std.mem.indexOfScalar(u8, line, '=') orelse return null;
+    if (eq == 0 or std.mem.indexOfAny(u8, line[0..eq], " \t$") != null) return null;
+    return extractIdent(line[0..eq]);
+}
+
+fn parseCssVariable(line: []const u8) ?[]const u8 {
+    if (startsWith(line, "$")) {
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| return line[0..colon];
+    }
+    if (startsWith(line, "--")) {
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| return line[0..colon];
+    }
+    return null;
+}
+
+fn parseCssSelector(line: []const u8) ?[]const u8 {
+    if (std.mem.indexOfScalar(u8, line, '{') == null) return null;
+    if (line.len < 2 or (line[0] != '.' and line[0] != '#')) return null;
+    var end: usize = 1;
+    while (end < line.len) : (end += 1) {
+        const ch = line[end];
+        if (!(std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-')) break;
+    }
+    return if (end > 1) line[0..end] else null;
+}
+
+fn stripSqlLineComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "--")) return "";
+    if (std.mem.indexOf(u8, trimmed, "--")) |pos| return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    return trimmed;
+}
+
+const SqlSymbol = struct {
+    name: []const u8,
+    kind: SymbolKind,
+};
+
+fn parseSqlCreate(line: []const u8) ?SqlSymbol {
+    if (!startsWithIgnoreCase(line, "create ")) return null;
+    var rest = std.mem.trimStart(u8, line["create ".len..], " \t");
+    if (startsWithIgnoreCase(rest, "or replace ")) rest = std.mem.trimStart(u8, rest["or replace ".len..], " \t");
+    if (parseSqlCreateKind(rest, "table ", .struct_def)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "view ", .struct_def)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "index ", .constant)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "function ", .function)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "procedure ", .function)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "trigger ", .method)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "type ", .type_alias)) |sym| return sym;
+    return null;
+}
+
+fn parseSqlCreateKind(rest: []const u8, keyword: []const u8, kind: SymbolKind) ?SqlSymbol {
+    if (!startsWithIgnoreCase(rest, keyword)) return null;
+    var body = std.mem.trimStart(u8, rest[keyword.len..], " \t");
+    if (startsWithIgnoreCase(body, "if not exists ")) body = std.mem.trimStart(u8, body["if not exists ".len..], " \t");
+    const name = firstSqlIdent(body) orelse return null;
+    return .{ .name = name, .kind = kind };
+}
+
+fn firstSqlIdent(s: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trimStart(u8, s, " \t\"`[");
+    if (trimmed.len == 0) return null;
+    var end: usize = 0;
+    while (end < trimmed.len and trimmed[end] != ' ' and trimmed[end] != '\t' and
+        trimmed[end] != '(' and trimmed[end] != ';' and trimmed[end] != '"' and
+        trimmed[end] != '`' and trimmed[end] != ']') : (end += 1)
+    {}
+    if (end == 0) return null;
+    const raw = trimmed[0..end];
+    if (std.mem.lastIndexOfScalar(u8, raw, '.')) |dot| {
+        if (dot + 1 < raw.len) return raw[dot + 1 ..];
+    }
+    return raw;
+}
+
+fn stripFortranComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "!")) return "";
+    if (std.mem.indexOfScalar(u8, trimmed, '!')) |pos| return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    return trimmed;
+}
+
+fn parseFortranUse(line: []const u8) ?[]const u8 {
+    if (!startsWithIgnoreCase(line, "use ")) return null;
+    var rest = std.mem.trimStart(u8, line[4..], " \t");
+    if (startsWithIgnoreCase(rest, "intrinsic")) return null;
+    if (std.mem.indexOf(u8, rest, "::")) |pos| rest = std.mem.trimStart(u8, rest[pos + 2 ..], " \t");
+    return extractIdent(rest);
+}
+
+fn parseFortranTypeName(line: []const u8) ?[]const u8 {
+    if (!startsWithIgnoreCase(line, "type")) return null;
+    const sep = std.mem.indexOf(u8, line, "::") orelse return null;
+    return extractIdent(std.mem.trimStart(u8, line[sep + 2 ..], " \t"));
+}
+
+fn extractAtName(line: []const u8) ?[]const u8 {
+    const at = std.mem.indexOfScalar(u8, line, '@') orelse return null;
+    return extractLlvmLikeName(line[at + 1 ..]);
+}
+
+fn extractLlvmGlobalName(line: []const u8) ?[]const u8 {
+    if (line.len == 0 or (line[0] != '@' and line[0] != '%')) return null;
+    return extractLlvmLikeName(line[1..]);
+}
+
+fn extractLlvmLikeName(s: []const u8) ?[]const u8 {
+    if (s.len == 0) return null;
+    if (s[0] == '"') {
+        if (std.mem.indexOfScalar(u8, s[1..], '"')) |end| return s[1 .. end + 1];
+        return null;
+    }
+    var end: usize = 0;
+    while (end < s.len) : (end += 1) {
+        const ch = s[end];
+        if (!(std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-' or ch == '.' or ch == '$')) break;
     }
     return if (end > 0) s[0..end] else null;
 }
@@ -3882,7 +4345,7 @@ fn containsAny(s: []const u8, needles: []const []const u8) bool {
 }
 
 fn skipKeywords(s: []const u8) []const u8 {
-    const keywords = [_][]const u8{ "export ", "async ", "function ", "const ", "let ", "var " };
+    const keywords = [_][]const u8{ "export ", "default ", "async ", "abstract ", "function ", "class ", "interface ", "enum ", "type ", "const ", "let ", "var " };
     var result = s;
     for (keywords) |kw| {
         if (std.mem.startsWith(u8, result, kw)) {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -100,6 +100,20 @@ pub const Language = enum(u8) {
     yaml,
     unknown,
     dart,
+    java,
+    kotlin,
+    svelte,
+    vue,
+    astro,
+    shell,
+    css,
+    scss,
+    sql,
+    protobuf,
+    fortran,
+    llvm_ir,
+    mlir,
+    tablegen,
 };
 
 pub fn detectLanguage(path: []const u8) Language {
@@ -107,7 +121,8 @@ pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".c") or std.mem.endsWith(u8, path, ".h")) return .c;
     if (std.mem.endsWith(u8, path, ".cpp") or std.mem.endsWith(u8, path, ".hpp") or
         std.mem.endsWith(u8, path, ".cc") or std.mem.endsWith(u8, path, ".hh") or
-        std.mem.endsWith(u8, path, ".cxx") or std.mem.endsWith(u8, path, ".hxx"))
+        std.mem.endsWith(u8, path, ".cxx") or std.mem.endsWith(u8, path, ".hxx") or
+        std.mem.endsWith(u8, path, ".mm"))
         return .cpp;
     if (std.mem.endsWith(u8, path, ".py")) return .python;
     if (std.mem.endsWith(u8, path, ".js") or std.mem.endsWith(u8, path, ".jsx")) return .javascript;
@@ -122,6 +137,20 @@ pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".json")) return .json;
     if (std.mem.endsWith(u8, path, ".yaml") or std.mem.endsWith(u8, path, ".yml")) return .yaml;
     if (std.mem.endsWith(u8, path, ".dart")) return .dart;
+    if (std.mem.endsWith(u8, path, ".java")) return .java;
+    if (std.mem.endsWith(u8, path, ".kt")) return .kotlin;
+    if (std.mem.endsWith(u8, path, ".svelte")) return .svelte;
+    if (std.mem.endsWith(u8, path, ".vue")) return .vue;
+    if (std.mem.endsWith(u8, path, ".astro")) return .astro;
+    if (std.mem.endsWith(u8, path, ".sh")) return .shell;
+    if (std.mem.endsWith(u8, path, ".css")) return .css;
+    if (std.mem.endsWith(u8, path, ".scss")) return .scss;
+    if (std.mem.endsWith(u8, path, ".sql")) return .sql;
+    if (std.mem.endsWith(u8, path, ".proto")) return .protobuf;
+    if (std.mem.endsWith(u8, path, ".f90")) return .fortran;
+    if (std.mem.endsWith(u8, path, ".ll")) return .llvm_ir;
+    if (std.mem.endsWith(u8, path, ".mlir")) return .mlir;
+    if (std.mem.endsWith(u8, path, ".td")) return .tablegen;
     return .unknown;
 }
 
@@ -3031,9 +3060,15 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
     if (trimmed.len == 0) return true;
     return switch (language) {
         .zig, .rust, .go_lang => std.mem.startsWith(u8, trimmed, "//"),
-        .python, .ruby, .r => std.mem.startsWith(u8, trimmed, "#"),
+        .python, .ruby, .r, .shell => std.mem.startsWith(u8, trimmed, "#"),
         .hcl => std.mem.startsWith(u8, trimmed, "#") or std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
-        .javascript, .typescript, .c, .cpp, .dart => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .javascript, .typescript, .c, .cpp, .dart, .java, .kotlin, .protobuf, .mlir, .tablegen => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .svelte, .vue, .astro => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*") or std.mem.startsWith(u8, trimmed, "<!--"),
+        .css => std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .scss => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .sql => std.mem.startsWith(u8, trimmed, "--") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
+        .fortran => std.mem.startsWith(u8, trimmed, "!"),
+        .llvm_ir => std.mem.startsWith(u8, trimmed, ";"),
         else => false,
     };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -557,9 +557,13 @@ fn mainImpl() !void {
             s.reset,
         });
     } else if (std.mem.eql(u8, cmd, "serve")) {
-        const port: u16 = blk: {
-            const raw = cio.posixGetenv("CODEDB_PORT") orelse break :blk 7719;
-            break :blk std.fmt.parseInt(u16, raw, 10) catch 7719;
+        const raw_port = cio.posixGetenv("CODEDB_PORT") orelse {
+            std.log.err("codedb serve: HTTP server is off by default. Set CODEDB_PORT=<port> to enable (suggested: 47719 — 7719 and 8080 collide often).", .{});
+            std.process.exit(1);
+        };
+        const port: u16 = std.fmt.parseInt(u16, raw_port, 10) catch {
+            std.log.err("codedb serve: CODEDB_PORT={s} is not a valid u16 port.", .{raw_port});
+            std.process.exit(1);
         };
         var agents = AgentRegistry.init(allocator);
         defer agents.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -557,7 +557,10 @@ fn mainImpl() !void {
             s.reset,
         });
     } else if (std.mem.eql(u8, cmd, "serve")) {
-        const port: u16 = 7719;
+        const port: u16 = blk: {
+            const raw = cio.posixGetenv("CODEDB_PORT") orelse break :blk 7719;
+            break :blk std.fmt.parseInt(u16, raw, 10) catch 7719;
+        };
         var agents = AgentRegistry.init(allocator);
         defer agents.deinit();
         _ = try agents.register("__filesystem__");

--- a/src/main.zig
+++ b/src/main.zig
@@ -557,13 +557,9 @@ fn mainImpl() !void {
             s.reset,
         });
     } else if (std.mem.eql(u8, cmd, "serve")) {
-        const raw_port = cio.posixGetenv("CODEDB_PORT") orelse {
-            std.log.err("codedb serve: HTTP server is off by default. Set CODEDB_PORT=<port> to enable (suggested: 47719 — 7719 and 8080 collide often).", .{});
-            std.process.exit(1);
-        };
-        const port: u16 = std.fmt.parseInt(u16, raw_port, 10) catch {
-            std.log.err("codedb serve: CODEDB_PORT={s} is not a valid u16 port.", .{raw_port});
-            std.process.exit(1);
+        const port: u16 = blk: {
+            const raw = cio.posixGetenv("CODEDB_PORT") orelse break :blk 6767;
+            break :blk std.fmt.parseInt(u16, raw, 10) catch 6767;
         };
         var agents = AgentRegistry.init(allocator);
         defer agents.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -945,15 +945,11 @@ fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allo
 }
 fn idleWatchdog(shutdown: *std.atomic.Value(bool)) void {
     const mcp = @import("mcp.zig");
+    const stdin = cio.File.stdin();
     while (!shutdown.load(.acquire)) {
-        // Sleep in 1s increments for responsive shutdown
-        for (0..10) |_| {
-            if (shutdown.load(.acquire)) return;
-            cio.sleepMs(1000);
-        }
-
-        // Quick liveness check: poll stdin for POLLHUP (client disconnected)
-        const stdin = cio.File.stdin();
+        // Quick liveness check: poll stdin for POLLHUP (client disconnected).
+        // This stays independent from the longer idle timeout so dead MCP
+        // clients are reaped promptly.
         var poll_fds = [_]std.posix.pollfd{.{
             .fd = stdin.handle,
             .events = std.posix.POLL.IN | std.posix.POLL.HUP,
@@ -977,5 +973,7 @@ fn idleWatchdog(shutdown: *std.atomic.Value(bool)) void {
             shutdown.store(true, .release);
             return;
         }
+
+        cio.sleepMs(mcp.dead_client_poll_ms);
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,7 +65,7 @@ fn mainImpl() !void {
     const stdout = cio.File.stdout();
     const use_color = stdout.isTty();
     const s = sty.style(use_color);
-    const out = Out{ .file = stdout, .alloc = allocator };
+    var out = Out{ .file = stdout, .alloc = allocator };
 
     const args = try cio.argsAlloc(allocator);
     defer cio.argsFree(allocator, args);
@@ -104,6 +104,13 @@ fn mainImpl() !void {
     } else {
         printUsage(out, s);
         std.process.exit(1);
+    }
+
+    // MCP stdio reserves stdout for JSON-RPC — route status/error output to
+    // stderr so startup/failure paths don't corrupt the protocol stream.
+    // See #304.
+    if (std.mem.eql(u8, cmd, "mcp")) {
+        out.file = cio.File.stderr();
     }
 
     // Handle --version early (no root needed)

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1270,6 +1270,12 @@ fn handleBundle(
     }
 
     const w = cio.listWriter(out, alloc);
+    // Refresh the idle clock as we start the bundle — long bundles (slow
+    // sub-ops, many ops, remote fetches) would otherwise leave
+    // `last_activity` frozen at message-arrival time, and the watchdog
+    // would close stdin mid-processing. Repeated inside the loop so each
+    // completed sub-op keeps us marked active. See #278.
+    last_activity.store(cio.milliTimestamp(), .release);
     for (ops, 0..) |op, i| {
         if (op != .object) {
             w.print("--- [{d}] error ---\nop must be an object\n", .{i}) catch {};
@@ -1319,6 +1325,9 @@ fn handleBundle(
         w.print("--- [{d}] {s} ---\n", .{ i, tool_name }) catch {};
         out.appendSlice(alloc, sub_out.items) catch {};
         w.writeAll("\n") catch {};
+
+        // Per-op activity refresh — see top of this fn.
+        last_activity.store(cio.milliTimestamp(), .release);
     }
 }
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -446,7 +446,10 @@ pub var last_activity: std.atomic.Value(i64) = std.atomic.Value(i64).init(0);
 
 /// How long (ms) the server may sit idle before auto-exiting.
 /// Claude Code restarts MCP servers on demand, so this is safe.
-pub const idle_timeout_ms: i64 = 10 * 60 * 1000; // 10 minutes — allows long debugging sessions; stdin EOF is detected by the watchdog poll
+pub const idle_timeout_ms: i64 = 60 * 60 * 1000; // 1 hour — allows long debugging sessions; stdin EOF is still detected separately.
+
+/// How often the watchdog checks whether the MCP client disconnected.
+pub const dead_client_poll_ms: u64 = 1000;
 
 // ── Serve-first scan state (issue #207) ─────────────────────────────────────
 //

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1390,6 +1390,23 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
     var url_buf: [512]u8 = undefined;
     const query = getStr(args, "query");
 
+    // Require a non-empty 'query' for actions that actually consume it.
+    // Silently sending `q=` to the remote turned real user mistakes into
+    // empty/garbage responses — fail fast with a pointer at the right field.
+    const needs_query = std.mem.eql(u8, action, "search") or
+        (is_wiki and (std.mem.eql(u8, action, "symbol") or std.mem.eql(u8, action, "outline")));
+    if (needs_query and (query == null or query.?.len == 0)) {
+        out.appendSlice(alloc, "error: action '") catch {};
+        out.appendSlice(alloc, action) catch {};
+        if (std.mem.eql(u8, action, "search")) {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the search text)") catch {};
+        } else if (std.mem.eql(u8, action, "symbol")) {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the identifier name to look up)") catch {};
+        } else {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the file path to outline)") catch {};
+        }
+        return;
+    }
     if (is_wiki) {
         // wiki.codes uses flat slugs: owner/repo → owner-repo. The Vercel
         // /api/query proxy takes slug+endpoint+q and server-side-auths to

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -24,9 +24,65 @@ const root_policy = @import("root_policy.zig");
 const release_info = @import("release_info.zig");
 // ── Project cache ────────────────────────────────────────────────────────────
 
+const SnapshotCache = struct {
+    const MAX_CACHED_BYTES = 16 * 1024 * 1024;
+
+    seq: u64 = std.math.maxInt(u64),
+    bytes: ?[]u8 = null,
+    mu: cio.Mutex = .{},
+
+    fn deinit(self: *SnapshotCache, alloc: std.mem.Allocator) void {
+        if (self.bytes) |bytes| {
+            alloc.free(bytes);
+            self.bytes = null;
+        }
+    }
+
+    fn appendIfFresh(self: *SnapshotCache, alloc: std.mem.Allocator, out: *std.ArrayList(u8), seq: u64) bool {
+        self.mu.lock();
+        defer self.mu.unlock();
+        const bytes = self.bytes orelse return false;
+        if (self.seq != seq) return false;
+        out.appendSlice(alloc, bytes) catch return false;
+        return true;
+    }
+
+    /// Takes ownership of `fresh` if it becomes the cache entry. If another
+    /// caller filled the same seq first, frees `fresh` and appends the winner.
+    fn putAndAppend(self: *SnapshotCache, alloc: std.mem.Allocator, out: *std.ArrayList(u8), seq: u64, fresh: []u8) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        if (fresh.len > MAX_CACHED_BYTES) {
+            if (self.bytes) |bytes| {
+                alloc.free(bytes);
+                self.bytes = null;
+            }
+            self.seq = std.math.maxInt(u64);
+            out.appendSlice(alloc, fresh) catch {};
+            alloc.free(fresh);
+            return;
+        }
+
+        if (self.bytes) |bytes| {
+            if (self.seq == seq) {
+                alloc.free(fresh);
+                out.appendSlice(alloc, bytes) catch {};
+                return;
+            }
+            alloc.free(bytes);
+        }
+
+        self.seq = seq;
+        self.bytes = fresh;
+        out.appendSlice(alloc, fresh) catch {};
+    }
+};
+
 const ProjectCtx = struct {
     explorer: *Explorer,
     store: *Store,
+    snapshot_cache: *SnapshotCache,
 };
 
 fn getProjectDataDir(allocator: std.mem.Allocator, project_path: []const u8) ?[]u8 {
@@ -107,6 +163,7 @@ const ProjectCache = struct {
         path: []u8,
         explorer: Explorer,
         store: Store,
+        snapshot_cache: SnapshotCache,
         last_used: i64,
     };
 
@@ -114,6 +171,7 @@ const ProjectCache = struct {
     alloc: std.mem.Allocator,
     entries: [MAX_CACHED]?*Entry,
     default_path: []const u8,
+    default_snapshot_cache: SnapshotCache,
 
     fn init(alloc_: std.mem.Allocator, default_path_: []const u8) ProjectCache {
         return .{
@@ -121,12 +179,15 @@ const ProjectCache = struct {
             .alloc = alloc_,
             .entries = [_]?*Entry{null} ** MAX_CACHED,
             .default_path = default_path_,
+            .default_snapshot_cache = .{},
         };
     }
 
     fn deinit(self: *ProjectCache) void {
+        self.default_snapshot_cache.deinit(self.alloc);
         for (&self.entries) |*slot| {
             if (slot.*) |entry| {
+                entry.snapshot_cache.deinit(self.alloc);
                 entry.explorer.deinit();
                 entry.store.deinit();
                 self.alloc.free(entry.path);
@@ -143,9 +204,9 @@ const ProjectCache = struct {
         default_exp: *Explorer,
         default_store: *Store,
     ) !ProjectCtx {
-        const p = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store };
+        const p = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache };
         if (std.mem.eql(u8, p, self.default_path))
-            return ProjectCtx{ .explorer = default_exp, .store = default_store };
+            return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache };
         if (!root_policy.isIndexableRoot(p))
             return error.PathNotAllowed;
 
@@ -157,7 +218,7 @@ const ProjectCache = struct {
             if (slot.*) |entry| {
                 if (std.mem.eql(u8, entry.path, p)) {
                     entry.last_used = now;
-                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store };
+                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache };
                 }
             }
         }
@@ -171,6 +232,7 @@ const ProjectCache = struct {
         new_entry.explorer = Explorer.init(self.alloc);
         new_entry.explorer.setRoot(io, p);
         new_entry.store = Store.init(self.alloc);
+        new_entry.snapshot_cache = .{};
         new_entry.last_used = now;
 
         var snap_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -230,6 +292,7 @@ const ProjectCache = struct {
                 }
             }
             const evict = self.entries[oldest_i].?;
+            evict.snapshot_cache.deinit(self.alloc);
             evict.explorer.deinit();
             evict.store.deinit();
             self.alloc.free(evict.path);
@@ -238,7 +301,7 @@ const ProjectCache = struct {
         }
 
         self.entries[target_slot] = new_entry;
-        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store };
+        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store, .snapshot_cache = &new_entry.snapshot_cache };
     }
 };
 
@@ -762,7 +825,7 @@ fn dispatch(
         .codedb_edit => handleEdit(io, alloc, args, out, default_store, default_explorer, agents),
         .codedb_changes => handleChanges(alloc, args, out, default_store),
         .codedb_status => handleStatus(alloc, out, ctx.store, ctx.explorer),
-        .codedb_snapshot => handleSnapshot(alloc, out, ctx.explorer, ctx.store),
+        .codedb_snapshot => handleSnapshot(alloc, out, ctx.explorer, ctx.store, ctx.snapshot_cache),
         .codedb_bundle => handleBundle(io, alloc, args, out, ctx.store, ctx.explorer, agents, cache),
         .codedb_remote => handleRemote(alloc, args, out),
         .codedb_projects => handleProjects(io, alloc, out),
@@ -1230,13 +1293,15 @@ fn handleStatus(alloc: std.mem.Allocator, out: *std.ArrayList(u8), store: *Store
     }) catch {};
 }
 
-fn handleSnapshot(alloc: std.mem.Allocator, out: *std.ArrayList(u8), explorer: *Explorer, store: *Store) void {
+fn handleSnapshot(alloc: std.mem.Allocator, out: *std.ArrayList(u8), explorer: *Explorer, store: *Store, cache: *SnapshotCache) void {
+    const seq = store.currentSeq();
+    if (cache.appendIfFresh(alloc, out, seq)) return;
+
     const snap = snapshot_json.buildSnapshot(explorer, store, alloc) catch {
         out.appendSlice(alloc, "error: snapshot build failed") catch {};
         return;
     };
-    defer alloc.free(snap);
-    out.appendSlice(alloc, snap) catch {};
+    cache.putAndAppend(alloc, out, seq, snap);
 }
 
 fn handleBundle(
@@ -2614,4 +2679,46 @@ test "issue-258: cached project reads use the project root after contents are re
     handleRead(io, testing.allocator, &parsed.value.object, &out, ctx.explorer);
 
     try testing.expect(std.mem.indexOf(u8, out.items, "const project = \"secondary\";") != null);
+}
+
+test "codedb_snapshot cache reuses output until store seq changes" {
+    const io = testing.io;
+    const alloc = testing.allocator;
+
+    var explorer = Explorer.init(alloc);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(alloc);
+    defer store.deinit();
+    _ = try store.recordSnapshot("src/main.zig", "pub fn main() void {}\n".len, 0xabc);
+
+    var agents = AgentRegistry.init(alloc);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = BenchContext.init(alloc, ".");
+    defer bench_ctx.deinit();
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, "{}", .{});
+    defer parsed.deinit();
+    const args = &parsed.value.object;
+
+    var first: std.ArrayList(u8) = .empty;
+    defer first.deinit(alloc);
+    bench_ctx.runDispatch(io, alloc, .codedb_snapshot, args, &first, &store, &explorer, &agents);
+
+    var second: std.ArrayList(u8) = .empty;
+    defer second.deinit(alloc);
+    bench_ctx.runDispatch(io, alloc, .codedb_snapshot, args, &second, &store, &explorer, &agents);
+    try testing.expectEqualStrings(first.items, second.items);
+
+    try explorer.indexFile("src/main.zig", "pub fn changed() void {}\n");
+    _ = try store.recordSnapshot("src/main.zig", "pub fn changed() void {}\n".len, 0xdef);
+
+    var third: std.ArrayList(u8) = .empty;
+    defer third.deinit(alloc);
+    bench_ctx.runDispatch(io, alloc, .codedb_snapshot, args, &third, &store, &explorer, &agents);
+    try testing.expect(std.mem.indexOf(u8, third.items, "changed") != null);
+    try testing.expect(!std.mem.eql(u8, first.items, third.items));
 }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -368,7 +368,7 @@ const tools_list =
     \\{"name":"codedb_status","description":"Get current codedb status: number of indexed files and current sequence number.","inputSchema":{"type":"object","properties":{"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]}},
     \\{"name":"codedb_snapshot","description":"Get the full pre-rendered snapshot of the codebase as a single JSON blob. Contains tree, all outlines, symbol index, and dependency graph. Ideal for caching or deploying to edge workers.","inputSchema":{"type":"object","properties":{"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]}},
     \\{"name":"codedb_bundle","description":"Batch multiple queries in one call. Max 20 ops. WARNING: Avoid bundling multiple codedb_read calls on large files — use codedb_outline + codedb_symbol instead. Bundle outline+symbol+search, not full file reads. Total response is not size-capped, so large bundles can exceed token limits.","inputSchema":{"type":"object","properties":{"ops":{"type":"array","items":{"type":"object","properties":{"tool":{"type":"string","description":"Tool name (e.g. codedb_outline, codedb_symbol, codedb_read)"},"arguments":{"type":"object","description":"Tool arguments"}},"required":["tool"]},"description":"Array of tool calls to execute"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["ops"]}},
-    \\{"name":"codedb_remote","description":"Query any GitHub repo via codedb.codegraff.com cloud intelligence. Gets file tree, symbol outlines, or searches code in external repos without cloning. Use when you need to understand a dependency, check an external API, or explore a repo you don't have locally.","inputSchema":{"type":"object","properties":{"repo":{"type":"string","description":"GitHub repo in owner/repo format (e.g. justrach/merjs)"},"action":{"type":"string","enum":["tree","outline","search","meta"],"description":"What to query: tree (file list), outline (symbols), search (text search), meta (repo info)"},"query":{"type":"string","description":"Search query (required when action=search)"}},"required":["repo","action"]}},
+    \\{"name":"codedb_remote","description":"Query any GitHub repo via cloud intelligence. Default backend 'codegraff' (codedb.codegraff.com) gets file tree, symbol outlines, searches, repo meta. Backend 'wiki' (wiki.codes) fronts the Hetzner parquet router and adds exact-identifier lookup (action=symbol) and hot-pin policy (action=policy). Use when you need to understand a dependency, check an external API, or explore a repo you don't have locally.","inputSchema":{"type":"object","properties":{"repo":{"type":"string","description":"GitHub repo in owner/repo format (e.g. justrach/merjs)"},"action":{"type":"string","enum":["tree","outline","search","meta","symbol","policy"],"description":"What to query. codegraff backend: tree, outline, search, meta. wiki backend: tree, outline, search, symbol, policy."},"query":{"type":"string","description":"Action-specific argument. search: text query. symbol: identifier name. outline: file path. tree/meta/policy: unused."},"backend":{"type":"string","enum":["codegraff","wiki"],"description":"Which remote indexer to query. Default: codegraff. Use 'wiki' for symbol/policy actions or richer parquet-backed results."}},"required":["repo","action"]}},
     \\{"name":"codedb_projects","description":"List all locally indexed projects on this machine. Shows project paths, data directory hashes, and whether a snapshot exists. Use to discover what codebases are available.","inputSchema":{"type":"object","properties":{},"required":[]}},
     \\{"name":"codedb_index","description":"Index a local folder on this machine. Scans all source files, builds outlines/trigrams/word indexes, and creates a codedb.snapshot in the target directory. After indexing, the folder is queryable via the project param on any tool.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to the folder to index (e.g. /Users/you/myproject)"}},"required":["path"]}},
     \\{"name":"codedb_find","description":"Fuzzy file search — finds files by approximate name. Typo-tolerant subsequence matching with word-boundary and filename bonuses. Use when you know roughly what file you're looking for but not the exact path. Much faster than codedb_tree + manual scan.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Fuzzy search query (e.g. 'authmidlware', 'test_auth', 'main.zig')"},"max_results":{"type":"integer","description":"Maximum results to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["query"]}},
@@ -1328,24 +1328,51 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         return;
     };
     const action = getStr(args, "action") orelse {
-        out.appendSlice(alloc, "error: missing 'action' (tree, outline, search, meta)") catch {};
+        out.appendSlice(alloc, "error: missing 'action' (tree, outline, search, meta, symbol, policy)") catch {};
         return;
     };
-    // Validate action against whitelist to prevent SSRF/path injection
-    const valid_actions = [_][]const u8{ "tree", "outline", "search", "meta" };
+
+    // Backend selection: default preserves existing behavior. "wiki" routes
+    // through the codedb-cloud / wiki.codes Vercel proxy, which fronts the
+    // Hetzner parquet router and exposes a superset of actions (adds
+    // `symbol` and `policy`).
+    const backend = getStr(args, "backend") orelse "codegraff";
+    const is_wiki = std.mem.eql(u8, backend, "wiki");
+    const is_codegraff = std.mem.eql(u8, backend, "codegraff");
+    if (!is_wiki and !is_codegraff) {
+        out.appendSlice(alloc, "error: invalid backend, must be one of: codegraff, wiki") catch {};
+        return;
+    }
+
+    // Per-backend action allowlists. Wiki adds symbol + policy, drops meta;
+    // codegraff stays as shipped.
+    const codegraff_actions = [_][]const u8{ "tree", "outline", "search", "meta" };
+    const wiki_actions = [_][]const u8{ "tree", "outline", "search", "symbol", "policy" };
+    const allowed: []const []const u8 = if (is_wiki) &wiki_actions else &codegraff_actions;
     var action_valid = false;
-    for (valid_actions) |va| {
+    for (allowed) |va| {
         if (std.mem.eql(u8, action, va)) {
             action_valid = true;
             break;
         }
     }
     if (!action_valid) {
-        out.appendSlice(alloc, "error: invalid action, must be one of: tree, outline, search, meta") catch {};
+        out.appendSlice(alloc, "error: action '") catch {};
+        out.appendSlice(alloc, action) catch {};
+        out.appendSlice(alloc, "' not supported on backend '") catch {};
+        out.appendSlice(alloc, backend) catch {};
+        out.appendSlice(alloc, "' (") catch {};
+        if (is_wiki) {
+            out.appendSlice(alloc, "wiki supports: tree, outline, search, symbol, policy)") catch {};
+        } else {
+            out.appendSlice(alloc, "codegraff supports: tree, outline, search, meta)") catch {};
+        }
         return;
     }
 
-    // Validate repo format: must be "owner/name" with no path traversal
+    // Validate repo format: must be "owner/name" with no path traversal.
+    // (Same rule for both backends — slug derivation below just replaces
+    // the single '/' with '-'.)
     if (std.mem.indexOf(u8, repo, "..") != null or
         std.mem.indexOf(u8, repo, "//") != null or
         repo[0] == '/' or
@@ -1354,17 +1381,83 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
         return;
     }
-    // Ensure exactly one slash (owner/repo, not owner/repo/extra/path)
     const slash_pos = std.mem.indexOfScalar(u8, repo, '/').?;
     if (std.mem.indexOfScalarPos(u8, repo, slash_pos + 1, '/') != null) {
         out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
         return;
     }
 
-    // Build URL and curl args
     var url_buf: [512]u8 = undefined;
     const query = getStr(args, "query");
 
+    if (is_wiki) {
+        // wiki.codes uses flat slugs: owner/repo → owner-repo. The Vercel
+        // /api/query proxy takes slug+endpoint+q and server-side-auths to
+        // the Hetzner router. No client secrets.
+        var slug_buf: [256]u8 = undefined;
+        if (repo.len >= slug_buf.len) {
+            out.appendSlice(alloc, "error: repo too long") catch {};
+            return;
+        }
+        @memcpy(slug_buf[0..repo.len], repo);
+        for (slug_buf[0..repo.len]) |*c| {
+            if (c.* == '/') c.* = '-';
+        }
+        const slug = slug_buf[0..repo.len];
+
+        const base_url = std.fmt.bufPrint(&url_buf, "https://www.wiki.codes/api/query", .{}) catch {
+            out.appendSlice(alloc, "error: URL too long") catch {};
+            return;
+        };
+        var slug_param_buf: [320]u8 = undefined;
+        const slug_param = std.fmt.bufPrint(&slug_param_buf, "slug={s}", .{slug}) catch {
+            out.appendSlice(alloc, "error: slug too long") catch {};
+            return;
+        };
+        var ep_param_buf: [64]u8 = undefined;
+        const ep_param = std.fmt.bufPrint(&ep_param_buf, "endpoint={s}", .{action}) catch {
+            out.appendSlice(alloc, "error: endpoint too long") catch {};
+            return;
+        };
+        var q_param_buf: [1024]u8 = undefined;
+        const q_param = std.fmt.bufPrint(&q_param_buf, "q={s}", .{query orelse ""}) catch {
+            out.appendSlice(alloc, "error: query too long") catch {};
+            return;
+        };
+
+        const result = cio.runCapture(.{
+            .allocator = alloc,
+            .argv = &.{
+                "curl",                 "-sf",
+                "--max-time",           "30",
+                "-G",
+                "--data-urlencode",     slug_param,
+                "--data-urlencode",     ep_param,
+                "--data-urlencode",     q_param,
+                base_url,
+            },
+        }) catch {
+            out.appendSlice(alloc, "error: failed to fetch from wiki.codes") catch {};
+            return;
+        };
+        defer alloc.free(result.stdout);
+        defer alloc.free(result.stderr);
+        if (result.term.Exited != 0) {
+            out.appendSlice(alloc, "error: wiki.codes returned error for ") catch {};
+            out.appendSlice(alloc, slug) catch {};
+            out.appendSlice(alloc, "/") catch {};
+            out.appendSlice(alloc, action) catch {};
+            if (result.stderr.len > 0) {
+                out.appendSlice(alloc, " — ") catch {};
+                out.appendSlice(alloc, result.stderr[0..@min(result.stderr.len, 200)]) catch {};
+            }
+            return;
+        }
+        out.appendSlice(alloc, result.stdout) catch {};
+        return;
+    }
+
+    // codegraff backend — unchanged from the shipping behavior.
     if (std.mem.eql(u8, action, "search")) {
         const base_url = std.fmt.bufPrint(&url_buf, "https://codedb.codegraff.com/{s}/search", .{repo}) catch {
             out.appendSlice(alloc, "error: URL too long") catch {};
@@ -1375,7 +1468,6 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             out.appendSlice(alloc, "error: query too long") catch {};
             return;
         };
-        // -G + --data-urlencode lets curl handle encoding spaces etc.
         const result = cio.runCapture(.{
             .allocator = alloc,
             .argv = &.{ "curl", "-sf", "--max-time", "30", "-G", "--data-urlencode", q_param, base_url },

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -431,7 +431,7 @@ const tools_list =
     \\{"name":"codedb_status","description":"Get current codedb status: number of indexed files and current sequence number.","inputSchema":{"type":"object","properties":{"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]}},
     \\{"name":"codedb_snapshot","description":"Get the full pre-rendered snapshot of the codebase as a single JSON blob. Contains tree, all outlines, symbol index, and dependency graph. Ideal for caching or deploying to edge workers.","inputSchema":{"type":"object","properties":{"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]}},
     \\{"name":"codedb_bundle","description":"Batch multiple queries in one call. Max 20 ops. WARNING: Avoid bundling multiple codedb_read calls on large files — use codedb_outline + codedb_symbol instead. Bundle outline+symbol+search, not full file reads. Total response is not size-capped, so large bundles can exceed token limits.","inputSchema":{"type":"object","properties":{"ops":{"type":"array","items":{"type":"object","properties":{"tool":{"type":"string","description":"Tool name (e.g. codedb_outline, codedb_symbol, codedb_read)"},"arguments":{"type":"object","description":"Tool arguments"}},"required":["tool"]},"description":"Array of tool calls to execute"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["ops"]}},
-    \\{"name":"codedb_remote","description":"Query any GitHub repo via cloud intelligence. Default backend 'codegraff' (codedb.codegraff.com) gets file tree, symbol outlines, searches, repo meta. Backend 'wiki' (wiki.codes) fronts the Hetzner parquet router and adds exact-identifier lookup (action=symbol) and hot-pin policy (action=policy). Use when you need to understand a dependency, check an external API, or explore a repo you don't have locally.","inputSchema":{"type":"object","properties":{"repo":{"type":"string","description":"GitHub repo in owner/repo format (e.g. justrach/merjs)"},"action":{"type":"string","enum":["tree","outline","search","meta","symbol","policy"],"description":"What to query. codegraff backend: tree, outline, search, meta. wiki backend: tree, outline, search, symbol, policy."},"query":{"type":"string","description":"Action-specific argument. search: text query. symbol: identifier name. outline: file path. tree/meta/policy: unused."},"backend":{"type":"string","enum":["codegraff","wiki"],"description":"Which remote indexer to query. Default: codegraff. Use 'wiki' for symbol/policy actions or richer parquet-backed results."}},"required":["repo","action"]}},
+    \\{"name":"codedb_remote","description":"Query any GitHub repo via cloud intelligence. Default backend 'codegraff' (codedb.codegraff.com) gets file tree, symbol outlines, searches, repo meta. Backend 'wiki' (api.wiki.codes) fronts the Hetzner parquet router and adds exact-identifier lookup, hot-pin policy, dependency/CVE scoring artifacts, and commit metadata. Use when you need to understand a dependency, check an external API, or explore a repo you don't have locally.","inputSchema":{"type":"object","properties":{"repo":{"type":"string","description":"GitHub repo in owner/repo format (e.g. justrach/merjs). With backend=wiki, raw wiki slugs such as chromium are also accepted."},"action":{"type":"string","enum":["tree","outline","search","meta","symbol","policy","deps","score","cves","commits","branches","dep-history"],"description":"What to query. codegraff backend: tree, outline, search, meta. wiki backend: tree, outline, search, symbol, policy, deps, score, cves, commits, branches, dep-history."},"query":{"type":"string","description":"Action-specific argument. search: text query. symbol: identifier name. outline: file path. tree/meta/policy/deps/commits/branches/dep-history: unused. score/cves: optional scope fallback."},"scope":{"type":"string","enum":["runtime","all"],"description":"For wiki score/cves only. Defaults to runtime; use all to include dev/tooling dependencies."},"backend":{"type":"string","enum":["codegraff","wiki"],"description":"Which remote indexer to query. Default: codegraff. Use 'wiki' for api.wiki.codes symbol, policy, dependency, CVE, and history actions."}},"required":["repo","action"]}},
     \\{"name":"codedb_projects","description":"List all locally indexed projects on this machine. Shows project paths, data directory hashes, and whether a snapshot exists. Use to discover what codebases are available.","inputSchema":{"type":"object","properties":{},"required":[]}},
     \\{"name":"codedb_index","description":"Index a local folder on this machine. Scans all source files, builds outlines/trigrams/word indexes, and creates a codedb.snapshot in the target directory. After indexing, the folder is queryable via the project param on any tool.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to the folder to index (e.g. /Users/you/myproject)"}},"required":["path"]}},
     \\{"name":"codedb_find","description":"Fuzzy file search — finds files by approximate name. Typo-tolerant subsequence matching with word-boundary and filename bonuses. Use when you know roughly what file you're looking for but not the exact path. Much faster than codedb_tree + manual scan.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Fuzzy search query (e.g. 'authmidlware', 'test_auth', 'main.zig')"},"max_results":{"type":"integer","description":"Maximum results to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["query"]}},
@@ -1396,6 +1396,76 @@ fn handleBundle(
     }
 }
 
+fn isRemoteRepoChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_' or c == '-' or c == '.';
+}
+
+fn isRemoteRepoPart(part: []const u8) bool {
+    if (part.len == 0) return false;
+    if (std.mem.eql(u8, part, ".") or std.mem.eql(u8, part, "..")) return false;
+    for (part) |c| {
+        if (!isRemoteRepoChar(c)) return false;
+    }
+    return true;
+}
+
+fn isCodegraffRepo(repo: []const u8) bool {
+    if (repo.len == 0 or repo[0] == '/') return false;
+    if (std.mem.indexOf(u8, repo, "..") != null or
+        std.mem.indexOf(u8, repo, "//") != null)
+    {
+        return false;
+    }
+    const slash_pos = std.mem.indexOfScalar(u8, repo, '/') orelse return false;
+    if (std.mem.indexOfScalarPos(u8, repo, slash_pos + 1, '/') != null) return false;
+    return isRemoteRepoPart(repo[0..slash_pos]) and isRemoteRepoPart(repo[slash_pos + 1 ..]);
+}
+
+fn wikiSlugForRepo(repo: []const u8, buf: []u8) ?[]const u8 {
+    if (repo.len == 0 or repo.len >= buf.len or repo[0] == '/') return null;
+    if (std.mem.indexOf(u8, repo, "..") != null or
+        std.mem.indexOf(u8, repo, "//") != null)
+    {
+        return null;
+    }
+
+    if (std.mem.indexOfScalar(u8, repo, '/')) |slash_pos| {
+        if (std.mem.indexOfScalarPos(u8, repo, slash_pos + 1, '/') != null) return null;
+        if (!isRemoteRepoPart(repo[0..slash_pos]) or !isRemoteRepoPart(repo[slash_pos + 1 ..])) return null;
+
+        @memcpy(buf[0..repo.len], repo);
+        buf[slash_pos] = '-';
+        return buf[0..repo.len];
+    }
+
+    if (!isRemoteRepoPart(repo)) return null;
+    @memcpy(buf[0..repo.len], repo);
+    return buf[0..repo.len];
+}
+
+test "wikiSlugForRepo normalizes owner repo and raw slugs" {
+    var buf: [256]u8 = undefined;
+
+    try testing.expectEqualStrings("justrach-codedb", wikiSlugForRepo("justrach/codedb", buf[0..]).?);
+    try testing.expectEqualStrings("vercel-next.js", wikiSlugForRepo("vercel/next.js", buf[0..]).?);
+    try testing.expectEqualStrings("chromium", wikiSlugForRepo("chromium", buf[0..]).?);
+}
+
+test "remote repo validation rejects traversal and malformed paths" {
+    var buf: [256]u8 = undefined;
+
+    try testing.expect(isCodegraffRepo("justrach/codedb"));
+    try testing.expect(!isCodegraffRepo("chromium"));
+    try testing.expect(!isCodegraffRepo("../codedb"));
+    try testing.expect(!isCodegraffRepo("justrach//codedb"));
+    try testing.expect(!isCodegraffRepo("justrach/codedb/extra"));
+
+    try testing.expect(wikiSlugForRepo("chromium", buf[0..]) != null);
+    try testing.expect(wikiSlugForRepo("../codedb", buf[0..]) == null);
+    try testing.expect(wikiSlugForRepo("justrach//codedb", buf[0..]) == null);
+    try testing.expect(wikiSlugForRepo("justrach/codedb/extra", buf[0..]) == null);
+}
+
 fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8)) void {
     const repo = getStr(args, "repo") orelse {
         out.appendSlice(alloc, "error: missing 'repo' (e.g. justrach/merjs)") catch {};
@@ -1407,9 +1477,8 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
     };
 
     // Backend selection: default preserves existing behavior. "wiki" routes
-    // through the codedb-cloud / wiki.codes Vercel proxy, which fronts the
-    // Hetzner parquet router and exposes a superset of actions (adds
-    // `symbol` and `policy`).
+    // directly to api.wiki.codes, which fronts the Hetzner parquet router and
+    // exposes code intelligence plus compact dependency/security artifacts.
     const backend = getStr(args, "backend") orelse "codegraff";
     const is_wiki = std.mem.eql(u8, backend, "wiki");
     const is_codegraff = std.mem.eql(u8, backend, "codegraff");
@@ -1418,10 +1487,22 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         return;
     }
 
-    // Per-backend action allowlists. Wiki adds symbol + policy, drops meta;
-    // codegraff stays as shipped.
+    // Per-backend action allowlists. Wiki adds symbol/security/history
+    // artifacts, drops meta; codegraff stays as shipped.
     const codegraff_actions = [_][]const u8{ "tree", "outline", "search", "meta" };
-    const wiki_actions = [_][]const u8{ "tree", "outline", "search", "symbol", "policy" };
+    const wiki_actions = [_][]const u8{
+        "tree",
+        "outline",
+        "search",
+        "symbol",
+        "policy",
+        "deps",
+        "score",
+        "cves",
+        "commits",
+        "branches",
+        "dep-history",
+    };
     const allowed: []const []const u8 = if (is_wiki) &wiki_actions else &codegraff_actions;
     var action_valid = false;
     for (allowed) |va| {
@@ -1437,26 +1518,21 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         out.appendSlice(alloc, backend) catch {};
         out.appendSlice(alloc, "' (") catch {};
         if (is_wiki) {
-            out.appendSlice(alloc, "wiki supports: tree, outline, search, symbol, policy)") catch {};
+            out.appendSlice(alloc, "wiki supports: tree, outline, search, symbol, policy, deps, score, cves, commits, branches, dep-history)") catch {};
         } else {
             out.appendSlice(alloc, "codegraff supports: tree, outline, search, meta)") catch {};
         }
         return;
     }
 
-    // Validate repo format: must be "owner/name" with no path traversal.
-    // (Same rule for both backends — slug derivation below just replaces
-    // the single '/' with '-'.)
-    if (std.mem.indexOf(u8, repo, "..") != null or
-        std.mem.indexOf(u8, repo, "//") != null or
-        repo[0] == '/' or
-        std.mem.indexOfScalar(u8, repo, '/') == null)
-    {
-        out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
-        return;
-    }
-    const slash_pos = std.mem.indexOfScalar(u8, repo, '/').?;
-    if (std.mem.indexOfScalarPos(u8, repo, slash_pos + 1, '/') != null) {
+    var wiki_slug_buf: [256]u8 = undefined;
+    var wiki_slug: []const u8 = "";
+    if (is_wiki) {
+        wiki_slug = wikiSlugForRepo(repo, wiki_slug_buf[0..]) orelse {
+            out.appendSlice(alloc, "error: invalid wiki repo, use owner/repo or raw wiki slug (e.g. justrach/codedb or chromium)") catch {};
+            return;
+        };
+    } else if (!isCodegraffRepo(repo)) {
         out.appendSlice(alloc, "error: invalid repo format, use owner/repo (e.g. justrach/merjs)") catch {};
         return;
     }
@@ -1482,69 +1558,70 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         return;
     }
     if (is_wiki) {
-        // wiki.codes uses flat slugs: owner/repo → owner-repo. The Vercel
-        // /api/query proxy takes slug+endpoint+q and server-side-auths to
-        // the Hetzner router. No client secrets.
-        var slug_buf: [256]u8 = undefined;
-        if (repo.len >= slug_buf.len) {
-            out.appendSlice(alloc, "error: repo too long") catch {};
-            return;
-        }
-        @memcpy(slug_buf[0..repo.len], repo);
-        for (slug_buf[0..repo.len]) |*c| {
-            if (c.* == '/') c.* = '-';
-        }
-        const slug = slug_buf[0..repo.len];
-
-        const base_url = std.fmt.bufPrint(&url_buf, "https://www.wiki.codes/api/query", .{}) catch {
+        // api.wiki.codes serves the router directly:
+        // /api/<slug>/<endpoint>, where owner/repo also normalizes to
+        // owner-repo for slugs that were indexed that way.
+        const url = std.fmt.bufPrint(&url_buf, "https://api.wiki.codes/api/{s}/{s}", .{ wiki_slug, action }) catch {
             out.appendSlice(alloc, "error: URL too long") catch {};
             return;
         };
-        var slug_param_buf: [320]u8 = undefined;
-        const slug_param = std.fmt.bufPrint(&slug_param_buf, "slug={s}", .{slug}) catch {
-            out.appendSlice(alloc, "error: slug too long") catch {};
-            return;
-        };
-        var ep_param_buf: [64]u8 = undefined;
-        const ep_param = std.fmt.bufPrint(&ep_param_buf, "endpoint={s}", .{action}) catch {
-            out.appendSlice(alloc, "error: endpoint too long") catch {};
-            return;
-        };
-        var q_param_buf: [1024]u8 = undefined;
-        const q_param = std.fmt.bufPrint(&q_param_buf, "q={s}", .{query orelse ""}) catch {
-            out.appendSlice(alloc, "error: query too long") catch {};
-            return;
-        };
 
-        const result = cio.runCapture(.{
+        var param_buf: [1024]u8 = undefined;
+        const result = if (std.mem.eql(u8, action, "search") or
+            std.mem.eql(u8, action, "symbol") or
+            std.mem.eql(u8, action, "outline"))
+        blk: {
+            const param_name: []const u8 = if (std.mem.eql(u8, action, "search"))
+                "q"
+            else if (std.mem.eql(u8, action, "symbol"))
+                "name"
+            else
+                "path";
+            const param = std.fmt.bufPrint(&param_buf, "{s}={s}", .{ param_name, query.? }) catch {
+                out.appendSlice(alloc, "error: query too long") catch {};
+                return;
+            };
+            break :blk cio.runCapture(.{
+                .allocator = alloc,
+                .argv = &.{ "curl", "-sf", "--max-time", "30", "-G", "--data-urlencode", param, url },
+            });
+        } else if (std.mem.eql(u8, action, "score") or std.mem.eql(u8, action, "cves")) blk: {
+            const scope = getStr(args, "scope") orelse query orelse "runtime";
+            if (!std.mem.eql(u8, scope, "runtime") and !std.mem.eql(u8, scope, "all")) {
+                out.appendSlice(alloc, "error: scope must be 'runtime' or 'all'") catch {};
+                return;
+            }
+            const param = std.fmt.bufPrint(&param_buf, "scope={s}", .{scope}) catch {
+                out.appendSlice(alloc, "error: scope too long") catch {};
+                return;
+            };
+            break :blk cio.runCapture(.{
+                .allocator = alloc,
+                .argv = &.{ "curl", "-sf", "--max-time", "30", "-G", "--data-urlencode", param, url },
+            });
+        } else cio.runCapture(.{
             .allocator = alloc,
-            .argv = &.{
-                "curl",                 "-sf",
-                "--max-time",           "30",
-                "-G",
-                "--data-urlencode",     slug_param,
-                "--data-urlencode",     ep_param,
-                "--data-urlencode",     q_param,
-                base_url,
-            },
-        }) catch {
-            out.appendSlice(alloc, "error: failed to fetch from wiki.codes") catch {};
+            .argv = &.{ "curl", "-sf", "--max-time", "30", url },
+        });
+
+        const captured = result catch {
+            out.appendSlice(alloc, "error: failed to fetch from api.wiki.codes") catch {};
             return;
         };
-        defer alloc.free(result.stdout);
-        defer alloc.free(result.stderr);
-        if (result.term.Exited != 0) {
-            out.appendSlice(alloc, "error: wiki.codes returned error for ") catch {};
-            out.appendSlice(alloc, slug) catch {};
+        defer alloc.free(captured.stdout);
+        defer alloc.free(captured.stderr);
+        if (captured.term.Exited != 0) {
+            out.appendSlice(alloc, "error: api.wiki.codes returned error for ") catch {};
+            out.appendSlice(alloc, wiki_slug) catch {};
             out.appendSlice(alloc, "/") catch {};
             out.appendSlice(alloc, action) catch {};
-            if (result.stderr.len > 0) {
+            if (captured.stderr.len > 0) {
                 out.appendSlice(alloc, " — ") catch {};
-                out.appendSlice(alloc, result.stderr[0..@min(result.stderr.len, 200)]) catch {};
+                out.appendSlice(alloc, captured.stderr[0..@min(captured.stderr.len, 200)]) catch {};
             }
             return;
         }
-        out.appendSlice(alloc, result.stdout) catch {};
+        out.appendSlice(alloc, captured.stdout) catch {};
         return;
     }
 

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.578";
+pub const semver = "0.2.579";

--- a/src/server.zig
+++ b/src/server.zig
@@ -696,6 +696,11 @@ fn readSome(io: std.Io, stream: std.Io.net.Stream, dest: []u8) !usize {
 fn isPathSafe(path: []const u8) bool {
     if (path.len == 0) return false;
     if (path[0] == '/') return false;
+    // Block null bytes (path truncation attack).
+    if (std.mem.indexOfScalar(u8, path, 0) != null) return false;
+    // Block backslash separators so Windows-style `..\..\x` can't bypass the
+    // forward-slash `..` check below. Matches mcp.isPathSafe.
+    if (std.mem.indexOfScalar(u8, path, '\\') != null) return false;
     var it = std.mem.splitScalar(u8, path, '/');
     while (it.next()) |component| {
         if (std.mem.eql(u8, component, "..")) return false;

--- a/src/server.zig
+++ b/src/server.zig
@@ -365,7 +365,11 @@ fn handleConnection(
             respondJson(&conn, "403 Forbidden", "{\"error\":\"path traversal not allowed\"}");
             return;
         }
-        const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
+        const root_dir = explorer.root_dir orelse {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"root not configured\"}");
+            return;
+        };
+        const content = root_dir.readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
             error.FileNotFound => {
                 respondJson(&conn, "404 Not Found", "{\"error\":\"file not found\"}");
                 return;

--- a/src/server.zig
+++ b/src/server.zig
@@ -1,15 +1,20 @@
-// codedb HTTP server — DISABLED on 0.16 migration (issue #285).
+// codedb HTTP server — ported to Zig 0.16 std.Io.net (issue #285).
 //
-// The legacy HTTP port server (`codedb serve --port`) used std.net which was
-// removed in 0.16. MCP stdio mode is the primary entry, so this port is kept
-// as a stub that returns an error. When 0.16's std.Io.net stabilizes enough
-// to rebuild this, restore from `git show 0.2.578~0:src/server.zig`.
+// This restores the port server that upstream stubbed out in commit 56ea465
+// (v0.2.578). The route set and JSON response shapes match the pre-0.16
+// implementation byte-for-byte; only the transport layer (listen/accept/read/
+// write/close) was rewritten against the new `std.Io.net` surface. MCP stdio
+// remains the primary entry, but `codedb serve --port` is once again usable
+// by external clients that speak HTTP/1.1.
 
 const std = @import("std");
+const cio = @import("cio.zig");
 const Store = @import("store.zig").Store;
 const AgentRegistry = @import("agent.zig").AgentRegistry;
 const Explorer = @import("explore.zig").Explorer;
+const snapshot_json = @import("snapshot_json.zig");
 const watcher = @import("watcher.zig");
+const edit_mod = @import("edit.zig");
 
 pub fn serve(
     io: std.Io,
@@ -20,12 +25,823 @@ pub fn serve(
     queue: *watcher.EventQueue,
     port: u16,
 ) !void {
-    _ = io;
-    _ = allocator;
-    _ = store;
-    _ = agents;
-    _ = explorer;
     _ = queue;
-    _ = port;
-    return error.ServerDisabledOn016;
+
+    const addr = std.Io.net.IpAddress.parse("127.0.0.1", port) catch unreachable;
+    var srv = try addr.listen(io, .{
+        .reuse_address = true,
+        .mode = .stream,
+        .protocol = .tcp,
+    });
+    defer srv.deinit(io);
+
+    while (true) {
+        const stream = srv.accept(io) catch |err| switch (err) {
+            error.WouldBlock, error.ConnectionAborted => continue,
+            else => return err,
+        };
+        const ctx = allocator.create(HandlerCtx) catch {
+            stream.close(io);
+            continue;
+        };
+        ctx.* = .{
+            .io = io,
+            .allocator = allocator,
+            .store = store,
+            .agents = agents,
+            .explorer = explorer,
+            .stream = stream,
+        };
+        const t = std.Thread.spawn(.{}, handleThread, .{ctx}) catch {
+            stream.close(io);
+            allocator.destroy(ctx);
+            continue;
+        };
+        t.detach();
+    }
+}
+
+const HandlerCtx = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    store: *Store,
+    agents: *AgentRegistry,
+    explorer: *Explorer,
+    stream: std.Io.net.Stream,
+};
+
+fn handleThread(ctx: *HandlerCtx) void {
+    const io = ctx.io;
+    const allocator = ctx.allocator;
+    defer {
+        ctx.stream.close(io);
+        allocator.destroy(ctx);
+    }
+    handleConnection(io, allocator, ctx.store, ctx.agents, ctx.explorer, ctx.stream);
+}
+
+/// Thin wrapper that owns a TCP stream plus a matching `std.Io.Writer` with a
+/// small drain buffer. The response helpers below call `writeAll` followed by
+/// `flush`, and the buffer is only used so the Io.Writer interface has a place
+/// to stage bytes before the vectored drain hits the socket.
+const Conn = struct {
+    io: std.Io,
+    stream: std.Io.net.Stream,
+    writer: std.Io.net.Stream.Writer,
+
+    fn init(io: std.Io, stream: std.Io.net.Stream, buf: []u8) Conn {
+        return .{
+            .io = io,
+            .stream = stream,
+            .writer = stream.writer(io, buf),
+        };
+    }
+
+    /// Best-effort flush+write of `bytes`. Silently drops errors — the remote
+    /// may have closed; we just want to finish the handler cleanly in that
+    /// case so the caller's `defer stream.close(io)` runs.
+    fn writeAll(self: *Conn, bytes: []const u8) void {
+        self.writer.interface.writeAll(bytes) catch {};
+    }
+
+    fn flush(self: *Conn) void {
+        self.writer.interface.flush() catch {};
+    }
+};
+
+fn handleConnection(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    store: *Store,
+    agents: *AgentRegistry,
+    explorer: *Explorer,
+    stream: std.Io.net.Stream,
+) void {
+    var buf: [65536]u8 = undefined;
+
+    var total: usize = 0;
+    const first_n = readSome(io, stream, buf[0..]) catch return;
+    if (first_n == 0) return;
+    total = first_n;
+
+    var write_buf: [4096]u8 = undefined;
+    var conn = Conn.init(io, stream, &write_buf);
+
+    // If this is a POST, we may need to drain more bytes until we have the
+    // full header block + declared Content-Length body.
+    if (std.mem.startsWith(u8, buf[0..total], "POST")) {
+        var header_end_opt = std.mem.indexOf(u8, buf[0..total], "\r\n\r\n");
+        while (header_end_opt == null and total < buf.len) {
+            const extra = readSome(io, stream, buf[total..]) catch {
+                respondJson(&conn, "400 Bad Request", "{\"error\":\"invalid request\"}");
+                return;
+            };
+            if (extra == 0) break;
+            total += extra;
+            header_end_opt = std.mem.indexOf(u8, buf[0..total], "\r\n\r\n");
+        }
+
+        const header_end = header_end_opt orelse {
+            if (total == buf.len) {
+                respondJson(&conn, "413 Payload Too Large", "{\"error\":\"request too large\"}");
+            } else {
+                respondJson(&conn, "400 Bad Request", "{\"error\":\"malformed headers\"}");
+            }
+            return;
+        };
+
+        const body_start = header_end + 4;
+        const headers = buf[0..header_end];
+        var content_length: ?usize = null;
+        var lines = std.mem.splitSequence(u8, headers, "\r\n");
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+            const name = std.mem.trim(u8, line[0..colon], " \t");
+            const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+            if (std.ascii.eqlIgnoreCase(name, "Content-Length")) {
+                content_length = std.fmt.parseInt(usize, value, 10) catch {
+                    respondJson(&conn, "400 Bad Request", "{\"error\":\"invalid content-length\"}");
+                    return;
+                };
+                break;
+            }
+        }
+
+        const body_len = content_length orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing content-length\"}");
+            return;
+        };
+        if (body_len > buf.len - body_start) {
+            respondJson(&conn, "413 Payload Too Large", "{\"error\":\"request too large\"}");
+            return;
+        }
+
+        const expected_total = body_start + body_len;
+        while (total < expected_total) {
+            const extra = readSome(io, stream, buf[total..expected_total]) catch {
+                respondJson(&conn, "400 Bad Request", "{\"error\":\"invalid request body\"}");
+                return;
+            };
+            if (extra == 0) {
+                respondJson(&conn, "400 Bad Request", "{\"error\":\"truncated request body\"}");
+                return;
+            }
+            total += extra;
+        }
+        total = expected_total;
+    }
+
+    const request = buf[0..total];
+
+    // ── Health ──
+    if (std.mem.startsWith(u8, request, "GET /health")) {
+        respondJson(&conn, "200 OK", "{\"status\":\"ok\"}");
+        return;
+    }
+
+    // ── Agent: register ──
+    if (std.mem.startsWith(u8, request, "POST /agent/register")) {
+        const body = extractBody(request);
+        const name = if (body.len > 0) extractJsonString(body, "name") orelse "unnamed" else "unnamed";
+        const id = agents.register(name) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"register failed\"}");
+            return;
+        };
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.print("{{\"id\":{d},\"name\":\"", .{id}) catch return;
+        writeJsonEscaped(&out, allocator, name) catch return;
+        w.writeAll("\"}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Agent: heartbeat ──
+    if (std.mem.startsWith(u8, request, "POST /agent/heartbeat")) {
+        const agent_id = extractQueryParamInt(request, "id") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?id=\"}");
+            return;
+        };
+        agents.heartbeat(agent_id);
+        respondJson(&conn, "200 OK", "{\"ok\":true}");
+        return;
+    }
+
+    // ── Lock ──
+    if (std.mem.startsWith(u8, request, "POST /lock")) {
+        const agent_id = extractQueryParamInt(request, "agent") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?agent=\"}");
+            return;
+        };
+        const path = extractQueryParam(request, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?path=\"}");
+            return;
+        };
+        const got = agents.tryLock(agent_id, path, 30_000) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"lock failed\"}");
+            return;
+        };
+        if (got) {
+            respondJson(&conn, "200 OK", "{\"locked\":true}");
+        } else {
+            respondJson(&conn, "409 Conflict", "{\"locked\":false,\"error\":\"file locked by another agent\"}");
+        }
+        return;
+    }
+
+    // ── Unlock ──
+    if (std.mem.startsWith(u8, request, "POST /unlock")) {
+        const agent_id = extractQueryParamInt(request, "agent") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?agent=\"}");
+            return;
+        };
+        const path = extractQueryParam(request, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?path=\"}");
+            return;
+        };
+        agents.releaseLock(agent_id, path);
+        respondJson(&conn, "200 OK", "{\"unlocked\":true}");
+        return;
+    }
+
+    // ── Edit ──
+    if (std.mem.startsWith(u8, request, "POST /edit")) {
+        const body = extractBody(request);
+        if (body.len == 0) {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing body\"}");
+            return;
+        }
+        const parsed_body = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"invalid json\"}");
+            return;
+        };
+        defer parsed_body.deinit();
+        if (parsed_body.value != .object) {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"body must be object\"}");
+            return;
+        }
+
+        const body_obj = &parsed_body.value.object;
+        const path = jsonString(body_obj, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing path\"}");
+            return;
+        };
+        if (!isPathSafe(path)) {
+            respondJson(&conn, "403 Forbidden", "{\"error\":\"path traversal not allowed\"}");
+            return;
+        }
+
+        const agent_id = jsonU64(body_obj, "agent") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing agent\"}");
+            return;
+        };
+
+        const op_str = jsonString(body_obj, "op") orelse "replace";
+        const op: @import("version.zig").Op = if (std.mem.eql(u8, op_str, "insert"))
+            .insert
+        else if (std.mem.eql(u8, op_str, "delete"))
+            .delete
+        else
+            .replace;
+
+        var content: ?[]const u8 = null;
+        if (body_obj.get("content")) |value| {
+            switch (value) {
+                .string => |s| content = s,
+                .null => {},
+                else => {
+                    respondJson(&conn, "400 Bad Request", "{\"error\":\"content must be string\"}");
+                    return;
+                },
+            }
+        }
+
+        const range_start = jsonU64(body_obj, "range_start");
+        const range_end = jsonU64(body_obj, "range_end");
+        const after = jsonU64(body_obj, "after");
+
+        var req = edit_mod.EditRequest{
+            .path = path,
+            .agent_id = agent_id,
+            .op = op,
+            .content = content,
+        };
+        if (range_start != null and range_end != null) {
+            req.range = .{ @intCast(range_start.?), @intCast(range_end.?) };
+        }
+        if (after) |a| req.after = @intCast(a);
+
+        const result = edit_mod.applyEdit(io, allocator, store, agents, explorer, req) catch |err| {
+            var err_buf: [128]u8 = undefined;
+            const err_body = std.fmt.bufPrint(&err_buf, "{{\"error\":\"{s}\"}}", .{@errorName(err)}) catch return;
+            const status = switch (err) {
+                error.InvalidRange, error.MissingContent => "400 Bad Request",
+                error.FileLocked => "409 Conflict",
+                error.FileNotFound => "404 Not Found",
+                error.AccessDenied => "403 Forbidden",
+                else => "500 Internal Server Error",
+            };
+            respondJson(&conn, status, err_body);
+            return;
+        };
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.print("{{\"seq\":{d},\"hash\":{d},\"size\":{d}}}", .{ result.seq, result.new_hash, result.new_size }) catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── File read ──
+    if (std.mem.startsWith(u8, request, "GET /file/read")) {
+        const path = extractQueryParam(request, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?path=\"}");
+            return;
+        };
+        if (!isPathSafe(path)) {
+            respondJson(&conn, "403 Forbidden", "{\"error\":\"path traversal not allowed\"}");
+            return;
+        }
+        const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
+            error.FileNotFound => {
+                respondJson(&conn, "404 Not Found", "{\"error\":\"file not found\"}");
+                return;
+            },
+            else => {
+                respondJson(&conn, "500 Internal Server Error", "{\"error\":\"read failed\"}");
+                return;
+            },
+        };
+        defer allocator.free(content);
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"path\":\"") catch return;
+        writeJsonEscaped(&out, allocator, path) catch return;
+        w.print("\",\"size\":{d},\"content\":\"", .{content.len}) catch return;
+        writeJsonEscaped(&out, allocator, content) catch return;
+        w.writeAll("\"}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Changes since cursor ──
+    if (std.mem.startsWith(u8, request, "GET /changes")) {
+        const since = extractQueryParamInt(request, "since") orelse 0;
+        const changes = store.changesSinceDetailed(since, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"changes query failed\"}");
+            return;
+        };
+        defer allocator.free(changes);
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.print("{{\"since\":{d},\"seq\":{d},\"changes\":[", .{ since, store.currentSeq() }) catch return;
+        for (changes, 0..) |c, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("{\"path\":\"") catch return;
+            writeJsonEscaped(&out, allocator, c.path) catch return;
+            w.print("\",\"seq\":{d},\"op\":\"{s}\",\"size\":{d},\"timestamp\":{d}}}", .{
+                c.seq, @tagName(c.op), c.size, c.timestamp,
+            }) catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: tree ──
+    if (std.mem.startsWith(u8, request, "GET /explore/tree")) {
+        const tree = explorer.getTree(allocator, false) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"tree failed\"}");
+            return;
+        };
+        defer allocator.free(tree);
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"tree\":\"") catch return;
+        writeJsonEscaped(&out, allocator, tree) catch return;
+        w.writeAll("\"}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: outline ──
+    if (std.mem.startsWith(u8, request, "GET /explore/outline")) {
+        const path_raw = extractQueryParam(request, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?path=\"}");
+            return;
+        };
+        const path = percentDecode(allocator, path_raw) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"decode failed\"}");
+            return;
+        };
+        defer allocator.free(path);
+        if (!isPathSafe(path)) {
+            respondJson(&conn, "403 Forbidden", "{\"error\":\"path traversal not allowed\"}");
+            return;
+        }
+        var outline = explorer.getOutline(path, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"outline failed\"}");
+            return;
+        } orelse {
+            respondJson(&conn, "404 Not Found", "{\"error\":\"file not indexed\"}");
+            return;
+        };
+        defer outline.deinit();
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"path\":\"") catch return;
+        writeJsonEscaped(&out, allocator, outline.path) catch return;
+        w.print("\",\"language\":\"{s}\",\"lines\":{d},\"bytes\":{d},\"symbols\":[", .{
+            @tagName(outline.language), outline.line_count, outline.byte_size,
+        }) catch return;
+        for (outline.symbols.items, 0..) |sym, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("{\"name\":\"") catch return;
+            writeJsonEscaped(&out, allocator, sym.name) catch return;
+            w.print("\",\"kind\":\"{s}\",\"line_start\":{d},\"line_end\":{d}", .{
+                @tagName(sym.kind), sym.line_start, sym.line_end,
+            }) catch return;
+            if (sym.detail) |d| {
+                w.writeAll(",\"detail\":\"") catch return;
+                writeJsonEscaped(&out, allocator, d) catch return;
+                w.writeAll("\"") catch return;
+            }
+            w.writeAll("}") catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: symbol (find all) ──
+    if (std.mem.startsWith(u8, request, "GET /explore/symbol")) {
+        const name = extractQueryParam(request, "name") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?name=\"}");
+            return;
+        };
+        const results = explorer.findAllSymbols(name, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"search failed\"}");
+            return;
+        };
+        defer allocator.free(results);
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"name\":\"") catch return;
+        writeJsonEscaped(&out, allocator, name) catch return;
+        w.writeAll("\",\"results\":[") catch return;
+        for (results, 0..) |r, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("{\"path\":\"") catch return;
+            writeJsonEscaped(&out, allocator, r.path) catch return;
+            w.print("\",\"line\":{d},\"kind\":\"{s}\"", .{
+                r.symbol.line_start, @tagName(r.symbol.kind),
+            }) catch return;
+            if (r.symbol.detail) |d| {
+                w.writeAll(",\"detail\":\"") catch return;
+                writeJsonEscaped(&out, allocator, d) catch return;
+                w.writeAll("\"") catch return;
+            }
+            w.writeAll("}") catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: hot ──
+    if (std.mem.startsWith(u8, request, "GET /explore/hot")) {
+        const hot = explorer.getHotFiles(store, allocator, 10) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"hot files failed\"}");
+            return;
+        };
+        defer {
+            for (hot) |entry| allocator.free(entry);
+            allocator.free(hot);
+        }
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"files\":[") catch return;
+        for (hot, 0..) |path, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("\"") catch return;
+            writeJsonEscaped(&out, allocator, path) catch return;
+            w.writeAll("\"") catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: deps ──
+    if (std.mem.startsWith(u8, request, "GET /explore/deps")) {
+        const path_raw = extractQueryParam(request, "path") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?path=\"}");
+            return;
+        };
+        const path = percentDecode(allocator, path_raw) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"decode failed\"}");
+            return;
+        };
+        defer allocator.free(path);
+        const imported_by = explorer.getImportedBy(path, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"deps failed\"}");
+            return;
+        };
+        defer {
+            for (imported_by) |dep| allocator.free(dep);
+            allocator.free(imported_by);
+        }
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"path\":\"") catch return;
+        writeJsonEscaped(&out, allocator, path) catch return;
+        w.writeAll("\",\"imported_by\":[") catch return;
+        for (imported_by, 0..) |dep, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("\"") catch return;
+            writeJsonEscaped(&out, allocator, dep) catch return;
+            w.writeAll("\"") catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: word search (inverted index, O(1) lookup) ──
+    if (std.mem.startsWith(u8, request, "GET /explore/word")) {
+        const word_raw = extractQueryParam(request, "q") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?q=\"}");
+            return;
+        };
+        const word = percentDecode(allocator, word_raw) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"decode failed\"}");
+            return;
+        };
+        defer allocator.free(word);
+        const hits = explorer.searchWord(word, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"word search failed\"}");
+            return;
+        };
+        defer allocator.free(hits);
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"query\":\"") catch return;
+        writeJsonEscaped(&out, allocator, word) catch return;
+        w.writeAll("\",\"hits\":[") catch return;
+        explorer.mu.lockShared();
+        defer explorer.mu.unlockShared();
+        for (hits, 0..) |h, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("{\"path\":\"") catch return;
+            writeJsonEscaped(&out, allocator, explorer.word_index.hitPath(h)) catch return;
+            w.print("\",\"line\":{d}}}", .{h.line_num}) catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Explore: search (text grep, trigram-accelerated) ──
+    if (std.mem.startsWith(u8, request, "GET /explore/search")) {
+        const query_raw = extractQueryParam(request, "q") orelse {
+            respondJson(&conn, "400 Bad Request", "{\"error\":\"missing ?q=\"}");
+            return;
+        };
+        const query = percentDecode(allocator, query_raw) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"decode failed\"}");
+            return;
+        };
+        defer allocator.free(query);
+        const results = explorer.searchContent(query, allocator, 50) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"search failed\"}");
+            return;
+        };
+        defer {
+            for (results) |r| allocator.free(r.line_text);
+            allocator.free(results);
+        }
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(allocator);
+        const w = cio.listWriter(&out, allocator);
+        w.writeAll("{\"query\":\"") catch return;
+        writeJsonEscaped(&out, allocator, query) catch return;
+        w.writeAll("\",\"results\":[") catch return;
+        for (results, 0..) |r, i| {
+            if (i > 0) w.writeAll(",") catch return;
+            w.writeAll("{\"path\":\"") catch return;
+            writeJsonEscaped(&out, allocator, r.path) catch return;
+            w.print("\",\"line\":{d},\"text\":\"", .{r.line_num}) catch return;
+            writeJsonEscaped(&out, allocator, r.line_text) catch return;
+            w.writeAll("\"}") catch return;
+        }
+        w.writeAll("]}") catch return;
+        respondJson(&conn, "200 OK", out.items);
+        return;
+    }
+
+    // ── Snapshot ──
+    if (std.mem.startsWith(u8, request, "GET /snapshot")) {
+        const snap = snapshot_json.buildSnapshot(explorer, store, allocator) catch {
+            respondJson(&conn, "500 Internal Server Error", "{\"error\":\"snapshot build failed\"}");
+            return;
+        };
+        defer allocator.free(snap);
+        respondJson(&conn, "200 OK", snap);
+        return;
+    }
+
+    // ── Seq ──
+    if (std.mem.startsWith(u8, request, "GET /seq")) {
+        var seq_buf: [32]u8 = undefined;
+        const body = std.fmt.bufPrint(&seq_buf, "{{\"seq\":{d}}}", .{store.currentSeq()}) catch return;
+        respondJson(&conn, "200 OK", body);
+        return;
+    }
+
+    respondJson(&conn, "404 Not Found", "{\"error\":\"not found\"}");
+}
+
+// ── Transport helpers ───────────────────────────────────────────
+
+/// Read some bytes from the TCP stream into `dest`. Returns 0 on clean EOF.
+/// This is the direct-vtable analogue of the old `conn.stream.read`: no
+/// buffered reader state, so each call issues one `netRead` syscall.
+fn readSome(io: std.Io, stream: std.Io.net.Stream, dest: []u8) !usize {
+    if (dest.len == 0) return 0;
+    var iov: [1][]u8 = .{dest};
+    const n = try io.vtable.netRead(io.userdata, stream.socket.handle, &iov);
+    return n;
+}
+
+// ── Response helpers ────────────────────────────────────────────
+
+fn isPathSafe(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (path[0] == '/') return false;
+    var it = std.mem.splitScalar(u8, path, '/');
+    while (it.next()) |component| {
+        if (std.mem.eql(u8, component, "..")) return false;
+    }
+    return true;
+}
+
+fn respondJson(conn: *Conn, status: []const u8, body: []const u8) void {
+    var hdr_buf: [512]u8 = undefined;
+    const hdr = std.fmt.bufPrint(&hdr_buf, "HTTP/1.1 {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{ status, body.len }) catch return;
+    conn.writeAll(hdr);
+    conn.writeAll(body);
+    conn.flush();
+}
+
+/// Append a JSON-escaped version of `s` to the trailing `out` list.
+fn writeJsonEscaped(out: *std.ArrayList(u8), alloc: std.mem.Allocator, s: []const u8) !void {
+    for (s) |ch| {
+        switch (ch) {
+            '"' => try out.appendSlice(alloc, "\\\""),
+            '\\' => try out.appendSlice(alloc, "\\\\"),
+            '\n' => try out.appendSlice(alloc, "\\n"),
+            '\r' => try out.appendSlice(alloc, "\\r"),
+            '\t' => try out.appendSlice(alloc, "\\t"),
+            else => {
+                if (ch < 0x20) {
+                    const hex = "0123456789abcdef";
+                    const esc = [6]u8{ '\\', 'u', '0', '0', hex[ch >> 4], hex[ch & 0x0f] };
+                    try out.appendSlice(alloc, &esc);
+                } else {
+                    try out.append(alloc, ch);
+                }
+            },
+        }
+    }
+}
+
+// ── HTTP parsing helpers ────────────────────────────────────────
+
+fn extractQueryParam(request: []const u8, key: []const u8) ?[]const u8 {
+    const first_line_end = std.mem.indexOf(u8, request, "\r\n") orelse request.len;
+    const first_line = request[0..first_line_end];
+
+    const q_pos = std.mem.indexOfScalar(u8, first_line, '?') orelse return null;
+    const space_pos = std.mem.indexOfScalarPos(u8, first_line, q_pos, ' ') orelse first_line.len;
+    const query = first_line[q_pos + 1 .. space_pos];
+
+    var pairs = std.mem.splitScalar(u8, query, '&');
+    while (pairs.next()) |pair| {
+        if (std.mem.startsWith(u8, pair, key)) {
+            if (pair.len > key.len and pair[key.len] == '=') {
+                return pair[key.len + 1 ..];
+            }
+        }
+    }
+    return null;
+}
+
+fn percentDecode(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var i: usize = 0;
+    while (i < input.len) {
+        if (input[i] == '%' and i + 2 < input.len) {
+            const hi = std.fmt.charToDigit(input[i + 1], 16) catch {
+                try out.append(allocator, input[i]);
+                i += 1;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(input[i + 2], 16) catch {
+                try out.append(allocator, input[i]);
+                i += 1;
+                continue;
+            };
+            try out.append(allocator, (hi << 4) | lo);
+            i += 3;
+        } else if (input[i] == '+') {
+            try out.append(allocator, ' ');
+            i += 1;
+        } else {
+            try out.append(allocator, input[i]);
+            i += 1;
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn extractQueryParamInt(request: []const u8, key: []const u8) ?u64 {
+    const val = extractQueryParam(request, key) orelse return null;
+    return std.fmt.parseInt(u64, val, 10) catch null;
+}
+
+fn extractBody(request: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, request, "\r\n\r\n")) |pos| {
+        return request[pos + 4 ..];
+    }
+    return "";
+}
+
+fn jsonString(obj: *const std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    return switch (obj.get(key) orelse return null) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn jsonU64(obj: *const std.json.ObjectMap, key: []const u8) ?u64 {
+    return switch (obj.get(key) orelse return null) {
+        .integer => |n| if (n >= 0) @as(u64, @intCast(n)) else null,
+        else => null,
+    };
+}
+
+fn findUnescapedQuote(s: []const u8, start: usize) ?usize {
+    var i = start;
+    while (i < s.len) : (i += 1) {
+        if (s[i] == '\\') {
+            i += 1; // skip escaped char
+            continue;
+        }
+        if (s[i] == '"') return i;
+    }
+    return null;
+}
+
+/// Minimal JSON string extractor: finds "key":"value" and returns value.
+fn extractJsonString(json: []const u8, key: []const u8) ?[]const u8 {
+    // NOTE: This is a naive scanner that does NOT handle JSON escape sequences
+    // (e.g. \" inside string values will cause incorrect results). For correct
+    // parsing use std.json.parseFromSlice on the full body instead.
+    var pos: usize = 0;
+    while (pos < json.len) {
+        const key_start = std.mem.indexOfPos(u8, json, pos, "\"") orelse return null;
+        const key_end = std.mem.indexOfPos(u8, json, key_start + 1, "\"") orelse return null;
+        const found_key = json[key_start + 1 .. key_end];
+
+        if (std.mem.eql(u8, found_key, key)) {
+            // Skip ":"
+            var next = key_end + 1;
+            while (next < json.len and (json[next] == ':' or json[next] == ' ')) : (next += 1) {}
+            if (next >= json.len or json[next] != '"') return null;
+            const val_start = next + 1;
+            const val_end = findUnescapedQuote(json, val_start) orelse return null;
+            return json[val_start..val_end];
+        }
+        pos = key_end + 1;
+    }
+    return null;
 }

--- a/src/snapshot_json.zig
+++ b/src/snapshot_json.zig
@@ -11,19 +11,15 @@ pub fn buildSnapshot(explorer: *Explorer, store: *Store, alloc: std.mem.Allocato
     try w.writeAll("{");
     try w.print("\"seq\":{d},", .{store.currentSeq()});
 
-    const tree = try explorer.getTree(alloc, false);
-    defer alloc.free(tree);
-    try w.writeAll("\"tree\":\"");
-    try writeJsonEscaped(alloc, &buf, tree);
-    try w.writeAll("\",");
-
-    try w.writeAll("\"outlines\":{");
     {
         explorer.mu.lockShared();
         defer explorer.mu.unlockShared();
 
+        try buf.ensureTotalCapacity(alloc, roughSnapshotCapacity(explorer.outlines.count()));
+
         var paths: std.ArrayList([]const u8) = .empty;
         defer paths.deinit(alloc);
+        try paths.ensureTotalCapacity(alloc, explorer.outlines.count());
         var iter = explorer.outlines.iterator();
         while (iter.next()) |entry| {
             try paths.append(alloc, entry.key_ptr.*);
@@ -34,6 +30,11 @@ pub fn buildSnapshot(explorer: *Explorer, store: *Store, alloc: std.mem.Allocato
             }
         }.lessThan);
 
+        try w.writeAll("\"tree\":\"");
+        try writeTreeJsonEscaped(alloc, &buf, explorer, paths.items);
+        try w.writeAll("\",");
+
+        try w.writeAll("\"outlines\":{");
         for (paths.items, 0..) |path, pi| {
             if (pi > 0) try w.writeAll(",");
             try w.writeAll("\"");
@@ -67,37 +68,13 @@ pub fn buildSnapshot(explorer: *Explorer, store: *Store, alloc: std.mem.Allocato
             }
             try w.writeAll("]}");
         }
-    }
-    try w.writeAll("},");
+        try w.writeAll("},");
 
-    try w.writeAll("\"symbol_index\":{");
-    {
-        explorer.mu.lockShared();
-        defer explorer.mu.unlockShared();
-
-        var sym_map = std.StringHashMap(std.ArrayList(SymEntry)).init(alloc);
-        defer {
-            var si = sym_map.iterator();
-            while (si.next()) |e| e.value_ptr.deinit(alloc);
-            sym_map.deinit();
-        }
-
-        var oiter = explorer.outlines.iterator();
-        while (oiter.next()) |entry| {
-            for (entry.value_ptr.symbols.items) |sym| {
-                const gop = try sym_map.getOrPut(sym.name);
-                if (!gop.found_existing) gop.value_ptr.* = .empty;
-                try gop.value_ptr.append(alloc, .{
-                    .path = entry.key_ptr.*,
-                    .line = sym.line_start,
-                    .kind = sym.kind,
-                });
-            }
-        }
-
+        try w.writeAll("\"symbol_index\":{");
         var sym_keys: std.ArrayList([]const u8) = .empty;
         defer sym_keys.deinit(alloc);
-        var ski = sym_map.iterator();
+        try sym_keys.ensureTotalCapacity(alloc, explorer.symbol_index.count());
+        var ski = explorer.symbol_index.iterator();
         while (ski.next()) |e| try sym_keys.append(alloc, e.key_ptr.*);
         std.mem.sort([]const u8, sym_keys.items, {}, struct {
             fn lessThan(_: void, a: []const u8, b: []const u8) bool {
@@ -110,27 +87,23 @@ pub fn buildSnapshot(explorer: *Explorer, store: *Store, alloc: std.mem.Allocato
             try w.writeAll("\"");
             try writeJsonEscaped(alloc, &buf, name);
             try w.writeAll("\":[");
-            const locs = sym_map.get(name) orelse continue;
+            const locs = explorer.symbol_index.get(name) orelse continue;
             for (locs.items, 0..) |loc, li| {
                 if (li > 0) try w.writeAll(",");
                 try w.writeAll("{\"path\":\"");
                 try writeJsonEscaped(alloc, &buf, loc.path);
                 try w.print("\",\"line\":{d},\"kind\":\"{s}\"}}", .{
-                    loc.line, @tagName(loc.kind),
+                    loc.line_start, @tagName(loc.kind),
                 });
             }
             try w.writeAll("]");
         }
-    }
-    try w.writeAll("},");
+        try w.writeAll("},");
 
-    try w.writeAll("\"dep_graph\":{");
-    {
-        explorer.mu.lockShared();
-        defer explorer.mu.unlockShared();
-
+        try w.writeAll("\"dep_graph\":{");
         var dep_keys: std.ArrayList([]const u8) = .empty;
         defer dep_keys.deinit(alloc);
+        try dep_keys.ensureTotalCapacity(alloc, explorer.dep_graph.count());
         var diter = explorer.dep_graph.iterator();
         while (diter.next()) |e| try dep_keys.append(alloc, e.key_ptr.*);
         std.mem.sort([]const u8, dep_keys.items, {}, struct {
@@ -153,33 +126,93 @@ pub fn buildSnapshot(explorer: *Explorer, store: *Store, alloc: std.mem.Allocato
             }
             try w.writeAll("]");
         }
+        try w.writeAll("}");
     }
-    try w.writeAll("}}");
+    try w.writeAll("}");
 
     return buf.toOwnedSlice(alloc);
 }
 
-const SymEntry = struct {
-    path: []const u8,
-    line: u32,
-    kind: @import("explore.zig").SymbolKind,
-};
+fn roughSnapshotCapacity(file_count: usize) usize {
+    const min_capacity: usize = 64 * 1024;
+    const max_capacity: usize = 8 * 1024 * 1024;
+    const per_file: usize = 32 * 1024;
+    if (file_count == 0) return min_capacity;
+    if (file_count > max_capacity / per_file) return max_capacity;
+    return @max(min_capacity, file_count * per_file);
+}
+
+fn writeTreeJsonEscaped(alloc: std.mem.Allocator, out: *std.ArrayList(u8), explorer: *Explorer, paths: []const []const u8) !void {
+    const w = cio.listWriter(out, alloc);
+    var seen_dirs = std.StringHashMap(void).init(alloc);
+    defer seen_dirs.deinit();
+
+    for (paths) |path| {
+        const outline = explorer.outlines.get(path) orelse continue;
+
+        var prefix_end: usize = 0;
+        while (std.mem.indexOfScalarPos(u8, path, prefix_end, '/')) |sep| {
+            const dir = path[0 .. sep + 1];
+            if (!seen_dirs.contains(dir)) {
+                try seen_dirs.put(dir, {});
+                const depth = std.mem.count(u8, dir[0..sep], "/");
+                for (0..depth) |_| try w.writeAll("  ");
+                const dir_name = path[if (depth > 0) std.mem.lastIndexOfScalar(u8, dir[0..sep], '/').? + 1 else 0..sep];
+                try writeJsonEscaped(alloc, out, dir_name);
+                try w.writeAll("/\\n");
+            }
+            prefix_end = sep + 1;
+        }
+
+        const depth = std.mem.count(u8, path, "/");
+        for (0..depth) |_| try w.writeAll("  ");
+        const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
+        try writeJsonEscaped(alloc, out, basename);
+        try w.print("  {s}  {d}L  {d} sym\\n", .{
+            @tagName(outline.language),
+            outline.line_count,
+            outline.symbols.items.len,
+        });
+    }
+}
 
 fn writeJsonEscaped(alloc: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
-    for (s) |c| {
+    var start: usize = 0;
+    for (s, 0..) |c, i| {
         switch (c) {
-            '"' => try out.appendSlice(alloc, "\\\""),
-            '\\' => try out.appendSlice(alloc, "\\\\"),
-            '\n' => try out.appendSlice(alloc, "\\n"),
-            '\r' => try out.appendSlice(alloc, "\\r"),
-            '\t' => try out.appendSlice(alloc, "\\t"),
+            '"' => {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
+                try out.appendSlice(alloc, "\\\"");
+                start = i + 1;
+            },
+            '\\' => {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
+                try out.appendSlice(alloc, "\\\\");
+                start = i + 1;
+            },
+            '\n' => {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
+                try out.appendSlice(alloc, "\\n");
+                start = i + 1;
+            },
+            '\r' => {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
+                try out.appendSlice(alloc, "\\r");
+                start = i + 1;
+            },
+            '\t' => {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
+                try out.appendSlice(alloc, "\\t");
+                start = i + 1;
+            },
             else => if (c < 0x20) {
+                if (i > start) try out.appendSlice(alloc, s[start..i]);
                 const hex = "0123456789abcdef";
                 const esc = [6]u8{ '\\', 'u', '0', '0', hex[c >> 4], hex[c & 0x0f] };
                 try out.appendSlice(alloc, &esc);
-            } else {
-                try out.append(alloc, c);
+                start = i + 1;
             },
         }
     }
+    if (start < s.len) try out.appendSlice(alloc, s[start..]);
 }

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -246,6 +246,20 @@ fn writeLanguages(writer: anytype, language_mask: u32) !void {
         "yaml",
         "unknown",
         "dart",
+        "java",
+        "kotlin",
+        "svelte",
+        "vue",
+        "astro",
+        "shell",
+        "css",
+        "scss",
+        "sql",
+        "protobuf",
+        "fortran",
+        "llvm_ir",
+        "mlir",
+        "tablegen",
     };
     var first = true;
     for (names, 0..) |name, idx| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2142,6 +2142,10 @@ test "detectLanguage: all supported extensions" {
     try testing.expect(explore.detectLanguage("util.h") == .c);
     try testing.expect(explore.detectLanguage("app.cpp") == .cpp);
     try testing.expect(explore.detectLanguage("app.hpp") == .cpp);
+    try testing.expect(explore.detectLanguage("app.cc") == .cpp);
+    try testing.expect(explore.detectLanguage("app.hh") == .cpp);
+    try testing.expect(explore.detectLanguage("app.cxx") == .cpp);
+    try testing.expect(explore.detectLanguage("app.hxx") == .cpp);
     try testing.expect(explore.detectLanguage("script.py") == .python);
     try testing.expect(explore.detectLanguage("app.js") == .javascript);
     try testing.expect(explore.detectLanguage("comp.jsx") == .javascript);
@@ -6179,6 +6183,129 @@ test "issue-215: R setClass parsed" {
 test "issue-215: detectLanguage handles .r and .R" {
     try testing.expectEqual(Language.r, explore.detectLanguage("script.r"));
     try testing.expectEqual(Language.r, explore.detectLanguage("analysis.R"));
+}
+
+test "issue-319: C parser extracts includes macros types and functions" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/core.c",
+        \\#include <stdio.h>
+        \\#include "local.h"
+        \\#define MAX_SIZE 64
+        \\#define SQUARE(x) ((x) * (x))
+        \\struct Worker {
+        \\    int id;
+        \\};
+        \\enum Mode {
+        \\    MODE_A,
+        \\};
+        \\union Value {
+        \\    int i;
+        \\};
+        \\typedef unsigned long size_alias_t;
+        \\static inline const char *worker_name(const struct Worker *worker) {
+        \\    return "worker";
+        \\}
+        \\void *alloc_item(size_t size)
+        \\{
+        \\    return malloc(size);
+        \\}
+    );
+
+    const outline = try explorer.getOutline("src/core.c", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.c, outline.language);
+    try testing.expectEqual(@as(usize, 2), outline.imports.items.len);
+    try testing.expectEqualStrings("stdio.h", outline.imports.items[0]);
+    try testing.expectEqualStrings("local.h", outline.imports.items[1]);
+
+    const max_size = try explorer.findAllSymbols("MAX_SIZE", alloc);
+    defer alloc.free(max_size);
+    try testing.expectEqual(@as(usize, 1), max_size.len);
+    try testing.expectEqual(SymbolKind.macro_def, max_size[0].symbol.kind);
+
+    const square = try explorer.findAllSymbols("SQUARE", alloc);
+    defer alloc.free(square);
+    try testing.expectEqual(@as(usize, 1), square.len);
+    try testing.expectEqual(SymbolKind.macro_def, square[0].symbol.kind);
+
+    const worker = try explorer.findAllSymbols("Worker", alloc);
+    defer alloc.free(worker);
+    try testing.expectEqual(@as(usize, 1), worker.len);
+    try testing.expectEqual(SymbolKind.struct_def, worker[0].symbol.kind);
+
+    const mode = try explorer.findAllSymbols("Mode", alloc);
+    defer alloc.free(mode);
+    try testing.expectEqual(@as(usize, 1), mode.len);
+    try testing.expectEqual(SymbolKind.enum_def, mode[0].symbol.kind);
+
+    const value = try explorer.findAllSymbols("Value", alloc);
+    defer alloc.free(value);
+    try testing.expectEqual(@as(usize, 1), value.len);
+    try testing.expectEqual(SymbolKind.union_def, value[0].symbol.kind);
+
+    const alias = try explorer.findAllSymbols("size_alias_t", alloc);
+    defer alloc.free(alias);
+    try testing.expectEqual(@as(usize, 1), alias.len);
+    try testing.expectEqual(SymbolKind.type_alias, alias[0].symbol.kind);
+
+    const worker_name = try explorer.findAllSymbols("worker_name", alloc);
+    defer alloc.free(worker_name);
+    try testing.expectEqual(@as(usize, 1), worker_name.len);
+    try testing.expectEqual(SymbolKind.function, worker_name[0].symbol.kind);
+
+    const alloc_item = try explorer.findAllSymbols("alloc_item", alloc);
+    defer alloc.free(alloc_item);
+    try testing.expectEqual(@as(usize, 1), alloc_item.len);
+    try testing.expectEqual(SymbolKind.function, alloc_item[0].symbol.kind);
+}
+
+test "issue-319: C parser avoids comments strings prototypes and macro calls" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/noise.c",
+        \\// int fake_comment(void) {
+        \\/* int fake_block(void) { */
+        \\const char *s = "int fake_string(void) {";
+        \\typedef int (*handler_fn)(int);
+        \\int prototype_only(void);
+        \\EXPORT_SYMBOL(real_function);
+        \\if (real_function()) {
+        \\}
+        \\int real_function(void) {
+        \\    return 1;
+        \\}
+    );
+
+    const real = try explorer.findAllSymbols("real_function", alloc);
+    defer alloc.free(real);
+    try testing.expectEqual(@as(usize, 1), real.len);
+    try testing.expectEqual(SymbolKind.function, real[0].symbol.kind);
+
+    const fake_comment = try explorer.findAllSymbols("fake_comment", alloc);
+    defer alloc.free(fake_comment);
+    try testing.expectEqual(@as(usize, 0), fake_comment.len);
+
+    const fake_block = try explorer.findAllSymbols("fake_block", alloc);
+    defer alloc.free(fake_block);
+    try testing.expectEqual(@as(usize, 0), fake_block.len);
+
+    const fake_string = try explorer.findAllSymbols("fake_string", alloc);
+    defer alloc.free(fake_string);
+    try testing.expectEqual(@as(usize, 0), fake_string.len);
+
+    const prototype = try explorer.findAllSymbols("prototype_only", alloc);
+    defer alloc.free(prototype);
+    try testing.expectEqual(@as(usize, 0), prototype.len);
+
+    const handler = try explorer.findAllSymbols("handler_fn", alloc);
+    defer alloc.free(handler);
+    try testing.expectEqual(@as(usize, 0), handler.len);
 }
 
 test "issue-179: Python inline docstring does not leak symbols" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6347,6 +6347,32 @@ test "issue-321: common detected extensions produce outlines" {
     const alloc = arena.allocator();
     var explorer = Explorer.init(alloc);
 
+    try explorer.indexFile("src/math.cc",
+        \\#include <vector>
+        \\class Calculator {
+        \\public:
+        \\    int add(int a, int b) {
+        \\        return a + b;
+        \\    }
+        \\};
+        \\int free_add(int a, int b) {
+        \\    return a + b;
+        \\}
+    );
+    try explorer.indexFile("src/Bridge.mm",
+        \\#import "Bridge.h"
+        \\@interface BrowserController
+        \\- (void)loadPage:(NSString *)url;
+        \\@end
+        \\@implementation BrowserController
+        \\- (void)loadPage:(NSString *)url { }
+        \\@end
+        \\class BrowserBridge {
+        \\};
+        \\int bridge_main(void) {
+        \\    return 0;
+        \\}
+    );
     try explorer.indexFile("src/App.java",
         \\package demo;
         \\import java.util.List;
@@ -6456,9 +6482,117 @@ test "issue-321: common detected extensions produce outlines" {
         \\let Namespace = "Toy";
     );
 
+    const cc_outline = try explorer.getOutline("src/math.cc", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.cpp, cc_outline.language);
+    try expectOutlineImport(&cc_outline, "vector");
+    try expectOutlineSymbol(&cc_outline, "Calculator", .class_def);
+    try expectOutlineSymbol(&cc_outline, "add", .function);
+    try expectOutlineSymbol(&cc_outline, "free_add", .function);
+
+    const mm_outline = try explorer.getOutline("src/Bridge.mm", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.cpp, mm_outline.language);
+    try expectOutlineImport(&mm_outline, "Bridge.h");
+    try expectOutlineSymbol(&mm_outline, "BrowserController", .class_def);
+    try expectOutlineSymbol(&mm_outline, "loadPage", .method);
+    try expectOutlineSymbol(&mm_outline, "BrowserBridge", .class_def);
+    try expectOutlineSymbol(&mm_outline, "bridge_main", .function);
+
     const java_outline = try explorer.getOutline("src/App.java", alloc) orelse return error.TestUnexpectedResult;
     try testing.expectEqual(Language.java, java_outline.language);
-    try testing.expectEqualStrings("java.util.List", java_outline.imports.items[0]);
+    try expectOutlineImport(&java_outline, "java.util.List");
+    try expectOutlineSymbol(&java_outline, "Worker", .class_def);
+    try expectOutlineSymbol(&java_outline, "run", .method);
+    try expectOutlineSymbol(&java_outline, "RunnableThing", .interface_def);
+    try expectOutlineSymbol(&java_outline, "Mode", .enum_def);
+    try expectOutlineSymbol(&java_outline, "Pair", .class_def);
+
+    const kt_outline = try explorer.getOutline("src/App.kt", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.kotlin, kt_outline.language);
+    try expectOutlineImport(&kt_outline, "kotlinx.coroutines.runBlocking");
+    try expectOutlineSymbol(&kt_outline, "User", .class_def);
+    try expectOutlineSymbol(&kt_outline, "Repo", .interface_def);
+    try expectOutlineSymbol(&kt_outline, "KotlinMode", .enum_def);
+    try expectOutlineSymbol(&kt_outline, "loadUser", .function);
+    try expectOutlineSymbol(&kt_outline, "answer", .constant);
+
+    const svelte_outline = try explorer.getOutline("src/Widget.svelte", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.svelte, svelte_outline.language);
+    try expectOutlineImport(&svelte_outline, "./Thing.svelte");
+    try expectOutlineSymbol(&svelte_outline, "title", .constant);
+    try expectOutlineSymbol(&svelte_outline, "renderTitle", .function);
+    try expectOutlineSymbol(&svelte_outline, ".card", .class_def);
+
+    const vue_outline = try explorer.getOutline("src/View.vue", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.vue, vue_outline.language);
+    try expectOutlineImport(&vue_outline, "./Child.vue");
+    try expectOutlineSymbol(&vue_outline, "count", .constant);
+    try expectOutlineSymbol(&vue_outline, "inc", .function);
+
+    const astro_outline = try explorer.getOutline("src/Page.astro", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.astro, astro_outline.language);
+    try expectOutlineImport(&astro_outline, "../layouts/Layout.astro");
+    try expectOutlineSymbol(&astro_outline, "title", .constant);
+
+    const shell_outline = try explorer.getOutline("scripts/build.sh", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.shell, shell_outline.language);
+    try expectOutlineImport(&shell_outline, "./env.sh");
+    try expectOutlineSymbol(&shell_outline, "build_app", .function);
+    try expectOutlineSymbol(&shell_outline, "deploy_app", .function);
+    try expectOutlineSymbol(&shell_outline, "BUILD_MODE", .variable);
+
+    const css_outline = try explorer.getOutline("styles/app.css", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.css, css_outline.language);
+    try expectOutlineSymbol(&css_outline, "--brand", .constant);
+    try expectOutlineSymbol(&css_outline, ".button", .class_def);
+    try expectOutlineSymbol(&css_outline, "fade", .function);
+
+    const scss_outline = try explorer.getOutline("styles/app.scss", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.scss, scss_outline.language);
+    try expectOutlineSymbol(&scss_outline, "$gap", .constant);
+    try expectOutlineSymbol(&scss_outline, "center", .function);
+    try expectOutlineSymbol(&scss_outline, ".panel", .class_def);
+
+    const sql_outline = try explorer.getOutline("db/schema.sql", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.sql, sql_outline.language);
+    try expectOutlineSymbol(&sql_outline, "users", .struct_def);
+    try expectOutlineSymbol(&sql_outline, "do_thing", .function);
+    try expectOutlineSymbol(&sql_outline, "idx_users_id", .constant);
+
+    const proto_outline = try explorer.getOutline("api/service.proto", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.protobuf, proto_outline.language);
+    try expectOutlineImport(&proto_outline, "google/protobuf/timestamp.proto");
+    try expectOutlineSymbol(&proto_outline, "User", .struct_def);
+    try expectOutlineSymbol(&proto_outline, "Status", .enum_def);
+    try expectOutlineSymbol(&proto_outline, "UserService", .interface_def);
+    try expectOutlineSymbol(&proto_outline, "GetUser", .method);
+
+    const fortran_outline = try explorer.getOutline("math/solver.f90", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.fortran, fortran_outline.language);
+    try expectOutlineImport(&fortran_outline, "mathlib");
+    try expectOutlineSymbol(&fortran_outline, "solver", .class_def);
+    try expectOutlineSymbol(&fortran_outline, "Particle", .struct_def);
+    try expectOutlineSymbol(&fortran_outline, "step", .function);
+    try expectOutlineSymbol(&fortran_outline, "energy", .function);
+
+    const llvm_outline = try explorer.getOutline("ir/module.ll", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.llvm_ir, llvm_outline.language);
+    try expectOutlineSymbol(&llvm_outline, "Pair", .type_alias);
+    try expectOutlineSymbol(&llvm_outline, "global_value", .variable);
+    try expectOutlineSymbol(&llvm_outline, "main", .function);
+
+    const mlir_outline = try explorer.getOutline("ir/dialect.mlir", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.mlir, mlir_outline.language);
+    try expectOutlineSymbol(&mlir_outline, "kernel_mod", .class_def);
+    try expectOutlineSymbol(&mlir_outline, "kernel", .function);
+
+    const td_outline = try explorer.getOutline("llvm/records.td", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.tablegen, td_outline.language);
+    try expectOutlineImport(&td_outline, "Base.td");
+    try expectOutlineSymbol(&td_outline, "Register", .class_def);
+    try expectOutlineSymbol(&td_outline, "Pat", .class_def);
+    try expectOutlineSymbol(&td_outline, "R0", .constant);
+    try expectOutlineSymbol(&td_outline, "ADD", .constant);
+    try expectOutlineSymbol(&td_outline, "Namespace", .variable);
 
     const worker = try explorer.findAllSymbols("Worker", alloc);
     defer alloc.free(worker);
@@ -6520,6 +6654,20 @@ test "issue-321: common detected extensions produce outlines" {
     const r0 = try explorer.findAllSymbols("R0", alloc);
     defer alloc.free(r0);
     try testing.expectEqual(@as(usize, 1), r0.len);
+}
+
+fn expectOutlineSymbol(outline: *const explore.FileOutline, name: []const u8, kind: SymbolKind) !void {
+    for (outline.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.name, name) and sym.kind == kind) return;
+    }
+    return error.TestUnexpectedResult;
+}
+
+fn expectOutlineImport(outline: *const explore.FileOutline, import_path: []const u8) !void {
+    for (outline.imports.items) |imp| {
+        if (std.mem.eql(u8, imp, import_path)) return;
+    }
+    return error.TestUnexpectedResult;
 }
 
 test "issue-179: Python inline docstring does not leak symbols" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5136,9 +5136,14 @@ test "issue-116: getGitHead returns valid SHA for git repos" {
     }
 }
 
-test "issue-148: idle timeout is 10 minutes" {
+test "issue-148: idle timeout is 1 hour" {
     const mcp = @import("mcp.zig");
-    try testing.expectEqual(@as(i64, 10 * 60 * 1000), mcp.idle_timeout_ms);
+    try testing.expectEqual(@as(i64, 60 * 60 * 1000), mcp.idle_timeout_ms);
+}
+
+test "issue-148: dead MCP clients are polled every second" {
+    const mcp = @import("mcp.zig");
+    try testing.expectEqual(@as(u64, 1000), mcp.dead_client_poll_ms);
 }
 
 test "issue-148: POLLHUP detects closed pipe" {
@@ -5204,31 +5209,31 @@ test "issue-148: idle watchdog respects activity timestamp" {
     // Set activity to "just now"
     mcp.last_activity.store(cio.milliTimestamp(), .release);
 
-    // With 10-minute timeout, checking now should NOT trigger exit
+    // With 1-hour timeout, checking now should NOT trigger exit
     const last = mcp.last_activity.load(.acquire);
     const now = cio.milliTimestamp();
     try testing.expect(now - last < mcp.idle_timeout_ms);
 }
 
-test "issue-148: MCP session survives 2-minute idle" {
+test "issue-148: MCP session survives 30-minute idle" {
     const mcp = @import("mcp.zig");
-    // With the old 2-min timeout, an activity 3 minutes ago would trigger exit.
-    // With the new 10-min timeout, it should be fine.
-    const three_min_ago = cio.milliTimestamp() - (3 * 60 * 1000);
+    // With the old 10-min timeout, an activity 30 minutes ago would trigger exit.
+    // With the new 1-hour timeout, it should be fine.
+    const thirty_min_ago = cio.milliTimestamp() - (30 * 60 * 1000);
 
     // Save and restore
     const saved = mcp.last_activity.load(.acquire);
     defer mcp.last_activity.store(saved, .release);
 
-    mcp.last_activity.store(three_min_ago, .release);
+    mcp.last_activity.store(thirty_min_ago, .release);
     const last = mcp.last_activity.load(.acquire);
     const now = cio.milliTimestamp();
 
-    // Should NOT exceed 10-minute timeout
+    // Should NOT exceed 1-hour timeout
     try testing.expect(now - last < mcp.idle_timeout_ms);
 
-    // Should have exceeded old 2-minute timeout
-    try testing.expect(now - last > 2 * 60 * 1000);
+    // Should have exceeded old 10-minute timeout
+    try testing.expect(now - last > 10 * 60 * 1000);
 }
 
 test "issue-148: open pipe does not trigger HUP" {
@@ -5270,8 +5275,8 @@ test "issue-148: codedb mcp exits when stdin is closed" {
         child.stdin = null;
     }
 
-    // Wait up to 15 seconds for the process to exit
-    // (watchdog polls every 10s, so it should detect POLLHUP within ~10s)
+    // Wait for the process to exit. The main read loop exits on stdin EOF;
+    // the watchdog also polls dead clients every second as a backup.
     const start = cio.milliTimestamp();
     const term = child.wait(io) catch {
         // If wait fails, the process is stuck — test fails
@@ -5287,8 +5292,8 @@ test "issue-148: codedb mcp exits when stdin is closed" {
         else => {},
     }
 
-    // Should exit within 15 seconds (10s poll interval + margin)
-    try testing.expect(elapsed < 15_000);
+    // Should exit promptly after stdin closes.
+    try testing.expect(elapsed < 5_000);
 }
 
 const MmapTrigramIndex = @import("index.zig").MmapTrigramIndex;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6341,6 +6341,187 @@ test "issue-319: C parser avoids comments strings prototypes and macro calls" {
     try testing.expectEqual(@as(usize, 0), handler.len);
 }
 
+test "issue-321: common detected extensions produce outlines" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/App.java",
+        \\package demo;
+        \\import java.util.List;
+        \\public class Worker {
+        \\    public void run() {}
+        \\}
+        \\interface RunnableThing {}
+        \\enum Mode { A }
+        \\record Pair(int left, int right) {}
+    );
+    try explorer.indexFile("src/App.kt",
+        \\package demo
+        \\import kotlinx.coroutines.runBlocking
+        \\data class User(val name: String)
+        \\interface Repo
+        \\enum class KotlinMode { A }
+        \\fun loadUser(): User = User("a")
+        \\val answer = 42
+    );
+    try explorer.indexFile("src/Widget.svelte",
+        \\<script>
+        \\import Thing from './Thing.svelte';
+        \\export let title;
+        \\function renderTitle() {}
+        \\</script>
+        \\.card { color: red; }
+    );
+    try explorer.indexFile("src/View.vue",
+        \\<script setup>
+        \\import Child from './Child.vue'
+        \\const count = 0
+        \\function inc() {}
+        \\</script>
+    );
+    try explorer.indexFile("src/Page.astro",
+        \\---
+        \\import Layout from '../layouts/Layout.astro';
+        \\const title = 'Home';
+        \\---
+    );
+    try explorer.indexFile("scripts/build.sh",
+        \\source ./env.sh
+        \\function build_app() {
+        \\}
+        \\deploy_app() {
+        \\}
+        \\BUILD_MODE=release
+    );
+    try explorer.indexFile("styles/app.css",
+        \\:root {
+        \\  --brand: red;
+        \\}
+        \\.button {
+        \\  color: var(--brand);
+        \\}
+        \\@keyframes fade {}
+    );
+    try explorer.indexFile("styles/app.scss",
+        \\$gap: 8px;
+        \\@mixin center {}
+        \\.panel {}
+    );
+    try explorer.indexFile("db/schema.sql",
+        \\CREATE TABLE users (id integer);
+        \\CREATE OR REPLACE FUNCTION do_thing() RETURNS void AS $$ SELECT 1; $$ LANGUAGE sql;
+        \\CREATE INDEX idx_users_id ON users(id);
+    );
+    try explorer.indexFile("api/service.proto",
+        \\syntax = "proto3";
+        \\import "google/protobuf/timestamp.proto";
+        \\message User {}
+        \\enum Status { STATUS_OK = 0; }
+        \\service UserService {
+        \\  rpc GetUser (User) returns (User);
+        \\}
+    );
+    try explorer.indexFile("math/solver.f90",
+        \\module solver
+        \\use mathlib
+        \\type :: Particle
+        \\end type
+        \\subroutine step()
+        \\end subroutine
+        \\function energy()
+        \\end function
+    );
+    try explorer.indexFile("ir/module.ll",
+        \\%Pair = type { i32, i32 }
+        \\@global_value = global i32 0
+        \\define i32 @main() {
+        \\  ret i32 0
+        \\}
+    );
+    try explorer.indexFile("ir/dialect.mlir",
+        \\module @kernel_mod {
+        \\  func.func @kernel() {
+        \\    return
+        \\  }
+        \\}
+    );
+    try explorer.indexFile("llvm/records.td",
+        \\include "Base.td"
+        \\class Register<string name>;
+        \\multiclass Pat<string op>;
+        \\def R0 : Register<"r0">;
+        \\defm ADD : Pat<"add">;
+        \\let Namespace = "Toy";
+    );
+
+    const java_outline = try explorer.getOutline("src/App.java", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.java, java_outline.language);
+    try testing.expectEqualStrings("java.util.List", java_outline.imports.items[0]);
+
+    const worker = try explorer.findAllSymbols("Worker", alloc);
+    defer alloc.free(worker);
+    try testing.expectEqual(@as(usize, 1), worker.len);
+    try testing.expectEqual(SymbolKind.class_def, worker[0].symbol.kind);
+
+    const run = try explorer.findAllSymbols("run", alloc);
+    defer alloc.free(run);
+    try testing.expectEqual(@as(usize, 1), run.len);
+    try testing.expectEqual(SymbolKind.method, run[0].symbol.kind);
+
+    const user = try explorer.findAllSymbols("User", alloc);
+    defer alloc.free(user);
+    try testing.expect(user.len >= 2);
+
+    const load_user = try explorer.findAllSymbols("loadUser", alloc);
+    defer alloc.free(load_user);
+    try testing.expectEqual(@as(usize, 1), load_user.len);
+    try testing.expectEqual(SymbolKind.function, load_user[0].symbol.kind);
+
+    const title = try explorer.findAllSymbols("title", alloc);
+    defer alloc.free(title);
+    try testing.expect(title.len >= 2);
+
+    const build_app = try explorer.findAllSymbols("build_app", alloc);
+    defer alloc.free(build_app);
+    try testing.expectEqual(@as(usize, 1), build_app.len);
+    try testing.expectEqual(SymbolKind.function, build_app[0].symbol.kind);
+
+    const button = try explorer.findAllSymbols(".button", alloc);
+    defer alloc.free(button);
+    try testing.expectEqual(@as(usize, 1), button.len);
+
+    const users = try explorer.findAllSymbols("users", alloc);
+    defer alloc.free(users);
+    try testing.expectEqual(@as(usize, 1), users.len);
+    try testing.expectEqual(SymbolKind.struct_def, users[0].symbol.kind);
+
+    const user_service = try explorer.findAllSymbols("UserService", alloc);
+    defer alloc.free(user_service);
+    try testing.expectEqual(@as(usize, 1), user_service.len);
+    try testing.expectEqual(SymbolKind.interface_def, user_service[0].symbol.kind);
+
+    const particle = try explorer.findAllSymbols("Particle", alloc);
+    defer alloc.free(particle);
+    try testing.expectEqual(@as(usize, 1), particle.len);
+    try testing.expectEqual(SymbolKind.struct_def, particle[0].symbol.kind);
+
+    const main_sym = try explorer.findAllSymbols("main", alloc);
+    defer alloc.free(main_sym);
+    try testing.expectEqual(@as(usize, 1), main_sym.len);
+    try testing.expectEqual(SymbolKind.function, main_sym[0].symbol.kind);
+
+    const kernel = try explorer.findAllSymbols("kernel", alloc);
+    defer alloc.free(kernel);
+    try testing.expectEqual(@as(usize, 1), kernel.len);
+    try testing.expectEqual(SymbolKind.function, kernel[0].symbol.kind);
+
+    const r0 = try explorer.findAllSymbols("R0", alloc);
+    defer alloc.free(r0);
+    try testing.expectEqual(@as(usize, 1), r0.len);
+}
+
 test "issue-179: Python inline docstring does not leak symbols" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1896,7 +1896,7 @@ test "detectLanguage: public access and correct detection" {
     try testing.expect(explore.detectLanguage("src/main.zig") == .zig);
     try testing.expect(explore.detectLanguage("app.py") == .python);
     try testing.expect(explore.detectLanguage("index.ts") == .typescript);
-    try testing.expect(explore.detectLanguage("style.css") == .unknown);
+    try testing.expect(explore.detectLanguage("style.css") == .css);
 }
 
 test "extractLines: without line numbers" {
@@ -1991,6 +1991,24 @@ test "isCommentOrBlank: cpp block and line comments" {
     try testing.expect(isCommentOrBlank("  /* cpp block comment */", .cpp));
     try testing.expect(isCommentOrBlank("  * continued block comment", .cpp));
     try testing.expect(!isCommentOrBlank("  int x = 0;", .cpp));
+}
+
+test "isCommentOrBlank: detected extension language comments" {
+    try testing.expect(isCommentOrBlank("  // java line comment", .java));
+    try testing.expect(isCommentOrBlank("  // kotlin line comment", .kotlin));
+    try testing.expect(isCommentOrBlank("  <!-- component comment -->", .svelte));
+    try testing.expect(isCommentOrBlank("  <!-- component comment -->", .vue));
+    try testing.expect(isCommentOrBlank("  <!-- component comment -->", .astro));
+    try testing.expect(isCommentOrBlank("  # shell comment", .shell));
+    try testing.expect(isCommentOrBlank("  /* css block comment */", .css));
+    try testing.expect(isCommentOrBlank("  // scss line comment", .scss));
+    try testing.expect(isCommentOrBlank("  -- sql comment", .sql));
+    try testing.expect(isCommentOrBlank("  // proto comment", .protobuf));
+    try testing.expect(isCommentOrBlank("  ! fortran comment", .fortran));
+    try testing.expect(isCommentOrBlank("  ; llvm ir comment", .llvm_ir));
+    try testing.expect(isCommentOrBlank("  // mlir comment", .mlir));
+    try testing.expect(isCommentOrBlank("  // tablegen comment", .tablegen));
+    try testing.expect(!isCommentOrBlank("  SELECT * FROM users;", .sql));
 }
 
 test "isCommentOrBlank: tabs and mixed whitespace" {
@@ -2146,6 +2164,7 @@ test "detectLanguage: all supported extensions" {
     try testing.expect(explore.detectLanguage("app.hh") == .cpp);
     try testing.expect(explore.detectLanguage("app.cxx") == .cpp);
     try testing.expect(explore.detectLanguage("app.hxx") == .cpp);
+    try testing.expect(explore.detectLanguage("bridge.mm") == .cpp);
     try testing.expect(explore.detectLanguage("script.py") == .python);
     try testing.expect(explore.detectLanguage("app.js") == .javascript);
     try testing.expect(explore.detectLanguage("comp.jsx") == .javascript);
@@ -2158,6 +2177,20 @@ test "detectLanguage: all supported extensions" {
     try testing.expect(explore.detectLanguage("pkg.json") == .json);
     try testing.expect(explore.detectLanguage("config.yaml") == .yaml);
     try testing.expect(explore.detectLanguage("config.yml") == .yaml);
+    try testing.expect(explore.detectLanguage("Main.java") == .java);
+    try testing.expect(explore.detectLanguage("App.kt") == .kotlin);
+    try testing.expect(explore.detectLanguage("Widget.svelte") == .svelte);
+    try testing.expect(explore.detectLanguage("Widget.vue") == .vue);
+    try testing.expect(explore.detectLanguage("Page.astro") == .astro);
+    try testing.expect(explore.detectLanguage("bootstrap.sh") == .shell);
+    try testing.expect(explore.detectLanguage("styles.css") == .css);
+    try testing.expect(explore.detectLanguage("styles.scss") == .scss);
+    try testing.expect(explore.detectLanguage("schema.sql") == .sql);
+    try testing.expect(explore.detectLanguage("service.proto") == .protobuf);
+    try testing.expect(explore.detectLanguage("solver.f90") == .fortran);
+    try testing.expect(explore.detectLanguage("module.ll") == .llvm_ir);
+    try testing.expect(explore.detectLanguage("dialect.mlir") == .mlir);
+    try testing.expect(explore.detectLanguage("records.td") == .tablegen);
     try testing.expect(explore.detectLanguage("Makefile") == .unknown);
     try testing.expect(explore.detectLanguage("no_ext") == .unknown);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1647,6 +1647,14 @@ test "snapshot_json: snapshot builds and is valid JSON" {
     try testing.expect(parsed.value.object.contains("outlines"));
     try testing.expect(parsed.value.object.contains("symbol_index"));
     try testing.expect(parsed.value.object.contains("dep_graph"));
+
+    const tree = parsed.value.object.get("tree").?.string;
+    try testing.expect(std.mem.indexOf(u8, tree, "src/") != null);
+    try testing.expect(std.mem.indexOf(u8, tree, "main.zig") != null);
+
+    const symbol_index = parsed.value.object.get("symbol_index").?.object;
+    try testing.expect(symbol_index.contains("main"));
+    try testing.expect(symbol_index.contains("version"));
 }
 
 // ── Deep copy correctness tests ─────────────────────────────


### PR DESCRIPTION
## Summary

Syncs `main` to the current tip of `release/0.2.579`.

This release branch now includes the wiki/api.wiki.codes remote backend work, the restored local HTTP server path, MCP/server safety fixes, remote-query validation, the long-running bundle activity fix, the semver bump to `0.2.579`, the native C outline parser, extension/language detection coverage, lightweight outline parsers for the newly detected extension families, golden parser coverage for those extensions, clearer benchmark noise reporting, two snapshot performance improvements, and the direct `api.wiki.codes` MCP remote update, and the 1-hour MCP idle timeout with prompt dead-client cleanup.

## Included changes

- `c4cc763` Restore `codedb serve --port` on Zig 0.16.
- `2fbc66c` Route MCP status output to stderr so stdio MCP responses are not contaminated by status logs.
- `aaba92e` Make `codedb serve` port configurable through `CODEDB_PORT`.
- `14c3160` Make `codedb serve` explicitly opt-in.
- `8b43e89` Keep `codedb serve` available by default on port `6767`.
- `c9d773c` Add O(1) `findSymbol` lookup through the complete symbol index.
- `74ba881` Harden `server.isPathSafe` against null bytes and backslash traversal.
- `6ef7185` Resolve `/file/read` paths against the indexed root instead of process cwd.
- `fbb8b49` Make `findAllSymbols` merge indexed symbols with outline scan results so restored snapshots keep full coverage.
- `3233de4` Bump semver to `0.2.579`.
- `1f04fad` Add the `wiki` remote backend alongside the existing codegraff backend.
- `e7c9fd4` Add native C outline parsing for functions, structs, enums, unions, typedefs, macros, and common declarations.
- `56af2f6` Reject empty `codedb_remote` queries for actions that require user input.
- `3988c1f` Refresh MCP bundle `last_activity` during long-running bundle work so the idle watchdog does not close stdin mid-call.
- `ad52783` Add language detection coverage for `.mm`, `.java`, `.kt`, `.svelte`, `.vue`, `.astro`, `.sh`, `.css`, `.scss`, `.sql`, `.proto`, `.f90`, `.ll`, `.mlir`, and `.td`.
- `27b8d81` Add lightweight outline parsing for Java, Kotlin, Svelte/Vue/Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen.
- `3ca698b` Add per-extension golden outline checks and improve `.cc`/`.mm` parsing for C++ classes, `#import`, Objective-C interfaces/implementations/protocols, and ObjC method names.
- `5b76d9c` Make benchmark markdown status respect both the percentage threshold and absolute-ns threshold, with `NOISE` for tiny high-percent swings.
- `f6f12b6` Speed up snapshot JSON generation by reusing sorted paths, serializing the maintained symbol index, writing tree JSON directly, and chunking JSON escaping.
- `d99041b` Cache `codedb_snapshot` responses by store sequence with a 16 MB cap, so repeated snapshot calls skip JSON rebuild until edits/indexing advance the sequence.
- `32b5e3f` Point `codedb_remote` at `api.wiki.codes`, map native query params, add wiki security/history actions (`deps`, `score`, `cves`, `commits`, `branches`, `dep-history`), and accept raw wiki slugs such as `chromium`.
- `9a70fb4` Extend MCP idle timeout from 10 minutes to 1 hour while polling dead MCP clients every second.

## Parser coverage

- `.cc` parses C++ includes, classes, member-like functions, and free functions.
- `.mm` parses `#import`, Objective-C `@interface` / `@implementation` / `@protocol`, Objective-C method names, C++ classes, and C-style functions.
- Java/Kotlin parse imports, class-like declarations, methods/functions, and common vars/constants.
- Svelte/Vue/Astro parse script imports/functions/constants and simple style selectors.
- Shell parses sourced files, functions, and assignments.
- CSS/SCSS parse selectors, variables, keyframes, mixins, and functions.
- SQL parses common `CREATE ...` objects.
- protobuf parses imports, messages, enums, services, and RPCs.
- Fortran parses modules, uses, types, subroutines, functions, and programs.
- LLVM IR parses functions, declarations, globals, and type aliases.
- MLIR parses named modules and functions.
- TableGen parses includes, classes/multiclasses, defs/defms, and lets.

## Performance notes

The intended symbol lookup improvement in this release is `c9d773c`: `findSymbol` now uses the complete symbol index for O(1) lookup instead of relying on slower scan-style lookup for the common path. `fbb8b49` keeps that indexed path while merging in outline scan results, so restored snapshots keep coverage without losing the faster lookup path.

Snapshot performance was improved in two layers:

- PR #325: `codedb_snapshot` JSON generation dropped from `2,835,681 ns` to `1,351,605 ns` on GitHub CI (`-52.34%`).
- PR #326: repeated `codedb_snapshot` calls now reuse a cached response by store seq, dropping from `1,339,408 ns` to `256,474 ns` on GitHub CI (`-80.85%`) against the already-optimized base.

Benchmark reporting now shows both percent delta and absolute ns delta. Rows only fail when both thresholds are exceeded; high-percent tiny absolute swings are labeled `NOISE`, matching the actual CI gate.

## Validation

- PR #328 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #327 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #326 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #325 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #324 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #323 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #322 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #321 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #316 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #317 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- PR #320 `bench-regression / bench`: passed before merge into `release/0.2.579`.
- Local validation for #328: `zig build test`, `zig build`, and installed binary smoke confirmed MCP exits when stdin closes in ~285ms.
- Local validation for #327: `zig build`, `zig build test`, and live MCP smoke calls to `api.wiki.codes` for `justrach/codedb` symbol lookup, `axios/axios` CVEs, and raw slug `chromium` policy.
- Local validation for #326: `zig build test`, `zig build`, and local base/head benchmark comparison passed.
- Local validation for #325: `zig build test`, `zig build`, and local base/head benchmark comparison passed.
- Local validation for #324: `python3 -m unittest scripts/test_compare_bench.py` and `python3 -m py_compile scripts/compare-bench.py scripts/test_compare_bench.py`.
- Local validation for #323: `zig build test` and `zig build` passed.
- Local validation for #322: `zig build test` and `zig build` passed.
- Local validation for #321: `zig build test` and `zig build` passed.
- Local validation for #320: `zig build test` and `zig build` passed.

## Notes

This branch now points at merge commit `4e38a29`, the current `release/0.2.579` tip.

Supersedes #314, which only covered the wiki backend subset.
