### PR TITLE
feat(watcher): walk directory symlinks with cycle + escape detection (#405)

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9140,6 +9140,70 @@ test "issue-389: FilteredWalker yields symlinked source files" {
     try testing.expect(explorer.contents.contains("src/alias.zig"));
 }
 
+test "issue-405: FilteredWalker walks directory symlinks safely (cycle + escape)" {
+    // Follow-up to #389. The current FilteredWalker.next() (src/watcher.zig:319-323)
+    // treats sym_link entries as files when statFile reports .file, but silently
+    // drops sym_link entries whose target is a directory. Real repos rely on
+    // directory symlinks (monorepo package links, vendored deps, dotfile configs),
+    // so the indexer must walk them — but only safely. This test pins three things:
+    //   1. A file inside a symlinked subdirectory is indexed.
+    //   2. A symlink that introduces a cycle does not hang or duplicate entries.
+    //   3. (Implicit) The walker terminates in bounded time on the fixture.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    // Real directory `pkg/` with one source file.
+    try tmp_dir.dir.createDirPath(io, "pkg");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "pkg/inside.zig", .data = "pub fn inside() void {}\n" });
+
+    // A real directory `app/` that holds a directory-symlink `linked_pkg -> ../pkg`.
+    // We expect the walker to descend into `linked_pkg` and yield `app/linked_pkg/inside.zig`.
+    try tmp_dir.dir.createDirPath(io, "app");
+    var app_dir = try tmp_dir.dir.openDir(io, "app", .{ .iterate = true });
+    defer app_dir.close(io);
+    app_dir.symLink(io, "../pkg", "linked_pkg", .{}) catch |err| switch (err) {
+        // Skip on platforms / CI configurations that deny symlink creation.
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    // Cycle: `app/loop -> ..` points back at the workspace root. Without cycle
+    // detection a naive walker recurses forever via app/loop/app/loop/app/...
+    app_dir.symLink(io, "..", "loop", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
+
+    // 1. The in-target file must appear under the symlinked path. This is the
+    //    behaviour gap left by #389 — directory symlinks are currently ignored,
+    //    so this assertion fails on main.
+    try testing.expect(explorer.contents.contains("app/linked_pkg/inside.zig"));
+
+    // 2. The real path must also be indexed exactly once.
+    try testing.expect(explorer.contents.contains("pkg/inside.zig"));
+
+    // 3. The cycle must not have produced a deeply-nested duplicate entry.
+    //    If cycle detection is missing, paths like
+    //    `app/loop/app/loop/app/linked_pkg/inside.zig` would appear (or the
+    //    scan would never terminate). Assert no path contains "loop/app/loop".
+    var it = explorer.contents.iterator();
+    while (it.next()) |kv| {
+        const p = kv.key_ptr.*;
+        try testing.expect(std.mem.indexOf(u8, p, "loop/app/loop") == null);
+    }
+}
+
 test "issue-392: Swift parser" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -197,6 +197,8 @@ const FilteredWalker = struct {
     io: std.Io,
     dir_prefix_len: usize = 0,
     ignore_patterns: std.ArrayList([]const u8) = .empty,
+    real_root: []const u8 = &.{},
+    visited_real_paths: std.StringHashMapUnmanaged(void) = .empty,
 
     pub const Entry = struct {
         path: []const u8, // relative path — valid until next call to next()
@@ -213,6 +215,14 @@ const FilteredWalker = struct {
             .dir_handle = root,
             .iter = root.iterate(),
         });
+
+        var rr_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (root.realPathFile(io, ".", &rr_buf)) |rr_len| {
+            const dup = try allocator.dupe(u8, rr_buf[0..rr_len]);
+            self.real_root = dup;
+            const seed = try allocator.dupe(u8, rr_buf[0..rr_len]);
+            try self.visited_real_paths.put(allocator, seed, {});
+        } else |_| {}
 
         // Load .codedbignore if it exists
         if (root.readFileAlloc(io, ".codedbignore", allocator, .limited(64 * 1024))) |content| {
@@ -251,6 +261,10 @@ const FilteredWalker = struct {
         self.name_buffer.deinit(self.allocator);
         for (self.ignore_patterns.items) |p| self.allocator.free(p);
         self.ignore_patterns.deinit(self.allocator);
+        var it = self.visited_real_paths.keyIterator();
+        while (it.next()) |k| self.allocator.free(k.*);
+        self.visited_real_paths.deinit(self.allocator);
+        if (self.real_root.len > 0) self.allocator.free(self.real_root);
     }
 
     fn isIgnored(self: *FilteredWalker, name: []const u8, full_path: []const u8) bool {
@@ -319,6 +333,40 @@ const FilteredWalker = struct {
                 if (entry.kind != .file) {
                     if (entry.kind != .sym_link) continue;
                     const target_stat = top.dir_handle.statFile(self.io, entry.name, .{}) catch continue;
+                    if (target_stat.kind == .directory) {
+                        if (shouldSkipDir(entry.name)) continue;
+                        if (self.ignore_patterns.items.len > 0) {
+                            var check_buf: [std.fs.max_path_bytes]u8 = undefined;
+                            const check_path = if (self.dir_prefix_len > 0)
+                                std.fmt.bufPrint(&check_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch entry.name
+                            else
+                                entry.name;
+                            if (self.isIgnored(entry.name, check_path)) continue;
+                        }
+                        var rt_buf: [std.fs.max_path_bytes]u8 = undefined;
+                        const rt_len = top.dir_handle.realPathFile(self.io, entry.name, &rt_buf) catch continue;
+                        const real_target = rt_buf[0..rt_len];
+                        if (self.real_root.len == 0) continue;
+                        if (!std.mem.startsWith(u8, real_target, self.real_root)) continue;
+                        if (real_target.len != self.real_root.len and real_target[self.real_root.len] != '/') continue;
+                        const gop = self.visited_real_paths.getOrPut(self.allocator, real_target) catch continue;
+                        if (gop.found_existing) continue;
+                        const dup = self.allocator.dupe(u8, real_target) catch {
+                            _ = self.visited_real_paths.remove(real_target);
+                            continue;
+                        };
+                        gop.key_ptr.* = dup;
+                        const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
+                        if (self.name_buffer.items.len > 0)
+                            try self.name_buffer.append(self.allocator, '/');
+                        try self.name_buffer.appendSlice(self.allocator, entry.name);
+                        self.dir_prefix_len = self.name_buffer.items.len;
+                        try self.stack.append(self.allocator, .{
+                            .dir_handle = sub,
+                            .iter = sub.iterate(),
+                        });
+                        continue;
+                    }
                     if (target_stat.kind != .file) continue;
                 }
 

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -316,6 +316,9 @@ const FilteredWalker = struct {
                         if (self.isIgnored(entry.name, check_path)) continue;
                     }
                     const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
+                    errdefer sub.close(self.io);
+                    const saved_len = self.name_buffer.items.len;
+                    errdefer self.name_buffer.shrinkRetainingCapacity(saved_len);
 
                     // Extend the directory prefix in name_buffer
                     if (self.name_buffer.items.len > 0)
@@ -357,6 +360,9 @@ const FilteredWalker = struct {
                         };
                         gop.key_ptr.* = dup;
                         const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
+                        errdefer sub.close(self.io);
+                        const saved_len_sym = self.name_buffer.items.len;
+                        errdefer self.name_buffer.shrinkRetainingCapacity(saved_len_sym);
                         if (self.name_buffer.items.len > 0)
                             try self.name_buffer.append(self.allocator, '/');
                         try self.name_buffer.appendSlice(self.allocator, entry.name);


### PR DESCRIPTION
Closes #405. Extends the file-symlink fix from #389 to also walk directory symlinks. Cycle detection via realpath-keyed visited set; escape detection via real_root prefix check. Tests pass; suite green.