### PR TITLE
Persist project-cache snapshot after CLI indexing

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -265,6 +265,7 @@ fn mainImpl() !void {
                 s.reset,
             });
 
+            var release_contents_after_cache = false;
             if (heads_match) {
                 // Verify file count then load trigram from disk via mmap
                 const current_count = @as(u32, @intCast(explorer.outlines.count()));
@@ -319,7 +320,7 @@ fn mainImpl() !void {
                     explorer.trigram_index = .{ .mmap = loaded };
                     explorer.mu.unlock();
                 }
-                explorer.releaseContents();
+                release_contents_after_cache = true;
             }
 
             // If no freq table was loaded, build one from indexed content and
@@ -331,6 +332,15 @@ fn mainImpl() !void {
                         std.log.warn("could not persist frequency table: {}", .{err});
                     };
                 }
+            }
+
+            if (!std.mem.eql(u8, cmd, "snapshot")) {
+                snapshot_mod.writeProjectCacheSnapshot(io, &explorer, abs_root, allocator) catch |err| {
+                    std.log.warn("could not persist project-cache snapshot: {}", .{err});
+                };
+            }
+            if (release_contents_after_cache) {
+                explorer.releaseContents();
             }
         } // end else (no snapshot)
     }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2844,6 +2844,61 @@ test "issue-258: cached project reads use the project root after contents are re
     try testing.expect(std.mem.indexOf(u8, out.items, "const project = \"secondary\";") != null);
 }
 
+test "ProjectCache loads project from central snapshot cache" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "src/main.zig",
+        .data = "pub fn cachedProject() void {}\n",
+    });
+
+    var project_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_path_len = try tmp.dir.realPathFile(io, ".", &project_path_buf);
+    const project_path = project_path_buf[0..project_path_len];
+
+    const data_dir = getProjectDataDir(testing.allocator, project_path) orelse return error.OutOfMemory;
+    defer testing.allocator.free(data_dir);
+    const central_snapshot = try std.fmt.allocPrint(testing.allocator, "{s}/codedb.snapshot", .{data_dir});
+    defer testing.allocator.free(central_snapshot);
+    const project_txt = try std.fmt.allocPrint(testing.allocator, "{s}/project.txt", .{data_dir});
+    defer testing.allocator.free(project_txt);
+    defer {
+        std.Io.Dir.cwd().deleteFile(io, central_snapshot) catch {};
+        std.Io.Dir.cwd().deleteFile(io, project_txt) catch {};
+        std.Io.Dir.cwd().deleteDir(io, data_dir) catch {};
+    }
+
+    var snapshot_src = Explorer.init(testing.allocator);
+    defer snapshot_src.deinit();
+    snapshot_src.setRoot(io, project_path);
+    try snapshot_src.indexFile("src/main.zig", "pub fn cachedProject() void {}\n");
+    try snapshot_mod.writeProjectCacheSnapshot(io, &snapshot_src, project_path, testing.allocator);
+
+    const root_snapshot = try std.fmt.allocPrint(testing.allocator, "{s}/codedb.snapshot", .{project_path});
+    defer testing.allocator.free(root_snapshot);
+    if (std.Io.Dir.cwd().access(io, root_snapshot, .{})) |_| {
+        return error.UnexpectedRootSnapshot;
+    } else |_| {}
+
+    var default_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const default_path_len = try std.Io.Dir.cwd().realPathFile(io, ".", &default_path_buf);
+    const default_path = default_path_buf[0..default_path_len];
+
+    var default_explorer = Explorer.init(testing.allocator);
+    defer default_explorer.deinit();
+    var default_store = Store.init(testing.allocator);
+    defer default_store.deinit();
+
+    var cache = ProjectCache.init(testing.allocator, default_path);
+    defer cache.deinit();
+
+    const ctx = try cache.get(io, project_path, &default_explorer, &default_store);
+    try testing.expect(ctx.explorer.outlines.contains("src/main.zig"));
+}
+
 test "codedb_snapshot cache reuses output until store seq changes" {
     const io = testing.io;
     const alloc = testing.allocator;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -995,7 +995,15 @@ pub fn writeSnapshotDual(
     allocator: std.mem.Allocator,
 ) !void {
     try writeSnapshot(io, explorer, root_path, output_path, allocator);
+    writeProjectCacheSnapshot(io, explorer, root_path, allocator) catch {};
+}
 
+pub fn writeProjectCacheSnapshot(
+    io: std.Io,
+    explorer: *Explorer,
+    root_path: []const u8,
+    allocator: std.mem.Allocator,
+) !void {
     const hash = std.hash.Wyhash.hash(0, root_path);
     const home_raw = cio.posixGetenv("HOME") orelse return;
     const home = allocator.dupe(u8, home_raw) catch return;
@@ -1009,12 +1017,11 @@ pub fn writeSnapshotDual(
 
     const proj_txt = std.fmt.allocPrint(allocator, "{s}/project.txt", .{dir_path}) catch return;
     defer allocator.free(proj_txt);
-    if (std.Io.Dir.cwd().createFile(io, proj_txt, .{})) |f| {
-        f.writeStreamingAll(io, root_path) catch {};
-        f.close(io);
-    } else |_| {}
+    var f = try std.Io.Dir.cwd().createFile(io, proj_txt, .{ .truncate = true });
+    f.writeStreamingAll(io, root_path) catch {};
+    f.close(io);
 
-    writeSnapshot(io, explorer, root_path, secondary, allocator) catch {};
+    try writeSnapshot(io, explorer, root_path, secondary, allocator);
 }
 
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {


### PR DESCRIPTION
## Summary

- persist a central `~/.codedb/projects/<hash>/codedb.snapshot` after normal CLI scans
- keep repo roots clean: `codedb /path tree` does not create `/path/codedb.snapshot`
- reuse the central snapshot writer from `snapshot` mode and truncate `project.txt` when refreshing
- add regression coverage for `ProjectCache` loading a project from the central snapshot cache only

## Why

`codedb /path tree` printed `indexed`, but a later MCP call with `project=/path` failed with `SnapshotLoadFailed` because only side indexes were persisted. After this change, CLI indexing and MCP project loading agree on the cache contract.

## Validation

- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- smoke: fresh throwaway project, run `codedb /path tree`, verify no root snapshot, verify central snapshot exists, verify MCP `codedb_tree`, `codedb_symbol`, and `codedb_status` load `project=/path`
