### PR TITLE
Fix scan-race & snapshot-loader inconsistency (#378, #379)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -534,6 +534,17 @@ pub fn getScanState() ScanState {
     return @enumFromInt(scan_state_atomic.load(.acquire));
 }
 
+pub var scan_wait_timeout_ms: u64 = 2000;
+
+fn waitForScanReady(timeout_ms: u64) void {
+    if (getScanState() == .ready) return;
+    const deadline = cio.milliTimestamp() + @as(i64, @intCast(timeout_ms));
+    while (getScanState() != .ready) {
+        if (cio.milliTimestamp() >= deadline) return;
+        cio.sleepMs(25);
+    }
+}
+
 // ── Session state for MCP protocol ──────────────────────────────────────────
 
 const Session = struct {
@@ -873,6 +884,10 @@ fn dispatch(
         return;
     };
 
+    if (toolDependsOnScannedIndex(tool) and project_path == null) {
+        waitForScanReady(scan_wait_timeout_ms);
+    }
+
     if (tool == .codedb_word or (tool == .codedb_search and shouldLoadWordIndexForSearch(args))) {
         const effective_project = project_path orelse cache.default_path;
         loadProjectWordIndexFromDiskIfPresent(io, ctx.explorer, effective_project, alloc);
@@ -910,11 +925,7 @@ fn dispatch(
 fn appendScanProgressHint(alloc: std.mem.Allocator, out: *std.ArrayList(u8), tool: Tool) void {
     const state = getScanState();
     if (state == .ready) return;
-    // Only inject for tools whose output depends on the scanned index.
-    switch (tool) {
-        .codedb_search, .codedb_word, .codedb_outline, .codedb_symbol, .codedb_find, .codedb_glob, .codedb_tree, .codedb_ls, .codedb_deps => {},
-        else => return,
-    }
+    if (!toolDependsOnScannedIndex(tool)) return;
     const looks_empty =
         std.mem.indexOf(u8, out.items, "0 results for ") != null or
         std.mem.indexOf(u8, out.items, "0 hits for ") != null or
@@ -924,6 +935,13 @@ fn appendScanProgressHint(alloc: std.mem.Allocator, out: *std.ArrayList(u8), too
     out.appendSlice(alloc, "\nnote: scan still in progress (state=") catch return;
     out.appendSlice(alloc, state.name()) catch return;
     out.appendSlice(alloc, "); results may be incomplete — retry shortly") catch return;
+}
+
+fn toolDependsOnScannedIndex(tool: Tool) bool {
+    return switch (tool) {
+        .codedb_search, .codedb_word, .codedb_outline, .codedb_symbol, .codedb_find, .codedb_glob, .codedb_tree, .codedb_ls, .codedb_deps => true,
+        else => false,
+    };
 }
 
 // ── Tool handlers ───────────────────────────────────────────────────────────

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -549,11 +549,9 @@ pub fn loadSnapshotValidated(
     }
 
     // Validate file_count matches META expectation (issue-40)
+    if (file_count == 0) return false;
     if (expected_file_count) |expected| {
         if (file_count != expected) return false;
-    } else if (file_count == 0) {
-        // No META and no files loaded — corrupt or empty snapshot
-        return false;
     }
 
     // Load frequency table if present
@@ -845,10 +843,9 @@ fn loadSnapshotFast(
         file_count += 1;
     }
 
+    if (file_count == 0) return false;
     if (expected_file_count) |expected| {
         if (file_count != expected) return false;
-    } else if (file_count == 0) {
-        return false;
     }
 
     if (outline_states.count() != 0) return false;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3678,10 +3678,8 @@ test "issue-46: empty-repo snapshot rejected on load" {
     const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/test.codedb", .{dir_path});
     defer testing.allocator.free(snap_path);
 
-    // Write snapshot of empty repo (no files indexed)
     try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
 
-    // Load into fresh explorer + store
     var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena2.deinit();
     var exp2 = Explorer.init(arena2.allocator());
@@ -3689,8 +3687,8 @@ test "issue-46: empty-repo snapshot rejected on load" {
     defer store.deinit();
 
     const loaded = snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, testing.allocator);
-    // Valid empty-repo snapshot should be accepted; currently returns false (bug: file_count == 0)
-    try testing.expect(loaded);
+    try testing.expect(!loaded);
+    try testing.expect(exp2.outlines.count() == 0);
 }
 
 test "issue-220: snapshot fast load restores outlines and lazily rebuilds word index" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8802,6 +8802,34 @@ test "issue-378: search waits briefly for scan to reach ready instead of returni
     try testing.expect(std.mem.indexOf(u8, out.items, "scan still in progress") == null);
 }
 
+test "issue-379: snapshot loader returns true with zero outlines for empty-explorer snapshot" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var exp = Explorer.init(aa);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/empty.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    var exp2 = Explorer.init(testing.allocator);
+    defer exp2.deinit();
+    var store2 = Store.init(testing.allocator);
+    defer store2.deinit();
+
+    const loaded = snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store2, testing.allocator);
+    if (loaded) {
+        try testing.expect(exp2.outlines.count() > 0);
+    }
+}
+
 test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8762,6 +8762,46 @@ test "issue-bug2: tool calls during scan-in-progress hint at scan state" {
     try testing.expect(std.mem.indexOf(u8, out.items, "scan still in progress") != null);
 }
 
+test "issue-378: search waits briefly for scan to reach ready instead of returning empty" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const prev_state = mcp_mod.getScanState();
+    defer mcp_mod.setScanState(prev_state);
+    mcp_mod.setScanState(.walking);
+
+    const Flipper = struct {
+        fn run(exp: *Explorer) void {
+            cio.sleepMs(100);
+            exp.indexFile("src/late.zig", "fn waitsForScanMarker() void {}\n") catch return;
+            mcp_mod.setScanState(.ready);
+        }
+    };
+    const t = try std.Thread.spawn(.{}, Flipper.run, .{&explorer});
+    defer t.join();
+
+    const args_json =
+        \\{"query":"waitsForScanMarker"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_search, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/late.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "scan still in progress") == null);
+}
+
 test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();


### PR DESCRIPTION
Two related but independent bugs filed and fixed on the same branch.

## Bug A — scan-race (#378)

When MCP starts up, the file walk + index build runs in a background thread (`scanBg`). v0.2.5795 only **labelled** the resulting race window — agents that called `codedb_search` / `codedb_word` / `codedb_outline` / `codedb_symbol` / `codedb_find` / `codedb_glob` / `codedb_tree` / `codedb_ls` / `codedb_deps` while the explorer was still partial got `0 results` plus a "scan still in progress" hint, which they read as authoritative. This change adds a bounded sleep-poll on `getScanState()` at the top of `dispatch` for that same allowlist (default 2 s ceiling, exposed via `mcp.scan_wait_timeout_ms`). Most repos finish the walk well under that window, so the race is now invisible for the common case while the existing hint still fires for the rare slow-repo case.

## Bug B — snapshot loader inconsistency (#379)

`loadSnapshotFast` / `loadSnapshotValidated` treated `META.file_count == 0` as a successful "valid empty snapshot" load because the optional-unwrap branch matched `0 == 0` before the `file_count == 0` fallback could fire. Downstream, `loadTrigramFromDiskIfPresent` populated the trigram from a separate disk file, so `codedb_status` reported `outlines: 0, trigram_index: mmap (N files)` — the silent breakage in the bug report. Reordering the checks so `file_count == 0` is always a failure forces the caller to do a real scan, producing a consistent outlines/trigram pair. The pre-existing `issue-46` test was asserting the old (buggy) "empty-repo snapshot accepted on load" invariant under a misleading name (the GitHub issue #46 is actually about a different trigram-swap race) and has been updated to assert the new invariant.

## Walk-time measurements (this codedb repo, ~110 Zig files)

Cold MCP startup (no central snapshot, no trigram disk file, no project-root snapshot):

```
ready at 322.5 ms
ready at 272.1 ms
ready at 287.3 ms
```

Warm MCP startup (snapshot present, trigram disk present):

```
warm ready at 13.6 ms
warm ready at 11.7 ms
warm ready at 11.5 ms
```

CLI snapshot from cold cache: `time codedb . snapshot codedb.snapshot` → 70 ms wall (6.2 ms scan + 42.7 ms snapshot write).

The 2 s ceiling chosen for `scan_wait_timeout_ms` is comfortably > 5× the typical cold-start scan time on this repo.

Probe used: spawn `codedb mcp` with `CODEDB_ROOT` set, send `initialize` + `notifications/initialized`, then poll `tools/call codedb_status` every 1–5 ms and time until `scan: ready` appears in the second content block.

## Test plan

- [x] `zig build test` — 448/448 pass at HEAD (was 446 baseline + 2 new tests = 448).
- [x] `issue-378` failing test verified failing on main, passing after fix commit.
- [x] `issue-379` failing test verified failing on main, passing after fix commit.
- [x] `issue-46` test updated to match the new `loadSnapshot returns false for empty snapshots` invariant; passes.
- [x] No changes outside `src/`. `dist/`, `codedb.snapshot`, version not touched.

Closes #378.
Closes #379.