### PR TITLE
fix(watcher): FilteredWalker yields file symlinks (#389)

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9038,3 +9038,38 @@ test "issue-388: TrigramIndex.removeFile frees owned path on tombstone" {
     // deinit. The bug leaks the dup on the tombstoned id_to_path slot
     // (cleared to ""), so deinit's `if (p.len > 0) free(p)` misses it.
 }
+
+test "issue-389: FilteredWalker yields symlinked source files" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "src");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/target.zig", .data = "pub fn linked() void {}\n// MARKER_LINE\n" });
+
+    // Create an in-workspace symlink: src/alias.zig -> target.zig (relative).
+    var src_dir = try tmp_dir.dir.openDir(io, "src", .{ .iterate = true });
+    defer src_dir.close(io);
+    src_dir.symLink(io, "target.zig", "alias.zig", .{}) catch |err| switch (err) {
+        // If the OS denies symlinks (e.g. CI without privilege on Windows),
+        // skip the test rather than report a false negative.
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
+
+    // Both the real file and the symlinked alias must be indexed. The bug at
+    // src/watcher.zig:319 drops every entry whose kind != .file, silently
+    // skipping symlinks even when they point at in-workspace source files.
+    try testing.expect(explorer.contents.contains("src/target.zig"));
+    try testing.expect(explorer.contents.contains("src/alias.zig"));
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -316,7 +316,11 @@ const FilteredWalker = struct {
                     continue;
                 }
 
-                if (entry.kind != .file) continue;
+                if (entry.kind != .file) {
+                    if (entry.kind != .sym_link) continue;
+                    const target_stat = top.dir_handle.statFile(self.io, entry.name, .{}) catch continue;
+                    if (target_stat.kind != .file) continue;
+                }
 
                 // Build full relative path by appending filename
                 if (self.dir_prefix_len > 0)


### PR DESCRIPTION
Closes #389.

## Summary
- `FilteredWalker.next()` now stats `.sym_link` entries via `dir_handle.statFile` (which follows the link). If the target is a regular file, the entry falls through to the existing file branch and is yielded.
- Directory-symlinks remain unwalked (intentional follow-up — needs cycle + escape detection).

## Test plan
- [x] `zig build test` — issue-389 test passes; existing watcher tests (parallel initial scan, queue, etc.) green; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)