### PR TITLE
fix(mcp): accept name/path/pattern/q as aliases for codedb_find query

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2928,8 +2928,11 @@ fn handleIndex(
 }
 
 fn handleFind(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
-    const query = getStr(args, "query") orelse {
-        out.appendSlice(alloc, "error: missing 'query'") catch {};
+    // Telemetry showed 71% of codedb_find calls were failing with
+    // "missing 'query'" — agents were passing `name`/`path`/`pattern`/`q`
+    // instead, misled by the "FILE-NAME search" framing. Accept aliases.
+    const query = getStr(args, "query") orelse getStr(args, "name") orelse getStr(args, "path") orelse getStr(args, "pattern") orelse getStr(args, "q") orelse {
+        out.appendSlice(alloc, "error: missing 'query' (also accepted: 'name', 'path', 'pattern', 'q')") catch {};
         appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11550,3 +11550,85 @@ test "issue-negq: negative-query search short-circuits Tier 5 full scan" {
     // ruled out a match. On main this expectation fails (count == 1).
     try testing.expectEqual(@as(u64, 0), explorer.search_tier5_count);
 }
+
+test "issue-471a: codedb_find accepts query/name/path/pattern/q aliases" {
+    // Real-user telemetry (24h) showed 71% of codedb_find calls failing with
+    // "missing 'query'" because agents passed the search term under `name`,
+    // `path`, `pattern`, or `q` (misled by the "FILE-NAME search" framing in
+    // the tool description). Regression: every common alias must succeed.
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+    try explorer.indexFile("src/auth_middleware.go", "package auth\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const aliases = [_][]const u8{ "query", "name", "path", "pattern", "q" };
+    for (aliases) |key| {
+        const bundle_json = try std.fmt.allocPrint(
+            testing.allocator,
+            "{{\"ops\":[{{\"tool\":\"codedb_find\",\"arguments\":{{\"{s}\":\"main\"}}}}]}}",
+            .{key},
+        );
+        defer testing.allocator.free(bundle_json);
+
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, bundle_json, .{});
+        defer parsed.deinit();
+
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(testing.allocator);
+        bench_ctx.runDispatch(io, testing.allocator, .codedb_bundle, &parsed.value.object, &out, &store, &explorer, &agents);
+
+        // Every alias must succeed: no "missing" error, and the matching
+        // file must appear in the response.
+        if (std.mem.indexOf(u8, out.items, "missing 'query'") != null) {
+            std.debug.print("alias '{s}' failed with: {s}\n", .{ key, out.items });
+            return error.AliasRejected;
+        }
+        try testing.expect(std.mem.indexOf(u8, out.items, "main.zig") != null);
+    }
+}
+
+test "issue-471b: codedb_find error message enumerates accepted aliases" {
+    // If an agent calls codedb_find with no recognized key, the error message
+    // must enumerate the accepted aliases so the agent can self-correct on
+    // the next call instead of repeating the same broken call.
+    var explorer = Explorer.init(testing.allocator);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".");
+    defer bench_ctx.deinit();
+
+    const bundle_json =
+        \\{"ops":[{"tool":"codedb_find","arguments":{"bogus":"main"}}]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, bundle_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_bundle, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // Error must enumerate the alias list so the agent can self-correct.
+    try testing.expect(std.mem.indexOf(u8, out.items, "missing 'query'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "name") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "path") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "pattern") != null);
+}
+


### PR DESCRIPTION
## Summary

Real-user telemetry (24h, ~566 calls) showed `codedb_find` failing at a **71% rate** — every failure was `error: missing 'query'`. The 22-byte error response signature was unmistakable: agents are passing the search term under a different key name.

The most likely culprit is the tool description: it leads with "Fuzzy **FILE-NAME** search ONLY", which strongly suggests `name` or `path` as the argument key. Some agents probably also try `pattern` (cross-contamination from `codedb_glob`) or `q` (short form).

Rather than retrain every agent, just accept all five common aliases:

```zig
const query = getStr(args, "query")
    orelse getStr(args, "name")
    orelse getStr(args, "path")
    orelse getStr(args, "pattern")
    orelse getStr(args, "q")
    orelse { ... };
```

When all five are missing, the error message now enumerates the accepted aliases AND echoes the keys the agent actually sent (the existing `appendBundleArgKeysDiagnostic` helper), so a confused agent can self-correct on the next call.

## Measured impact (locally)

| arg key | before | after |
|---|---|---|
| `query: "useEffect"` | OK | OK |
| `name: "useEffect"` | `error: missing 'query'` | **OK** |
| `path: "useEffect"` | `error: missing 'query'` | **OK** |
| `pattern: "useEffect"` | `error: missing 'query'` | **OK** |
| `q: "useEffect"` | `error: missing 'query'` | **OK** |
| `{bogus: "x"}` | terse error | clearer error with alias list |

Expected production effect: roughly 71% → ~0% failure rate on `codedb_find`, depending on what fraction of failures are bogus calls vs. argname mismatches. Either way: the alias path is sub-µs, so this is pure upside.

## Test plan
- [x] `zig build` (ReleaseFast) passes
- [x] `zig build test` — 486/487 pass (1 pre-existing failure on `main`: `issue-44`)
- [x] All five alias keys verified via MCP envelope: each returns identical results to `query`
- [x] Truly-missing input still fires the error path with the expanded message