### PR TITLE
release/0.2.5794: received-keys diagnostic across all single-tool handlers (#356 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.5794 - 2026-05-04
+
+`0.2.5794` extends [#356](https://github.com/justrach/codedb/issues/356) phase 2 — the `received keys: [...]` diagnostic now lands on every single-tool handler with a required argument. Tiny release; entirely an ergonomics polish on top of `0.2.5793`.
+
+### Reliability ([#356](https://github.com/justrach/codedb/issues/356) phase 2)
+
+The `received keys: [...]` self-diagnose hint is now wired into:
+
+- `codedb_outline` — missing `'path'`
+- `codedb_symbol` — missing `'name'`
+- `codedb_search` — missing `'query'`
+- `codedb_word` — missing `'word'`
+- `codedb_deps` — missing `'path'`
+- `codedb_read` — missing `'path'`
+
+Combined with phase 1 (`codedb_query` pipeline steps and `codedb_bundle` ops), every read-path tool now surfaces the keys it actually received when a required argument is missing. Callers can self-diagnose typos like `file_path` vs `path` without retrying blind. `codedb_edit` deliberately keeps the bare error — write operations should fail loudly without hinting at alternatives.
+
 ## 0.2.5793 - 2026-05-04
 
 `0.2.5793` is a search recall, ranking, and reliability release on top of `0.2.5792`. All three items from [#363](https://github.com/justrach/codedb/issues/363) plus phase 1 of [#356](https://github.com/justrach/codedb/issues/356) are resolved.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5793",
+    .version = "0.2.5794",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .mcp_zig = .{

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -916,6 +916,7 @@ fn handleTree(alloc: std.mem.Allocator, out: *std.ArrayList(u8), explorer: *Expl
 fn handleOutline(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const path = getStr(args, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     const compact = getBool(args, "compact");
@@ -949,6 +950,7 @@ fn handleOutline(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
 fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const name = getStr(args, "name") orelse {
         out.appendSlice(alloc, "error: missing 'name' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     const include_body = getBool(args, "body");
@@ -983,6 +985,7 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
 fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const query = getStr(args, "query") orelse {
         out.appendSlice(alloc, "error: missing 'query' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     const max_results: usize = if (getInt(args, "max_results")) |n| @intCast(@max(1, @min(n, 10000))) else 50;
@@ -1120,6 +1123,7 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
 fn handleWord(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const word = getStr(args, "word") orelse {
         out.appendSlice(alloc, "error: missing 'word' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     const hits = explorer.searchWord(word, alloc) catch {
@@ -1157,6 +1161,7 @@ fn handleHot(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *st
 fn handleDeps(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const path = getStr(args, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     const direction = getStr(args, "direction") orelse "imported_by";
@@ -1233,6 +1238,7 @@ fn handleDeps(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
 fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const path = getStr(args, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path' argument") catch {};
+        appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
     if (!isPathSafe(path)) {

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5793";
+pub const semver = "0.2.5794";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8346,3 +8346,173 @@ test "issue-356-3: codedb_query surfaces received keys on missing-arg errors" {
     try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "q") != null);
 }
+
+test "issue-356-p2: codedb_outline missing path surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"file_path":"src/main.zig"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_outline, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'path'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "file_path") != null);
+}
+
+test "issue-356-p2: codedb_symbol missing name surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"symbol":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_symbol, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'name'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "symbol") != null);
+}
+
+test "issue-356-p2: codedb_search missing query surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"q":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_search, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'query'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+}
+
+test "issue-356-p2: codedb_word missing word surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"w":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_word, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'word'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+}
+
+test "issue-356-p2: codedb_read missing path surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"file":"src/main.zig"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_read, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'path'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+}
+
+test "issue-356-p2: codedb_deps missing path surfaces received keys" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"target":"src/main.zig"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_deps, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'path'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
+}


### PR DESCRIPTION
## Summary

Tiny ergonomics-polish release on top of v0.2.5793. Phase 2 of #356.

The \`received keys: [...]\` self-diagnose diagnostic that landed in v0.2.5792 (#357 \`codedb_bundle\`) and v0.2.5793 (#356 phase 1, \`codedb_query\` pipeline steps) is now wired into every other single-tool handler with a required string argument:

| Handler | Required arg |
|---|---|
| \`codedb_outline\` | \`path\` |
| \`codedb_symbol\` | \`name\` |
| \`codedb_search\` | \`query\` |
| \`codedb_word\` | \`word\` |
| \`codedb_deps\` | \`path\` |
| \`codedb_read\` | \`path\` |

Sending \`{"file_path":"foo"}\` to \`codedb_outline\` now returns:
\`\`\`
error: missing 'path' argument
received keys: [file_path]
\`\`\`

\`codedb_edit\` deliberately keeps the bare error — write operations shouldn't hint at alternatives.

## Test plan

- [x] \`zig build test\` — 434/434 pass
- [x] 6 failing tests under \`issue-356-p2\` land before the fix (per CLAUDE.md repo policy)

## Commits

\`\`\`
378e8e9 test(issue-356-p2): failing tests for received-keys diagnostic across single-tool handlers
4f14193 fix(mcp): received-keys diagnostic across all single-tool handlers (#356)
5f00087 docs: add 0.2.5794 changelog entry
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)