### PR TITLE
feat(search): per-file cap on codedb_search scope=true (#390)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1110,9 +1110,22 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
 
         const w = cio.listWriter(out, alloc);
         w.print("{d} results for '{s}':\n", .{ results.len, query }) catch {};
+        var file_counts = std.StringHashMap(u8).init(alloc);
+        defer file_counts.deinit();
+        const max_per_file: u8 = 5;
+        var shown: usize = 0;
         for (results) |r| {
             if (path_glob) |g| if (!globMatch(g, r.path)) continue;
             if (compact and explore_mod.isCommentOrBlank(r.line_text, explore_mod.detectLanguage(r.path))) continue;
+            const gop = file_counts.getOrPut(r.path) catch continue;
+            if (!gop.found_existing) gop.value_ptr.* = 0;
+            gop.value_ptr.* += 1;
+            if (gop.value_ptr.* > max_per_file) {
+                if (gop.value_ptr.* == max_per_file + 1) {
+                    w.print("  {s} ... (more matches truncated)\n", .{r.path}) catch {};
+                }
+                continue;
+            }
             if (r.scope_name) |sn| {
                 w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
                     r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
@@ -1120,6 +1133,10 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             } else {
                 w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
             }
+            shown += 1;
+        }
+        if (shown < results.len) {
+            w.print("({d} shown, {d} truncated)\n", .{ shown, results.len - shown }) catch {};
         }
     } else if (is_regex) {
         const results = explorer.searchContentRegex(query, alloc, max_results) catch {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9169,3 +9169,55 @@ test "issue-387: appendId preserves JSON-RPC numeric and number_string ids" {
         try testing.expectEqualStrings("12345678901234567890", buf.items);
     }
 }
+
+test "issue-390: codedb_search scope=true caps matches per file" {
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+
+    // Build a "dominant" file with 20 matches plus several files with 1 match
+    // each. Without a per-file cap on the scope=true path, the dominant file
+    // alone drowns the response. The plain/regex branches already enforce
+    // max_per_file=5 (mcp.zig:1141, 1198), but the scope=true branch does not.
+    var dominant_buf: std.ArrayList(u8) = .empty;
+    defer dominant_buf.deinit(testing.allocator);
+    try dominant_buf.appendSlice(testing.allocator, "pub fn dominant() void {\n");
+    for (0..20) |_| try dominant_buf.appendSlice(testing.allocator, "    // FROBNICATE token\n");
+    try dominant_buf.appendSlice(testing.allocator, "}\n");
+    try explorer.indexFile("src/dominant.zig", dominant_buf.items);
+    try explorer.indexFile("src/a.zig", "// FROBNICATE here\npub fn a() void {}\n");
+    try explorer.indexFile("src/b.zig", "// FROBNICATE here\npub fn b() void {}\n");
+    try explorer.indexFile("src/c.zig", "// FROBNICATE here\npub fn c() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"query":"FROBNICATE","scope":true,"max_results":100}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_search, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // Count "src/dominant.zig:" occurrences (one per emitted match line).
+    var dominant_lines: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, out.items, i, "src/dominant.zig:")) |pos| {
+        dominant_lines += 1;
+        i = pos + 1;
+    }
+    // The plain-search per-file cap is 5; scope=true should match. Without
+    // any cap, all 20 matches surface and starve the smaller files.
+    try testing.expect(dominant_lines <= 5);
+    // The other files still surface — the cap shouldn't tank recall, just
+    // bound the dominant file's share.
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/a.zig:") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/b.zig:") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/c.zig:") != null);
+}


### PR DESCRIPTION
Closes #390.

## Summary
- Ports the `file_counts` + `max_per_file=5` + `"... (more matches truncated)"` machinery from the regex branch into the `scope=true` branch of `codedb_search`. A single dense file no longer drowns the response.
- Keeps the scope-branch print format intact (`[in {scope_name} ...]` annotation preserved).

## Test plan
- [x] `zig build test` — issue-390 test passes; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)