### PR TITLE
release/0.2.5795: close #356 — phase 3 (stale-index hint, read fuzzy, query stages tail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.5795 - 2026-05-04
+
+`0.2.5795` closes out [#356](https://github.com/justrach/codedb/issues/356) with phase 3 — three small ergonomics polishes that complete the rewritten reliability scope.
+
+### Reliability ([#356](https://github.com/justrach/codedb/issues/356) phase 3)
+
+- **`codedb_outline`: stale-index recovery hint.** When a path isn't indexed, the response already gets fuzzy suggestions (phase 1). It now also includes `hint: try codedb_index if the file was added recently` so agents know how to recover from a freshly-added file the watcher hasn't seen yet — no more relying on tribal knowledge of the operator command.
+- **`codedb_read`: fuzzy path fallback on read failure.** `codedb_outline` already surfaces `did you mean:` suggestions when its path doesn't index; `codedb_read` now does the same when its disk read fails. A mistyped path is recoverable in one shot without a separate `codedb_find` round-trip.
+- **`codedb_query`: per-stage summary tail.** Successful pipelines now emit a structured `--- stages ---` block listing each step's op and outgoing file count. Long pipelines become legible at a glance without parsing the unstructured per-step output above it.
+
+With this release, [#356](https://github.com/justrach/codedb/issues/356) is closed:
+- ✅ Phase 1 — pipeline partial results, outline fuzzy fallback, query received-keys diagnostic (0.2.5793)
+- ✅ Phase 2 — received-keys diagnostic across all single-tool handlers (0.2.5794)
+- ✅ Phase 3 — stale-index hint, read fuzzy fallback, query per-stage summary (0.2.5795)
+
 ## 0.2.5794 - 2026-05-04
 
 `0.2.5794` extends [#356](https://github.com/justrach/codedb/issues/356) phase 2 — the `received keys: [...]` diagnostic now lands on every single-tool handler with a required argument. Tiny release; entirely an ergonomics polish on top of `0.2.5793`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5794",
+    .version = "0.2.5795",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .mcp_zig = .{

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -929,6 +929,11 @@ fn handleOutline(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
         // Issue #356-2: fuzzy path fallback — surface top matches so the
         // caller can self-correct without a separate codedb_find round-trip.
         appendFuzzyPathSuggestions(alloc, out, explorer, path);
+        // Issue #356-p3: stale-index recovery hint. The most common cause of
+        // 'not indexed' once you've ruled out a typo is a freshly-added file
+        // the watcher hasn't seen yet — pointing at codedb_index makes the
+        // recovery action explicit.
+        out.appendSlice(alloc, "\nhint: try codedb_index if the file was added recently\n") catch {};
         return;
     };
     defer outline.deinit();
@@ -1261,6 +1266,10 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         break :blk std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(10 * 1024 * 1024)) catch {
             out.appendSlice(alloc, "error: failed to read file: ") catch {};
             out.appendSlice(alloc, path) catch {};
+            // Issue #356-p3: fuzzy fallback so a mistyped path is recoverable
+            // without a separate codedb_find round-trip — same shape as
+            // codedb_outline already does.
+            appendFuzzyPathSuggestions(alloc, out, explorer, path);
             return;
         };
     };
@@ -2379,6 +2388,12 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
     var have_set = false;
     const w = cio.listWriter(out, alloc);
 
+    // Issue #356-p3: per-stage summary so long pipelines are debuggable
+    // without re-parsing the unstructured per-step output above the tail.
+    const StageInfo = struct { op: []const u8, files_out: usize };
+    var stages: std.ArrayList(StageInfo) = .empty;
+    defer stages.deinit(alloc);
+
     for (pipeline, 0..) |step_val, step_i| {
         if (step_val != .object) {
             w.print("error: step {d} must be object\n", .{step_i}) catch {};
@@ -2780,11 +2795,23 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
             w.print("error: unknown op '{s}'\n", .{op}) catch {};
             return;
         }
+        // Issue #356-p3: track each successfully-completed step.
+        stages.append(alloc, .{ .op = op, .files_out = file_set.items.len }) catch {};
     }
 
     if (out.items.len == 0 and have_set) {
         w.print("{d} files:\n", .{file_set.items.len}) catch {};
         for (file_set.items) |path| w.print("  {s}\n", .{path}) catch {};
+    }
+
+    // Issue #356-p3: per-stage summary tail. Lists each completed step's op
+    // and outgoing file count so callers can audit a multi-step pipeline at
+    // a glance without re-parsing the unstructured output above.
+    if (stages.items.len > 0) {
+        w.print("\n--- stages ---\n", .{}) catch {};
+        for (stages.items, 0..) |s, i| {
+            w.print("{d}: {s} ({d} files)\n", .{ i, s.op, s.files_out }) catch {};
+        }
     }
 }
 

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5794";
+pub const semver = "0.2.5795";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8516,3 +8516,123 @@ test "issue-356-p2: codedb_deps missing path surfaces received keys" {
     try testing.expect(std.mem.indexOf(u8, out.items, "missing 'path'") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "received keys") != null);
 }
+
+test "issue-356-p3: codedb_query emits per-stage summary tail on success" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+    try explorer.indexFile("src/lib.zig", "pub fn helper() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    // Two-step pipeline that succeeds. Phase 3 emits a summary tail so
+    // callers can see which step did what without re-parsing the
+    // unstructured per-step output above it.
+    const pipe_json =
+        \\{"pipeline":[
+        \\  {"op":"find","query":"main"},
+        \\  {"op":"sort","by":"path"}
+        \\]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, pipe_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_query, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // Stage summary appears at the end of a successful pipeline.
+    try testing.expect(std.mem.indexOf(u8, out.items, "--- stages ---") != null);
+    // Lists each step with op and outgoing file count.
+    try testing.expect(std.mem.indexOf(u8, out.items, "0: find") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "1: sort") != null);
+}
+
+test "issue-356-p3: codedb_outline includes actionable hint when parser fails" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    // Outline a path that's NOT indexed (no setRoot, so disk read won't
+    // help either). The "file not indexed" error already gets fuzzy
+    // suggestions from phase 1. This test pins that the hint format is
+    // actionable — specifically that a 'try codedb_index' suggestion
+    // appears so users know how to recover from a stale index.
+    const args_json =
+        \\{"path":"src/notindexed.zig"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_outline, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "file not indexed") != null);
+    // Phase 3 adds a 'codedb_index' hint so callers know how to recover
+    // from a stale index in addition to the 'did you mean' suggestions.
+    try testing.expect(std.mem.indexOf(u8, out.items, "codedb_index") != null);
+}
+
+test "issue-356-p3: codedb_read appends fuzzy suggestions when path is unreadable" {
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(tmp_io, "src");
+    try tmp.dir.writeFile(tmp_io, .{
+        .sub_path = "src/main.zig",
+        .data = "pub fn main() void {}\n",
+    });
+
+    var project_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_path_len = try tmp.dir.realPathFile(tmp_io, ".", &project_path_buf);
+    const project_path = project_path_buf[0..project_path_len];
+
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    explorer.setRoot(tmp_io, project_path);
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+    try explorer.indexFile("src/lib.zig", "pub fn helper() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, project_path);
+    defer bench_ctx.deinit();
+
+    // Read a non-indexed, non-existent path. Pre-fix: bare 'failed to read file'.
+    // Post-fix: append fuzzy suggestions like outline already does.
+    const args_json =
+        \\{"path":"src/man.zig"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_read, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "failed to read file") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "did you mean") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
+}


### PR DESCRIPTION
## Summary

Closes #356.

Three small ergonomics polishes that wrap up the rewritten #356 reliability scope:

- \`codedb_outline\` 'file not indexed': append \`hint: try codedb_index if the file was added recently\` alongside the existing fuzzy suggestions.
- \`codedb_read\` 'failed to read file': append fuzzy 'did you mean:' suggestions like \`codedb_outline\` already does.
- \`codedb_query\` successful pipelines: emit a structured \`--- stages ---\` summary tail listing each step's op + outgoing file count.

#356 acceptance summary across all 3 phases:
- ✅ Phase 1 (v0.2.5793) — pipeline partial results, outline fuzzy fallback, query received-keys diagnostic
- ✅ Phase 2 (v0.2.5794) — received-keys diagnostic across all single-tool handlers
- ✅ Phase 3 (this PR, v0.2.5795) — stale-index hint, read fuzzy, query stages tail

## Test plan

- [x] \`zig build test\` — 437/437 pass
- [x] 3 failing tests under \`issue-356-p3\` land before the fix (per CLAUDE.md repo policy)

## Commits

\`\`\`
6084025 test(issue-356-p3): failing tests for outline 'codedb_index' hint, read fuzzy fallback on disk-read failure, codedb_query per-stage summary
c588308 fix(mcp): close out #356 — stale-index hint, read fuzzy fallback, codedb_query per-stage summary
8041c98 docs: add 0.2.5795 changelog — close #356
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)