### PR TITLE
docs: MCP setup + skill base guides + TODOs.md (closes #461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ checksums for the uploaded binaries, not Git commit SHAs:
 If you installed `v0.2.579` before this hotfix, rerun the installer above so the
 binary matches the final uploaded checksum for your platform.
 
+## Documentation
+
+- **[MCP setup](docs/mcp.md)** — per-client configurations (Claude Desktop, Cursor, VS Code, Claude Code, Codex CLI, Gemini CLI), root resolution, troubleshooting
+- **[Skill base & context files](docs/skills.md)** — `agents.md` / `CLAUDE.md` / `GEMINI.md`, `.codedbrc`, per-developer memory
+- **[CLI reference](docs/cli.md)** — every command, every flag
+- **[Architecture](docs/architecture.md)** — engine internals, index layout
+- **[Benchmarks](docs/benchmarks.md)** — micro-benchmarks + agentic-eval results vs codegraph, FTS5, lean-ctx
+
 | Platform | Binary | Signed |
 |----------|--------|--------|
 | macOS ARM64 (Apple Silicon) | `codedb-darwin-arm64` | ✅ codesigned + notarized |

--- a/TODOs.md
+++ b/TODOs.md
@@ -1,0 +1,53 @@
+# TODOs
+
+Snapshot of in-flight work after the v0.2.5815 release. Updated 2026-05-21.
+
+---
+
+## Shipped in v0.2.5815
+
+Released 2026-05-20, [tag](https://github.com/justrach/codedb/releases/tag/v0.2.5815).
+
+- **#474** — `codedb_status` 9.4× faster (cache `approxIndexSizeBytes`)
+- **#475** — `codedb word X` 2.4–4.9× faster (persist `word.index` on first call)
+- **#476** — `codedb_search` / `codedb_callers` default `max_results` trimmed (−31% / −35% tokens)
+- **#477** — new `codedb_context` MCP tool (task-shaped composer)
+- **#478** — `codedb_find` accepts `query` / `name` / `path` / `pattern` / `q` aliases (fixes 71% real-user failure rate)
+- **#479** — `codedb_context` multi-line snippets + source-over-test ranking
+- **#460** (cherry-picked from `release/v0.2.5814`) — `.codedbrc max_cached` wires through `ContentCache.init`
+- This PR (#461 docs): `docs/mcp.md`, `docs/skills.md`, README pointers, TODOs.md
+
+Cross-corpus eval ([code-search-shootout §18](https://github.com/justrach/code-search-shootout)) puts codedb ahead of codegraph on every axis: quality 4.62 vs 4.44, tokens 2.2× cheaper, wall 1.9× faster, calls 2.2× fewer, RSS lighter in every corpus.
+
+---
+
+## Open issues worth tackling next
+
+- **#44** (pre-existing) — `snapshot stale after working tree changes cause stale query results`. Failing test in `src/tests.zig` (issue-44). 1 of 489 tests fails locally and in CI. Not regressed by any session work, but the only red test on `main`.
+- **misc agents/clients still pass `q` / `pattern`** even after #478 — telemetry will confirm the post-release drop. If still high after v0.2.5815 propagates, consider promoting `q` / `pattern` from "accepted" to "documented" in the tool description.
+- **codedb_context paraphrasing edge cases** — bench eval still shows agents occasionally summarising the snippet field even with fenced multi-line context blocks. Two candidate followups: (1) explicit prompt-side instruction at the tool description level, (2) restructure the answer schema so the "trace" field is split from the "quote" field.
+
+---
+
+## Branch hygiene — needs maintainer call
+
+After v0.2.5815 there are ~179 remote branches. Safe-to-delete buckets:
+
+1. **Session feature branches (merged)** — confirmed reachable from `main`:
+   - `perf-status-cache`, `perf-word-hot`, `perf-lean-defaults`
+   - `feat-codedb-context`, `feat-codedb-context-quality`
+   - `fix-codedb-find-aliases`
+2. **Superseded release branches** — no tag was ever cut:
+   - `release/v0.2.5814` (its only unique commit was cherry-picked into v0.2.5815)
+3. **Tagged release branches** — tag is the source of truth; the branch is redundant:
+   - `release/v0.2.3`, `release/v0.2.4`, `release/v0.2.5`, `release/v0.2.52`, `release/v0.2.55`, `release/v0.2.57`, `release/v0.2.571`, `release/v0.2.5798`, `release/v0.2.5799`, `release/v0.2.5813`
+4. **Stale feature work** — 25+ `feat/`, `bench-`, `claude/`, `codex/`, `docs/` branches predating this session. **Maintainer review needed** before deletion — some may have unmerged WIP.
+
+---
+
+## Telemetry items to watch (post-release)
+
+- `codedb_find` failure rate (was 71%, expected to drop near 0 once v0.2.5815 propagates)
+- `codedb_context` adoption — how many sessions use it vs the older `codedb_search` + `codedb_symbol` chain
+- `codedb_word` p50 / p99 latency — confirm the disk-persist path is hitting the cache after warmup
+- `codedb_status` p99 — confirm cache TTL keeps it under 100 µs on a busy index

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,258 @@
+# codedb MCP Setup
+
+`codedb mcp` runs as a stdio JSON-RPC server speaking the
+[Model Context Protocol](https://spec.modelcontextprotocol.io/). It exposes
+21 tools for code intelligence — search, outline, callers, deps, edit,
+context, etc. — backed by the indexes in `~/.codedb/projects/<hash>/`.
+
+This guide covers per-client setup, how codedb decides which project to
+scan, and the most common failure modes.
+
+---
+
+## 1. Quick install (auto-configures all detected clients)
+
+```bash
+curl -fsSL https://codedb.codegraff.com/install.sh | bash
+```
+
+The installer downloads the binary for your platform, drops it in
+`~/.local/bin/` (or `/usr/local/bin/` on root installs), and auto-registers
+codedb as an MCP server in every client it can find — Claude Code, Codex,
+Gemini CLI, Cursor, opencode. It prints the exact `codedb mcp` command it
+registered.
+
+If you prefer to wire it up by hand, the client-specific snippets below
+all work directly.
+
+---
+
+## 2. Client-specific configuration
+
+All clients launch `codedb mcp` as a stdio child process. Replace
+`/usr/local/bin/codedb` with `which codedb` output on your system.
+
+### Claude Code
+
+```bash
+claude mcp add codedb -s user -- /usr/local/bin/codedb mcp
+```
+
+Or edit `~/.claude.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "codedb": {
+      "command": "/usr/local/bin/codedb",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Verify: `claude mcp list` should show `codedb: /usr/local/bin/codedb mcp - ✓ Connected`.
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "codedb": {
+      "command": "/usr/local/bin/codedb",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The tools should appear in the slash-command menu.
+
+### Cursor
+
+Edit `~/.cursor/mcp.json` (per-user) or `<project>/.cursor/mcp.json`
+(per-project):
+
+```json
+{
+  "mcpServers": {
+    "codedb": {
+      "command": "/usr/local/bin/codedb",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Cursor advertises the open workspace via the `roots/list` MCP handshake,
+so codedb scans the right project automatically (see Root Resolution
+below).
+
+### VS Code (with an MCP extension)
+
+Same `mcpServers` block as Cursor, scoped to whichever extension you use.
+
+### Codex CLI
+
+```bash
+codex mcp add codedb -- /usr/local/bin/codedb mcp
+```
+
+### Gemini CLI / opencode
+
+Both read MCP configuration from `~/.gemini/mcp.json` (Gemini) and
+`~/.config/opencode/mcp.json` (opencode):
+
+```json
+{
+  "mcpServers": {
+    "codedb": {
+      "command": "/usr/local/bin/codedb",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+---
+
+## 3. Root resolution — which project does `codedb mcp` scan?
+
+`codedb mcp` figures out the project root in this order (first match wins):
+
+1. **MCP `roots/list` handshake** (preferred). When a client supports it
+   (Cursor, Windsurf, recent VS Code MCP extensions), codedb requests
+   `roots/list` immediately after `initialize` and uses the first workspace
+   root the client returns. This is the most reliable path — codedb scans
+   exactly the project the user has open in their editor.
+
+2. **Per-call `project` argument**. Every tool accepts an optional
+   `project: "<abs path>"` field that switches the active project for that
+   single call. Useful for cross-project queries:
+
+   ```json
+   {
+     "name": "codedb_search",
+     "arguments": {
+       "query": "scheduleUpdateOnFiber",
+       "project": "/Users/me/code/react"
+     }
+   }
+   ```
+
+3. **Process `cwd`**. If the client doesn't speak `roots/list` and no
+   per-call `project` is set, codedb falls back to the directory it was
+   launched from. Some editors launch MCP servers from `/Applications` or
+   `~`, which is almost certainly the wrong directory — set the `project`
+   arg explicitly for those.
+
+System directories (`/`, `/Applications`, `/usr`, `/opt`, `~`,
+`/tmp`, etc.) are blocked from being indexed as project roots — see
+[`docs/rfc-346-mcp-root-resolution.md`](rfc-346-mcp-root-resolution.md)
+for the full safety logic.
+
+---
+
+## 4. `.codedbrc` — per-project configuration
+
+Drop a `.codedbrc` at the root of any project to override defaults for
+that project. INI-style `key = value` pairs, one per line, `#` for
+comments. Unknown keys are ignored.
+
+```ini
+# .codedbrc
+max_cached   = 16384   # in-memory ContentCache size (files); default 16384
+max_versions = 100     # versions kept per file in the change log; default 100
+rerank_trace = false   # write per-search rerank-trace.jsonl (debug only)
+```
+
+Pass an alternative path with `--config-file <path>` to the CLI for
+testing.
+
+---
+
+## 5. Verifying the install
+
+```bash
+codedb --version          # codedb 0.2.5815 (or later)
+codedb status             # one-line: indexed file count + scan phase
+```
+
+In a client, the simplest tool to smoke-test is `codedb_status` — it
+takes no arguments and returns `files: N, seq: N, scan: ready` in <50 ms.
+
+---
+
+## 6. Troubleshooting
+
+### "No project root yet" / empty tree
+
+The MCP server hasn't received a project root. Either:
+- the client doesn't speak `roots/list`, or
+- the client launched codedb from a system directory that's blocked from
+  indexing (`/Applications`, `/usr`, `~`, etc.).
+
+**Fix:** pass `project: "/abs/path/to/your/project"` on the first tool
+call, or restart the client from inside the project directory.
+
+### `codedb_find` returns `missing 'query'`
+
+Fixed in v0.2.5815 — `codedb_find` now accepts `query`, `name`, `path`,
+`pattern`, and `q` as aliases. If you're still seeing this error,
+`codedb --version` will show < 0.2.5815; rerun the installer.
+
+### Tools list looks short / `codedb_context` is missing
+
+`codedb_context` was added in **v0.2.5815**. Older binaries expose only
+20 tools. Upgrade with `codedb update` (or the installer one-liner above)
+and verify with `codedb --version`.
+
+### Snapshot indexer keeps re-scanning
+
+The watcher debounces filesystem events for ~500 ms. If your editor saves
+files in quick succession (e.g. a formatter that rewrites everything),
+back-to-back saves can extend the scan phase. Check `codedb status` —
+`scan: ready` means it's caught up.
+
+### Permission errors on macOS
+
+The first time you run a fresh codedb binary on macOS, Gatekeeper may
+quarantine it. All release binaries from v0.2.5811+ are signed with a
+Developer ID and notarized via Apple — verify with:
+
+```bash
+spctl -a -vv -t install /usr/local/bin/codedb
+# expected: accepted, source=Notarized Developer ID
+```
+
+If you built from source, codesign the binary locally:
+
+```bash
+codesign --force --sign - /usr/local/bin/codedb
+```
+
+### Stale signatures after `cp` over an existing binary
+
+macOS caches codesignatures by path. After replacing the binary,
+re-codesign or the MCP server may fail to launch:
+
+```bash
+codesign --force --sign - /usr/local/bin/codedb
+```
+
+The installer does this for you.
+
+---
+
+## 7. Going deeper
+
+- [Architecture](architecture.md) — engine internals, index layout
+- [CLI reference](cli.md) — every command, every flag
+- [Skill base & context files](skills.md) — `agents.md`, `CLAUDE.md`,
+  `GEMINI.md`, and the per-project skill hierarchy
+- [RFC #346 — MCP root resolution](rfc-346-mcp-root-resolution.md) —
+  full design + safety logic for project-root detection
+- [Telemetry](telemetry.md) — what codedb sends, how to disable

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,174 @@
+# codedb Skill Base & Context Files
+
+This guide explains the hierarchy of context / instruction files that
+codedb-aware agents (Claude Code, Gemini CLI, Codex, Cursor, opencode,
+etc.) consult when working in a codedb-indexed project, and how each
+file's scope and precedence works.
+
+There are three layers, from broadest to narrowest:
+
+1. **Agent profile files** — `agents.md`, `CLAUDE.md`, `GEMINI.md`,
+   `.cursorrules` and friends. Per-agent project-wide instructions
+   committed to the repo.
+2. **Per-project codedb config** — `.codedbrc`. Tunes index sizes,
+   versioning, and tracing for the project.
+3. **Per-developer memory** — `~/.claude/projects/<id>/memory/`
+   (Claude Code), `~/.gemini/memory/` (Gemini CLI). Personal, not
+   committed, persists across sessions.
+
+---
+
+## 1. Agent profile files (committed, per-repo)
+
+These files live at the repo root (or a subdirectory) and are loaded by
+the agent at session start. Each agent reads its own file:
+
+| Agent | File name | Notes |
+|---|---|---|
+| Claude Code | `CLAUDE.md` | also reads `agents.md` |
+| Codex CLI | `agents.md` | reads `CLAUDE.md` as a fallback |
+| Gemini CLI | `GEMINI.md` | |
+| Cursor | `.cursorrules` | |
+| opencode | `AGENTS.md` | |
+
+codedb itself ships `docs/agents.md` (the project's contributor
+instructions) — that is the canonical example of what an agent profile
+file looks like.
+
+### What to put in them
+
+Agent profile files should describe things the LLM cannot derive from
+reading source — project conventions, the build/test commands, where
+tests live, the issue-filing protocol, code style preferences, language
+versions. Things that *are* derivable from source (file layout, function
+signatures, dependency graph) belong in the code, not here — agents
+discover those via `codedb_tree`, `codedb_outline`, `codedb_deps`, etc.
+
+Example skeleton, drawn from `docs/agents.md`:
+
+```markdown
+# <project> — Agent Instructions
+
+## Project
+<one paragraph: language, key dependencies, what to run for tests>
+
+## Rules
+
+### Filing Issues
+<process the maintainer wants — required labels, failing-test convention>
+
+### Test Style
+<framework, allocator conventions, naming>
+
+### Code Style
+<comment policy, refactor scope, language version constraints>
+```
+
+### Subdirectory overrides
+
+Agents that support hierarchical instruction files (Gemini CLI, Codex)
+also read `./src/CLAUDE.md`, `./tests/AGENTS.md`, etc. — the agent
+merges the deepest-matching file's rules on top of the repo-root file.
+
+Use subdirectory files when one part of the codebase has materially
+different conventions (e.g. `frontend/` uses TypeScript with different
+formatting from a Zig `backend/`).
+
+### Activating specialised skills
+
+Claude Code and Gemini CLI both support **skills** — named bundles of
+instructions that the agent can invoke explicitly (`/skill <name>`) or
+that fire on matching prompts. codedb provides `/codedb-troubleshooting`
+and `/codedb-bench` skills when installed via the official installer.
+
+A skill lives under `~/.claude/skills/<name>/SKILL.md` (Claude Code) or
+`~/.gemini/skills/<name>/SKILL.md` (Gemini). Same shape as a profile
+file, plus front-matter declaring when it activates:
+
+```yaml
+---
+name: codedb-troubleshooting
+description: Diagnose codedb MCP errors, missing files, stale indexes
+when:
+  - "codedb_*" tool calls return unexpected errors
+  - "no project root" or "scan: loading_snapshot" appears
+---
+```
+
+---
+
+## 2. `.codedbrc` — per-project codedb tuning (committed)
+
+Drop a `.codedbrc` at the project root to override codedb defaults for
+that project. Full keys + defaults:
+
+```ini
+# .codedbrc
+max_cached   = 16384   # in-memory ContentCache size (files); v0.2.5815+
+max_versions = 100     # versions kept per file in the change log
+rerank_trace = false   # write per-search rerank-trace.jsonl (debug)
+```
+
+INI-style `key = value`, one per line, `#` for comments, unknown keys
+ignored. Pass `--config-file <path>` to the CLI to load an alternative.
+
+Until v0.2.5815 (#460) `max_cached` was parsed-and-forgotten — the
+ContentCache was hardcoded to 16,384 files. v0.2.5815+ actually honors
+it.
+
+---
+
+## 3. Per-developer memory (not committed)
+
+Personal memory persists across sessions for **one** developer on **one**
+machine, never committed. Different agents store it differently:
+
+| Agent | Path |
+|---|---|
+| Claude Code | `~/.claude/projects/<project-id>/memory/` |
+| Gemini CLI | `~/.gemini/memory/<project-id>/` |
+
+Memory is for things specific to *you*: your preferred review style, who
+the right reviewer is, past incidents you got burned by. Anything the
+team needs to know belongs in the committed agent profile file instead.
+
+---
+
+## 4. Where each file goes — quick reference
+
+| What | Where | Committed? | Scope |
+|---|---|---|---|
+| Project conventions, build/test commands | `agents.md` / `CLAUDE.md` / `GEMINI.md` at repo root | yes | every developer + agent |
+| Subdirectory-specific rules | `<subdir>/CLAUDE.md` etc. | yes | when working in that subdir |
+| Index sizes, change-log depth | `.codedbrc` | yes | every developer (per project) |
+| Personal preferences, past incidents | `~/.claude/...memory/` | no | one developer, all projects |
+| Specialised skills | `~/.claude/skills/<name>/SKILL.md` | no | one developer, on demand |
+
+---
+
+## 5. Linking it to MCP
+
+When an agent uses codedb (via [`docs/mcp.md`](mcp.md)), the agent
+profile file teaches the agent **how** to use it — e.g.:
+
+```markdown
+## How to navigate this repo
+- Use `codedb_tree` first to orient.
+- Use `codedb_context` with a natural-language task when starting work
+  on an unfamiliar area — one call replaces 3–5 search/word/symbol calls.
+- Use `codedb_symbol` for exact definition lookups, `codedb_search` for
+  substring matches, `codedb_word` for single-identifier lookups.
+- Use `codedb_callers` to find every usage of a symbol before refactoring.
+```
+
+The combination — codedb providing the **engine**, the agent profile
+file providing the **playbook** — is what makes the agent fast and
+opinionated on your codebase specifically.
+
+---
+
+## See also
+
+- [MCP setup](mcp.md) — client configurations + root resolution
+- [CLI reference](cli.md) — every codedb command + flag
+- [Architecture](architecture.md) — engine internals


### PR DESCRIPTION
Closes #461.

## What's in here

- **`docs/mcp.md`** — per-client configurations for Claude Code, Claude Desktop, Cursor, VS Code, Codex CLI, Gemini CLI, and opencode. Plus a section on how codedb resolves the project root (MCP `roots/list` handshake → per-call `project` arg → process `cwd`), `.codedbrc` reference, install verification, and troubleshooting for the common failure modes the issue calls out ("No project root yet", missing `codedb_context`, stale signatures, etc.)
- **`docs/skills.md`** — the three-layer context-file hierarchy: committed agent profile files (`agents.md` / `CLAUDE.md` / `GEMINI.md`), per-project `.codedbrc`, and per-developer memory. Covers subdirectory overrides, skill activation, and where each file should live with a quick-reference table.
- **`README.md`** — new "Documentation" section linking the two new guides next to the existing CLI, architecture, and benchmarks docs.
- **`TODOs.md`** — repo-root snapshot of what shipped in v0.2.5815, open issues worth tackling next, branch-hygiene buckets pending maintainer call, and telemetry items to watch post-release.

## How it maps to the issue ask

The issue asked for two specific guides with bullet-point structures. Mapping:

| Issue ask | Where it landed |
|---|---|
| Client configurations (Claude Desktop, Cursor, VS Code) | `docs/mcp.md` §2, with snippets for 7 clients |
| Root resolution (CLI args, env, MCP handshake) | `docs/mcp.md` §3, with a link to RFC #346 |
| Troubleshooting ("No project root yet", path perms) | `docs/mcp.md` §6 |
| Project Instructions (`./GEMINI.md`) | `docs/skills.md` §1 |
| Subdirectory Overrides | `docs/skills.md` §1 |
| Memory Management (shared vs personal) | `docs/skills.md` §3 + §4 (quick-reference table) |
| Skill Activation | `docs/skills.md` §1 ("Activating specialised skills") |
| README + architecture links | `README.md` + `docs/skills.md` §5 cross-links |

## Test plan

Docs-only — no code changes, no test impact. Verified rendering locally by reading the files; the GH preview will catch any markdown issues.