### PR TITLE
[codex] Add native C outline parser

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -105,7 +105,10 @@ pub const Language = enum(u8) {
 pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".zig")) return .zig;
     if (std.mem.endsWith(u8, path, ".c") or std.mem.endsWith(u8, path, ".h")) return .c;
-    if (std.mem.endsWith(u8, path, ".cpp") or std.mem.endsWith(u8, path, ".hpp")) return .cpp;
+    if (std.mem.endsWith(u8, path, ".cpp") or std.mem.endsWith(u8, path, ".hpp") or
+        std.mem.endsWith(u8, path, ".cc") or std.mem.endsWith(u8, path, ".hh") or
+        std.mem.endsWith(u8, path, ".cxx") or std.mem.endsWith(u8, path, ".hxx"))
+        return .cpp;
     if (std.mem.endsWith(u8, path, ".py")) return .python;
     if (std.mem.endsWith(u8, path, ".js") or std.mem.endsWith(u8, path, ".jsx")) return .javascript;
     if (std.mem.endsWith(u8, path, ".ts") or std.mem.endsWith(u8, path, ".tsx")) return .typescript;
@@ -862,6 +865,8 @@ pub const Explorer = struct {
                 try parser.parsePythonLine(trimmed, line_num, &outline);
             } else if (outline.language == .typescript or outline.language == .javascript) {
                 try parser.parseTsLine(trimmed, line_num, &outline);
+            } else if (outline.language == .c or outline.language == .cpp) {
+                try parser.parseCLine(trimmed, line_num, &outline);
             } else if (outline.language == .rust) {
                 try parser.parseRustLine(trimmed, line_num, &outline, prev_line_trimmed);
             } else if (outline.language == .php) {
@@ -1869,6 +1874,39 @@ pub const Explorer = struct {
                 errdefer a.free(import_copy);
                 try outline.imports.append(a, import_copy);
             }
+        }
+    }
+
+    fn parseCLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "#include")) {
+            if (extractCIncludePath(line)) |path| {
+                const import_copy = try a.dupe(u8, path);
+                errdefer a.free(import_copy);
+                try outline.imports.append(a, import_copy);
+            }
+            try appendOutlineSymbol(a, outline, line, .import, line_num, line);
+            return;
+        }
+
+        if (startsWith(line, "#define")) {
+            const rest = std.mem.trimStart(u8, line["#define".len..], " \t");
+            if (extractIdent(rest)) |name| {
+                try appendOutlineSymbol(a, outline, name, .macro_def, line_num, line);
+            }
+            return;
+        }
+
+        if (parseCNamedType(line)) |type_sym| {
+            try appendOutlineSymbol(a, outline, type_sym.name, type_sym.kind, line_num, line);
+            return;
+        }
+
+        if (extractCFunctionName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
         }
     }
 
@@ -3535,6 +3573,27 @@ fn startsWith(haystack: []const u8, needle: []const u8) bool {
     return std.mem.startsWith(u8, haystack, needle);
 }
 
+fn appendOutlineSymbol(
+    allocator: std.mem.Allocator,
+    outline: *FileOutline,
+    name: []const u8,
+    kind: SymbolKind,
+    line_num: u32,
+    detail: []const u8,
+) !void {
+    const name_copy = try allocator.dupe(u8, name);
+    errdefer allocator.free(name_copy);
+    const detail_copy = try allocator.dupe(u8, detail);
+    errdefer allocator.free(detail_copy);
+    try outline.symbols.append(allocator, .{
+        .name = name_copy,
+        .kind = kind,
+        .line_start = line_num,
+        .line_end = line_num,
+        .detail = detail_copy,
+    });
+}
+
 fn extractIdent(s: []const u8) ?[]const u8 {
     const max_ident_len: usize = 256;
     var end: usize = 0;
@@ -3547,7 +3606,13 @@ fn extractIdent(s: []const u8) ?[]const u8 {
     return if (end > 0) s[0..end] else null;
 }
 
-fn extractLastIdent(s: []const u8) ?[]const u8 {
+const IdentSpan = struct {
+    text: []const u8,
+    start: usize,
+    end: usize,
+};
+
+fn extractLastIdentSpan(s: []const u8) ?IdentSpan {
     if (s.len == 0) return null;
 
     var end = s.len;
@@ -3564,7 +3629,148 @@ fn extractLastIdent(s: []const u8) ?[]const u8 {
         if (!(std.ascii.isAlphanumeric(ch) or ch == '_')) break;
         start -= 1;
     }
-    return s[start..end];
+    return .{ .text = s[start..end], .start = start, .end = end };
+}
+
+fn extractLastIdent(s: []const u8) ?[]const u8 {
+    return if (extractLastIdentSpan(s)) |span| span.text else null;
+}
+
+fn stripLineComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "//")) return "";
+    if (std.mem.indexOf(u8, trimmed, "//")) |pos| {
+        return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    }
+    return trimmed;
+}
+
+fn extractCIncludePath(line: []const u8) ?[]const u8 {
+    const rest = std.mem.trimStart(u8, line["#include".len..], " \t");
+    if (rest.len >= 2 and rest[0] == '<') {
+        if (std.mem.indexOfScalar(u8, rest[1..], '>')) |end| {
+            if (end == 0) return null;
+            return rest[1 .. end + 1];
+        }
+    }
+    return extractStringLiteral(rest);
+}
+
+const CTypeSymbol = struct {
+    name: []const u8,
+    kind: SymbolKind,
+};
+
+fn parseCNamedType(line: []const u8) ?CTypeSymbol {
+    const stripped = stripCAttributesPrefix(line);
+    if (startsWith(stripped, "typedef ")) {
+        const rest = std.mem.trimStart(u8, stripped["typedef ".len..], " \t");
+        if (parseCBraceType(rest)) |sym| return sym;
+        if (std.mem.indexOf(u8, rest, "(*") != null) return null;
+        if (std.mem.indexOfScalar(u8, rest, ';')) |semi| {
+            const before_semi = rest[0..semi];
+            if (extractLastIdent(before_semi)) |name| {
+                if (!isCKeyword(name)) return .{ .name = name, .kind = .type_alias };
+            }
+        }
+        return null;
+    }
+    return parseCBraceType(stripped);
+}
+
+fn parseCBraceType(line: []const u8) ?CTypeSymbol {
+    if (std.mem.indexOfScalar(u8, line, '{') == null) return null;
+    if (startsWith(line, "struct ")) {
+        return parseCTypeAfterKeyword(line["struct ".len..], .struct_def);
+    }
+    if (startsWith(line, "enum ")) {
+        return parseCTypeAfterKeyword(line["enum ".len..], .enum_def);
+    }
+    if (startsWith(line, "union ")) {
+        return parseCTypeAfterKeyword(line["union ".len..], .union_def);
+    }
+    return null;
+}
+
+fn parseCTypeAfterKeyword(rest: []const u8, kind: SymbolKind) ?CTypeSymbol {
+    const trimmed = std.mem.trimStart(u8, rest, " \t");
+    if (trimmed.len == 0 or trimmed[0] == '{') return null;
+    if (extractIdent(trimmed)) |name| {
+        if (!isCKeyword(name)) return .{ .name = name, .kind = kind };
+    }
+    return null;
+}
+
+fn extractCFunctionName(line: []const u8) ?[]const u8 {
+    const stripped = stripCAttributesPrefix(line);
+    if (stripped.len == 0 or stripped[0] == '#') return null;
+    if (startsWith(stripped, "typedef ")) return null;
+    if (std.mem.indexOfScalar(u8, stripped, ';') != null) return null;
+
+    const search_end = std.mem.indexOfScalar(u8, stripped, '{') orelse stripped.len;
+    if (search_end == 0) return null;
+    const signature = std.mem.trimEnd(u8, stripped[0..search_end], " \t");
+    const open_paren = std.mem.lastIndexOfScalar(u8, signature, '(') orelse return null;
+    if (std.mem.indexOfScalar(u8, signature[open_paren..], ')') == null) return null;
+    if (std.mem.indexOf(u8, signature, "(*") != null) return null;
+
+    const before_paren = std.mem.trimEnd(u8, signature[0..open_paren], " \t");
+    const span = extractLastIdentSpan(before_paren) orelse return null;
+    const name = span.text;
+    if (isCKeyword(name)) return null;
+
+    const before_name = std.mem.trim(u8, before_paren[0..span.start], " \t*(&");
+    if (before_name.len == 0) return null;
+    if (hasCAssignmentBeforeName(before_name)) return null;
+    if (isCForbiddenFunctionPrefix(before_name)) return null;
+    if (std.mem.endsWith(u8, before_name, ".") or std.mem.endsWith(u8, before_name, "->")) return null;
+
+    return name;
+}
+
+fn stripCAttributesPrefix(line: []const u8) []const u8 {
+    var rest = std.mem.trimStart(u8, line, " \t");
+    while (startsWith(rest, "__attribute__((")) {
+        if (std.mem.indexOf(u8, rest, "))")) |end| {
+            rest = std.mem.trimStart(u8, rest[end + 2 ..], " \t");
+        } else break;
+    }
+    return rest;
+}
+
+fn hasCAssignmentBeforeName(prefix: []const u8) bool {
+    for (prefix, 0..) |ch, i| {
+        if (ch != '=') continue;
+        const prev = if (i > 0) prefix[i - 1] else 0;
+        const next = if (i + 1 < prefix.len) prefix[i + 1] else 0;
+        if (prev == '=' or prev == '!' or prev == '<' or prev == '>' or next == '=') continue;
+        return true;
+    }
+    return false;
+}
+
+fn isCForbiddenFunctionPrefix(prefix: []const u8) bool {
+    const first = extractIdent(std.mem.trimStart(u8, prefix, " \t*(&")) orelse return false;
+    return std.mem.eql(u8, first, "return") or
+        std.mem.eql(u8, first, "case") or
+        std.mem.eql(u8, first, "sizeof") or
+        std.mem.eql(u8, first, "if") or
+        std.mem.eql(u8, first, "for") or
+        std.mem.eql(u8, first, "while") or
+        std.mem.eql(u8, first, "switch");
+}
+
+fn isCKeyword(s: []const u8) bool {
+    const keywords = [_][]const u8{
+        "if",       "for",      "while",  "switch", "return",   "sizeof",
+        "case",     "do",       "else",   "struct", "enum",     "union",
+        "typedef",  "static",   "extern", "inline", "const",    "volatile",
+        "register", "restrict", "auto",   "break",  "continue",
+    };
+    for (keywords) |kw| {
+        if (std.mem.eql(u8, s, kw)) return true;
+    }
+    return false;
 }
 
 fn firstIndexOfAny(s: []const u8, chars: []const u8) ?usize {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2142,6 +2142,10 @@ test "detectLanguage: all supported extensions" {
     try testing.expect(explore.detectLanguage("util.h") == .c);
     try testing.expect(explore.detectLanguage("app.cpp") == .cpp);
     try testing.expect(explore.detectLanguage("app.hpp") == .cpp);
+    try testing.expect(explore.detectLanguage("app.cc") == .cpp);
+    try testing.expect(explore.detectLanguage("app.hh") == .cpp);
+    try testing.expect(explore.detectLanguage("app.cxx") == .cpp);
+    try testing.expect(explore.detectLanguage("app.hxx") == .cpp);
     try testing.expect(explore.detectLanguage("script.py") == .python);
     try testing.expect(explore.detectLanguage("app.js") == .javascript);
     try testing.expect(explore.detectLanguage("comp.jsx") == .javascript);
@@ -6179,6 +6183,129 @@ test "issue-215: R setClass parsed" {
 test "issue-215: detectLanguage handles .r and .R" {
     try testing.expectEqual(Language.r, explore.detectLanguage("script.r"));
     try testing.expectEqual(Language.r, explore.detectLanguage("analysis.R"));
+}
+
+test "issue-319: C parser extracts includes macros types and functions" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/core.c",
+        \\#include <stdio.h>
+        \\#include "local.h"
+        \\#define MAX_SIZE 64
+        \\#define SQUARE(x) ((x) * (x))
+        \\struct Worker {
+        \\    int id;
+        \\};
+        \\enum Mode {
+        \\    MODE_A,
+        \\};
+        \\union Value {
+        \\    int i;
+        \\};
+        \\typedef unsigned long size_alias_t;
+        \\static inline const char *worker_name(const struct Worker *worker) {
+        \\    return "worker";
+        \\}
+        \\void *alloc_item(size_t size)
+        \\{
+        \\    return malloc(size);
+        \\}
+    );
+
+    const outline = try explorer.getOutline("src/core.c", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.c, outline.language);
+    try testing.expectEqual(@as(usize, 2), outline.imports.items.len);
+    try testing.expectEqualStrings("stdio.h", outline.imports.items[0]);
+    try testing.expectEqualStrings("local.h", outline.imports.items[1]);
+
+    const max_size = try explorer.findAllSymbols("MAX_SIZE", alloc);
+    defer alloc.free(max_size);
+    try testing.expectEqual(@as(usize, 1), max_size.len);
+    try testing.expectEqual(SymbolKind.macro_def, max_size[0].symbol.kind);
+
+    const square = try explorer.findAllSymbols("SQUARE", alloc);
+    defer alloc.free(square);
+    try testing.expectEqual(@as(usize, 1), square.len);
+    try testing.expectEqual(SymbolKind.macro_def, square[0].symbol.kind);
+
+    const worker = try explorer.findAllSymbols("Worker", alloc);
+    defer alloc.free(worker);
+    try testing.expectEqual(@as(usize, 1), worker.len);
+    try testing.expectEqual(SymbolKind.struct_def, worker[0].symbol.kind);
+
+    const mode = try explorer.findAllSymbols("Mode", alloc);
+    defer alloc.free(mode);
+    try testing.expectEqual(@as(usize, 1), mode.len);
+    try testing.expectEqual(SymbolKind.enum_def, mode[0].symbol.kind);
+
+    const value = try explorer.findAllSymbols("Value", alloc);
+    defer alloc.free(value);
+    try testing.expectEqual(@as(usize, 1), value.len);
+    try testing.expectEqual(SymbolKind.union_def, value[0].symbol.kind);
+
+    const alias = try explorer.findAllSymbols("size_alias_t", alloc);
+    defer alloc.free(alias);
+    try testing.expectEqual(@as(usize, 1), alias.len);
+    try testing.expectEqual(SymbolKind.type_alias, alias[0].symbol.kind);
+
+    const worker_name = try explorer.findAllSymbols("worker_name", alloc);
+    defer alloc.free(worker_name);
+    try testing.expectEqual(@as(usize, 1), worker_name.len);
+    try testing.expectEqual(SymbolKind.function, worker_name[0].symbol.kind);
+
+    const alloc_item = try explorer.findAllSymbols("alloc_item", alloc);
+    defer alloc.free(alloc_item);
+    try testing.expectEqual(@as(usize, 1), alloc_item.len);
+    try testing.expectEqual(SymbolKind.function, alloc_item[0].symbol.kind);
+}
+
+test "issue-319: C parser avoids comments strings prototypes and macro calls" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/noise.c",
+        \\// int fake_comment(void) {
+        \\/* int fake_block(void) { */
+        \\const char *s = "int fake_string(void) {";
+        \\typedef int (*handler_fn)(int);
+        \\int prototype_only(void);
+        \\EXPORT_SYMBOL(real_function);
+        \\if (real_function()) {
+        \\}
+        \\int real_function(void) {
+        \\    return 1;
+        \\}
+    );
+
+    const real = try explorer.findAllSymbols("real_function", alloc);
+    defer alloc.free(real);
+    try testing.expectEqual(@as(usize, 1), real.len);
+    try testing.expectEqual(SymbolKind.function, real[0].symbol.kind);
+
+    const fake_comment = try explorer.findAllSymbols("fake_comment", alloc);
+    defer alloc.free(fake_comment);
+    try testing.expectEqual(@as(usize, 0), fake_comment.len);
+
+    const fake_block = try explorer.findAllSymbols("fake_block", alloc);
+    defer alloc.free(fake_block);
+    try testing.expectEqual(@as(usize, 0), fake_block.len);
+
+    const fake_string = try explorer.findAllSymbols("fake_string", alloc);
+    defer alloc.free(fake_string);
+    try testing.expectEqual(@as(usize, 0), fake_string.len);
+
+    const prototype = try explorer.findAllSymbols("prototype_only", alloc);
+    defer alloc.free(prototype);
+    try testing.expectEqual(@as(usize, 0), prototype.len);
+
+    const handler = try explorer.findAllSymbols("handler_fn", alloc);
+    defer alloc.free(handler);
+    try testing.expectEqual(@as(usize, 0), handler.len);
 }
 
 test "issue-179: Python inline docstring does not leak symbols" {


### PR DESCRIPTION
## Summary

Adds native C/C++ outline parsing to codedb's existing line parser path.

This covers:

- `#include` imports
- `#define` macros
- named `struct`, `enum`, and `union` declarations
- simple typedef aliases
- likely function definitions, including pointer returns and brace-on-next-line style
- additional C++ extension detection for `.cc`, `.hh`, `.cxx`, and `.hxx`

## Why

wiki.codes production storage currently has a large C/C++ corpus with tree/search coverage but no structural symbols:

```text
language=c    files=177123  files_with_symbols=0  symbols=0
language=cpp  files=50596   files_with_symbols=0  symbols=0
```

The root cause is that `detectLanguage` recognizes `.c` and `.h`, and the brace-language helpers already include C/C++, but `parseOutlineWithParser` never dispatches C/C++ files to a parser.

## Safety

The parser is intentionally conservative. It skips prototypes, function pointer typedefs, control-flow calls, comments, strings, and macro calls instead of trying to classify ambiguous C syntax.

## Validation

```text
zig build test
zig build
```

Closes #319.
