### PR TITLE
fix(mcp): reject codedb_projects in bundle — v0.2.5810 (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.5810 - 2026-05-07
+
+`0.2.5810` blocks `codedb_projects` from being a valid `codedb_bundle` sub-op ([#441](https://github.com/justrach/codedb/issues/441)).
+
+### MCP ([#441](https://github.com/justrach/codedb/issues/441))
+
+- **`codedb_bundle` rejects `codedb_projects` sub-ops.** `codedb_projects` lists every indexed project on the machine — a global directory enumeration unrelated to whatever repo the agent is actually working on. When a planner sees a previous bundle that called `codedb_projects`, it tends to replay the same shape (e.g. 5x `codedb_projects` in one batch), and recent-message attention bias amplifies it on continuation: graff and similar resumable clients ship the delta + `previous_response_id`, so the previous assistant message dominates the planner's context. Block it at the dispatcher, mirroring the existing rejections of `codedb_bundle` (recursive) and `codedb_edit` (write op). The `oneOf` discriminated schema (opt-in via `CODEDB_DISCRIMINATED_SCHEMA=1`) also drops the `codedb_projects` branch, so model output can't suggest it. Standalone calls to `codedb_projects` outside a bundle are unchanged.
+
 ## 0.2.5809 - 2026-05-07
 
 `0.2.5809` is a hotfix for a v0.2.5808 regression: the discriminated `oneOf` on `codedb_bundle` ops items (Stage 2 of [#437](https://github.com/justrach/codedb/issues/437)) breaks every MCP client backed by the OpenAI Responses API (codex, forgecode, etc.). OpenAI's strict-mode tool-schema validator rejects `oneOf` outright with `Invalid schema for function 'mcp_codedb_tool_codedb_bundle': 'oneOf' is not permitted`, which makes the entire `codedb_bundle` tool unusable on those clients.

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -575,6 +575,8 @@ pub fn buildAugmentedToolsList(alloc: std.mem.Allocator) ![]u8 {
         const sub_name = sub_name_v.string;
         if (std.mem.eql(u8, sub_name, "codedb_bundle")) continue;
         if (std.mem.eql(u8, sub_name, "codedb_edit")) continue;
+        // issue #441: codedb_projects is dispatcher-rejected in bundle; don't advertise it.
+        if (std.mem.eql(u8, sub_name, "codedb_projects")) continue;
         const sub_schema = t.object.get("inputSchema") orelse continue;
 
         var tool_const: std.json.ObjectMap = .{};
@@ -2020,6 +2022,17 @@ fn handleBundle(
         }
         if (tool == .codedb_edit) {
             w.print("--- [{d}] {s} ---\nerror: write operations not allowed in bundle\n", .{ i, tool_name }) catch {};
+            fail_count += 1;
+            continue;
+        }
+        if (tool == .codedb_projects) {
+            // codedb_projects lists every indexed project machine-wide — a
+            // global directory enumeration unrelated to the current repo.
+            // Planners that see one such call tend to replay the shape (5x
+            // codedb_projects in one bundle), so block it at the dispatcher.
+            // It is still callable as a standalone tool for cases where a
+            // global listing genuinely is what's wanted.
+            w.print("--- [{d}] {s} ---\nerror: codedb_projects not allowed in bundle\n", .{ i, tool_name }) catch {};
             fail_count += 1;
             continue;
         }

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5809";
+pub const semver = "0.2.5810";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10452,6 +10452,68 @@ test "issue-424-A: bundle envelope errors carry the 'error:' prefix consistently
     try testing.expect(std.mem.indexOf(u8, out2.items, "error: missing 'tool'") != null);
 }
 
+test "issue-441: bundle rejects codedb_projects sub-op" {
+    // codedb_projects lists every indexed project on the machine, which is a
+    // global directory enumeration unrelated to whatever repo the agent is
+    // working on. When a planner sees a previous bundle that called
+    // codedb_projects, it tends to replay the same shape — re-emitting 5x
+    // codedb_projects ops as if that were the canonical "what do I do here"
+    // call. Block it at the dispatcher, mirroring the existing rejections of
+    // codedb_bundle (recursive) and codedb_edit (write op).
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const bundle_json =
+        \\{"ops":[{"tool":"codedb_projects","arguments":{}}]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, bundle_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_bundle, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // The op must be rejected with an explicit error, not silently dispatched.
+    try testing.expect(std.mem.indexOf(u8, out.items, "error: codedb_projects not allowed in bundle") != null);
+}
+
+test "issue-441: codedb_projects branch is excluded from augmented oneOf" {
+    // Mirror of the dispatcher rejection at the schema level — when the
+    // discriminated oneOf is opted into via CODEDB_DISCRIMINATED_SCHEMA=1,
+    // there must not be a oneOf branch advertising codedb_projects as a
+    // valid sub-tool, since the bundle dispatcher rejects it at runtime.
+    const augmented = try mcp_mod.buildAugmentedToolsList(testing.allocator);
+    defer testing.allocator.free(augmented);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, augmented, .{});
+    defer parsed.deinit();
+
+    const tools = parsed.value.object.get("tools").?.array;
+    var bundle_items: ?std.json.Value = null;
+    for (tools.items) |t| {
+        if (std.mem.eql(u8, t.object.get("name").?.string, "codedb_bundle")) {
+            bundle_items = t.object.get("inputSchema").?.object.get("properties").?.object.get("ops").?.object.get("items").?;
+            break;
+        }
+    }
+    const one_of = bundle_items.?.object.get("oneOf").?.array;
+
+    for (one_of.items) |branch| {
+        const props = branch.object.get("properties").?.object;
+        const tool_v = props.get("tool").?;
+        const tool_const = tool_v.object.get("const") orelse continue;
+        try testing.expect(!std.mem.eql(u8, tool_const.string, "codedb_projects"));
+    }
+}
+
 test "issue-434: codedb_bundle ops items schema requires arguments field" {
     // The codedb_bundle inputSchema in tools_list advertises ops items as
     // {required: ["tool"]} with arguments as a bare {type: "object"} that


### PR DESCRIPTION
## Summary

Block `codedb_projects` from being a valid `codedb_bundle` sub-op. It's a global directory enumeration that planners replay when they see it once — recent-message attention bias on resumable clients (graff, etc., that ship `delta + previous_response_id`) amplifies the loop. Mirroring the existing rejections of `codedb_bundle` (recursive) and `codedb_edit` (write).

Fixes #441.

## Change

- `handleBundle` in `src/mcp.zig` rejects `codedb_projects` with `error: codedb_projects not allowed in bundle`.
- `buildAugmentedToolsList` excludes `codedb_projects` from the discriminated `oneOf` branches (matching the dispatcher-level rejection).
- Standalone calls to `codedb_projects` outside a bundle are unchanged — it's still a useful tool when a global listing genuinely is what's wanted.

## Test plan

- [x] `zig build test` — 515/515 pass. Two new tests (`issue-441: bundle rejects codedb_projects sub-op`, `issue-441: codedb_projects branch is excluded from augmented oneOf`) fail on main and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)