### PR TITLE
hotfix: v0.2.5809 — codedb_bundle oneOf is opt-in (fixes OpenAI strict-mode rejection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.5809 - 2026-05-07
+
+`0.2.5809` is a hotfix for a v0.2.5808 regression: the discriminated `oneOf` on `codedb_bundle` ops items (Stage 2 of [#437](https://github.com/justrach/codedb/issues/437)) breaks every MCP client backed by the OpenAI Responses API (codex, forgecode, etc.). OpenAI's strict-mode tool-schema validator rejects `oneOf` outright with `Invalid schema for function 'mcp_codedb_tool_codedb_bundle': 'oneOf' is not permitted`, which makes the entire `codedb_bundle` tool unusable on those clients.
+
+### MCP
+
+- **`oneOf` is now opt-in via `CODEDB_DISCRIMINATED_SCHEMA=1`.** By default, `tools/list` serves the raw schema with only Stage 1's `required: ["tool", "arguments"]` (from [#434](https://github.com/justrach/codedb/issues/434)) — works on every MCP client. Anthropic-backed clients that benefit from the discriminated `oneOf` can re-enable it by setting the env var on the codedb process. The `buildAugmentedToolsList` builder is unchanged; only the call site in `mcp.zig` is gated on the env var. The `#424` runtime inline-args fallback continues to handle non-conformant clients.
+
+### Compatibility
+
+- v0.2.5808 set the bundle schema to a structure OpenAI's validator rejects. If you upgraded yesterday and saw `tools[N].parameters` errors from codex/forgecode, this is the fix — no opt-in needed.
+- Anthropic-backed clients (Claude Code, etc.) that want the stronger constraint: `export CODEDB_DISCRIMINATED_SCHEMA=1` before launching the MCP server.
+
 ## 0.2.5808 - 2026-05-06
 
 `0.2.5808` is a tool-schema fix for `codedb_bundle` plus an opt-in rerank-trace logger for offline ranking experiments. Three PRs ship together: [#435](https://github.com/justrach/codedb/pull/435) (Stage 1 of [#434](https://github.com/justrach/codedb/issues/434)), [#438](https://github.com/justrach/codedb/pull/438) (Stage 2 of [#437](https://github.com/justrach/codedb/issues/437)), and [#436](https://github.com/justrach/codedb/pull/436) (rerank-trace logger).

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -692,11 +692,20 @@ pub fn run(
     var cache = ProjectCache.init(alloc, default_path);
     defer cache.deinit();
 
-    // Build the augmented `tools/list` payload once at startup. Falls back
-    // to the raw `tools_list` const if augmentation fails for any reason
-    // (parse error, OOM) — clients still get a valid schema, just without
-    // the discriminated oneOf on the bundle ops.
+    // Build the `tools/list` payload. The discriminated `oneOf` on the
+    // codedb_bundle ops items (issue #437) is incompatible with OpenAI's
+    // strict-mode tool-schema validator, which rejects `oneOf` outright with
+    // "'oneOf' is not permitted" — breaking codex/forgecode and any other
+    // OpenAI-Responses-API-backed MCP client. Default to the raw schema (which
+    // still has Stage 1's required: ["tool", "arguments"] from #434). Set
+    // CODEDB_DISCRIMINATED_SCHEMA=1 to opt back into the augmented oneOf for
+    // Anthropic-backed clients that benefit from it.
+    const discriminated_opt_in = blk_opt: {
+        const v = cio.posixGetenv("CODEDB_DISCRIMINATED_SCHEMA") orelse break :blk_opt false;
+        break :blk_opt std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
+    };
     const tools_list_response: []const u8 = blk: {
+        if (!discriminated_opt_in) break :blk tools_list;
         const augmented = buildAugmentedToolsList(alloc) catch break :blk tools_list;
         break :blk augmented;
     };

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5808";
+pub const semver = "0.2.5809";


### PR DESCRIPTION
## Summary

v0.2.5808 broke OpenAI-Responses-API-backed MCP clients (codex, forgecode, etc.). OpenAI's strict-mode tool-schema validator rejects `oneOf` outright:

```
Invalid schema for function 'mcp_codedb_tool_codedb_bundle': In context=('properties', 'ops', 'items'), 'oneOf' is not permitted.
```

This makes the entire `codedb_bundle` tool unusable on those clients. Anthropic accepts `oneOf` and benefits from the constraint, so the builder isn't going away — just gated behind an env var.

## Change

- Default: `tools/list` serves the raw schema with Stage 1's `required: ["tool", "arguments"]` only. Works on every MCP client.
- Opt-in: `CODEDB_DISCRIMINATED_SCHEMA=1` re-enables the augmented `oneOf` for Anthropic-backed clients (Claude Code, etc.) that want the stronger constraint.
- `buildAugmentedToolsList` itself is unchanged; only the call site in `pub fn run` is gated.

## Test plan

- [x] `zig build test` — 513/513 pass.
- [ ] Stdio MCP probe against the new binary confirms no `oneOf` in the served bundle items by default; setting `CODEDB_DISCRIMINATED_SCHEMA=1` brings it back.
- [ ] forgecode / codex no longer rejects `mcp_codedb_tool_codedb_bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)