### PR TITLE
fix(snapshot): age-guard stale tmp cleanup; tighten .env filter (#408, #410)

### DIFF
--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -938,8 +938,9 @@ fn isSensitivePath(path: []const u8) bool {
         if (std.mem.eql(u8, basename, name)) return true;
     }
 
-    // Check if basename starts with .env (catches .env.anything)
-    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env")) return true;
+    // Catch .env, .env.anything; do NOT match .envoy, .envrc, .environment, etc.
+    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
+        (basename.len == 4 or basename[4] == '.')) return true;
 
     // Check extensions
     if (endsWith(basename, ".pem")) return true;
@@ -970,6 +971,9 @@ fn cleanupStaleTmpFiles(io: std.Io, output_path: []const u8) void {
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
 
+    const now_ns: i128 = cio.nanoTimestamp();
+    const min_age_ns: i128 = @as(i128, std.time.s_per_min) * std.time.ns_per_s;
+
     var iter = dir.iterate();
     while (iter.next(io) catch null) |entry| {
         if (entry.kind != .file) continue;
@@ -979,6 +983,11 @@ fn cleanupStaleTmpFiles(io: std.Io, output_path: []const u8) void {
             std.mem.startsWith(u8, name, basename) and
             endsWith(name, ".tmp"))
         {
+            // Age guard: skip in-flight tmps from concurrent writers.
+            // Only delete leftovers crashed processes left behind (>60s old).
+            const st = dir.statFile(io, name, .{}) catch continue;
+            const m_ns: i128 = @intCast(st.mtime.nanoseconds);
+            if (now_ns - m_ns < min_age_ns) continue;
             dir.deleteFile(io, name) catch {};
         }
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9394,3 +9394,52 @@ test "issue-405: cleanupStaleTmpFiles deletes in-flight sibling tmp files" {
         return error.TestExpectedSiblingTmpPreserved;
     };
 }
+
+test "issue-409: snapshot .env prefix filter wrongly excludes .envoy/.environment files" {
+    // BUG: snapshot.zig:isSensitivePath uses
+    //     if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env")) return true;
+    // to catch .env, .env.local, .env.production, etc. The check is a raw
+    // 4-byte prefix match — so any basename whose first 4 bytes are ".env"
+    // is rejected, including legitimate, non-secret files such as:
+    //
+    //   .envoy.json     — Envoy proxy config
+    //   .environment    — generic config name
+    //   .envconfig.yaml — anything starting with ".env"
+    //
+    // These files end up silently dropped from the snapshot's CONTENT,
+    // TREE, and OUTLINE_STATE sections, so a save/load round-trip loses
+    // them entirely. The watcher.zig copy of isSensitivePath has the same
+    // bug, so they are also excluded from live indexing.
+    //
+    // Reproducer: index a non-secret .envoy.json alongside a normal file,
+    // snapshot, load, and observe that .envoy.json is missing.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+
+    var exp = Explorer.init(aa);
+    try exp.indexFile("a.zig", "pub fn alpha() void {}\n");
+    // .envoy.json is the canonical Envoy proxy config name — not a secret.
+    try exp.indexFile(".envoy.json", "{\"listeners\":[]}\n");
+    try testing.expectEqual(@as(usize, 2), exp.outlines.count());
+
+    const snap_path = try std.fs.path.join(aa, &.{ dir_path, "snap.codedb" });
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, aa);
+
+    var exp2 = Explorer.init(aa);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, aa));
+
+    // Expected: both files round-trip through the snapshot.
+    // Current (bug): only "a.zig" survives — ".envoy.json" was excluded by
+    // the .env prefix check at write time.
+    try testing.expect(exp2.outlines.contains("a.zig"));
+    try testing.expect(exp2.outlines.contains(".envoy.json"));
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9337,3 +9337,60 @@ test "issue-407: root_policy blocks /var and its non-folders subtree" {
     try testing.expect(!root_policy.isIndexableRoot("/private/var"));
     try testing.expect(!root_policy.isIndexableRoot("/private/var/log"));
 }
+
+test "issue-405: cleanupStaleTmpFiles deletes in-flight sibling tmp files" {
+    // BUG: snapshot.zig:cleanupStaleTmpFiles deletes ANY file matching
+    // `<basename>*.tmp` in the snapshot directory with no age guard.
+    // If a sibling writer (another process / parallel scan) is mid-write
+    // — i.e. it has just created `<output>.<rand>.tmp` and is still
+    // streaming bytes into it before the final rename(tmp, dest) — then a
+    // concurrent loadSnapshotValidated() will unlink the sibling's
+    // in-flight tmp file. The sibling's subsequent rename then fails with
+    // ENOENT and the snapshot write silently aborts.
+    //
+    // Reproduces deterministically by simulating the in-flight tmp file
+    // and observing that loadSnapshotValidated removes it.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+
+    // Step 1: write a real, valid snapshot at <dir>/snap.codedb so
+    // loadSnapshotValidated has something legitimate to read.
+    var exp = Explorer.init(aa);
+    try exp.indexFile("a.zig", "pub fn alpha() void {}\n");
+    const snap_path = try std.fs.path.join(aa, &.{ dir_path, "snap.codedb" });
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, aa);
+
+    // Step 2: simulate a SIBLING writer that has just created its tmp file
+    // but has NOT yet renamed. This file matches the cleanup pattern
+    // (starts with basename, ends with ".tmp").
+    const sibling_tmp = try std.fs.path.join(aa, &.{ dir_path, "snap.codedb.deadbeef.tmp" });
+    {
+        var f = try std.Io.Dir.cwd().createFile(io, sibling_tmp, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "in-flight write");
+    }
+
+    // Sanity: the sibling tmp exists.
+    std.Io.Dir.cwd().access(io, sibling_tmp, .{}) catch return error.TestUnexpectedResult;
+
+    // Step 3: run loadSnapshotValidated. cleanupStaleTmpFiles is the
+    // first thing it does. After this, the sibling's in-flight tmp
+    // file MUST still exist — otherwise the sibling's rename will fail.
+    var exp2 = Explorer.init(aa);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = snapshot_mod.loadSnapshotValidated(io, snap_path, null, &exp2, &store, aa);
+
+    // Expected: the in-flight sibling tmp is preserved.
+    // Current (bug): cleanupStaleTmpFiles unconditionally deletes it.
+    std.Io.Dir.cwd().access(io, sibling_tmp, .{}) catch {
+        return error.TestExpectedSiblingTmpPreserved;
+    };
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1083,8 +1083,9 @@ pub fn isSensitivePath(path: []const u8) bool {
             std.mem.indexOf(u8, path, ".aws/") != null) return true;
         return false;
     }
-    // .env* wildcard (catches .env, .env.local, .env.production, etc.)
-    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env")) return true;
+    // .env, .env.<token>; do NOT match .envoy, .envrc, .environment, etc.
+    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
+        (basename.len == 4 or basename[4] == '.')) return true;
     // Exact matches
     const sensitive_names = [_][]const u8{
         ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",


### PR DESCRIPTION
Closes #408, #410. cleanupStaleTmpFiles now skips tmps under ~60s old (preserving in-flight writes). isSensitivePath .env filter requires exact match or '.env.' prefix. Tests pass; suite green.