### PR TITLE
fix(mcp): disable codedb_bundle by default (v0.2.5811, #443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+## 0.2.5811 - 2026-05-07
+
+`0.2.5811` disables `codedb_bundle` advertisement by default ([#443](https://github.com/justrach/codedb/issues/443)).
+
+### MCP ([#443](https://github.com/justrach/codedb/issues/443))
+
+- **`codedb_bundle` is no longer advertised in `tools/list` by default.** Across multiple stages — empty-args schema (#434), `oneOf` augmentation (#437), OpenAI strict-mode regression (#440), and `codedb_projects` replay-loop (#441) — the bundle has remained a footgun for OpenAI clients (codex, forgecode, etc.) because the default schema can't bind sub-tool argument shape without `oneOf`, and `oneOf` is OpenAI-strict-incompatible. Disable the advertisement entirely until the schema can be reworked to bind args inline (no `arguments` wrapper). The dispatcher-side handler stays so any client with a cached schema doesn't crash on call. Set `CODEDB_BUNDLE_ENABLED=1` to re-advertise.
+- **New helper `buildToolsListResponse(alloc, opts)`** centralizes the env-var-gated `tools/list` builder previously inlined in `run()`. `opts` are `{ bundle_enabled, discriminated_opt_in }`. Always returns an allocator-owned slice.
+
 ## 0.2.5810 - 2026-05-07
 
 `0.2.5810` blocks `codedb_projects` from being a valid `codedb_bundle` sub-op ([#441](https://github.com/justrach/codedb/issues/441)).

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -532,6 +532,46 @@ pub const tools_list =
 ///
 /// Caller owns returned slice. The intermediate parse and the slices it
 /// references are freed before return.
+pub const ToolsListOpts = struct {
+    bundle_enabled: bool = false,
+    discriminated_opt_in: bool = false,
+};
+
+/// Build the runtime `tools/list` response. Honors the bundle and
+/// discriminated-schema env-var gates that run() reads. Always returns an
+/// allocator-owned slice the caller must free.
+pub fn buildToolsListResponse(alloc: std.mem.Allocator, opts: ToolsListOpts) ![]u8 {
+    if (opts.bundle_enabled and opts.discriminated_opt_in) {
+        return buildAugmentedToolsList(alloc);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, a, tools_list, .{});
+
+    const root_obj = &parsed.value.object;
+    const tools_val = root_obj.getPtr("tools") orelse return error.MalformedToolsList;
+    if (tools_val.* != .array) return error.MalformedToolsList;
+
+    if (!opts.bundle_enabled) {
+        var filtered: std.json.Array = .init(a);
+        for (tools_val.array.items) |t| {
+            if (t == .object) {
+                if (t.object.get("name")) |n| {
+                    if (n == .string and std.mem.eql(u8, n.string, "codedb_bundle")) continue;
+                }
+            }
+            try filtered.append(t);
+        }
+        tools_val.* = .{ .array = filtered };
+    }
+
+    const out_in_arena = try std.json.Stringify.valueAlloc(a, parsed.value, .{});
+    return try alloc.dupe(u8, out_in_arena);
+}
+
 pub fn buildAugmentedToolsList(alloc: std.mem.Allocator) ![]u8 {
     var arena = std.heap.ArenaAllocator.init(alloc);
     defer arena.deinit();
@@ -702,15 +742,25 @@ pub fn run(
     // still has Stage 1's required: ["tool", "arguments"] from #434). Set
     // CODEDB_DISCRIMINATED_SCHEMA=1 to opt back into the augmented oneOf for
     // Anthropic-backed clients that benefit from it.
+    //
+    // Issue #443: even with all the above, OpenAI clients still emit empty
+    // `arguments: {}` for bundle sub-ops because the schema can't bind
+    // sub-tool argument shape without `oneOf`. Disable the bundle entirely
+    // by default — the dispatcher handler stays so cached-schema clients
+    // don't crash, but tools/list no longer advertises it. Set
+    // CODEDB_BUNDLE_ENABLED=1 to re-advertise.
     const discriminated_opt_in = blk_opt: {
         const v = cio.posixGetenv("CODEDB_DISCRIMINATED_SCHEMA") orelse break :blk_opt false;
         break :blk_opt std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
     };
-    const tools_list_response: []const u8 = blk: {
-        if (!discriminated_opt_in) break :blk tools_list;
-        const augmented = buildAugmentedToolsList(alloc) catch break :blk tools_list;
-        break :blk augmented;
+    const bundle_enabled = blk_be: {
+        const v = cio.posixGetenv("CODEDB_BUNDLE_ENABLED") orelse break :blk_be false;
+        break :blk_be std.mem.eql(u8, v, "1") or std.mem.eql(u8, v, "true");
     };
+    const tools_list_response: []const u8 = buildToolsListResponse(alloc, .{
+        .bundle_enabled = bundle_enabled,
+        .discriminated_opt_in = discriminated_opt_in,
+    }) catch tools_list;
     defer if (tools_list_response.ptr != tools_list.ptr) alloc.free(tools_list_response);
     var session = Session{
         .alloc = alloc,

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5810";
+pub const semver = "0.2.5811";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10514,6 +10514,69 @@ test "issue-441: codedb_projects branch is excluded from augmented oneOf" {
     }
 }
 
+test "issue-443: codedb_bundle is omitted from default tools/list response" {
+    // The codedb_bundle tool has been a footgun across multiple stages:
+    //   #434 — schema permitted empty arguments (Stage 1 fix: required arguments)
+    //   #437 — Stage 2 oneOf augmentation broke OpenAI strict-mode (#440 hotfix)
+    //   #441 — codedb_projects sub-op replay loop in planners
+    // Even with all of the above, OpenAI clients still emit
+    // {"tool":"codedb_*","arguments":{}} because the default schema's
+    // arguments field is a bare {type:"object"} with no inner shape, and
+    // the discriminated oneOf is opt-in only.
+    //
+    // Disable codedb_bundle entirely until the schema can be reworked to
+    // bind sub-tool arguments inline (no `arguments` wrapper), removing
+    // the empty-args footgun structurally. The dispatcher-side handler
+    // stays so clients with cached schemas don't crash, but the runtime
+    // tools/list response no longer advertises it. CODEDB_BUNDLE_ENABLED=1
+    // re-enables advertisement for callers that want to re-engage it.
+    const response = try mcp_mod.buildToolsListResponse(testing.allocator, .{
+        .bundle_enabled = false,
+        .discriminated_opt_in = false,
+    });
+    defer testing.allocator.free(response);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, response, .{});
+    defer parsed.deinit();
+
+    const tools = parsed.value.object.get("tools").?.array;
+    for (tools.items) |t| {
+        const name = t.object.get("name").?.string;
+        try testing.expect(!std.mem.eql(u8, name, "codedb_bundle"));
+    }
+
+    // Sanity: legitimate tools still advertised.
+    var saw_search = false;
+    var saw_outline = false;
+    for (tools.items) |t| {
+        const name = t.object.get("name").?.string;
+        if (std.mem.eql(u8, name, "codedb_search")) saw_search = true;
+        if (std.mem.eql(u8, name, "codedb_outline")) saw_outline = true;
+    }
+    try testing.expect(saw_search);
+    try testing.expect(saw_outline);
+}
+
+test "issue-443: codedb_bundle is advertised when CODEDB_BUNDLE_ENABLED=1" {
+    // Re-enable path. When bundle_enabled is true the runtime response
+    // includes codedb_bundle, exactly as it did before this gate.
+    const response = try mcp_mod.buildToolsListResponse(testing.allocator, .{
+        .bundle_enabled = true,
+        .discriminated_opt_in = false,
+    });
+    defer testing.allocator.free(response);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, response, .{});
+    defer parsed.deinit();
+
+    const tools = parsed.value.object.get("tools").?.array;
+    var saw_bundle = false;
+    for (tools.items) |t| {
+        if (std.mem.eql(u8, t.object.get("name").?.string, "codedb_bundle")) saw_bundle = true;
+    }
+    try testing.expect(saw_bundle);
+}
+
 test "issue-434: codedb_bundle ops items schema requires arguments field" {
     // The codedb_bundle inputSchema in tools_list advertises ops items as
     // {required: ["tool"]} with arguments as a bare {type: "object"} that


### PR DESCRIPTION
## Summary

- Disables `codedb_bundle` advertisement in `tools/list` by default. The dispatcher-side handler stays so any client with a cached schema doesn't crash on call. Set `CODEDB_BUNDLE_ENABLED=1` to re-advertise.
- Refactors the inline tools_list builder in `run()` into `buildToolsListResponse(alloc, opts)` with `{ bundle_enabled, discriminated_opt_in }` flags.
- Bumps to v0.2.5811.

## Why

Across multiple stages — #434 (empty-args), #437 (oneOf augmentation), #440 (OpenAI strict-mode regression), #441 (codedb_projects replay) — `codedb_bundle` has remained a footgun for OpenAI/codex/forgecode clients. The default schema can't bind sub-tool argument shape without `oneOf`, and `oneOf` is OpenAI-strict-incompatible, so we keep seeing `arguments: {}` payloads followed by `received keys: [tool, arguments]` errors. Disable until the schema can be reworked to bind args inline (no `arguments` wrapper).

Closes #443.

## Test plan

- [x] `zig build test` — all 517 tests pass
- [x] `test "issue-443: codedb_bundle is omitted from default tools/list response"` — runtime response with `bundle_enabled = false` does not advertise codedb_bundle
- [x] `test "issue-443: codedb_bundle is advertised when CODEDB_BUNDLE_ENABLED=1"` — re-enable path works
- [x] Existing #434, #437, #441 schema tests on `tools_list` const continue to pass (the canonical full-schema const is unchanged; only the runtime response is filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)