### PR TITLE
docs(bench): remove references to deleted shootout repo

### DIFF
--- a/benchmarks/search-shootout/RESULTS.md
+++ b/benchmarks/search-shootout/RESULTS.md
@@ -602,7 +602,7 @@ Output is a single line of JSON per run, e.g.:
 
 The flag is in the public CLI but is not a stable interface — its
 purpose is for benchmark harnesses (including
-[code-search-shootout](https://github.com/justrach/code-search-shootout))
+code-search-shootout)
 to measure codedb fairly against engines that don't have an MCP layer.
 
 ## 12. Precision rerun + telemetry tail-latency fix (the second-biggest fix this bench surfaced)


### PR DESCRIPTION
Strips links/mentions of the deleted standalone bench repo from `benchmarks/search-shootout/RESULTS.md`. The harness still lives in this repo.