### PR TITLE
fix(index): TrigramIndex.removeFile frees owned path before tombstone (#388)

### DIFF
--- a/src/index.zig
+++ b/src/index.zig
@@ -796,19 +796,22 @@ pub const TrigramIndex = struct {
         _ = self.path_to_id.remove(path);
         // Free the doc_id slot for reuse on next indexFile call.
         self.free_ids.append(self.allocator, doc_id) catch {};
-        self.id_to_path.items[doc_id] = "";
-        const trigrams = self.file_trigrams.getPtr(path) orelse return;
-        for (trigrams.items) |tri| {
-            if (self.index.getPtr(tri)) |posting_list| {
-                posting_list.removeDocId(doc_id);
-                if (posting_list.items.items.len == 0) {
-                    posting_list.deinit(self.allocator);
-                    _ = self.index.remove(tri);
+        if (self.file_trigrams.getPtr(path)) |trigrams| {
+            for (trigrams.items) |tri| {
+                if (self.index.getPtr(tri)) |posting_list| {
+                    posting_list.removeDocId(doc_id);
+                    if (posting_list.items.items.len == 0) {
+                        posting_list.deinit(self.allocator);
+                        _ = self.index.remove(tri);
+                    }
                 }
             }
+            trigrams.deinit(self.allocator);
+            _ = self.file_trigrams.remove(path);
         }
-        trigrams.deinit(self.allocator);
-        _ = self.file_trigrams.remove(path);
+        const old_path = self.id_to_path.items[doc_id];
+        if (self.owns_paths and old_path.len > 0) self.allocator.free(old_path);
+        self.id_to_path.items[doc_id] = "";
     }
 
     pub fn indexFile(self: *TrigramIndex, path: []const u8, content: []const u8) !void {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9020,3 +9020,21 @@ test "issue-386: telemetry recordToolCall preserves UTF-8 codepoint boundaries" 
     // produces invalid bytes — std.unicode.utf8ValidateSlice rejects them.
     try testing.expect(std.unicode.utf8ValidateSlice(recorded));
 }
+
+test "issue-388: TrigramIndex.removeFile frees owned path on tombstone" {
+    // owns_paths=true means getOrCreateDocId duped the path so callers can
+    // free their copy. removeFile must release that dup before tombstoning
+    // the slot — otherwise every snapshot-loaded session leaks one path
+    // allocation per file removed/re-indexed.
+    var idx = TrigramIndex.init(testing.allocator);
+    defer idx.deinit();
+    idx.owns_paths = true;
+
+    const path = "src/leaky.zig";
+    try idx.indexFile(path, "pub fn leaky() void {}\n");
+    idx.removeFile(path);
+
+    // testing.allocator reports any unfreed bytes when this scope exits via
+    // deinit. The bug leaks the dup on the tombstoned id_to_path slot
+    // (cleared to ""), so deinit's `if (p.len > 0) free(p)` misses it.
+}


### PR DESCRIPTION
Closes #388.

## Summary
- `TrigramIndex.removeFile` now frees the duped path on `id_to_path[doc_id]` (when `owns_paths=true`) before tombstoning the slot. Eliminates the steady-state leak that hit every snapshot-loaded session on every re-indexFile / file-deletion.
- Operations are reordered so `path_to_id.remove` and `file_trigrams.remove` run first using the function-arg `path`, avoiding any aliasing UAF when the caller's path slice happens to share storage with the duped one.

## Test plan
- [x] `zig build test` — issue-388 test passes; existing leak/index tests (issue-246, -247, -227) green; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)