### PR TITLE
fix(explore): skip-trigram files compete in Tier 1; share recall pipeline (#447, #451)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1556,6 +1556,12 @@ pub const Explorer = struct {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
+        return self.searchContentLocked(query, allocator, max_results, true);
+    }
+
+    fn searchContentLocked(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize, emit_trace: bool) ![]const SearchResult {
+        if (max_results == 0) return try allocator.alloc(SearchResult, 0);
+
         var result_list: std.ArrayList(SearchResult) = .empty;
         errdefer result_list.deinit(allocator);
 
@@ -1574,7 +1580,15 @@ pub const Explorer = struct {
         // canonical source file's posting-list entries are reached.
         const word_hits = self.word_index.search(query);
         if (word_hits.len > 0 and word_hits.len <= max_results * 2) {
-            const tier0_per_file_cap: usize = @max(1, max_results / 5);
+            var tier0_files = std.StringHashMap(void).init(allocator);
+            defer tier0_files.deinit();
+            for (word_hits) |hit| {
+                const hit_path = self.word_index.hitPath(hit);
+                if (hit_path.len == 0) continue;
+                tier0_files.put(hit_path, {}) catch {};
+            }
+            const tier0_file_divisor = @max(@as(usize, 1), @min(@as(usize, 5), tier0_files.count()));
+            const tier0_per_file_cap: usize = @max(1, max_results / tier0_file_divisor);
             var tier0_per_file = std.StringHashMap(usize).init(allocator);
             defer tier0_per_file.deinit();
             const passes = [_]bool{ false, true }; // pass 0 = code, pass 1 = doc
@@ -1602,11 +1616,11 @@ pub const Explorer = struct {
                     });
                     gop.value_ptr.* += 1;
                     searched.put(hit_path, {}) catch {};
-                    if (result_list.items.len >= max_results) return self.rerankAndFinalize(&result_list, query, allocator);
+                    if (result_list.items.len >= max_results) return self.rerankAndFinalize(&result_list, query, allocator, emit_trace);
                 }
             }
             if (result_list.items.len >= max_results)
-                return self.rerankAndFinalize(&result_list, query, allocator);
+                return self.rerankAndFinalize(&result_list, query, allocator, emit_trace);
         }
 
         // Tier 0.5: prefix expansion — find all indexed keys that begin with the query.
@@ -1639,54 +1653,62 @@ pub const Explorer = struct {
         const candidate_paths = self.trigram_index.candidates(query, allocator);
         defer if (candidate_paths) |cp| allocator.free(cp);
 
-        // Tier 1: trigram candidates — fast path, skips files already found by Tier 0.
-        if (candidate_paths) |cp| {
-            if (cp.len > 0) {
-                // Issue #427: rank candidates by per-file word-index hit count
-                // (desc) so the definition-dense file scans first; fall back to
-                // file content length (asc) so small files still come before
-                // unrelated large files at the same hit count. Pre-fix the
-                // sort key was content length alone, which buried the canonical
-                // file behind unrelated short files when max_per_file was 1.
-                var hits_per_file = std.StringHashMap(u32).init(allocator);
-                defer hits_per_file.deinit();
-                for (word_hits) |hit| {
-                    const hp = self.word_index.hitPath(hit);
-                    if (hp.len == 0) continue;
-                    const gop_h = try hits_per_file.getOrPut(hp);
-                    if (!gop_h.found_existing) gop_h.value_ptr.* = 0;
-                    gop_h.value_ptr.* += 1;
-                }
-                const SortCtx = struct {
-                    contents: *const std.StringHashMap([]const u8),
-                    counts: *const std.StringHashMap(u32),
-                    pub fn lessThan(ctx: @This(), a: []const u8, b: []const u8) bool {
-                        const a_count = ctx.counts.get(a) orelse 0;
-                        const b_count = ctx.counts.get(b) orelse 0;
-                        if (a_count != b_count) return a_count > b_count;
-                        const a_len = if (ctx.contents.get(a)) |c| c.len else std.math.maxInt(usize);
-                        const b_len = if (ctx.contents.get(b)) |c| c.len else std.math.maxInt(usize);
-                        return a_len < b_len;
-                    }
-                };
-                std.mem.sort([]const u8, @constCast(cp), SortCtx{ .contents = &self.contents, .counts = &hits_per_file }, SortCtx.lessThan);
-
-                const estimated_total = cp.len + self.skip_trigram_files.count();
-                const max_per_file = @max(@as(usize, 1), max_results / @max(@as(usize, 1), estimated_total));
-                for (cp) |path| {
-                    if (searched.contains(path)) continue;
-                    const ref = self.readContentForSearch(path, allocator) orelse continue;
-                    defer ref.deinit();
-                    try searchInContent(path, ref.data, query, allocator, max_per_file, max_results, &result_list);
-                    if (result_list.items.len >= max_results)
-                        return self.rerankAndFinalize(&result_list, query, allocator);
-                }
-            }
+        // Tier 1: ranked candidates. Trigram-indexed files form the normal fast
+        // path, but skip-trigram files with word-index hits must compete here
+        // too; otherwise large canonical files can be starved before Tier 3.
+        var hits_per_file = std.StringHashMap(u32).init(allocator);
+        defer hits_per_file.deinit();
+        for (word_hits) |hit| {
+            const hp = self.word_index.hitPath(hit);
+            if (hp.len == 0) continue;
+            const gop_h = try hits_per_file.getOrPut(hp);
+            if (!gop_h.found_existing) gop_h.value_ptr.* = 0;
+            gop_h.value_ptr.* += 1;
         }
 
-        // Mark all Tier 1 candidates as searched.
+        var tier1_paths: std.ArrayList([]const u8) = .empty;
+        defer tier1_paths.deinit(allocator);
+        var tier1_seen = std.StringHashMap(void).init(allocator);
+        defer tier1_seen.deinit();
+
         if (candidate_paths) |cp| {
-            for (cp) |p| searched.put(p, {}) catch {};
+            for (cp) |path| {
+                const gop = try tier1_seen.getOrPut(path);
+                if (!gop.found_existing) try tier1_paths.append(allocator, path);
+            }
+        }
+        var skip_candidate_iter = self.skip_trigram_files.keyIterator();
+        while (skip_candidate_iter.next()) |key_ptr| {
+            if (!hits_per_file.contains(key_ptr.*)) continue;
+            const gop = try tier1_seen.getOrPut(key_ptr.*);
+            if (!gop.found_existing) try tier1_paths.append(allocator, key_ptr.*);
+        }
+
+        if (tier1_paths.items.len > 0) {
+            const SortCtx = struct {
+                contents: *const std.StringHashMap([]const u8),
+                counts: *const std.StringHashMap(u32),
+                pub fn lessThan(ctx: @This(), a: []const u8, b: []const u8) bool {
+                    const a_count = ctx.counts.get(a) orelse 0;
+                    const b_count = ctx.counts.get(b) orelse 0;
+                    if (a_count != b_count) return a_count > b_count;
+                    const a_len = if (ctx.contents.get(a)) |c| c.len else std.math.maxInt(usize);
+                    const b_len = if (ctx.contents.get(b)) |c| c.len else std.math.maxInt(usize);
+                    return a_len < b_len;
+                }
+            };
+            std.mem.sort([]const u8, tier1_paths.items, SortCtx{ .contents = &self.contents, .counts = &hits_per_file }, SortCtx.lessThan);
+
+            const max_per_file = @max(@as(usize, 1), max_results / @max(@as(usize, 1), tier1_paths.items.len));
+            for (tier1_paths.items) |path| {
+                if (searched.contains(path)) continue;
+                const ref = self.readContentForSearch(path, allocator) orelse continue;
+                defer ref.deinit();
+                searched.put(path, {}) catch {};
+                try searchInContent(path, ref.data, query, allocator, max_per_file, max_results, &result_list);
+                if (result_list.items.len >= max_results)
+                    return self.rerankAndFinalize(&result_list, query, allocator, emit_trace);
+            }
         }
 
         // Tier 2: sparse candidates — LAZY, only computed when Tier 1 found nothing.
@@ -1749,7 +1771,7 @@ pub const Explorer = struct {
                 if (result_list.items.len >= max_results) break;
             }
         }
-        return self.rerankAndFinalize(&result_list, query, allocator);
+        return self.rerankAndFinalize(&result_list, query, allocator, emit_trace);
     }
 
     /// Run the multi-signal rerank in place, then transfer ownership of
@@ -1762,6 +1784,7 @@ pub const Explorer = struct {
         result_list: *std.ArrayList(SearchResult),
         query: []const u8,
         allocator: std.mem.Allocator,
+        emit_trace: bool,
     ) ![]const SearchResult {
         for (result_list.items) |*r| {
             r.score = self.rerankSignalScore(r.*, query);
@@ -1776,7 +1799,7 @@ pub const Explorer = struct {
                 }
             }.lessThan);
         }
-        self.appendRerankTrace(query, result_list.items);
+        if (emit_trace) self.appendRerankTrace(query, result_list.items);
         return result_list.toOwnedSlice(allocator);
     }
 
@@ -2091,7 +2114,6 @@ pub const Explorer = struct {
 
         return result_list.toOwnedSlice(allocator);
     }
-
 
     /// Search file contents using a regex pattern with trigram acceleration.
     /// Decomposes the regex to extract literal trigrams for candidate filtering,
@@ -3852,6 +3874,15 @@ pub const Explorer = struct {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
+        const base_results = try self.searchContentLocked(query, allocator, max_results, false);
+        defer {
+            for (base_results) |r| {
+                allocator.free(r.line_text);
+                allocator.free(r.path);
+            }
+            allocator.free(base_results);
+        }
+
         var result_list: std.ArrayList(ScopedSearchResult) = .empty;
         errdefer {
             for (result_list.items) |r| {
@@ -3861,69 +3892,27 @@ pub const Explorer = struct {
             }
             result_list.deinit(allocator);
         }
+        try result_list.ensureTotalCapacity(allocator, base_results.len);
 
-        const sparse_paths = self.sparse_ngram_index.candidates(query, allocator);
-        defer if (sparse_paths) |sp| allocator.free(sp);
-        const candidate_paths = self.trigram_index.candidates(query, allocator);
-        defer if (candidate_paths) |cp| allocator.free(cp);
+        for (base_results) |r| {
+            const path_copy = try allocator.dupe(u8, r.path);
+            errdefer allocator.free(path_copy);
+            const line_text = try allocator.dupe(u8, r.line_text);
+            errdefer allocator.free(line_text);
 
-        var searched = std.StringHashMap(void).init(allocator);
-        defer searched.deinit();
+            const scope = self.findEnclosingSymbolLocked(r.path, r.line_num);
+            const scope_name = if (scope) |s| try allocator.dupe(u8, s.name) else null;
+            errdefer if (scope_name) |n| allocator.free(n);
 
-        if (sparse_paths != null and sparse_paths.?.len > 0) {
-            if (candidate_paths != null and candidate_paths.?.len > 0) {
-                var sparse_set = std.StringHashMap(void).init(allocator);
-                defer sparse_set.deinit();
-                for (sparse_paths.?) |p| try sparse_set.put(p, {});
-                for (candidate_paths.?) |path| {
-                    if (!sparse_set.contains(path)) continue;
-                    const ref = self.readContentForSearch(path, allocator) orelse continue;
-                    defer ref.deinit();
-                    try searched.put(path, {});
-                    try self.searchInContentWithScope(path, ref.data, query, allocator, max_results, &result_list);
-                    if (result_list.items.len >= max_results) break;
-                }
-            } else {
-                for (sparse_paths.?) |path| {
-                    const ref = self.readContentForSearch(path, allocator) orelse continue;
-                    defer ref.deinit();
-                    try searched.put(path, {});
-                    try self.searchInContentWithScope(path, ref.data, query, allocator, max_results, &result_list);
-                    if (result_list.items.len >= max_results) break;
-                }
-            }
-        } else {
-            const use_trigram = candidate_paths != null and candidate_paths.?.len > 0;
-            if (use_trigram) {
-                for (candidate_paths.?) |path| {
-                    const ref = self.readContentForSearch(path, allocator) orelse continue;
-                    defer ref.deinit();
-                    try searched.put(path, {});
-                    try self.searchInContentWithScope(path, ref.data, query, allocator, max_results, &result_list);
-                    if (result_list.items.len >= max_results) break;
-                }
-            } else {
-                var iter = self.outlines.keyIterator();
-                while (iter.next()) |key_ptr| {
-                    const ref = self.readContentForSearch(key_ptr.*, allocator) orelse continue;
-                    defer ref.deinit();
-                    try self.searchInContentWithScope(key_ptr.*, ref.data, query, allocator, max_results, &result_list);
-                    if (result_list.items.len >= max_results) break;
-                }
-                return result_list.toOwnedSlice(allocator);
-            }
-        }
-
-        if (result_list.items.len < max_results) {
-            var iter = self.outlines.keyIterator();
-            while (iter.next()) |key_ptr| {
-                if (searched.contains(key_ptr.*)) continue;
-                if (self.trigram_index.containsFile(key_ptr.*)) continue;
-                const ref = self.readContentForSearch(key_ptr.*, allocator) orelse continue;
-                defer ref.deinit();
-                try self.searchInContentWithScope(key_ptr.*, ref.data, query, allocator, max_results, &result_list);
-                if (result_list.items.len >= max_results) break;
-            }
+            result_list.appendAssumeCapacity(.{
+                .path = path_copy,
+                .line_num = r.line_num,
+                .line_text = line_text,
+                .scope_name = scope_name,
+                .scope_kind = if (scope) |s| s.kind else null,
+                .scope_start = if (scope) |s| s.line_start else 0,
+                .scope_end = if (scope) |s| s.line_end else 0,
+            });
         }
 
         return result_list.toOwnedSlice(allocator);
@@ -4120,6 +4109,7 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
 
 fn searchInContent(path: []const u8, content: []const u8, query: []const u8, allocator: std.mem.Allocator, max_per_file: usize, max_results: usize, result_list: *std.ArrayList(SearchResult)) !void {
     if (query.len == 0 or content.len == 0) return;
+    if (result_list.items.len >= max_results) return;
     // Issue #431: bail when the query is longer than the file. Without this
     // guard, `content.len - query.len + 1` below underflows usize → integer
     // overflow panic in Debug, SIGBUS in ReleaseFast.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11154,6 +11154,54 @@ test "issue-447: searchContent surfaces large (>64KB) skip-trigram files for com
     try testing.expect(found_canonical);
 }
 
+test "issue-451: searchContentWithScope shares skip-trigram recall with searchContent" {
+    // scope=true used to duplicate searchContent's candidate pipeline. That
+    // meant fixes for large skip-trigram files could land in plain search
+    // while scoped search and codedb_callers stayed stale.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    var i: usize = 0;
+    while (i < 12) : (i += 1) {
+        var path_buf: [32]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "small_{d}.zig", .{i});
+        try explorer.indexFile(path, "fn s() void { _ = widgetX; }\n");
+    }
+
+    const canonical_content =
+        "fn canonical() void {\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "}\n";
+    try explorer.indexFileSkipTrigram("canonical.zig", canonical_content);
+
+    const results = try explorer.searchContentWithScope("widgetX", testing.allocator, 5);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+            if (r.scope_name) |n| testing.allocator.free(n);
+        }
+        testing.allocator.free(results);
+    }
+
+    var found_canonical = false;
+    var found_canonical_scope = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "canonical.zig")) {
+            found_canonical = true;
+            if (r.scope_name) |n| {
+                if (std.mem.eql(u8, n, "canonical")) found_canonical_scope = true;
+            }
+        }
+    }
+    try testing.expect(found_canonical);
+    try testing.expect(found_canonical_scope);
+}
 
 test "rerank-trace: appends one JSON line per searchContent when enabled" {
     const tmp_io = testing.io;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11090,6 +11090,71 @@ test "issue-429-e: searchContent rerank penalises doc-language files so code bea
     try testing.expectEqualStrings("src/caller.zig", results[0].path);
 }
 
+test "issue-447: searchContent surfaces large (>64KB) skip-trigram files for common identifiers" {
+    // watcher.zig:446 forces skip_trigram=true for files >64KB. Such files
+    // are NOT in self.trigram_index — they live in self.skip_trigram_files
+    // and are only reached via Tier 3 of searchContent, which runs after
+    // Tier 1 (trigram candidates).
+    //
+    // For a common identifier with a wide spread of incidental mentions
+    // across small files plus a canonical definition site in a large
+    // (>64KB) source file, Tier 1 fills the result quota with small-file
+    // hits and Tier 3 never runs — so the canonical large file is
+    // completely invisible from search results.
+    //
+    // Real-world repro on this very repo: `codedb search Explorer` returns
+    // 27 hits, ZERO from src/explore.zig (where `pub const Explorer = struct`
+    // lives at line 495 and there are 85 word-index hits for the term).
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator());
+
+    // 12 small files, each with one occurrence of widgetX. They go into the
+    // trigram index normally and form the Tier 1 candidate pool.
+    var i: usize = 0;
+    while (i < 12) : (i += 1) {
+        var path_buf: [32]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "small_{d}.zig", .{i});
+        try explorer.indexFile(path, "fn s() void { _ = widgetX; }\n");
+    }
+
+    // Canonical file: indexFileSkipTrigram simulates the >64KB skip-trigram
+    // path. The file mentions widgetX many times (this is where the
+    // definition lives in real codebases — it's the canonical answer).
+    const canonical_content =
+        "fn canonical() void {\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "    _ = widgetX;\n" ++
+        "}\n";
+    try explorer.indexFileSkipTrigram("canonical.zig", canonical_content);
+
+    // max_results=5 so the 12 small files can saturate. Expected behaviour:
+    // canonical.zig appears in the result set (it has more occurrences than
+    // any small file). Pre-fix: small files fill all 5 slots via Tier 1 and
+    // canonical.zig never gets read.
+    const results = try explorer.searchContent("widgetX", testing.allocator, 5);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+
+    var found_canonical = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "canonical.zig")) {
+            found_canonical = true;
+            break;
+        }
+    }
+    try testing.expect(found_canonical);
+}
+
+
 test "rerank-trace: appends one JSON line per searchContent when enabled" {
     const tmp_io = testing.io;
     var tmp = testing.tmpDir(.{});


### PR DESCRIPTION
## Summary

- Skip-trigram files (>64KB) with word-index hits now compete in Tier 1 ranking, so the canonical definition site for a common identifier no longer gets starved when small-file noise fills the quota first.
- `searchContentWithScope` is rewritten as a thin annotator over `searchContent` (via new `searchContentLocked`), eliminating the divergent second pipeline that caused #447's fix to skip `codedb_callers` and scope=true search.
- Tier 0 per-file divisor is capped at `min(5, distinct-hit-files)` so a single canonical file is no longer rationed to 1/5 of `max_results`.

## Issues

Closes #451 (scope=true / callers invisibility).
Reaffirms #447 fix and prevents regression of the same bug class.

## Test plan

- [x] `zig build test` — both `issue-447` and the new `issue-451` test pass.
- [x] `issue-451` test asserts the canonical large file is reachable via `searchContentWithScope` AND that the scope annotation (`scope_name == "canonical"`) is correctly attached.
- [ ] Manual: run `codedb search Explorer --scope` against this repo and confirm `src/explore.zig` appears.
- [ ] Manual: `codedb callers Explorer` against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)