### PR TITLE
fix(mcp): appendId echoes .float and .number_string ids (#387)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3118,6 +3118,14 @@ pub fn appendId(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), id: ?std.json
             mcpj.writeEscaped(alloc, buf, s);
             buf.append(alloc, '"') catch return;
         },
+        .float => |f| {
+            var tmp: [32]u8 = undefined;
+            const s = std.fmt.bufPrint(&tmp, "{d}", .{f}) catch return;
+            buf.appendSlice(alloc, s) catch return;
+        },
+        .number_string => |s| {
+            buf.appendSlice(alloc, s) catch return;
+        },
         else => buf.appendSlice(alloc, "null") catch return,
     } else {
         buf.appendSlice(alloc, "null") catch return;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3106,7 +3106,7 @@ const getInt = mcpj.getInt;
 pub const getBool = mcpj.getBool;
 const eql = mcpj.eql;
 
-fn appendId(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), id: ?std.json.Value) void {
+pub fn appendId(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), id: ?std.json.Value) void {
     if (id) |v| switch (v) {
         .integer => |n| {
             var tmp: [20]u8 = undefined;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9137,3 +9137,35 @@ test "issue-392: Swift parser" {
     try testing.expect(found_top_fn);
     try testing.expect(found_method);
 }
+
+test "issue-387: appendId preserves JSON-RPC numeric and number_string ids" {
+    // JSON-RPC ids are typed as String|Number|Null. The MCP server must echo
+    // the id verbatim so the client can correlate the reply with its request.
+    // appendId currently only handles .integer and .string — .float and
+    // .number_string fall through to "null", breaking correlation for any
+    // client that uses a fractional id (some test runners) or that the JSON
+    // parser materializes as number_string.
+
+    // Float id round-trips: parsing "3.5" yields .float, which must serialize
+    // back to "3.5" (or any representation a JSON parser accepts as the same
+    // number) — NOT "null".
+    {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "3.5", .{});
+        defer parsed.deinit();
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(testing.allocator);
+        mcp_mod.appendId(testing.allocator, &buf, parsed.value);
+        try testing.expect(!std.mem.eql(u8, buf.items, "null"));
+    }
+
+    // number_string round-trips: a request with `"id": 12345678901234567890`
+    // (>i64) is parsed as .number_string. The reply must echo the digits, not
+    // the literal "null".
+    {
+        const v = std.json.Value{ .number_string = "12345678901234567890" };
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(testing.allocator);
+        mcp_mod.appendId(testing.allocator, &buf, v);
+        try testing.expectEqualStrings("12345678901234567890", buf.items);
+    }
+}


### PR DESCRIPTION
Closes #387.

## Summary
- Adds `.float` and `.number_string` arms to `appendId` in `src/mcp.zig`, so JSON-RPC reply id correlation no longer breaks for fractional or >i64 numeric ids.
- Exposes `appendId` as `pub` so the failing test can call it directly.

## Test plan
- [x] `zig build test` — issue-387 test passes; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)