### PR TITLE
fix(explore): #450 max_results overshoot + #448 rerank stem/case

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1786,7 +1786,7 @@ pub const Explorer = struct {
 
         if (self.outlines.get(r.path)) |outline| {
             for (outline.symbols.items) |sym| {
-                if (sym.line_start == r.line_num and std.mem.eql(u8, sym.name, query)) {
+                if (sym.line_start == r.line_num and asciiEqlIgnoreCase(sym.name, query)) {
                     score += 5.0;
                     break;
                 }
@@ -1800,13 +1800,20 @@ pub const Explorer = struct {
             score += 15.0;
         } else if (asciiContainsIgnoreCase(stem, query)) {
             score += 8.0;
+        } else if (stem.len >= 3 and asciiContainsIgnoreCase(query, stem)) {
+            // Issue #448: symmetric stem/query containment. Query "Explorer"
+            // should boost src/explore.zig — the user's intent clearly names
+            // the file even though stem "explore" doesn't contain "Explorer".
+            // Gate on stem.len>=3 so trivial stems (single-letter files,
+            // numeric basenames) don't false-boost long queries.
+            score += 8.0;
         }
         // Path-segment match boost: query matches a directory segment in
         // the path (e.g. query="parser" boosts src/parser/foo.zig). Weaker
         // than basename match because the file's own name is a stronger
         // intent signal than the directory it lives in. Skip when basename
         // already matched to avoid double-counting.
-        if (!asciiContainsIgnoreCase(stem, query) and pathHasSegmentIgnoreCase(r.path, query)) {
+        if (!asciiContainsIgnoreCase(stem, query) and !(stem.len >= 3 and asciiContainsIgnoreCase(query, stem)) and pathHasSegmentIgnoreCase(r.path, query)) {
             score += 6.0;
         }
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -4120,6 +4120,11 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
 
 fn searchInContent(path: []const u8, content: []const u8, query: []const u8, allocator: std.mem.Allocator, max_per_file: usize, max_results: usize, result_list: *std.ArrayList(SearchResult)) !void {
     if (query.len == 0 or content.len == 0) return;
+    // Issue #450: bail when the caller's quota is already met. Without this
+    // entry guard, Tier 0.5 prefix expansion can fill result_list to
+    // max_results, then Tier 1 trigram scans append one more match before
+    // its post-call cap check fires — overshooting the contract by one.
+    if (result_list.items.len >= max_results) return;
     // Issue #431: bail when the query is longer than the file. Without this
     // guard, `content.len - query.len + 1` below underflows usize → integer
     // overflow panic in Debug, SIGBUS in ReleaseFast.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2634,6 +2634,66 @@ test "regexMatch: dot-star" {
     try testing.expect(regexMatch("helloworld", "hello.*world"));
 }
 
+test "issue-450: searchContent prefix tier respects max_results" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("a.zig", "const abcx = 1;\n");
+    try explorer.indexFile("b.zig", "const abcy = 1;\n");
+    try explorer.indexFile("c.zig", "const zzabczz = 1;\n");
+
+    const results = try explorer.searchContent("abc", testing.allocator, 2);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len <= 2);
+}
+
+test "issue-448: rerank boosts basename when query contains stem" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("src/aaa.zig", "// Explorer is mentioned here\n");
+    try explorer.indexFile("src/explore.zig", "// Explorer is mentioned here\n");
+
+    const results = try explorer.searchContent("Explorer", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 1);
+    try testing.expectEqualStrings("src/explore.zig", results[0].path);
+}
+
+test "issue-448: rerank symbol-definition boost is case-insensitive" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    try explorer.indexFile("aaa.zig", "// store is mentioned here\n");
+    try explorer.indexFile("zzz.zig", "pub const Store = struct {};\n");
+
+    const results = try explorer.searchContent("store", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 1);
+    try testing.expectEqualStrings("zzz.zig", results[0].path);
+}
+
 test "explorer: searchContentRegex end-to-end" {
     var explorer_inst = Explorer.init(testing.allocator);
     defer explorer_inst.deinit();


### PR DESCRIPTION
## Summary
- Fixes [#450](https://github.com/justrach/codedb/issues/450): `searchContent` overshoots `max_results` by one when Tier 0.5 prefix expansion fills the list and Tier 1 still runs.
- Fixes [#448](https://github.com/justrach/codedb/issues/448) (both parts): rerank now uses symmetric basename-stem containment (so query "Explorer" boosts `src/explore.zig`) and case-insensitive symbol-definition equality (so query "store" boosts `pub const Store`).

## Commits
1. `test(explore): failing tests for #450 and #448` — three tests that fail on `main`.
2. `fix(explore): clamp searchInContent to max_results (#450)` — one-line entry guard at the top of `searchInContent`.
3. `fix(explore): symmetric basename-stem + case-insensitive symbol boost (#448)` — narrow tweaks in `rerankSignalScore`.

Per CLAUDE.md: failing tests committed separately from fixes.

## Test plan
- [x] `zig build test` passes (full suite, all 521+ tests including the three new `issue-450` / `issue-448` blocks).
- [x] Per-test verification: each `issue-XX` test fails on `main` and passes after its fix commit.
- [ ] No CI regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)