### PR TITLE
feat(explore): opt-in rerank-trace logger for offline tuning

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -17,6 +17,10 @@ pub const Config = struct {
     max_versions: usize = 100,
     /// Cap on files kept in the Explorer's in-memory content cache. Default 1000.
     max_cached: u32 = 1000,
+    /// When true, append one JSON line per searchContent invocation to
+    /// <data_dir>/rerank-traces.jsonl. v0 logger for offline rerank-tuning
+    /// experiments. Off by default — opt in via .codedbrc.
+    rerank_trace: bool = false,
 
     pub const default: Config = .{};
 
@@ -37,6 +41,8 @@ pub const Config = struct {
             } else if (std.mem.eql(u8, key, "max_cached")) {
                 cfg.max_cached = std.fmt.parseInt(u32, val, 10) catch return error.InvalidMaxCached;
                 if (cfg.max_cached == 0) return error.InvalidMaxCached;
+            } else if (std.mem.eql(u8, key, "rerank_trace")) {
+                cfg.rerank_trace = parseBool(val) catch return error.InvalidRerankTrace;
             }
         }
         return cfg;
@@ -91,6 +97,12 @@ pub const Config = struct {
     }
 };
 
+fn parseBool(val: []const u8) !bool {
+    if (std.mem.eql(u8, val, "true") or std.mem.eql(u8, val, "1")) return true;
+    if (std.mem.eql(u8, val, "false") or std.mem.eql(u8, val, "0")) return false;
+    return error.InvalidBool;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -129,4 +141,17 @@ test "config: malformed value rejected" {
     try testing.expectError(error.InvalidMaxVersions, Config.parse("max_versions = not_a_number\n"));
     try testing.expectError(error.InvalidMaxVersions, Config.parse("max_versions = 0\n"));
     try testing.expectError(error.InvalidMaxCached, Config.parse("max_cached = 0\n"));
+}
+
+test "config: rerank_trace defaults off and parses true/false" {
+    const cfg_default = Config.default;
+    try testing.expect(cfg_default.rerank_trace == false);
+
+    const cfg_on = try Config.parse("rerank_trace = true\n");
+    try testing.expect(cfg_on.rerank_trace == true);
+
+    const cfg_off = try Config.parse("rerank_trace = false\n");
+    try testing.expect(cfg_off.rerank_trace == false);
+
+    try testing.expectError(error.InvalidRerankTrace, Config.parse("rerank_trace = maybe\n"));
 }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -515,6 +515,10 @@ pub const Explorer = struct {
     /// .codedbrc (#102). Beyond this threshold, readContentForSearch falls
     /// back to disk reads.
     content_cache_limit: u32 = 1000,
+    /// When non-null, append one JSON line per searchContent invocation
+    /// to this path (v0 rerank-trace experiment). Borrowed; caller owns
+    /// the slice for the Explorer's lifetime.
+    rerank_trace_path: ?[]const u8 = null,
 
     pub fn setRoot(self: *Explorer, io: std.Io, root_path: []const u8) void {
         self.io = io;
@@ -1741,6 +1745,7 @@ pub const Explorer = struct {
                 }
             }.lessThan);
         }
+        self.appendRerankTrace(query, result_list.items);
         return result_list.toOwnedSlice(allocator);
     }
 
@@ -1789,6 +1794,91 @@ pub const Explorer = struct {
         }
 
         return score;
+    }
+
+    /// Append one JSON line per searchContent invocation. v0 logger for the
+    /// rerank-tuning experiment — pure observation, never affects ranking.
+    /// Silent no-op when path is unset, io is unset, or any I/O step fails.
+    /// Caps query at 256 bytes, results at 50 entries, file at 10 MB
+    /// (rotates by truncate-clobber).
+    fn appendRerankTrace(self: *const Explorer, query: []const u8, results: []const SearchResult) void {
+        const path = self.rerank_trace_path orelse return;
+        const io_inst = self.io orelse return;
+
+        const max_query: usize = 256;
+        const max_results_logged: usize = 50;
+        const size_limit: u64 = 10 * 1024 * 1024;
+
+        var buf: [16 * 1024]u8 = undefined;
+        var pos: usize = 0;
+
+        const ts = cio.milliTimestamp();
+        const head = std.fmt.bufPrint(buf[pos..], "{{\"ts\":{d},\"query\":\"", .{ts}) catch return;
+        pos += head.len;
+
+        const q_clamped = query[0..@min(query.len, max_query)];
+        pos += writeJsonEscaped(buf[pos..], q_clamped);
+
+        const sep = "\",\"results\":[";
+        if (pos + sep.len > buf.len) return;
+        @memcpy(buf[pos..][0..sep.len], sep);
+        pos += sep.len;
+
+        var any_emitted = false;
+        const n = @min(results.len, max_results_logged);
+        var i: usize = 0;
+        while (i < n) : (i += 1) {
+            const r = results[i];
+            const sep_len: usize = if (any_emitted) 1 else 0;
+            const tail_reserve: usize = 3; // "]}\n"
+            const escaped_path_budget: usize = 2 * r.path.len;
+            const fixed_overhead: usize = "{\"path\":\"".len + "\",\"line\":,\"score\":}".len + 32;
+            if (pos + sep_len + escaped_path_budget + fixed_overhead + tail_reserve > buf.len) break;
+
+            if (any_emitted) {
+                buf[pos] = ',';
+                pos += 1;
+            }
+            const open = "{\"path\":\"";
+            @memcpy(buf[pos..][0..open.len], open);
+            pos += open.len;
+            pos += writeJsonEscaped(buf[pos..], r.path);
+            const obj_tail = std.fmt.bufPrint(buf[pos..], "\",\"line\":{d},\"score\":{d:.4}}}", .{ r.line_num, r.score }) catch break;
+            pos += obj_tail.len;
+            any_emitted = true;
+        }
+
+        const close = "]}\n";
+        if (pos + close.len > buf.len) return;
+        @memcpy(buf[pos..][0..close.len], close);
+        pos += close.len;
+
+        var file = std.Io.Dir.cwd().openFile(io_inst, path, .{ .mode = .write_only }) catch blk: {
+            break :blk std.Io.Dir.cwd().createFile(io_inst, path, .{ .truncate = false }) catch return;
+        };
+        var current_size = file.length(io_inst) catch {
+            file.close(io_inst);
+            return;
+        };
+        if (current_size >= size_limit) {
+            file.close(io_inst);
+            file = std.Io.Dir.cwd().createFile(io_inst, path, .{ .truncate = true }) catch return;
+            current_size = 0;
+        }
+        defer file.close(io_inst);
+
+        const locked = blk: {
+            file.lock(io_inst, .exclusive) catch break :blk false;
+            break :blk true;
+        };
+        defer if (locked) file.unlock(io_inst);
+
+        if (locked) {
+            current_size = file.length(io_inst) catch current_size;
+            if (current_size >= size_limit) current_size = 0;
+        }
+
+        file.writePositionalAll(io_inst, buf[0..pos], current_size) catch {};
     }
 
     /// BM25-ranked content search. Tokenizes the query the same way the word
@@ -4501,6 +4591,39 @@ fn countOccurrences(text: []const u8, needle: []const u8) f32 {
         } else break;
     }
     return count;
+}
+
+/// Minimal JSON string escaper for the rerank-trace logger. Writes escaped
+/// bytes into `out`, returns bytes written. Stops cleanly when `out` is full.
+fn writeJsonEscaped(out: []u8, input: []const u8) usize {
+    var w: usize = 0;
+    for (input) |c| {
+        if (w >= out.len) break;
+        switch (c) {
+            '"' => {
+                if (w + 2 > out.len) break;
+                out[w] = '\\';
+                out[w + 1] = '"';
+                w += 2;
+            },
+            '\\' => {
+                if (w + 2 > out.len) break;
+                out[w] = '\\';
+                out[w + 1] = '\\';
+                w += 2;
+            },
+            '\n', '\r', '\t' => {
+                out[w] = ' ';
+                w += 1;
+            },
+            else => {
+                if (c < 0x20) continue;
+                out[w] = c;
+                w += 1;
+            },
+        }
+    }
+    return w;
 }
 
 fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1732,10 +1732,10 @@ pub const Explorer = struct {
         query: []const u8,
         allocator: std.mem.Allocator,
     ) ![]const SearchResult {
+        for (result_list.items) |*r| {
+            r.score = self.rerankSignalScore(r.*, query);
+        }
         if (result_list.items.len > 1) {
-            for (result_list.items) |*r| {
-                r.score = self.rerankSignalScore(r.*, query);
-            }
             std.sort.block(SearchResult, result_list.items, {}, struct {
                 pub fn lessThan(_: void, a: SearchResult, b: SearchResult) bool {
                     if (a.score != b.score) return a.score > b.score;

--- a/src/main.zig
+++ b/src/main.zig
@@ -228,6 +228,14 @@ fn mainImpl() !void {
 
     var explorer = Explorer.init(allocator);
     explorer.content_cache_limit = cfg.max_cached;
+
+    const rerank_trace_path: ?[]u8 = if (cfg.rerank_trace)
+        (std.fmt.allocPrint(allocator, "{s}/rerank-traces.jsonl", .{data_dir}) catch null)
+    else
+        null;
+    defer if (rerank_trace_path) |p| allocator.free(p);
+    if (rerank_trace_path) |p| explorer.rerank_trace_path = p;
+
     explorer.setRoot(io, root);
     defer explorer.deinit();
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10822,3 +10822,139 @@ test "issue-429-e: searchContent rerank penalises doc-language files so code bea
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("src/caller.zig", results[0].path);
 }
+
+test "rerank-trace: appends one JSON line per searchContent when enabled" {
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path_len = try tmp.dir.realPathFile(tmp_io, ".", &path_buf);
+    const tmp_path = path_buf[0..tmp_path_len];
+
+    const trace_path = try std.fmt.allocPrint(testing.allocator, "{s}/rerank-traces.jsonl", .{tmp_path});
+    defer testing.allocator.free(trace_path);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    explorer.io = tmp_io;
+    explorer.rerank_trace_path = trace_path;
+
+    try explorer.indexFile("src/widgetX.zig", "pub fn process() void { _ = widgetX; }\n");
+    try explorer.indexFile("src/unrelated.zig", "pub fn process() void { _ = widgetX; }\n");
+
+    const results = try explorer.searchContent("widgetX", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+
+    const f = try std.Io.Dir.cwd().openFile(tmp_io, trace_path, .{});
+    defer f.close(tmp_io);
+    const size = try f.length(tmp_io);
+    try testing.expect(size > 0);
+
+    const data = try testing.allocator.alloc(u8, @intCast(size));
+    defer testing.allocator.free(data);
+    _ = try f.readPositionalAll(tmp_io, data, 0);
+
+    try testing.expectEqual(@as(u8, '\n'), data[data.len - 1]);
+    var nl_count: usize = 0;
+    for (data) |c| if (c == '\n') {
+        nl_count += 1;
+    };
+    try testing.expectEqual(@as(usize, 1), nl_count);
+
+    try testing.expect(std.mem.indexOf(u8, data, "\"query\":\"widgetX\"") != null);
+    try testing.expect(std.mem.indexOf(u8, data, "src/widgetX.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, data, "\"results\":[") != null);
+}
+
+test "rerank-trace: disabled by default — no file is created" {
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path_len = try tmp.dir.realPathFile(tmp_io, ".", &path_buf);
+    const tmp_path = path_buf[0..tmp_path_len];
+
+    const probe_path = try std.fmt.allocPrint(testing.allocator, "{s}/should-not-exist.jsonl", .{tmp_path});
+    defer testing.allocator.free(probe_path);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    explorer.io = tmp_io;
+    // rerank_trace_path stays null — opt-in only.
+
+    try explorer.indexFile("a.zig", "pub fn t() void { _ = sym; }\n");
+    try explorer.indexFile("b.zig", "pub fn t() void { _ = sym; }\n");
+
+    const results = try explorer.searchContent("sym", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 1);
+
+    const open_err = std.Io.Dir.cwd().openFile(tmp_io, probe_path, .{});
+    try testing.expectError(error.FileNotFound, open_err);
+}
+
+test "rerank-trace: clobbers when file exceeds size limit" {
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path_len = try tmp.dir.realPathFile(tmp_io, ".", &path_buf);
+    const tmp_path = path_buf[0..tmp_path_len];
+
+    const trace_path = try std.fmt.allocPrint(testing.allocator, "{s}/big.jsonl", .{tmp_path});
+    defer testing.allocator.free(trace_path);
+
+    {
+        const f = try std.Io.Dir.cwd().createFile(tmp_io, trace_path, .{ .truncate = true });
+        defer f.close(tmp_io);
+        const target_size: u64 = 11 * 1024 * 1024;
+        var chunk: [4096]u8 = undefined;
+        @memset(&chunk, 'x');
+        var written: u64 = 0;
+        while (written < target_size) : (written += chunk.len) {
+            try f.writePositionalAll(tmp_io, &chunk, written);
+        }
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    explorer.io = tmp_io;
+    explorer.rerank_trace_path = trace_path;
+
+    try explorer.indexFile("a.zig", "pub fn t() void { _ = sym; }\n");
+    try explorer.indexFile("b.zig", "pub fn t() void { _ = sym; }\n");
+
+    const results = try explorer.searchContent("sym", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+
+    const f = try std.Io.Dir.cwd().openFile(tmp_io, trace_path, .{});
+    defer f.close(tmp_io);
+    const new_size = try f.length(tmp_io);
+    try testing.expect(new_size > 0);
+    try testing.expect(new_size < 16 * 1024);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10958,3 +10958,53 @@ test "rerank-trace: clobbers when file exceeds size limit" {
     try testing.expect(new_size > 0);
     try testing.expect(new_size < 16 * 1024);
 }
+
+test "rerank-trace: single-result query records non-zero rerank score" {
+    // Pre-fix: rerankAndFinalize only scored when items.len > 1, so a
+    // single-result trace logged score=0.0 — misleading for offline analysis
+    // because it looked identical to a zero-confidence match. The fix runs
+    // scoring unconditionally and only sorts when there's more than one item.
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path_len = try tmp.dir.realPathFile(tmp_io, ".", &path_buf);
+    const tmp_path = path_buf[0..tmp_path_len];
+
+    const trace_path = try std.fmt.allocPrint(testing.allocator, "{s}/single.jsonl", .{tmp_path});
+    defer testing.allocator.free(trace_path);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+    explorer.io = tmp_io;
+    explorer.rerank_trace_path = trace_path;
+
+    // Only one file mentions the query — guarantees results.len == 1.
+    try explorer.indexFile("src/loneSym.zig", "pub fn loneSym() void {}\n");
+    try explorer.indexFile("src/other.zig", "pub fn unrelated() void {}\n");
+
+    const results = try explorer.searchContent("loneSym", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expectEqual(@as(usize, 1), results.len);
+    // Symbol-def boost (+5) + basename-substring boost (+8) + per-line freq
+    // means score is well above zero — verifies scoring actually ran.
+    try testing.expect(results[0].score > 1.0);
+
+    const f = try std.Io.Dir.cwd().openFile(tmp_io, trace_path, .{});
+    defer f.close(tmp_io);
+    const size = try f.length(tmp_io);
+    const data = try testing.allocator.alloc(u8, @intCast(size));
+    defer testing.allocator.free(data);
+    _ = try f.readPositionalAll(tmp_io, data, 0);
+
+    try testing.expect(std.mem.indexOf(u8, data, "\"score\":0.0000") == null);
+    try testing.expect(std.mem.indexOf(u8, data, "src/loneSym.zig") != null);
+}


### PR DESCRIPTION
## Summary

Adds an opt-in JSONL logger that captures every `searchContent` call so we can collect data for offline rerank tuning experiments. Pure observation — does not change ranking behavior.

Enable via `.codedbrc`:

```
rerank_trace = true
```

When set, each search appends one line to `<data_dir>/rerank-traces.jsonl`:

```json
{"ts":1778294611234,"query":"widgetX","results":[{"path":"src/widgetX.zig","line":1,"score":21.0000},{"path":"src/unrelated.zig","line":1,"score":1.0000}]}
```

Off by default. Capped: 256 byte queries, 50 results per line, 10 MB file (rotates by truncate-clobber). All I/O errors are swallowed — logging never breaks a search.

## Why

Today the multi-signal rerank in [`rerankSignalScore`](src/explore.zig:1748) uses 7 hand-tuned constants (+5 sym-def, +15/+8 basename, +6 path-seg, ×0.6 tests, ×0.4 vendor, ×0.5 doc). Different repos want different priors (a tests-heavy monorepo wants the ×0.6 test penalty softened; a vendored-deps repo wants ×0.4 cranked harder). Before deciding whether online learning-to-rank from agent traces is worth building, we want to look at the raw data first. This PR is just the v0 logger to enable that.

## Commits

- **54b6b72** — feat: the logger itself, opt-in via `.codedbrc`
- **d4391db** — fix: caught by end-to-end binary verification — pre-fix, single-result queries logged `score:0.0` because the scoring loop was guarded behind `len > 1`. Lifted scoring out of the guard, kept the sort inside.

## Implementation notes

- New field `Config.rerank_trace: bool` parsed from `.codedbrc` (`src/config.zig`)
- New field `Explorer.rerank_trace_path: ?[]const u8` (borrowed slice; caller-owned for the Explorer's lifetime). Set from `main.zig` to `<data_dir>/rerank-traces.jsonl` when the flag is on.
- `appendRerankTrace` called from `rerankAndFinalize` — runs inside the existing read lock; writes are protected by an advisory file lock for cross-process safety; uses a 16 KB stack buffer with conservative per-entry budgeting so partial entries never produce invalid JSON.
- `writeJsonEscaped` free helper for minimal JSON escaping (`"`, `\`, control chars).

## Test plan

- [x] `zig build test` — 511/511 pass (4 new tests; main was 506)
- [x] Unit tests cover: opt-in writes one line, opt-out writes nothing, size cap clobbers correctly, single-result entries get non-zero scores, config parses `true`/`false`/malformed
- [x] **End-to-end binary verification (Sonnet 4.6 agent run twice):**
  - Build clean
  - Default off → no file created
  - Opt-in via `.codedbrc` → file appears at `~/.codedb/projects/<hash>/rerank-traces.jsonl`
  - All 9 lines (varied queries) parse as valid JSON via `python3 json.loads`
  - JSON escaping for `"` and `\` round-trips correctly
  - Multi-result queries: `widget.zig:1 (17.0) > widget.zig:2 (16.0) > other.zig:1 (1.0) > other.zig:2 (1.0)` — sort order preserved
  - Single-result query post-fix: `score: 1.0` (pre-fix would have been `0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)