### PR TITLE
codedb_remote: reject empty query on actions that consume it

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1390,6 +1390,23 @@ fn handleRemote(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
     var url_buf: [512]u8 = undefined;
     const query = getStr(args, "query");
 
+    // Require a non-empty 'query' for actions that actually consume it.
+    // Silently sending `q=` to the remote turned real user mistakes into
+    // empty/garbage responses — fail fast with a pointer at the right field.
+    const needs_query = std.mem.eql(u8, action, "search") or
+        (is_wiki and (std.mem.eql(u8, action, "symbol") or std.mem.eql(u8, action, "outline")));
+    if (needs_query and (query == null or query.?.len == 0)) {
+        out.appendSlice(alloc, "error: action '") catch {};
+        out.appendSlice(alloc, action) catch {};
+        if (std.mem.eql(u8, action, "search")) {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the search text)") catch {};
+        } else if (std.mem.eql(u8, action, "symbol")) {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the identifier name to look up)") catch {};
+        } else {
+            out.appendSlice(alloc, "' requires a non-empty 'query' (the file path to outline)") catch {};
+        }
+        return;
+    }
     if (is_wiki) {
         // wiki.codes uses flat slugs: owner/repo → owner-repo. The Vercel
         // /api/query proxy takes slug+endpoint+q and server-side-auths to


### PR DESCRIPTION
## Problem

\`codedb_remote action=search\` without a \`query\` argument silently sends \`q=\` (empty string) to the remote. The remote returns either an empty result set or a confusing error, and the user can't tell whether their search was genuinely empty or malformed. Same applies to \`action=symbol\` and \`action=outline\` on the wiki backend.

Found during triage of open issues while I was looking at #278 and #304 — this is a separate bug the validation I was auditing didn't catch.

## Fix

Validate that \`query\` is non-empty before building URLs, for actions that actually consume it:

- \`search\` (both backends) → requires query
- \`symbol\` (wiki backend) → requires query  
- \`outline\` (wiki backend) → requires query (the file path)
- \`tree\` / \`meta\` / \`policy\` → unchanged (these legitimately take no query)

Error messages are specific so the caller knows which field to supply:

\`\`\`
error: action 'search' requires a non-empty 'query' (the search text)
error: action 'symbol' requires a non-empty 'query' (the identifier name to look up)
error: action 'outline' requires a non-empty 'query' (the file path to outline)
\`\`\`

## Verified via MCP stdio

\`\`\`
codedb_remote {"repo":"x","action":"search"}
  → error with guidance
codedb_remote {"repo":"x","action":"symbol","backend":"wiki"}
  → error with guidance
codedb_remote {"repo":"sinclairzx81/typebox","action":"tree","backend":"wiki"}
  → succeeds (unchanged, 1.5s)
codedb_remote {"repo":"rust-lang/rust","action":"symbol","query":"HashMap","backend":"wiki"}
  → 25 results (unchanged)
\`\`\`

## Not a regression

The missing-query case was already broken before my wiki backend landed; \`codedb_remote action=search\` without a query has always silently sent an empty q= to codegraff. This just surfaces the failure with a useful error instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)