### PR TITLE
fix(explore): keep Tier 0 code-first diversity for popular identifiers (#449)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1573,40 +1573,47 @@ pub const Explorer = struct {
         // files with 10+ mentions each can fill result_list before the
         // canonical source file's posting-list entries are reached.
         const word_hits = self.word_index.search(query);
-        if (word_hits.len > 0 and word_hits.len <= max_results * 2) {
-            const tier0_per_file_cap: usize = @max(1, max_results / 5);
-            var tier0_per_file = std.StringHashMap(usize).init(allocator);
-            defer tier0_per_file.deinit();
-            const passes = [_]bool{ false, true }; // pass 0 = code, pass 1 = doc
-            for (passes) |is_doc_pass| {
-                if (result_list.items.len >= max_results) break;
-                for (word_hits) |hit| {
-                    const hit_path = self.word_index.hitPath(hit);
-                    if (hit_path.len == 0) continue;
-                    if (isDocLanguage(detectLanguage(hit_path)) != is_doc_pass) continue;
-                    const gop = tier0_per_file.getOrPut(hit_path) catch continue;
-                    if (!gop.found_existing) gop.value_ptr.* = 0;
-                    if (gop.value_ptr.* >= tier0_per_file_cap) continue;
-                    const ref = self.readContentForSearch(hit_path, allocator) orelse continue;
-                    defer ref.deinit();
-                    const line_text = extractLineByNumber(ref.data, hit.line_num) orelse continue;
-                    if (indexOfCaseInsensitive(line_text, query) == null) continue;
-                    const duped_text = try allocator.dupe(u8, line_text);
-                    errdefer allocator.free(duped_text);
-                    const duped_path = try allocator.dupe(u8, hit_path);
-                    errdefer allocator.free(duped_path);
-                    try result_list.append(allocator, .{
-                        .path = duped_path,
-                        .line_num = hit.line_num,
-                        .line_text = duped_text,
-                    });
-                    gop.value_ptr.* += 1;
-                    searched.put(hit_path, {}) catch {};
-                    if (result_list.items.len >= max_results) return self.rerankAndFinalize(&result_list, query, allocator);
-                }
+        if (word_hits.len > 0) {
+            var code_hit_count: usize = 0;
+            for (word_hits) |hit| {
+                const hp = self.word_index.hitPath(hit);
+                if (hp.len > 0 and !isDocLanguage(detectLanguage(hp))) code_hit_count += 1;
             }
-            if (result_list.items.len >= max_results)
-                return self.rerankAndFinalize(&result_list, query, allocator);
+            if (code_hit_count <= max_results * 2) {
+                const tier0_per_file_cap: usize = @max(1, max_results / 5);
+                var tier0_per_file = std.StringHashMap(usize).init(allocator);
+                defer tier0_per_file.deinit();
+                const passes = [_]bool{ false, true }; // pass 0 = code, pass 1 = doc
+                for (passes) |is_doc_pass| {
+                    if (result_list.items.len >= max_results) break;
+                    for (word_hits) |hit| {
+                        const hit_path = self.word_index.hitPath(hit);
+                        if (hit_path.len == 0) continue;
+                        if (isDocLanguage(detectLanguage(hit_path)) != is_doc_pass) continue;
+                        const gop = tier0_per_file.getOrPut(hit_path) catch continue;
+                        if (!gop.found_existing) gop.value_ptr.* = 0;
+                        if (gop.value_ptr.* >= tier0_per_file_cap) continue;
+                        const ref = self.readContentForSearch(hit_path, allocator) orelse continue;
+                        defer ref.deinit();
+                        const line_text = extractLineByNumber(ref.data, hit.line_num) orelse continue;
+                        if (indexOfCaseInsensitive(line_text, query) == null) continue;
+                        const duped_text = try allocator.dupe(u8, line_text);
+                        errdefer allocator.free(duped_text);
+                        const duped_path = try allocator.dupe(u8, hit_path);
+                        errdefer allocator.free(duped_path);
+                        try result_list.append(allocator, .{
+                            .path = duped_path,
+                            .line_num = hit.line_num,
+                            .line_text = duped_text,
+                        });
+                        gop.value_ptr.* += 1;
+                        searched.put(hit_path, {}) catch {};
+                        if (result_list.items.len >= max_results) return self.rerankAndFinalize(&result_list, query, allocator);
+                    }
+                }
+                if (result_list.items.len >= max_results)
+                    return self.rerankAndFinalize(&result_list, query, allocator);
+            }
         }
 
         // Tier 0.5: prefix expansion — find all indexed keys that begin with the query.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11275,3 +11275,44 @@ test "rerank-trace: single-result query records non-zero rerank score" {
     try testing.expect(std.mem.indexOf(u8, data, "\"score\":0.0000") == null);
     try testing.expect(std.mem.indexOf(u8, data, "src/loneSym.zig") != null);
 }
+
+test "issue-449: popular markdown should not disable Tier 0 code-first behavior" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    const md_block =
+        "fooBar mentioned here.\n" ++
+        "fooBar mentioned here.\n" ++
+        "fooBar mentioned here.\n" ++
+        "fooBar mentioned here.\n" ++
+        "fooBar mentioned here.\n";
+
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        var path_buf: [64]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "docs/notes_{d}.md", .{i});
+        try explorer.indexFile(path, md_block);
+    }
+
+    try explorer.indexFile("src/foo.zig",
+        "pub fn fooBar() void {}\n" ++
+            "pub fn caller1() void { fooBar(); }\n" ++
+            "pub fn caller2() void { fooBar(); }\n" ++
+            "pub fn caller3() void { fooBar(); }\n");
+
+    const results = try explorer.searchContent("fooBar", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+
+    var found_source = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "src/foo.zig")) found_source = true;
+    }
+    try testing.expect(found_source);
+}


### PR DESCRIPTION
## Summary
Fixes [#449](https://github.com/justrach/codedb/issues/449). Tier 0 of `searchContent` had a `word_hits.len <= max_results * 2` gate that skipped the whole Tier 0 code-first/doc-second diversity pass when a posting list got large. For popular identifiers like \`fooBar\`, that meant markdown files with many incidental mentions could fill \`max_results\` before any code file was scanned.

## Approach
Replace the total-hit-count gate with a code-language-only gate. The new check counts hits in code-language files specifically; when code hits stay within bounds, Tier 0's two-pass (code, then doc) runs even if total hits are large. When the population is all-code (the #427 scenario), Tier 1's existing hit-count sort takes over as before.

## Test plan
- [x] `zig build test` passes (519/519 including the new `issue-449` test).
- [x] `issue-427` regression scenario still passes (verified manually).

## Commits
1. `test: failing test for #449 (Tier 0 gate bypass)`
2. `fix(explore): keep Tier 0 code/doc diversity for popular identifiers (#449)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)