### PR TITLE
fix(agent): tryLock rejects crashed agents (#411)

### DIFF
--- a/src/agent.zig
+++ b/src/agent.zig
@@ -134,6 +134,7 @@ pub const AgentRegistry = struct {
 
         // Grant the lock.
         if (self.agents.getPtr(agent_id)) |a| {
+            if (a.state == .crashed) return false;
             if (a.locked_paths.getPtr(path)) |expiry| {
                 expiry.* = now + ttl_ms;
                 return true;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9290,3 +9290,23 @@ test "issue-391: codedb_callers rejects missing name" {
     try testing.expect(std.mem.startsWith(u8, out.items, "error:"));
     try testing.expect(std.mem.indexOf(u8, out.items, "name") != null);
 }
+
+test "issue-411: tryLock grants new locks to a crashed agent" {
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+
+    const id = try agents.register("zombie");
+
+    // Force the agent into the crashed state via reapStale.
+    const a = agents.agents.getPtr(id) orelse return error.TestUnexpectedResult;
+    a.last_seen = 0;
+    agents.reapStale(0);
+    try testing.expectEqual(@as(@TypeOf(a.state), .crashed), a.state);
+
+    // A crashed agent should not be allowed to acquire new advisory locks
+    // until it heartbeats back to .active. Today tryLock ignores .state and
+    // happily grants the lock — leaving the registry inconsistent (a
+    // .crashed agent suddenly holds fresh locks again).
+    const got = try agents.tryLock(id, "post-crash.zig", 60_000);
+    try testing.expect(got == false);
+}


### PR DESCRIPTION
Closes #411. tryLock now refuses agent_ids whose state is .crashed; the caller must re-register before re-acquiring locks. Test passes; suite green.