### PR TITLE
fix(store): close #367 — truncate data.log on open (folds into v0.2.5795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## 0.2.5795 - 2026-05-04
 
-`0.2.5795` closes out [#356](https://github.com/justrach/codedb/issues/356) with phase 3 — three small ergonomics polishes that complete the rewritten reliability scope.
+`0.2.5795` closes out [#356](https://github.com/justrach/codedb/issues/356) with phase 3 — three small ergonomics polishes that complete the rewritten reliability scope — plus a privacy/disk-leak fix for [#367](https://github.com/justrach/codedb/issues/367).
 
 ### Reliability ([#356](https://github.com/justrach/codedb/issues/356) phase 3)
 
 - **`codedb_outline`: stale-index recovery hint.** When a path isn't indexed, the response already gets fuzzy suggestions (phase 1). It now also includes `hint: try codedb_index if the file was added recently` so agents know how to recover from a freshly-added file the watcher hasn't seen yet — no more relying on tribal knowledge of the operator command.
 - **`codedb_read`: fuzzy path fallback on read failure.** `codedb_outline` already surfaces `did you mean:` suggestions when its path doesn't index; `codedb_read` now does the same when its disk read fails. A mistyped path is recoverable in one shot without a separate `codedb_find` round-trip.
 - **`codedb_query`: per-stage summary tail.** Successful pipelines now emit a structured `--- stages ---` block listing each step's op and outgoing file count. Long pipelines become legible at a glance without parsing the unstructured per-step output above it.
+
+### Storage ([#367](https://github.com/justrach/codedb/issues/367))
+
+- **`data.log`: truncate on open.** Previously, `Store.openDataLog` opened the file with `truncate=false` and seeded the write cursor to the existing length, while `Store.init` returned an empty in-memory index and nothing replayed the log on load. Net effect: every prior session's raw `codedb_edit` content (potentially including secrets/PII pasted into a `content` arg) accumulated forever as unreachable orphan bytes in a file that looks like a log but isn't read by anyone. The log is now truncated on every process start, since the in-memory index is always empty at that point and the on-disk bytes are unreachable.
 
 With this release, [#356](https://github.com/justrach/codedb/issues/356) is closed:
 - ✅ Phase 1 — pipeline partial results, outline fuzzy fallback, query received-keys diagnostic (0.2.5793)

--- a/src/store.zig
+++ b/src/store.zig
@@ -48,11 +48,13 @@ pub const Store = struct {
         if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| {
             std.Io.Dir.cwd().createDirPath(io, path[0..sep]) catch {};
         }
-        const file = try std.Io.Dir.cwd().createFile(io, path, .{ .read = true, .truncate = false });
+        // Truncate on open: in-memory index is empty at process start and nothing
+        // replays this file, so any pre-existing bytes are unreachable orphans
+        // (see #367 — raw edit content would otherwise leak across sessions).
+        const file = try std.Io.Dir.cwd().createFile(io, path, .{ .read = true, .truncate = true });
         self.data_log = file;
         self.io = io;
-        const sz = try file.length(io);
-        self.data_log_pos = sz;
+        self.data_log_pos = 0;
     }
 
     pub fn recordSnapshot(self: *Store, path: []const u8, size: u64, hash: u64) !u64 {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8636,3 +8636,44 @@ test "issue-356-p3: codedb_read appends fuzzy suggestions when path is unreadabl
     try testing.expect(std.mem.indexOf(u8, out.items, "did you mean") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
 }
+
+test "issue-367: openDataLog truncates orphan bytes from prior session" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp_dir.dir.realPathFile(io, ".", &dir_buf);
+    const dir_path = dir_buf[0..dir_path_len];
+
+    const log_path = try std.fmt.allocPrint(testing.allocator, "{s}/data.log", .{dir_path});
+    defer testing.allocator.free(log_path);
+
+    const orphan = "ORPHAN_SECRET_TOKEN_FROM_PRIOR_SESSION";
+    {
+        const f = try std.Io.Dir.cwd().createFile(io, log_path, .{ .truncate = true });
+        defer f.close(io);
+        try f.writePositionalAll(io, orphan, 0);
+    }
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try store.openDataLog(io, log_path);
+
+    const f = try std.Io.Dir.cwd().openFile(io, log_path, .{});
+    defer f.close(io);
+    const len = try f.length(io);
+    try testing.expectEqual(@as(u64, 0), len);
+    try testing.expectEqual(@as(u64, 0), store.data_log_pos);
+
+    const diff = "fresh diff";
+    _ = try store.recordEdit("foo.zig", 1, .replace, 0xABCD, diff.len, diff);
+
+    var buf: [128]u8 = undefined;
+    const f2 = try std.Io.Dir.cwd().openFile(io, log_path, .{});
+    defer f2.close(io);
+    const new_len = try f2.length(io);
+    try testing.expectEqual(@as(u64, diff.len), new_len);
+    const read_len = try f2.readPositionalAll(io, buf[0..diff.len], 0);
+    try testing.expectEqual(diff.len, read_len);
+    try testing.expectEqualStrings(diff, buf[0..diff.len]);
+}


### PR DESCRIPTION
## Summary

Fixes [#367](https://github.com/justrach/codedb/issues/367). The on-disk \`data.log\` accumulated raw \`codedb_edit\` content across every session because:

- \`Store.openDataLog\` opened the file with \`truncate=false\` and seeded \`data_log_pos\` to its existing length
- \`Store.init\` returned an empty in-memory version index
- Nothing replays the log on load — so any pre-existing bytes were unreachable orphans
- New writes were appended onto the orphan prefix, so the file grew without bound

Net effect was a privacy/forensics surprise: anything an agent pasted into \`codedb_edit\`'s \`content\` arg (secrets, tokens, PII) sat on disk indefinitely in a file that looks like a log but is never read.

**Fix:** truncate \`data.log\` unconditionally on open. The condition the reporter suggested (\"in-memory index is empty\") is always true at \`openDataLog\` time, so the truncation is unconditional. Future replay/persistence work can build a proper framed format on top.

This is being folded into the unreleased v0.2.5795 (tag pushed but GH release not yet published) — the tag will be moved forward to this commit before publishing.

## Test plan

- [x] Failing test added: \`tests.test.issue-367: openDataLog truncates orphan bytes from prior session\` (planted orphan bytes → openDataLog → expect file length 0 and data_log_pos 0; then write a diff and verify it lands at offset 0)
- [x] All tests: 438/438 pass (\`zig build test --summary all\`)
- [x] End-to-end repro from the issue body, validated by an agent on a freshly-built local binary:
  - Planted \`ORPHAN_SECRET_TOKEN_FROM_PRIOR_BUGGY_SESSION\` (44 bytes)
  - Ran the issue's exact two-edit MCP repro
  - Post-run \`xxd data.log\`: 78 bytes, orphan absent, only the two new edit-diff payloads at offsets 0x00 and 0x3E
  - Cross-session noop second run: file truncated back to 0 bytes (since openDataLog always truncates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)