### PR TITLE
mcp: refresh last_activity during long bundle processing (#278)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1270,6 +1270,12 @@ fn handleBundle(
     }
 
     const w = cio.listWriter(out, alloc);
+    // Refresh the idle clock as we start the bundle — long bundles (slow
+    // sub-ops, many ops, remote fetches) would otherwise leave
+    // `last_activity` frozen at message-arrival time, and the watchdog
+    // would close stdin mid-processing. Repeated inside the loop so each
+    // completed sub-op keeps us marked active. See #278.
+    last_activity.store(cio.milliTimestamp(), .release);
     for (ops, 0..) |op, i| {
         if (op != .object) {
             w.print("--- [{d}] error ---\nop must be an object\n", .{i}) catch {};
@@ -1319,6 +1325,9 @@ fn handleBundle(
         w.print("--- [{d}] {s} ---\n", .{ i, tool_name }) catch {};
         out.appendSlice(alloc, sub_out.items) catch {};
         w.writeAll("\n") catch {};
+
+        // Per-op activity refresh — see top of this fn.
+        last_activity.store(cio.milliTimestamp(), .release);
     }
 }
 


### PR DESCRIPTION
## Diagnosis

\`idleWatchdog\` in \`main.zig\` closes stdin when \`now - last_activity > idle_timeout_ms\` (10 min). But \`last_activity\` is only updated once per incoming message — right after \`readLineBuf\` at \`mcp.zig:474\`. Inside a single \`codedb_bundle\` call that takes longer than 10 minutes (many slow sub-ops, or ops that shell out to \`codedb_remote\` / \`codedb_tree\` on huge repos), the clock stays frozen at message-arrival time. At the 10-minute mark the watchdog closes stdin mid-processing.

The main thread finishes the bundle and writes the response fine (stdout is untouched), but the client — whose write-end of the stdin pipe just got \`EPIPE\`d — reports **"Transport closed"** on its next tool call. That matches the reporter's note in #278 that the issue shows up on "long enough sessions".

## Fix

Stamp \`last_activity\` at bundle start AND at the end of each completed sub-op inside \`handleBundle\`. Every sub-op is bounded by its own logic, so the watchdog can only fire when the main thread truly has nothing in flight.

No change to the idle path: a bundle that completes in under 10 min doesn't touch \`last_activity\` beyond what was already there; sessions that actually go idle still get reaped on the same schedule.

## Scope

- 9 lines added to \`src/mcp.zig\` inside \`handleBundle\`.
- No test change — this is a timing/watchdog interaction and the existing idle-watchdog tests cover the reaping path; covering this would need a multi-minute slow sub-op mock.
- Non-bundle code paths unchanged. If "Transport closed" still surfaces on single-tool calls we'll need a separate repro — this is the most obvious trigger given the reporter's description.

## Test plan

- [x] \`zig build\` green
- [x] Existing \`codedb_bundle\` behavior unchanged on short bundles (tested locally)
- [ ] Anecdotal: the original reporter should see "Transport closed" go away on long bundle sessions. Would help to get confirmation before we call #278 fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)