### PR TITLE
release: v0.2.5807 — search/rerank quality + crash fix (#425-#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.2.5807 - 2026-05-06
+
+`0.2.5807` is a search-quality + crash-fix release covering six issues. The headline is a multi-signal reranker for `searchContent` plus a P0 crash fix in `searchInContent`. All six fixes ship in a single bundle ([#425](https://github.com/justrach/codedb/issues/425), [#426](https://github.com/justrach/codedb/issues/426), [#427](https://github.com/justrach/codedb/issues/427), [#429](https://github.com/justrach/codedb/issues/429), [#430](https://github.com/justrach/codedb/issues/430), [#431](https://github.com/justrach/codedb/issues/431)).
+
+### Reliability ([#431](https://github.com/justrach/codedb/issues/431))
+
+- **`searchInContent`: bounds-check fixes a P0 crash.** When the query was longer than any indexed file's content, `content.len - query.len + 1` underflowed `usize` and the binary aborted with integer-overflow panic (Debug) or SIGBUS (ReleaseFast). One-line guard at the top of `searchInContent` returns early when `query.len > content.len`. Reachable from any user-supplied query that exceeded the smallest indexed file (e.g. a one-byte stub). Fixed.
+
+### Search quality ([#425](https://github.com/justrach/codedb/issues/425), [#426](https://github.com/justrach/codedb/issues/426))
+
+- **`codedb_callers`: whole-word match.** `handleCallers` previously substring-matched the symbol name across the index and only excluded the canonical definition line of the searched name itself. Searching for `fooBar` returned matches inside `fooBarExtended` — both its definition site and any references — as if they were call sites. A new `hasWholeWordMatch` check gates every emitted result on identifier-boundary characters on both sides of the hit.
+- **`codedb_callers`: language gate.** `handleCallers` fed `searchContentWithScope` across every indexed file regardless of language, so markdown design docs and other prose surfaced as call sites whenever the symbol name was mentioned. A new `langHasCallSites` predicate excludes data formats (`json`, `yaml`), markup/styling (`markdown`, `css`, `scss`), declarative schemas (`protobuf`), and unknown files.
+
+### Search ranking ([#427](https://github.com/justrach/codedb/issues/427), [#429](https://github.com/justrach/codedb/issues/429), [#430](https://github.com/justrach/codedb/issues/430))
+
+- **Tier 1 candidate sort by per-file word-hit count.** `searchContent`'s Tier 1 sorted trigram candidates by content length ascending and then capped per-file at `max(1, max_results / estimated_total)`. When small unrelated files dominated the candidate list, they each contributed one hit and saturated the result quota before the larger definition-dense file was scanned. Now Tier 1 ranks candidates by per-file word-index hit count (desc) with content length (asc) as a stable tiebreaker — the file with the most occurrences scans first.
+- **Tier 0 processes code before docs.** With `max_results=50` and the per-file cap of 10, five markdown files mentioning the query 10+ times each could collectively saturate the quota before the canonical source file was reached, leaving the source file completely absent from results. A new `isDocLanguage(Language)` predicate gates a two-pass loop: code-language hits first, doc-language hits second. Same per-file cap, same dedup, same early-return — only iteration order changes. Source files now win the recall race.
+- **Multi-signal rerank.** The post-pass rerank counted per-line query occurrences only and broke ties on path-asc + line-asc, which buried symbol-definition lines under alphabetically-earlier comment mentions, ranked `examples/foo.zig` above `src/foo.zig`, and lost basename-match intent entirely. New `rerankSignalScore` composes per-line occurrence count, a symbol-definition boost (+5 when the hit line is a defined symbol whose name matches the query, looked up via outlines), a basename-match boost (+15 exact stem, +8 substring, case-insensitive), a path-segment match boost (+6 for queries like `parser` matching `src/parser/foo.zig`), and a path-prior penalty (×0.6 for `tests/`, `examples/`; ×0.4 for `vendor/`, `node_modules/`, `third_party/`). Constants are tuned so a 5x-higher per-line frequency still wins on its own, while each signal individually flips alphabetic ties.
+- **Rerank applies on every return path.** Pre-fix the multi-signal rerank only ran on fall-through to the final return; Tier 0 and Tier 1 early-returns at `max_results` bypassed it entirely. Lifting the rerank into a `rerankAndFinalize` helper called from every searchContent return point gives the symbol-def / basename / path-prior signals consistent coverage regardless of which tier filled the quota.
+
+### Validation
+
+- 271 lines of regression tests in `src/tests.zig` — one or more per issue, all failing on `main` without the fix and passing with it. Bundle-level Sonnet 4.6 validation (real codebase, side-by-side comparison vs. the 0.2.5806 baseline) shows definition sites promoted to #1 for `handleCallers`, `pathHasSegment`, `BenchContext`, `Explorer`; `src/explore.zig` now ranks #1 for the `searchContent` query (was completely absent from baseline top-5); `src/watcher.zig` at #1 for `watcher`; no quality regressions on innocent queries; RSS delta under 1%.
+
 ## 0.2.5795 - 2026-05-04
 
 `0.2.5795` closes out [#356](https://github.com/justrach/codedb/issues/356) with phase 3 — three small ergonomics polishes that complete the rewritten reliability scope — plus a privacy/disk-leak fix for [#367](https://github.com/justrach/codedb/issues/367).

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -156,6 +156,17 @@ pub fn detectLanguage(path: []const u8) Language {
     return .unknown;
 }
 
+/// Returns true for languages whose content is primarily prose / data /
+/// markup rather than executable code. Used to deprioritise these files in
+/// content search so a CHANGELOG.md or design doc cannot starve a canonical
+/// source-file match (issue #430).
+pub fn isDocLanguage(lang: Language) bool {
+    return switch (lang) {
+        .markdown, .json, .yaml, .unknown => true,
+        else => false,
+    };
+}
+
 pub const SymbolResult = struct {
     path: []const u8,
     symbol: Symbol,
@@ -1522,33 +1533,42 @@ pub const Explorer = struct {
         // file (CHANGELOG.md, architecture.md, etc.) can't saturate the quota
         // and crowd out source-file matches that come later in the posting
         // list. Cap = max(1, max_results / 5).
+        // Issue #430: process code-language hits FIRST, then doc-language
+        // hits. With max_results=50 the per-file cap is 10, so 5 markdown
+        // files with 10+ mentions each can fill result_list before the
+        // canonical source file's posting-list entries are reached.
         const word_hits = self.word_index.search(query);
         if (word_hits.len > 0 and word_hits.len <= max_results * 2) {
             const tier0_per_file_cap: usize = @max(1, max_results / 5);
             var tier0_per_file = std.StringHashMap(usize).init(allocator);
             defer tier0_per_file.deinit();
-            for (word_hits) |hit| {
-                const hit_path = self.word_index.hitPath(hit);
-                if (hit_path.len == 0) continue;
-                const gop = tier0_per_file.getOrPut(hit_path) catch continue;
-                if (!gop.found_existing) gop.value_ptr.* = 0;
-                if (gop.value_ptr.* >= tier0_per_file_cap) continue;
-                const ref = self.readContentForSearch(hit_path, allocator) orelse continue;
-                defer ref.deinit();
-                const line_text = extractLineByNumber(ref.data, hit.line_num) orelse continue;
-                if (indexOfCaseInsensitive(line_text, query) == null) continue;
-                const duped_text = try allocator.dupe(u8, line_text);
-                errdefer allocator.free(duped_text);
-                const duped_path = try allocator.dupe(u8, hit_path);
-                errdefer allocator.free(duped_path);
-                try result_list.append(allocator, .{
-                    .path = duped_path,
-                    .line_num = hit.line_num,
-                    .line_text = duped_text,
-                });
-                gop.value_ptr.* += 1;
-                searched.put(hit_path, {}) catch {};
-                if (result_list.items.len >= max_results) return result_list.toOwnedSlice(allocator);
+            const passes = [_]bool{ false, true }; // pass 0 = code, pass 1 = doc
+            for (passes) |is_doc_pass| {
+                if (result_list.items.len >= max_results) break;
+                for (word_hits) |hit| {
+                    const hit_path = self.word_index.hitPath(hit);
+                    if (hit_path.len == 0) continue;
+                    if (isDocLanguage(detectLanguage(hit_path)) != is_doc_pass) continue;
+                    const gop = tier0_per_file.getOrPut(hit_path) catch continue;
+                    if (!gop.found_existing) gop.value_ptr.* = 0;
+                    if (gop.value_ptr.* >= tier0_per_file_cap) continue;
+                    const ref = self.readContentForSearch(hit_path, allocator) orelse continue;
+                    defer ref.deinit();
+                    const line_text = extractLineByNumber(ref.data, hit.line_num) orelse continue;
+                    if (indexOfCaseInsensitive(line_text, query) == null) continue;
+                    const duped_text = try allocator.dupe(u8, line_text);
+                    errdefer allocator.free(duped_text);
+                    const duped_path = try allocator.dupe(u8, hit_path);
+                    errdefer allocator.free(duped_path);
+                    try result_list.append(allocator, .{
+                        .path = duped_path,
+                        .line_num = hit.line_num,
+                        .line_text = duped_text,
+                    });
+                    gop.value_ptr.* += 1;
+                    searched.put(hit_path, {}) catch {};
+                    if (result_list.items.len >= max_results) return result_list.toOwnedSlice(allocator);
+                }
             }
             if (result_list.items.len >= max_results)
                 return result_list.toOwnedSlice(allocator);

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3945,6 +3945,10 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
 
 fn searchInContent(path: []const u8, content: []const u8, query: []const u8, allocator: std.mem.Allocator, max_per_file: usize, max_results: usize, result_list: *std.ArrayList(SearchResult)) !void {
     if (query.len == 0 or content.len == 0) return;
+    // Issue #431: bail when the query is longer than the file. Without this
+    // guard, `content.len - query.len + 1` below underflows usize → integer
+    // overflow panic in Debug, SIGBUS in ReleaseFast.
+    if (query.len > content.len) return;
     result_list.ensureTotalCapacity(allocator, result_list.items.len + @min(max_per_file, 16)) catch {};
     const first_lower: u8 = if (query[0] >= 'A' and query[0] <= 'Z') query[0] + 32 else query[0];
     const first_upper: u8 = if (query[0] >= 'a' and query[0] <= 'z') query[0] - 32 else query[0];

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1765,6 +1765,14 @@ pub const Explorer = struct {
         } else if (asciiContainsIgnoreCase(stem, query)) {
             score += 8.0;
         }
+        // Path-segment match boost: query matches a directory segment in
+        // the path (e.g. query="parser" boosts src/parser/foo.zig). Weaker
+        // than basename match because the file's own name is a stronger
+        // intent signal than the directory it lives in. Skip when basename
+        // already matched to avoid double-counting.
+        if (!asciiContainsIgnoreCase(stem, query) and pathHasSegmentIgnoreCase(r.path, query)) {
+            score += 6.0;
+        }
 
         if (pathHasSegment(r.path, "tests") or pathHasSegment(r.path, "test")) score *= 0.6;
         if (pathHasSegment(r.path, "examples") or pathHasSegment(r.path, "example")) score *= 0.6;
@@ -4510,6 +4518,14 @@ fn pathHasSegment(path: []const u8, segment: []const u8) bool {
     var iter = std.mem.tokenizeAny(u8, path, "/\\");
     while (iter.next()) |seg| {
         if (std.mem.eql(u8, seg, segment)) return true;
+    }
+    return false;
+}
+
+fn pathHasSegmentIgnoreCase(path: []const u8, segment: []const u8) bool {
+    var iter = std.mem.tokenizeAny(u8, path, "/\\");
+    while (iter.next()) |seg| {
+        if (asciiEqlIgnoreCase(seg, segment)) return true;
     }
     return false;
 }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1567,11 +1567,11 @@ pub const Explorer = struct {
                     });
                     gop.value_ptr.* += 1;
                     searched.put(hit_path, {}) catch {};
-                    if (result_list.items.len >= max_results) return result_list.toOwnedSlice(allocator);
+                    if (result_list.items.len >= max_results) return self.rerankAndFinalize(&result_list, query, allocator);
                 }
             }
             if (result_list.items.len >= max_results)
-                return result_list.toOwnedSlice(allocator);
+                return self.rerankAndFinalize(&result_list, query, allocator);
         }
 
         // Tier 0.5: prefix expansion — find all indexed keys that begin with the query.
@@ -1644,7 +1644,7 @@ pub const Explorer = struct {
                     defer ref.deinit();
                     try searchInContent(path, ref.data, query, allocator, max_per_file, max_results, &result_list);
                     if (result_list.items.len >= max_results)
-                        return result_list.toOwnedSlice(allocator);
+                        return self.rerankAndFinalize(&result_list, query, allocator);
                 }
             }
         }
@@ -1714,12 +1714,20 @@ pub const Explorer = struct {
                 if (result_list.items.len >= max_results) break;
             }
         }
+        return self.rerankAndFinalize(&result_list, query, allocator);
+    }
 
-        // Multi-signal rerank (issue #429): per-line occurrence count is the
-        // base, augmented with a symbol-definition boost (the line is the
-        // canonical definition of a symbol named after the query), a
-        // basename-match boost (file stem matches the query — strong intent
-        // signal), and a path-prior penalty for example/test/vendor paths.
+    /// Run the multi-signal rerank in place, then transfer ownership of
+    /// result_list to the caller. Centralised so every searchContent return
+    /// path (Tier 0 / Tier 1 early-return on max_results, fall-through to
+    /// final return) gets the same ranking — pre-fix only the fall-through
+    /// path applied multi-signal scoring.
+    fn rerankAndFinalize(
+        self: *const Explorer,
+        result_list: *std.ArrayList(SearchResult),
+        query: []const u8,
+        allocator: std.mem.Allocator,
+    ) ![]const SearchResult {
         if (result_list.items.len > 1) {
             for (result_list.items) |*r| {
                 r.score = self.rerankSignalScore(r.*, query);
@@ -1733,7 +1741,6 @@ pub const Explorer = struct {
                 }
             }.lessThan);
         }
-
         return result_list.toOwnedSlice(allocator);
     }
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1587,15 +1587,34 @@ pub const Explorer = struct {
         // Tier 1: trigram candidates — fast path, skips files already found by Tier 0.
         if (candidate_paths) |cp| {
             if (cp.len > 0) {
+                // Issue #427: rank candidates by per-file word-index hit count
+                // (desc) so the definition-dense file scans first; fall back to
+                // file content length (asc) so small files still come before
+                // unrelated large files at the same hit count. Pre-fix the
+                // sort key was content length alone, which buried the canonical
+                // file behind unrelated short files when max_per_file was 1.
+                var hits_per_file = std.StringHashMap(u32).init(allocator);
+                defer hits_per_file.deinit();
+                for (word_hits) |hit| {
+                    const hp = self.word_index.hitPath(hit);
+                    if (hp.len == 0) continue;
+                    const gop_h = try hits_per_file.getOrPut(hp);
+                    if (!gop_h.found_existing) gop_h.value_ptr.* = 0;
+                    gop_h.value_ptr.* += 1;
+                }
                 const SortCtx = struct {
                     contents: *const std.StringHashMap([]const u8),
+                    counts: *const std.StringHashMap(u32),
                     pub fn lessThan(ctx: @This(), a: []const u8, b: []const u8) bool {
+                        const a_count = ctx.counts.get(a) orelse 0;
+                        const b_count = ctx.counts.get(b) orelse 0;
+                        if (a_count != b_count) return a_count > b_count;
                         const a_len = if (ctx.contents.get(a)) |c| c.len else std.math.maxInt(usize);
                         const b_len = if (ctx.contents.get(b)) |c| c.len else std.math.maxInt(usize);
                         return a_len < b_len;
                     }
                 };
-                std.mem.sort([]const u8, @constCast(cp), SortCtx{ .contents = &self.contents }, SortCtx.lessThan);
+                std.mem.sort([]const u8, @constCast(cp), SortCtx{ .contents = &self.contents, .counts = &hits_per_file }, SortCtx.lessThan);
 
                 const estimated_total = cp.len + self.skip_trigram_files.count();
                 const max_per_file = @max(@as(usize, 1), max_results / @max(@as(usize, 1), estimated_total));

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1695,11 +1695,14 @@ pub const Explorer = struct {
             }
         }
 
-        // Frequency scoring: count query occurrences per line, then stable-sort by
-        // (score desc, path asc, line_num asc) so high-density hits surface first.
+        // Multi-signal rerank (issue #429): per-line occurrence count is the
+        // base, augmented with a symbol-definition boost (the line is the
+        // canonical definition of a symbol named after the query), a
+        // basename-match boost (file stem matches the query — strong intent
+        // signal), and a path-prior penalty for example/test/vendor paths.
         if (result_list.items.len > 1) {
             for (result_list.items) |*r| {
-                r.score = countOccurrences(r.line_text, query);
+                r.score = self.rerankSignalScore(r.*, query);
             }
             std.sort.block(SearchResult, result_list.items, {}, struct {
                 pub fn lessThan(_: void, a: SearchResult, b: SearchResult) bool {
@@ -1712,6 +1715,36 @@ pub const Explorer = struct {
         }
 
         return result_list.toOwnedSlice(allocator);
+    }
+
+    /// Compose the rerank signals for one search hit (issue #429).
+    fn rerankSignalScore(self: *const Explorer, r: SearchResult, query: []const u8) f32 {
+        var score: f32 = countOccurrences(r.line_text, query);
+
+        if (self.outlines.get(r.path)) |outline| {
+            for (outline.symbols.items) |sym| {
+                if (sym.line_start == r.line_num and std.mem.eql(u8, sym.name, query)) {
+                    score += 5.0;
+                    break;
+                }
+            }
+        }
+
+        const basename = std.fs.path.basename(r.path);
+        const stem_end = std.mem.indexOfScalar(u8, basename, '.') orelse basename.len;
+        const stem = basename[0..stem_end];
+        if (asciiEqlIgnoreCase(stem, query)) {
+            score += 15.0;
+        } else if (asciiContainsIgnoreCase(stem, query)) {
+            score += 8.0;
+        }
+
+        if (pathHasSegment(r.path, "tests") or pathHasSegment(r.path, "test")) score *= 0.6;
+        if (pathHasSegment(r.path, "examples") or pathHasSegment(r.path, "example")) score *= 0.6;
+        if (pathHasSegment(r.path, "vendor") or pathHasSegment(r.path, "node_modules") or
+            pathHasSegment(r.path, "third_party")) score *= 0.4;
+
+        return score;
     }
 
     /// BM25-ranked content search. Tokenizes the query the same way the word
@@ -4420,6 +4453,34 @@ fn countOccurrences(text: []const u8, needle: []const u8) f32 {
         } else break;
     }
     return count;
+}
+
+fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |x, y| {
+        if (std.ascii.toLower(x) != std.ascii.toLower(y)) return false;
+    }
+    return true;
+}
+
+fn asciiContainsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0 or haystack.len < needle.len) return false;
+    var i: usize = 0;
+    outer: while (i + needle.len <= haystack.len) : (i += 1) {
+        for (needle, 0..) |nc, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(nc)) continue :outer;
+        }
+        return true;
+    }
+    return false;
+}
+
+fn pathHasSegment(path: []const u8, segment: []const u8) bool {
+    var iter = std.mem.tokenizeAny(u8, path, "/\\");
+    while (iter.next()) |seg| {
+        if (std.mem.eql(u8, seg, segment)) return true;
+    }
+    return false;
 }
 fn startsWith(haystack: []const u8, needle: []const u8) bool {
     return std.mem.startsWith(u8, haystack, needle);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1351,6 +1351,7 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
 
     var shown: usize = 0;
     for (results) |r| {
+        if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
         var is_def = false;
         for (defs) |d| {
             if (r.line_num == d.symbol.line_start and std.mem.eql(u8, r.path, d.path)) {
@@ -1366,6 +1367,7 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     const w = cio.listWriter(out, alloc);
     w.print("{d} call sites for '{s}':\n", .{ shown, name }) catch {};
     for (results) |r| {
+        if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
         var is_def = false;
         for (defs) |d| {
             if (r.line_num == d.symbol.line_start and std.mem.eql(u8, r.path, d.path)) {
@@ -1406,6 +1408,17 @@ fn hasWholeWordMatch(haystack: []const u8, needle: []const u8) bool {
         search_from = pos + 1;
     }
     return false;
+}
+
+/// Languages where the concept of a "call site" is meaningful. Excludes
+/// data formats (json, yaml), markup/styling (markdown, css, scss),
+/// declarative schemas (protobuf), and unknown files — callers found
+/// inside these are mentions in prose or config, not real invocations.
+fn langHasCallSites(lang: explore_mod.Language) bool {
+    return switch (lang) {
+        .markdown, .json, .yaml, .css, .scss, .protobuf, .unknown => false,
+        else => true,
+    };
 }
 
 fn handleHot(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1358,7 +1358,9 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
                 break;
             }
         }
-        if (!is_def) shown += 1;
+        if (is_def) continue;
+        if (!hasWholeWordMatch(r.line_text, name)) continue;
+        shown += 1;
     }
 
     const w = cio.listWriter(out, alloc);
@@ -1372,6 +1374,7 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
             }
         }
         if (is_def) continue;
+        if (!hasWholeWordMatch(r.line_text, name)) continue;
         if (r.scope_name) |sn| {
             w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
                 r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
@@ -1380,6 +1383,29 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
             w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
         }
     }
+}
+
+fn isIdentChar(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or
+        (c >= 'A' and c <= 'Z') or
+        (c >= '0' and c <= '9') or
+        c == '_';
+}
+
+/// Returns true iff `needle` appears in `haystack` with non-identifier
+/// characters (or string boundary) on both sides — i.e. as a whole-word
+/// identifier match, not as a substring inside a longer identifier.
+fn hasWholeWordMatch(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0 or haystack.len < needle.len) return false;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, haystack, search_from, needle)) |pos| {
+        const before_ok = pos == 0 or !isIdentChar(haystack[pos - 1]);
+        const after_idx = pos + needle.len;
+        const after_ok = after_idx >= haystack.len or !isIdentChar(haystack[after_idx]);
+        if (before_ok and after_ok) return true;
+        search_from = pos + 1;
+    }
+    return false;
 }
 
 fn handleHot(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5806";
+pub const semver = "0.2.5807";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10451,3 +10451,46 @@ test "issue-424-A: bundle envelope errors carry the 'error:' prefix consistently
     bench_ctx.runDispatch(io, testing.allocator, .codedb_bundle, &parsed2.value.object, &out2, &store, &explorer, &agents);
     try testing.expect(std.mem.indexOf(u8, out2.items, "error: missing 'tool'") != null);
 }
+
+test "issue-425: codedb_callers excludes substring matches in unrelated identifiers" {
+    // handleCallers (mcp.zig:1339) currently calls searchContentWithScope(name)
+    // which is a *substring* full-text search. The only de-dup it performs is
+    // dropping lines that match the canonical definition of `name` itself.
+    // That means a search for "fooBar" returns lines mentioning the unrelated
+    // identifier "fooBarExtended" — both its definition site and any reference
+    // — as if they were call sites. The fix is a whole-word check on the hit
+    // line so substring matches in longer identifiers are excluded.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    try explorer.indexFile("def.zig", "pub fn fooBar() void {}\n");
+    // A different symbol whose name contains "fooBar" as a substring.
+    try explorer.indexFile("other.zig", "pub fn fooBarExtended() void {}\n");
+    // A genuine call site.
+    try explorer.indexFile("a.zig", "pub fn callerA() void {\n    fooBar();\n}\n");
+
+    const args_json =
+        \\{"name":"fooBar"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_callers, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // Real call site must still appear.
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig:2") != null);
+    // Substring-only matches in unrelated identifiers must NOT.
+    try testing.expect(std.mem.indexOf(u8, out.items, "other.zig") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "fooBarExtended") == null);
+    // Header reports the real count (1), not the inflated count (2).
+    try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'fooBar'") != null);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10765,3 +10765,27 @@ test "issue-431: searchContent does not crash when query is longer than content"
     }
     try testing.expect(results.len == 0);
 }
+
+test "issue-429-d: searchContent rerank boosts path-segment match" {
+    // Two files, same hit count, same content. The query "parser" appears
+    // as a directory segment of one path. Pre-fix the alphabetic tiebreak
+    // promotes "src/handlers/foo.zig" (h < p). Post-fix the path-segment
+    // match boost surfaces "src/parser/foo.zig" first.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("src/handlers/foo.zig", "// parser is mentioned here\n");
+    try explorer.indexFile("src/parser/foo.zig", "// parser is mentioned here\n");
+
+    const results = try explorer.searchContent("parser", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("src/parser/foo.zig", results[0].path);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10494,3 +10494,274 @@ test "issue-425: codedb_callers excludes substring matches in unrelated identifi
     // Header reports the real count (1), not the inflated count (2).
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'fooBar'") != null);
 }
+
+test "issue-426: codedb_callers excludes non-code files (markdown, docs)" {
+    // handleCallers (mcp.zig:1339) feeds searchContentWithScope across every
+    // indexed file regardless of language. Markdown and other documentation
+    // files that mention the symbol in prose surface as if they were call
+    // sites. The fix is a language gate: skip results from non-code files.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    try explorer.indexFile("def.zig", "pub fn fooBar() void {}\n");
+    try explorer.indexFile("a.zig", "pub fn callerA() void {\n    fooBar();\n}\n");
+    // Prose mention in a docs file — the identifier appears as a whole
+    // word, so this is independent of the substring-match bug (#425):
+    // even a perfect whole-word match on a markdown file is still not a
+    // call site.
+    try explorer.indexFile(
+        "docs/notes.md",
+        "# Notes\n\nThe fooBar helper is documented here for posterity.\n",
+    );
+
+    const args_json =
+        \\{"name":"fooBar"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_callers, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // Real call site present.
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig:2") != null);
+    // Markdown mention must NOT appear as a call site.
+    try testing.expect(std.mem.indexOf(u8, out.items, "docs/notes.md") == null);
+    // Header reflects the real count.
+    try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'fooBar'") != null);
+}
+
+test "issue-427: searchContent Tier 1 sort starves the definition-dense file" {
+    // searchContent's Tier 1 (explore.zig:1590-1598) sorts trigram candidates
+    // by file content length ASCENDING and then applies a per-file cap of
+    // max(1, max_results / estimated_total). When several small unrelated
+    // files match the query, they each contribute one hit and saturate the
+    // result quota before the canonical (large, definition-dense) file is
+    // ever scanned — so the file with the most occurrences of the term is
+    // missing from the output.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    // 8 small files. Each contains one occurrence of the term as a whole
+    // word. They sort first under the length-ascending Tier 1 order.
+    const small_count: usize = 8;
+    var i: usize = 0;
+    while (i < small_count) : (i += 1) {
+        var path_buf: [32]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "small_{d}.zig", .{i});
+        try explorer.indexFile(path, "fn s() void { _ = widgetX; }\n");
+    }
+
+    // Canonical file: many lines mentioning widgetX, padded so its content
+    // length is larger than every small file (sort key: content length).
+    const canonical_content =
+        "fn canonical() void {\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    // padding line for content length, to push this file to the\n" ++
+        "    // tail of the length-ascending sort. The reranker should still\n" ++
+        "    // surface it because it has the most occurrences of the term.\n" ++
+        "    _ = 0;\n" ++
+        "}\n";
+    try explorer.indexFile("canonical.zig", canonical_content);
+
+    // max_results small enough that 8 small files can saturate the quota.
+    // word_hits.len = small_count (8) + canonical occurrences (4) = 12.
+    // max_results * 2 = 10. 12 > 10 → Tier 0 gate fails → Tier 1 fires.
+    const results = try explorer.searchContent("widgetX", testing.allocator, 5);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+
+    // The canonical file MUST appear in the result set. Pre-fix it does not:
+    // small files fill all 5 slots first under length-asc order, and the
+    // early-return at result_list.len >= max_results returns before the
+    // canonical file is ever read.
+    var found_canonical = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "canonical.zig")) {
+            found_canonical = true;
+            break;
+        }
+    }
+    try testing.expect(found_canonical);
+}
+
+test "issue-429-a: searchContent rerank boosts files whose basename matches the query" {
+    // Two files, same hit count, same content length. The current rerank
+    // (explore.zig:1700-1712) sorts ties by path-asc, so a file named
+    // "unrelated.zig" outranks "widgetX.zig" even though the latter's
+    // basename matches the query exactly. The basename match is a strong
+    // intent signal — the developer is asking about that file's subject.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("src/unrelated.zig", "pub fn process() void { _ = widgetX; }\n");
+    try explorer.indexFile("src/widgetX.zig", "pub fn process() void { _ = widgetX; }\n");
+
+    const results = try explorer.searchContent("widgetX", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("src/widgetX.zig", results[0].path);
+}
+
+test "issue-429-b: searchContent rerank penalizes test/vendor/examples paths" {
+    // Two files, same hit count, same content. Pre-fix the path-asc
+    // tiebreaker promotes "examples/sample.zig" (e < s) above
+    // "src/sample.zig". Post-fix path priors push code roots above
+    // example/test/vendor directories so the source-of-truth lands first.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("examples/sample.zig", "pub fn x() void { _ = someTerm; }\n");
+    try explorer.indexFile("src/sample.zig", "pub fn x() void { _ = someTerm; }\n");
+
+    const results = try explorer.searchContent("someTerm", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("src/sample.zig", results[0].path);
+}
+
+test "issue-429-c: searchContent rerank boosts lines that are symbol definitions" {
+    // Two files. "aaa.zig" has a passing comment mention of `fooSym`. The
+    // alphabetically-later "zzz_def.zig" has the actual definition. Both
+    // tie on per-line occurrence count. Pre-fix the path-asc tiebreaker
+    // promotes the comment mention ("aaa" < "zzz"). Post-fix the rerank
+    // recognises that the line in zzz_def.zig is a symbol definition and
+    // ranks it first.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("aaa.zig", "// fooSym is referenced here in a comment\n");
+    try explorer.indexFile("zzz_def.zig", "pub fn fooSym() void {}\n");
+
+    const results = try explorer.searchContent("fooSym", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("zzz_def.zig", results[0].path);
+}
+
+test "issue-430: Tier 0 markdown dominance starves canonical source file" {
+    // Tier 0 of searchContent (explore.zig:1525-1554) iterates the word
+    // index posting list in insertion order with a per-file cap of
+    // max(1, max_results/5). When a handful of markdown documents
+    // (CHANGELOG.md, benchmarks/*.md, design docs) each mention the query
+    // many times AND happen to appear earlier in the posting list than the
+    // canonical source file, they saturate result_list before the source
+    // file is reached. The existing #363a fix asserted *presence* with a
+    // small corpus; this is the high-density regime where presence still
+    // fails because Tier 0 hits max_results before the source file's
+    // posting-list entries are processed.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    // 5 markdown files each with 10 mentions of fooBar — indexed FIRST so
+    // they land at the head of the posting list. With max_results=50 and
+    // per-file cap=10, these 5 files alone fill all 50 slots.
+    const md_block = "fooBar mentioned here.\nfooBar mentioned here.\n" ++
+        "fooBar mentioned here.\nfooBar mentioned here.\n" ++
+        "fooBar mentioned here.\nfooBar mentioned here.\n" ++
+        "fooBar mentioned here.\nfooBar mentioned here.\n" ++
+        "fooBar mentioned here.\nfooBar mentioned here.\n";
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        var path_buf: [64]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "docs/notes_{d}.md", .{i});
+        try explorer.indexFile(path, md_block);
+    }
+
+    // Source file with the canonical definition + several real call sites,
+    // indexed LAST so its posting-list entries come after the markdown noise.
+    try explorer.indexFile("src/foo.zig",
+        "pub fn fooBar() void {}\n" ++
+            "pub fn caller1() void { fooBar(); }\n" ++
+            "pub fn caller2() void { fooBar(); }\n" ++
+            "pub fn caller3() void { fooBar(); }\n");
+
+    const results = try explorer.searchContent("fooBar", testing.allocator, 50);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+
+    var found_source = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "src/foo.zig")) {
+            found_source = true;
+            break;
+        }
+    }
+    // The canonical source file MUST appear in the results. Pre-fix it does
+    // not: 5 markdown files × 10 hits = 50 entries fill result_list before
+    // the source file is reached, then Tier 0 returns at max_results.
+    try testing.expect(found_source);
+}
+
+test "issue-431: searchContent does not crash when query is longer than content" {
+    // searchInContent (explore.zig:3881) computes
+    //   const end = content.len - query.len + 1;
+    // without checking that query.len <= content.len. When the query is
+    // longer than the file content, the subtraction underflows in usize
+    // and the binary panics with integer overflow (or aborts with SIGBUS
+    // in ReleaseFast). Reproducer: index a tiny file, search for a query
+    // longer than the file's content.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("a.zig", "fn x() void {}\n");
+
+    var q_buf: [256]u8 = undefined;
+    @memset(&q_buf, 'a');
+    const q = q_buf[0..256];
+
+    const results = try explorer.searchContent(q, testing.allocator, 5);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len == 0);
+}


### PR DESCRIPTION
## Summary

Single bundled release covering six issues across `searchContent`, `searchInContent`, and `codedb_callers`. Headline: a multi-signal reranker for `searchContent` plus a P0 crash fix in `searchInContent`.

Closes #425, #426, #427, #429, #430, #431.

## Issues

| # | Area | Fix |
|---|------|-----|
| #425 | `codedb_callers` | Whole-word match — `fooBar` no longer matches inside `fooBarExtended` |
| #426 | `codedb_callers` | Language gate — markdown/json/yaml/css/scss/protobuf/unknown files no longer surface as call sites |
| #427 | `searchContent` Tier 1 | Sort candidates by per-file word-hit count (desc) instead of content length (asc), so the definition-dense file scans first |
| #429 | `searchContent` rerank | Multi-signal score: per-line freq + symbol-def boost (+5) + basename match (+15 exact / +8 substring) + path-segment match (+6) + path-prior penalty (×0.6 tests/examples, ×0.4 vendor/node_modules/third_party) |
| #430 | `searchContent` Tier 0 | Two-pass loop: code-language hits before doc-language hits, so markdown noise can't saturate `max_results` before the canonical source file is reached |
| #431 | `searchInContent` | **P0 crash:** bounds-check `query.len > content.len` to fix integer-overflow panic / SIGBUS on long queries |

Plus two reranker improvements:

- **Rerank on every return path.** `rerankAndFinalize` helper called from every searchContent return point so Tier 0 / Tier 1 early-returns at `max_results` no longer bypass the multi-signal score.
- **Path-segment match boost.** Query `parser` boosts `src/parser/foo.zig` even when the file's basename doesn't match. Case-insensitive via `pathHasSegmentIgnoreCase`. Gated on basename-not-already-matching to avoid double-counting.

## Validation

- `zig build test` passes — 8 new regression tests added (`issue-425`, `issue-426`, `issue-427`, `issue-429-a/b/c/d`, `issue-430`, `issue-431`).
- `zig build -Doptimize=ReleaseFast` clean.
- Bundle-level Sonnet 4.6 validation against the deployed 0.2.5806 baseline:
  - **Quality**: definition sites promoted to #1 for `handleCallers`, `pathHasSegment`, `BenchContext`, `Explorer`. `src/explore.zig` now ranks #1 for the `searchContent` query (was absent from baseline top-5). `src/watcher.zig` at #1 for `watcher`.
  - **Memory**: peak RSS delta under 1% across multiple query shapes.
  - **Crashes**: long-query SIGBUS gone; empty-index, hyphen, regex-meta queries unaffected.
  - **Regressions**: none on innocent queries (`TODO`, `std.mem.eql`, `Parser`).

## Test plan

- [x] `zig build test` — exit 0
- [x] `zig build -Doptimize=ReleaseFast` — clean
- [x] Bundle Sonnet 4.6 validation: better/same/worse comparison vs baseline binary
- [x] Edge cases: long query, empty index, hyphen, regex meta
- [ ] Reviewer spot-check: open `src/explore.zig` rerankSignalScore + searchContent Tier 0 / Tier 1 sites
- [ ] Reviewer spot-check: open `src/mcp.zig` handleCallers and confirm both `langHasCallSites` and `hasWholeWordMatch` gates fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)