### PR TITLE
fix(mcp): surface received-keys diagnostic inline in tty summary (folds into v0.2.5795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - **`data.log`: truncate on open.** Previously, `Store.openDataLog` opened the file with `truncate=false` and seeded the write cursor to the existing length, while `Store.init` returned an empty in-memory index and nothing replayed the log on load. Net effect: every prior session's raw `codedb_edit` content (potentially including secrets/PII pasted into a `content` arg) accumulated forever as unreachable orphan bytes in a file that looks like a log but isn't read by anyone. The log is now truncated on every process start, since the in-memory index is always empty at that point and the on-disk bytes are unreachable.
 
+### DX
+
+- **TTY summary surfaces received-keys diagnostic.** The `received keys: [...]` hint from #356 phase 1+2 only landed in `content[1]` of the MCP envelope, but many clients only render `content[0]` (the colored single-line summary). Missing-arg errors now append a compact `(received: [...])` tail to the summary too, so the diagnostic is visible regardless of how many blocks the client renders.
+
 With this release, [#356](https://github.com/justrach/codedb/issues/356) is closed:
 - ✅ Phase 1 — pipeline partial results, outline fuzzy fallback, query received-keys diagnostic (0.2.5793)
 - ✅ Phase 2 — received-keys diagnostic across all single-tool handlers (0.2.5794)

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3085,6 +3085,16 @@ pub fn mcpGenerateSummary(
         buf.appendSlice(alloc, MCP_DASH ++ MCP_RED) catch {};
         buf.appendSlice(alloc, msg[0..end]) catch {};
         buf.appendSlice(alloc, MCP_RESET) catch {};
+        // Issue #367-dx: surface the received-keys diagnostic inline so clients
+        // that only render content[0] (the TTY summary block) still see it.
+        if (std.mem.indexOf(u8, output, "received keys: [")) |s| {
+            const kstart = s + "received keys: [".len;
+            if (std.mem.indexOfScalarPos(u8, output, kstart, ']')) |kend| {
+                buf.appendSlice(alloc, "  " ++ MCP_DIM ++ "(received: [") catch {};
+                buf.appendSlice(alloc, output[kstart..kend]) catch {};
+                buf.appendSlice(alloc, "])" ++ MCP_RESET) catch {};
+            }
+        }
         return;
     }
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3065,7 +3065,7 @@ fn mcpAppendPath(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), path: []cons
     buf.appendSlice(alloc, MCP_RESET) catch {};
 }
 
-fn mcpGenerateSummary(
+pub fn mcpGenerateSummary(
     alloc: std.mem.Allocator,
     tool_name: []const u8,
     args: *const std.json.ObjectMap,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8677,3 +8677,28 @@ test "issue-367: openDataLog truncates orphan bytes from prior session" {
     try testing.expectEqual(diff.len, read_len);
     try testing.expectEqualStrings(diff, buf[0..diff.len]);
 }
+
+test "issue-367-dx: tty summary surfaces received keys on missing-arg error" {
+    const args_json =
+        \\{"file_path":"src/main.zig","weird_key":"x"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    const raw_output = "error: missing 'path' argument\nreceived keys: [file_path, weird_key]";
+
+    var summary: std.ArrayList(u8) = .empty;
+    defer summary.deinit(testing.allocator);
+
+    mcp_mod.mcpGenerateSummary(
+        testing.allocator,
+        "codedb_outline",
+        &parsed.value.object,
+        raw_output,
+        true,
+        &summary,
+    );
+
+    try testing.expect(std.mem.indexOf(u8, summary.items, "received") != null);
+    try testing.expect(std.mem.indexOf(u8, summary.items, "file_path") != null);
+}


### PR DESCRIPTION
## Summary

The \`received keys: [...]\` self-diagnose hint from #356 phase 1+2 only landed in \`content[1]\` of the MCP envelope (the raw output block), but many MCP clients only render \`content[0]\` (the colored single-line summary). Net effect: callers saw a bare \`missing 'path' argument\` with no indication of what they actually sent.

\`mcpGenerateSummary\` truncated the error message at the first \`\\n\`, dropping the diagnostic line entirely. This change scans the raw output for \`received keys: [...]\` and appends a compact \`(received: [keys])\` tail to the summary in dim color.

Folds into the unreleased v0.2.5795 (tag pushed but freshly moved earlier today). Tag will be moved forward again to this commit before the release assets are replaced.

## Test plan

- [x] Failing test added: \`tests.test.issue-367-dx: tty summary surfaces received keys on missing-arg error\`
- [x] All tests: 439/439 pass (\`zig build test --summary all\`)
- [ ] Local binary repro: invoke \`codedb_outline\` with \`{"file_path":"x"}\` and verify \`content[0]\` now contains \`(received: [file_path])\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)