### PR TITLE
parse: add lightweight outlines for common extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 >
 > codedb works and is used daily in production AI workflows, but:
 > - **Parser support** — Zig, C/C++, Python, TypeScript/JavaScript, Rust, Go, PHP, Ruby, HCL, R, Dart/Flutter
-> - **Language detection** — also tags Java, Kotlin, Svelte, Vue, Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen files in trees/snapshots
+> - **Lightweight outline support** — Java, Kotlin, Svelte, Vue, Astro, shell, CSS/SCSS, SQL, protobuf, Fortran, LLVM IR, MLIR, and TableGen
 > - **No auth** — HTTP server binds to localhost only
 > - **Snapshot format** may change between versions
 > - **MCP protocol** is JSON-RPC 2.0 over stdio (stable)

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -641,7 +641,12 @@ pub const Explorer = struct {
             outline.language == .cpp or outline.language == .typescript or
             outline.language == .javascript or outline.language == .rust or
             outline.language == .go_lang or outline.language == .php or
-            outline.language == .dart;
+            outline.language == .dart or outline.language == .java or
+            outline.language == .kotlin or outline.language == .svelte or
+            outline.language == .vue or outline.language == .astro or
+            outline.language == .css or outline.language == .scss or
+            outline.language == .protobuf or outline.language == .mlir or
+            outline.language == .tablegen;
 
         for (outline.symbols.items) |*sym| {
             // Skip single-line kinds
@@ -866,7 +871,12 @@ pub const Explorer = struct {
                 outline.language == .go_lang or outline.language == .c or
                 outline.language == .cpp or outline.language == .rust or
                 outline.language == .zig or outline.language == .hcl or
-                outline.language == .dart)
+                outline.language == .dart or outline.language == .java or
+                outline.language == .kotlin or outline.language == .svelte or
+                outline.language == .vue or outline.language == .astro or
+                outline.language == .css or outline.language == .scss or
+                outline.language == .protobuf or outline.language == .mlir or
+                outline.language == .tablegen)
             {
                 if (in_block_comment) {
                     if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
@@ -930,6 +940,28 @@ pub const Explorer = struct {
                 try parser.parseHclLine(trimmed, line_num, &outline);
             } else if (outline.language == .r) {
                 try parser.parseRLine(trimmed, line_num, &outline);
+            } else if (outline.language == .java) {
+                try parser.parseJavaLine(trimmed, line_num, &outline);
+            } else if (outline.language == .kotlin) {
+                try parser.parseKotlinLine(trimmed, line_num, &outline);
+            } else if (outline.language == .svelte or outline.language == .vue or outline.language == .astro) {
+                try parser.parseComponentLine(trimmed, line_num, &outline);
+            } else if (outline.language == .shell) {
+                try parser.parseShellLine(trimmed, line_num, &outline);
+            } else if (outline.language == .css or outline.language == .scss) {
+                try parser.parseStyleLine(trimmed, line_num, &outline);
+            } else if (outline.language == .sql) {
+                try parser.parseSqlLine(trimmed, line_num, &outline);
+            } else if (outline.language == .protobuf) {
+                try parser.parseProtoLine(trimmed, line_num, &outline);
+            } else if (outline.language == .fortran) {
+                try parser.parseFortranLine(trimmed, line_num, &outline);
+            } else if (outline.language == .llvm_ir) {
+                try parser.parseLlvmIrLine(trimmed, line_num, &outline);
+            } else if (outline.language == .mlir) {
+                try parser.parseMlirLine(trimmed, line_num, &outline);
+            } else if (outline.language == .tablegen) {
+                try parser.parseTableGenLine(trimmed, line_num, &outline);
             }
 
             prev_line_trimmed = trimmed;
@@ -1872,8 +1904,19 @@ pub const Explorer = struct {
     }
     fn parseTsLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
         const a = self.allocator;
-        if (containsAny(line, &.{ "function ", "const ", "export function ", "export const " })) {
-            const kind: SymbolKind = if (std.mem.indexOf(u8, line, "function") != null) .function else .constant;
+        if (containsAny(line, &.{ "function ", "const ", "let ", "var ", "class ", "interface ", "enum ", "type " })) {
+            const kind: SymbolKind = if (std.mem.indexOf(u8, line, "function") != null)
+                .function
+            else if (std.mem.indexOf(u8, line, "class ") != null)
+                .class_def
+            else if (std.mem.indexOf(u8, line, "interface ") != null)
+                .interface_def
+            else if (std.mem.indexOf(u8, line, "enum ") != null)
+                .enum_def
+            else if (std.mem.indexOf(u8, line, "type ") != null)
+                .type_alias
+            else
+                .constant;
             const trimmed = skipKeywords(line);
             if (extractIdent(trimmed)) |name| {
                 const name_copy = try a.dupe(u8, name);
@@ -1903,6 +1946,211 @@ pub const Explorer = struct {
                 errdefer a.free(import_copy);
                 try outline.imports.append(a, import_copy);
             }
+        }
+    }
+
+    fn parseJavaLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0 or startsWith(line, "@")) return;
+
+        if (parseDelimitedImport(line, "import ", ";")) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+
+        if (extractIdentAfterKeyword(line, "record ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "interface ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "enum ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractJvmMethodName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
+        }
+    }
+
+    fn parseKotlinLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0 or startsWith(line, "@")) return;
+
+        if (parseDelimitedImport(line, "import ", "")) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+
+        if (extractIdentAfterKeyword(line, "enum class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "interface ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "object ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "fun ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "val ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "var ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        }
+    }
+
+    fn parseComponentLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "<!--") or startsWith(line, "<script") or startsWith(line, "</script") or
+            startsWith(line, "<style") or startsWith(line, "</style"))
+            return;
+        if (startsWith(line, ".") or startsWith(line, "#") or startsWith(line, "@keyframes") or startsWith(line, "$") or startsWith(line, "--")) {
+            try self.parseStyleLine(line, line_num, outline);
+            return;
+        }
+        try self.parseTsLine(line, line_num, outline);
+    }
+
+    fn parseShellLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "#")) return;
+
+        if (startsWith(line, "source ")) {
+            const imp = firstShellWord(line["source ".len..]) orelse return;
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+        if (startsWith(line, ". ")) {
+            const imp = firstShellWord(line[2..]) orelse return;
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+        if (extractIdentAfterKeyword(line, "function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+            return;
+        }
+        if (std.mem.indexOf(u8, line, "()")) |pos| {
+            const before = std.mem.trim(u8, line[0..pos], " \t");
+            if (extractIdent(before)) |name| {
+                if (name.len == before.len) try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+            }
+            return;
+        }
+        if (parseShellAssignment(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        }
+    }
+
+    fn parseStyleLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, "/*") or startsWith(line, "*")) return;
+
+        if (extractIdentAfterKeyword(line, "@keyframes ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "@mixin ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "@function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (parseCssVariable(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (parseCssSelector(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        }
+    }
+
+    fn parseSqlLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripSqlLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (parseSqlCreate(line)) |sym| {
+            try appendOutlineSymbol(a, outline, sym.name, sym.kind, line_num, line);
+        }
+    }
+
+    fn parseProtoLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "import ")) {
+            if (extractStringLiteral(line)) |imp| try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "message ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "enum ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "service ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "rpc ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
+        }
+    }
+
+    fn parseFortranLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripFortranComment(raw_line);
+        if (line.len == 0) return;
+
+        if (parseFortranUse(line)) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "module ")) |name| {
+            if (!startsWithIgnoreCase(line, "module procedure ")) try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "program ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "subroutine ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (extractIdentAfterKeywordIgnoreCase(line, "function ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (parseFortranTypeName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+        }
+    }
+
+    fn parseLlvmIrLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or startsWith(line, ";")) return;
+
+        if (startsWith(line, "define ") or startsWith(line, "declare ")) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (line[0] == '@') {
+            if (extractLlvmGlobalName(line)) |name| try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        } else if (line[0] == '%' and std.mem.indexOf(u8, line, " = type") != null) {
+            if (extractLlvmGlobalName(line)) |name| try appendOutlineSymbol(a, outline, name, .type_alias, line_num, line);
+        }
+    }
+
+    fn parseMlirLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (std.mem.indexOf(u8, line, "module @") != null) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (std.mem.indexOf(u8, line, "func") != null and std.mem.indexOfScalar(u8, line, '@') != null) {
+            if (extractAtName(line)) |name| try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        }
+    }
+
+    fn parseTableGenLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0) return;
+
+        if (startsWith(line, "include ")) {
+            if (extractStringLiteral(line)) |imp| try appendImportSymbol(a, outline, imp, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "defm ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "def ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "multiclass ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "let ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
         }
     }
 
@@ -3629,6 +3877,19 @@ fn appendOutlineSymbol(
     });
 }
 
+fn appendImportSymbol(
+    allocator: std.mem.Allocator,
+    outline: *FileOutline,
+    import_path: []const u8,
+    line_num: u32,
+    detail: []const u8,
+) !void {
+    try appendOutlineSymbol(allocator, outline, import_path, .import, line_num, detail);
+    const import_copy = try allocator.dupe(u8, import_path);
+    errdefer allocator.free(import_copy);
+    try outline.imports.append(allocator, import_copy);
+}
+
 fn extractIdent(s: []const u8) ?[]const u8 {
     const max_ident_len: usize = 256;
     var end: usize = 0;
@@ -3637,6 +3898,208 @@ fn extractIdent(s: []const u8) ?[]const u8 {
         if (std.ascii.isAlphanumeric(ch) or ch == '_') {
             end += 1;
         } else break;
+    }
+    return if (end > 0) s[0..end] else null;
+}
+
+fn isIdentChar(ch: u8) bool {
+    return std.ascii.isAlphanumeric(ch) or ch == '_';
+}
+
+fn extractIdentAfterKeyword(line: []const u8, keyword: []const u8) ?[]const u8 {
+    var start: usize = 0;
+    while (std.mem.indexOfPos(u8, line, start, keyword)) |pos| {
+        if (pos > 0 and isIdentChar(line[pos - 1])) {
+            start = pos + 1;
+            continue;
+        }
+        return extractIdent(std.mem.trimStart(u8, line[pos + keyword.len ..], " \t"));
+    }
+    return null;
+}
+
+fn extractIdentAfterKeywordIgnoreCase(line: []const u8, keyword: []const u8) ?[]const u8 {
+    if (indexOfCaseInsensitive(line, keyword)) |pos| {
+        if (pos > 0 and isIdentChar(line[pos - 1])) return null;
+        return extractIdent(std.mem.trimStart(u8, line[pos + keyword.len ..], " \t"));
+    }
+    return null;
+}
+
+fn startsWithIgnoreCase(s: []const u8, prefix: []const u8) bool {
+    if (s.len < prefix.len) return false;
+    for (prefix, 0..) |p, i| {
+        if (std.ascii.toLower(s[i]) != std.ascii.toLower(p)) return false;
+    }
+    return true;
+}
+
+fn parseDelimitedImport(line: []const u8, prefix: []const u8, delimiter: []const u8) ?[]const u8 {
+    if (!startsWith(line, prefix)) return null;
+    var body = std.mem.trim(u8, line[prefix.len..], " \t;");
+    if (startsWith(body, "static ")) body = std.mem.trimStart(u8, body["static ".len..], " \t");
+    if (delimiter.len > 0) {
+        if (std.mem.indexOf(u8, body, delimiter)) |end| body = body[0..end];
+    }
+    body = std.mem.trim(u8, body, " \t;");
+    return if (body.len > 0) body else null;
+}
+
+fn extractJvmMethodName(line: []const u8) ?[]const u8 {
+    if (startsWith(line, "import ") or startsWith(line, "package ") or startsWith(line, "return ") or
+        startsWith(line, "throw ") or startsWith(line, "new "))
+        return null;
+    if (std.mem.indexOf(u8, line, " class ") != null or std.mem.indexOf(u8, line, " interface ") != null or
+        std.mem.indexOf(u8, line, " enum ") != null or std.mem.indexOf(u8, line, " record ") != null)
+        return null;
+    const open = std.mem.lastIndexOfScalar(u8, line, '(') orelse return null;
+    if (std.mem.indexOfScalar(u8, line[open..], ')') == null) return null;
+    const before = std.mem.trimEnd(u8, line[0..open], " \t");
+    const span = extractLastIdentSpan(before) orelse return null;
+    const name = span.text;
+    if (isControlKeyword(name)) return null;
+    const before_name = std.mem.trim(u8, before[0..span.start], " \t");
+    if (before_name.len == 0) return null;
+    if (std.mem.endsWith(u8, before_name, ".") or std.mem.endsWith(u8, before_name, "->") or
+        std.mem.endsWith(u8, before_name, "="))
+        return null;
+    return name;
+}
+
+fn isControlKeyword(name: []const u8) bool {
+    const keywords = [_][]const u8{ "if", "for", "while", "switch", "catch", "return", "throw", "new", "when" };
+    for (keywords) |kw| {
+        if (std.mem.eql(u8, name, kw)) return true;
+    }
+    return false;
+}
+
+fn firstShellWord(s: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trimStart(u8, s, " \t");
+    if (trimmed.len == 0) return null;
+    var end: usize = 0;
+    while (end < trimmed.len and trimmed[end] != ' ' and trimmed[end] != '\t' and trimmed[end] != ';') : (end += 1) {}
+    return if (end > 0) trimmed[0..end] else null;
+}
+
+fn parseShellAssignment(line: []const u8) ?[]const u8 {
+    const eq = std.mem.indexOfScalar(u8, line, '=') orelse return null;
+    if (eq == 0 or std.mem.indexOfAny(u8, line[0..eq], " \t$") != null) return null;
+    return extractIdent(line[0..eq]);
+}
+
+fn parseCssVariable(line: []const u8) ?[]const u8 {
+    if (startsWith(line, "$")) {
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| return line[0..colon];
+    }
+    if (startsWith(line, "--")) {
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| return line[0..colon];
+    }
+    return null;
+}
+
+fn parseCssSelector(line: []const u8) ?[]const u8 {
+    if (std.mem.indexOfScalar(u8, line, '{') == null) return null;
+    if (line.len < 2 or (line[0] != '.' and line[0] != '#')) return null;
+    var end: usize = 1;
+    while (end < line.len) : (end += 1) {
+        const ch = line[end];
+        if (!(std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-')) break;
+    }
+    return if (end > 1) line[0..end] else null;
+}
+
+fn stripSqlLineComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "--")) return "";
+    if (std.mem.indexOf(u8, trimmed, "--")) |pos| return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    return trimmed;
+}
+
+const SqlSymbol = struct {
+    name: []const u8,
+    kind: SymbolKind,
+};
+
+fn parseSqlCreate(line: []const u8) ?SqlSymbol {
+    if (!startsWithIgnoreCase(line, "create ")) return null;
+    var rest = std.mem.trimStart(u8, line["create ".len..], " \t");
+    if (startsWithIgnoreCase(rest, "or replace ")) rest = std.mem.trimStart(u8, rest["or replace ".len..], " \t");
+    if (parseSqlCreateKind(rest, "table ", .struct_def)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "view ", .struct_def)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "index ", .constant)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "function ", .function)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "procedure ", .function)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "trigger ", .method)) |sym| return sym;
+    if (parseSqlCreateKind(rest, "type ", .type_alias)) |sym| return sym;
+    return null;
+}
+
+fn parseSqlCreateKind(rest: []const u8, keyword: []const u8, kind: SymbolKind) ?SqlSymbol {
+    if (!startsWithIgnoreCase(rest, keyword)) return null;
+    var body = std.mem.trimStart(u8, rest[keyword.len..], " \t");
+    if (startsWithIgnoreCase(body, "if not exists ")) body = std.mem.trimStart(u8, body["if not exists ".len..], " \t");
+    const name = firstSqlIdent(body) orelse return null;
+    return .{ .name = name, .kind = kind };
+}
+
+fn firstSqlIdent(s: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trimStart(u8, s, " \t\"`[");
+    if (trimmed.len == 0) return null;
+    var end: usize = 0;
+    while (end < trimmed.len and trimmed[end] != ' ' and trimmed[end] != '\t' and
+        trimmed[end] != '(' and trimmed[end] != ';' and trimmed[end] != '"' and
+        trimmed[end] != '`' and trimmed[end] != ']') : (end += 1)
+    {}
+    if (end == 0) return null;
+    const raw = trimmed[0..end];
+    if (std.mem.lastIndexOfScalar(u8, raw, '.')) |dot| {
+        if (dot + 1 < raw.len) return raw[dot + 1 ..];
+    }
+    return raw;
+}
+
+fn stripFortranComment(raw_line: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, raw_line, " \t");
+    if (startsWith(trimmed, "!")) return "";
+    if (std.mem.indexOfScalar(u8, trimmed, '!')) |pos| return std.mem.trimEnd(u8, trimmed[0..pos], " \t");
+    return trimmed;
+}
+
+fn parseFortranUse(line: []const u8) ?[]const u8 {
+    if (!startsWithIgnoreCase(line, "use ")) return null;
+    var rest = std.mem.trimStart(u8, line[4..], " \t");
+    if (startsWithIgnoreCase(rest, "intrinsic")) return null;
+    if (std.mem.indexOf(u8, rest, "::")) |pos| rest = std.mem.trimStart(u8, rest[pos + 2 ..], " \t");
+    return extractIdent(rest);
+}
+
+fn parseFortranTypeName(line: []const u8) ?[]const u8 {
+    if (!startsWithIgnoreCase(line, "type")) return null;
+    const sep = std.mem.indexOf(u8, line, "::") orelse return null;
+    return extractIdent(std.mem.trimStart(u8, line[sep + 2 ..], " \t"));
+}
+
+fn extractAtName(line: []const u8) ?[]const u8 {
+    const at = std.mem.indexOfScalar(u8, line, '@') orelse return null;
+    return extractLlvmLikeName(line[at + 1 ..]);
+}
+
+fn extractLlvmGlobalName(line: []const u8) ?[]const u8 {
+    if (line.len == 0 or (line[0] != '@' and line[0] != '%')) return null;
+    return extractLlvmLikeName(line[1..]);
+}
+
+fn extractLlvmLikeName(s: []const u8) ?[]const u8 {
+    if (s.len == 0) return null;
+    if (s[0] == '"') {
+        if (std.mem.indexOfScalar(u8, s[1..], '"')) |end| return s[1 .. end + 1];
+        return null;
+    }
+    var end: usize = 0;
+    while (end < s.len) : (end += 1) {
+        const ch = s[end];
+        if (!(std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-' or ch == '.' or ch == '$')) break;
     }
     return if (end > 0) s[0..end] else null;
 }
@@ -3882,7 +4345,7 @@ fn containsAny(s: []const u8, needles: []const []const u8) bool {
 }
 
 fn skipKeywords(s: []const u8) []const u8 {
-    const keywords = [_][]const u8{ "export ", "async ", "function ", "const ", "let ", "var " };
+    const keywords = [_][]const u8{ "export ", "default ", "async ", "abstract ", "function ", "class ", "interface ", "enum ", "type ", "const ", "let ", "var " };
     var result = s;
     for (keywords) |kw| {
         if (std.mem.startsWith(u8, result, kw)) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6341,6 +6341,187 @@ test "issue-319: C parser avoids comments strings prototypes and macro calls" {
     try testing.expectEqual(@as(usize, 0), handler.len);
 }
 
+test "issue-321: common detected extensions produce outlines" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var explorer = Explorer.init(alloc);
+
+    try explorer.indexFile("src/App.java",
+        \\package demo;
+        \\import java.util.List;
+        \\public class Worker {
+        \\    public void run() {}
+        \\}
+        \\interface RunnableThing {}
+        \\enum Mode { A }
+        \\record Pair(int left, int right) {}
+    );
+    try explorer.indexFile("src/App.kt",
+        \\package demo
+        \\import kotlinx.coroutines.runBlocking
+        \\data class User(val name: String)
+        \\interface Repo
+        \\enum class KotlinMode { A }
+        \\fun loadUser(): User = User("a")
+        \\val answer = 42
+    );
+    try explorer.indexFile("src/Widget.svelte",
+        \\<script>
+        \\import Thing from './Thing.svelte';
+        \\export let title;
+        \\function renderTitle() {}
+        \\</script>
+        \\.card { color: red; }
+    );
+    try explorer.indexFile("src/View.vue",
+        \\<script setup>
+        \\import Child from './Child.vue'
+        \\const count = 0
+        \\function inc() {}
+        \\</script>
+    );
+    try explorer.indexFile("src/Page.astro",
+        \\---
+        \\import Layout from '../layouts/Layout.astro';
+        \\const title = 'Home';
+        \\---
+    );
+    try explorer.indexFile("scripts/build.sh",
+        \\source ./env.sh
+        \\function build_app() {
+        \\}
+        \\deploy_app() {
+        \\}
+        \\BUILD_MODE=release
+    );
+    try explorer.indexFile("styles/app.css",
+        \\:root {
+        \\  --brand: red;
+        \\}
+        \\.button {
+        \\  color: var(--brand);
+        \\}
+        \\@keyframes fade {}
+    );
+    try explorer.indexFile("styles/app.scss",
+        \\$gap: 8px;
+        \\@mixin center {}
+        \\.panel {}
+    );
+    try explorer.indexFile("db/schema.sql",
+        \\CREATE TABLE users (id integer);
+        \\CREATE OR REPLACE FUNCTION do_thing() RETURNS void AS $$ SELECT 1; $$ LANGUAGE sql;
+        \\CREATE INDEX idx_users_id ON users(id);
+    );
+    try explorer.indexFile("api/service.proto",
+        \\syntax = "proto3";
+        \\import "google/protobuf/timestamp.proto";
+        \\message User {}
+        \\enum Status { STATUS_OK = 0; }
+        \\service UserService {
+        \\  rpc GetUser (User) returns (User);
+        \\}
+    );
+    try explorer.indexFile("math/solver.f90",
+        \\module solver
+        \\use mathlib
+        \\type :: Particle
+        \\end type
+        \\subroutine step()
+        \\end subroutine
+        \\function energy()
+        \\end function
+    );
+    try explorer.indexFile("ir/module.ll",
+        \\%Pair = type { i32, i32 }
+        \\@global_value = global i32 0
+        \\define i32 @main() {
+        \\  ret i32 0
+        \\}
+    );
+    try explorer.indexFile("ir/dialect.mlir",
+        \\module @kernel_mod {
+        \\  func.func @kernel() {
+        \\    return
+        \\  }
+        \\}
+    );
+    try explorer.indexFile("llvm/records.td",
+        \\include "Base.td"
+        \\class Register<string name>;
+        \\multiclass Pat<string op>;
+        \\def R0 : Register<"r0">;
+        \\defm ADD : Pat<"add">;
+        \\let Namespace = "Toy";
+    );
+
+    const java_outline = try explorer.getOutline("src/App.java", alloc) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(Language.java, java_outline.language);
+    try testing.expectEqualStrings("java.util.List", java_outline.imports.items[0]);
+
+    const worker = try explorer.findAllSymbols("Worker", alloc);
+    defer alloc.free(worker);
+    try testing.expectEqual(@as(usize, 1), worker.len);
+    try testing.expectEqual(SymbolKind.class_def, worker[0].symbol.kind);
+
+    const run = try explorer.findAllSymbols("run", alloc);
+    defer alloc.free(run);
+    try testing.expectEqual(@as(usize, 1), run.len);
+    try testing.expectEqual(SymbolKind.method, run[0].symbol.kind);
+
+    const user = try explorer.findAllSymbols("User", alloc);
+    defer alloc.free(user);
+    try testing.expect(user.len >= 2);
+
+    const load_user = try explorer.findAllSymbols("loadUser", alloc);
+    defer alloc.free(load_user);
+    try testing.expectEqual(@as(usize, 1), load_user.len);
+    try testing.expectEqual(SymbolKind.function, load_user[0].symbol.kind);
+
+    const title = try explorer.findAllSymbols("title", alloc);
+    defer alloc.free(title);
+    try testing.expect(title.len >= 2);
+
+    const build_app = try explorer.findAllSymbols("build_app", alloc);
+    defer alloc.free(build_app);
+    try testing.expectEqual(@as(usize, 1), build_app.len);
+    try testing.expectEqual(SymbolKind.function, build_app[0].symbol.kind);
+
+    const button = try explorer.findAllSymbols(".button", alloc);
+    defer alloc.free(button);
+    try testing.expectEqual(@as(usize, 1), button.len);
+
+    const users = try explorer.findAllSymbols("users", alloc);
+    defer alloc.free(users);
+    try testing.expectEqual(@as(usize, 1), users.len);
+    try testing.expectEqual(SymbolKind.struct_def, users[0].symbol.kind);
+
+    const user_service = try explorer.findAllSymbols("UserService", alloc);
+    defer alloc.free(user_service);
+    try testing.expectEqual(@as(usize, 1), user_service.len);
+    try testing.expectEqual(SymbolKind.interface_def, user_service[0].symbol.kind);
+
+    const particle = try explorer.findAllSymbols("Particle", alloc);
+    defer alloc.free(particle);
+    try testing.expectEqual(@as(usize, 1), particle.len);
+    try testing.expectEqual(SymbolKind.struct_def, particle[0].symbol.kind);
+
+    const main_sym = try explorer.findAllSymbols("main", alloc);
+    defer alloc.free(main_sym);
+    try testing.expectEqual(@as(usize, 1), main_sym.len);
+    try testing.expectEqual(SymbolKind.function, main_sym[0].symbol.kind);
+
+    const kernel = try explorer.findAllSymbols("kernel", alloc);
+    defer alloc.free(kernel);
+    try testing.expectEqual(@as(usize, 1), kernel.len);
+    try testing.expectEqual(SymbolKind.function, kernel[0].symbol.kind);
+
+    const r0 = try explorer.findAllSymbols("R0", alloc);
+    defer alloc.free(r0);
+    try testing.expectEqual(@as(usize, 1), r0.len);
+}
+
 test "issue-179: Python inline docstring does not leak symbols" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
## Summary

Follows #321 by making the newly detected extension families produce useful outlines instead of only language tags.

Adds lightweight line-oriented outline parsing for:

- Java and Kotlin: imports, classes/interfaces/enums, methods/functions, common vars/constants
- Svelte/Vue/Astro: script imports/functions/constants plus simple style selectors
- shell: sourced files, functions, assignments
- CSS/SCSS: selectors, variables, keyframes, mixins/functions
- SQL: `CREATE TABLE/VIEW/INDEX/FUNCTION/PROCEDURE/TRIGGER/TYPE`
- protobuf: imports, messages, enums, services, RPCs
- Fortran: modules, `use`, types, subroutines, functions, programs
- LLVM IR: `define`/`declare`, globals, `%type = type`
- MLIR: named modules and `func` ops
- TableGen: includes, classes/multiclasses, defs/defms, lets

`.cc` and `.mm` continue through the existing C/C++ parser path.

## Scope

These are deliberately lightweight outline parsers, not full grammars. The goal is high-signal repo tree/symbol coverage for large corpora without adding parser dependencies.

## Validation

- [x] `zig build test`
- [x] `zig build`
- [x] Added cross-extension outline test covering imports and representative symbols for every new family
- [x] GitHub `bench-regression / bench` passed

## Benchmark notes

The benchmark check passed. The first run flagged `codedb_edit` and `codedb_status`; a rerun cleared `codedb_edit` but still flagged `codedb_status` at +22.87%.

The changed code only affects language outline parsing and README text. It does not touch `codedb_status` or `telemetry.approxIndexSizeBytes`, so this looks like benchmark noise or unrelated sensitivity in the status case. The rerun showed all parser/search/tree-adjacent tools within threshold:

- `codedb_outline` -2.80%
- `codedb_symbol` +4.02%
- `codedb_tree` +3.97%
- `codedb_find` -1.28%
- `codedb_search` +0.16%