### PR TITLE
feat(explore): Swift parser (#392)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -102,6 +102,7 @@ pub const Language = enum(u8) {
     dart,
     java,
     kotlin,
+    swift,
     svelte,
     vue,
     astro,
@@ -139,6 +140,7 @@ pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".dart")) return .dart;
     if (std.mem.endsWith(u8, path, ".java")) return .java;
     if (std.mem.endsWith(u8, path, ".kt")) return .kotlin;
+    if (std.mem.endsWith(u8, path, ".swift")) return .swift;
     if (std.mem.endsWith(u8, path, ".svelte")) return .svelte;
     if (std.mem.endsWith(u8, path, ".vue")) return .vue;
     if (std.mem.endsWith(u8, path, ".astro")) return .astro;
@@ -1017,6 +1019,8 @@ pub const Explorer = struct {
                 try parser.parseJavaLine(trimmed, line_num, &outline);
             } else if (outline.language == .kotlin) {
                 try parser.parseKotlinLine(trimmed, line_num, &outline);
+            } else if (outline.language == .swift) {
+                try parser.parseSwiftLine(trimmed, line_num, &outline);
             } else if (outline.language == .svelte or outline.language == .vue or outline.language == .astro) {
                 try parser.parseComponentLine(trimmed, line_num, &outline);
             } else if (outline.language == .shell) {
@@ -2224,6 +2228,29 @@ pub const Explorer = struct {
             try appendOutlineSymbol(a, outline, name, .constant, line_num, line);
         } else if (extractIdentAfterKeyword(line, "var ")) |name| {
             try appendOutlineSymbol(a, outline, name, .variable, line_num, line);
+        }
+    }
+
+    fn parseSwiftLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const line = stripLineComment(raw_line);
+        if (line.len == 0 or startsWith(line, "@") or startsWith(line, "/*") or startsWith(line, "*")) return;
+
+        if (parseDelimitedImport(line, "import ", "")) |imp| {
+            try appendImportSymbol(a, outline, imp, line_num, line);
+            return;
+        }
+
+        if (extractIdentAfterKeyword(line, "struct ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "protocol ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .interface_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "class ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "enum ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
+        } else if (extractIdentAfterKeyword(line, "func ")) |name| {
+            try appendOutlineSymbol(a, outline, name, .function, line_num, line);
         }
     }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9073,3 +9073,67 @@ test "issue-389: FilteredWalker yields symlinked source files" {
     try testing.expect(explorer.contents.contains("src/target.zig"));
     try testing.expect(explorer.contents.contains("src/alias.zig"));
 }
+
+test "issue-392: Swift parser" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("Sources/App/Greeter.swift",
+        \\import Foundation
+        \\import UIKit
+        \\
+        \\public struct Greeter {
+        \\    let name: String
+        \\
+        \\    public func greet() -> String {
+        \\        return "Hello, \(name)"
+        \\    }
+        \\}
+        \\
+        \\public class HomeViewController: UIViewController {
+        \\    public override func viewDidLoad() {
+        \\        super.viewDidLoad()
+        \\    }
+        \\}
+        \\
+        \\public protocol Reloadable {
+        \\    func reload()
+        \\}
+        \\
+        \\public enum LoadState {
+        \\    case idle
+        \\    case loading
+        \\}
+        \\
+        \\public func topLevel() -> Int { return 42 }
+    );
+
+    var outline = (try explorer.getOutline("Sources/App/Greeter.swift", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+
+    // Detected language must surface as "swift" — main has no Language.swift,
+    // so the file falls into .unknown and no parser runs.
+    try testing.expectEqualStrings("swift", @tagName(outline.language));
+
+    var found_struct = false;
+    var found_class = false;
+    var found_protocol = false;
+    var found_enum = false;
+    var found_top_fn = false;
+    var found_method = false;
+    for (outline.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.name, "Greeter")) found_struct = true;
+        if (std.mem.eql(u8, sym.name, "HomeViewController")) found_class = true;
+        if (std.mem.eql(u8, sym.name, "Reloadable")) found_protocol = true;
+        if (std.mem.eql(u8, sym.name, "LoadState")) found_enum = true;
+        if (std.mem.eql(u8, sym.name, "topLevel")) found_top_fn = true;
+        if (std.mem.eql(u8, sym.name, "greet")) found_method = true;
+    }
+    try testing.expect(found_struct);
+    try testing.expect(found_class);
+    try testing.expect(found_protocol);
+    try testing.expect(found_enum);
+    try testing.expect(found_top_fn);
+    try testing.expect(found_method);
+}


### PR DESCRIPTION
Closes #392.

## Summary
- Adds `Language.swift` and `.swift` extension detection.
- New `parseSwiftLine` (mirrors `parseKotlinLine`) recognizes:
  - `import X` → imports
  - `struct NAME`, `class NAME`, `protocol NAME`, `enum NAME` → type symbols
  - `func NAME(...)` → function/method symbols
  - Visibility/attribute prefixes (`public`, `open`, `override`, etc.) handled via word-boundary keyword search
- Protocols mapped to the existing `.interface_def` SymbolKind.

Out of scope (follow-up): brace-depth tracking to mark methods distinctly from top-level funcs (Kotlin parser doesn't either), `extension`, `typealias`, `let`/`var`, `case`, computed properties, multi-line block comments, multi-line string interpolation.

## Test plan
- [x] `zig build test` — issue-392 test passes; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)