### PR TITLE
perf: search + snapshot I/O optimizations

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "test-snapshot", .path = "src/test_snapshot.zig", .needs_mcp = false, .needs_nanoregex = true },
         .{ .name = "test-mcp",      .path = "src/test_mcp.zig",      .needs_mcp = true,  .needs_nanoregex = true },
         .{ .name = "test-query",    .path = "src/test_query.zig",    .needs_mcp = true,  .needs_nanoregex = true },
+        .{ .name = "test-bench",    .path = "src/test_bench.zig",    .needs_mcp = false, .needs_nanoregex = true },
     };
 
     for (test_files) |tf| {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1558,6 +1558,7 @@ pub const Explorer = struct {
                 path: []const u8,
                 count: u32,
                 first_seen: usize,
+                is_doc: bool,
             };
 
             var tier0_files_by_path = std.StringHashMap(Tier0File).init(allocator);
@@ -1572,6 +1573,7 @@ pub const Explorer = struct {
                         .path = hit_path,
                         .count = 0,
                         .first_seen = ordinal,
+                        .is_doc = isDocLanguage(detectLanguage(hit_path)),
                     };
                 }
                 gop.value_ptr.count +|= 1;
@@ -1588,9 +1590,7 @@ pub const Explorer = struct {
             if (tier0_files.items.len > 1) {
                 std.sort.block(Tier0File, tier0_files.items, {}, struct {
                     pub fn lessThan(_: void, a: Tier0File, b: Tier0File) bool {
-                        const a_doc = isDocLanguage(detectLanguage(a.path));
-                        const b_doc = isDocLanguage(detectLanguage(b.path));
-                        if (a_doc != b_doc) return !a_doc;
+                        if (a.is_doc != b.is_doc) return !a.is_doc;
                         if (a.count != b.count) return a.count > b.count;
                         if (a.first_seen != b.first_seen) return a.first_seen < b.first_seen;
                         return std.mem.lessThan(u8, a.path, b.path);
@@ -1747,11 +1747,10 @@ pub const Explorer = struct {
 
         const t4_start = cio.nanoTimestamp();
         if (result_list.items.len < max_results) {
-            const tier4_hits = self.word_index.search(query);
-            if (tier4_hits.len > 0) {
+            if (word_hits.len > 0) {
                 var word_paths = std.StringHashMap(void).init(allocator);
                 defer word_paths.deinit();
-                for (tier4_hits) |hit| word_paths.put(self.word_index.hitPath(hit), {}) catch {};
+                for (word_hits) |hit| word_paths.put(self.word_index.hitPath(hit), {}) catch {};
                 var wp_iter = word_paths.keyIterator();
                 while (wp_iter.next()) |key_ptr| {
                     if (searched.contains(key_ptr.*)) continue;
@@ -4148,8 +4147,14 @@ fn searchInContent(path: []const u8, content: []const u8, query: []const u8, all
     // overflow panic in Debug, SIGBUS in ReleaseFast.
     if (query.len > content.len) return;
     result_list.ensureTotalCapacity(allocator, result_list.items.len + @min(max_per_file, 16)) catch {};
-    const first_lower: u8 = if (query[0] >= 'A' and query[0] <= 'Z') query[0] + 32 else query[0];
-    const first_upper: u8 = if (query[0] >= 'a' and query[0] <= 'z') query[0] - 32 else query[0];
+    var query_lower_buf: [4096]u8 = undefined;
+    if (query.len > query_lower_buf.len) return;
+    for (query, 0..) |c, i| {
+        query_lower_buf[i] = if (c >= 'A' and c <= 'Z') c + 32 else c;
+    }
+    const query_lower = query_lower_buf[0..query.len];
+    const first_lower: u8 = query_lower[0];
+    const first_upper: u8 = if (first_lower >= 'a' and first_lower <= 'z') first_lower - 32 else first_lower;
     var file_hits: usize = 0;
     var pos: usize = 0;
     const end = content.len - query.len + 1;
@@ -4183,7 +4188,7 @@ fn searchInContent(path: []const u8, content: []const u8, query: []const u8, all
                 const cand = pos + offset;
                 if (cand >= end) break;
 
-                if (matchAtCaseInsensitive(content, cand, query)) {
+                if (matchAtCaseInsensitive(content, cand, query_lower)) {
                     // ── Match found ──
                     while (current_line_start < cand) {
                         if (simdIndexOfNewline(content, current_line_start)) |nl| {
@@ -4218,7 +4223,7 @@ fn searchInContent(path: []const u8, content: []const u8, query: []const u8, all
 
         // ── Scalar tail for last <16 bytes ──
         const c = content[pos];
-        if ((c == first_lower or c == first_upper) and matchAtCaseInsensitive(content, pos, query)) {
+        if ((c == first_lower or c == first_upper) and matchAtCaseInsensitive(content, pos, query_lower)) {
             while (current_line_start < pos) {
                 if (simdIndexOfNewline(content, current_line_start)) |nl| {
                     if (nl < pos) {
@@ -4284,11 +4289,10 @@ fn extractLineByNumber(content: []const u8, target_line: u32) ?[]const u8 {
     return null;
 }
 
-fn matchAtCaseInsensitive(content: []const u8, pos: usize, query: []const u8) bool {
-    if (pos + query.len > content.len) return false;
-    for (0..query.len) |j| {
+fn matchAtCaseInsensitive(content: []const u8, pos: usize, query_lower: []const u8) bool {
+    if (pos + query_lower.len > content.len) return false;
+    for (query_lower, 0..) |nc, j| {
         const hc = if (content[pos + j] >= 'A' and content[pos + j] <= 'Z') content[pos + j] + 32 else content[pos + j];
-        const nc = if (query[j] >= 'A' and query[j] <= 'Z') query[j] + 32 else query[j];
         if (hc != nc) return false;
     }
     return true;
@@ -5248,7 +5252,6 @@ pub fn fuzzyScore(query: []const u8, path: []const u8) ?f32 {
             }
         }
 
-        // Swap rows
         @memcpy(prev_h[0 .. path.len + 1], curr_h[0 .. path.len + 1]);
         @memcpy(prev_gap[0 .. path.len + 1], curr_gap[0 .. path.len + 1]);
     }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -271,13 +271,13 @@ pub fn writeSnapshot(
         const offset = file_writer.logicalPos();
         const index_mod = @import("index.zig");
         const table = index_mod.active_pair_freq;
-        var row_buf: [256 * 2]u8 = undefined;
-        for (table) |row| {
-            for (row, 0..) |val, j| {
-                std.mem.writeInt(u16, row_buf[j * 2 ..][0..2], val, .little);
+        var bulk_buf: [256 * 256 * 2]u8 = undefined;
+        for (table, 0..) |row, a| {
+            for (row, 0..) |val, b| {
+                std.mem.writeInt(u16, bulk_buf[(a * 256 + b) * 2 ..][0..2], val, .little);
             }
-            try fw.writeAll(&row_buf);
         }
+        try fw.writeAll(&bulk_buf);
         const end = file_writer.logicalPos();
         try sections.append(allocator, .{ .id = @intFromEnum(SectionId.freq_table), .offset = offset, .length = end - offset });
     }
@@ -559,20 +559,18 @@ pub fn loadSnapshotValidated(
         if (freq_entry.length == 256 * 256 * 2) {
             const index_mod = @import("index.zig");
             const ft = allocator.create([256][256]u16) catch return file_count > 0;
-            var fp: u64 = freq_entry.offset;
-            var row_buf: [256 * 2]u8 = undefined;
+            var bulk_buf: [256 * 256 * 2]u8 = undefined;
+            const nr = file.readPositionalAll(io, &bulk_buf, freq_entry.offset) catch {
+                allocator.destroy(ft);
+                return file_count > 0;
+            };
+            if (nr != bulk_buf.len) {
+                allocator.destroy(ft);
+                return file_count > 0;
+            }
             for (0..256) |a| {
-                const nr = file.readPositionalAll(io, &row_buf, fp) catch {
-                    allocator.destroy(ft);
-                    return file_count > 0;
-                };
-                if (nr != 512) {
-                    allocator.destroy(ft);
-                    return file_count > 0;
-                }
-                fp += 512;
                 for (0..256) |b| {
-                    ft[a][b] = std.mem.readInt(u16, row_buf[b * 2 ..][0..2], .little);
+                    ft[a][b] = std.mem.readInt(u16, bulk_buf[(a * 256 + b) * 2 ..][0..2], .little);
                 }
             }
             index_mod.setFrequencyTable(ft);
@@ -850,20 +848,18 @@ fn loadSnapshotFast(
             const ft = allocator.create([256][256]u16) catch return file_count > 0;
             const freq_file = std.Io.Dir.cwd().openFile(io, snapshot_path, .{}) catch return file_count > 0;
             defer freq_file.close(io);
-            var fp: u64 = freq_entry.offset;
-            var row_buf: [256 * 2]u8 = undefined;
+            var bulk_buf: [256 * 256 * 2]u8 = undefined;
+            const nr = freq_file.readPositionalAll(io, &bulk_buf, freq_entry.offset) catch {
+                allocator.destroy(ft);
+                return file_count > 0;
+            };
+            if (nr != bulk_buf.len) {
+                allocator.destroy(ft);
+                return file_count > 0;
+            }
             for (0..256) |a| {
-                const nr = freq_file.readPositionalAll(io, &row_buf, fp) catch {
-                    allocator.destroy(ft);
-                    return file_count > 0;
-                };
-                if (nr != 512) {
-                    allocator.destroy(ft);
-                    return file_count > 0;
-                }
-                fp += 512;
                 for (0..256) |b| {
-                    ft[a][b] = std.mem.readInt(u16, row_buf[b * 2 ..][0..2], .little);
+                    ft[a][b] = std.mem.readInt(u16, bulk_buf[(a * 256 + b) * 2 ..][0..2], .little);
                 }
             }
             index_mod.setFrequencyTable(ft);

--- a/src/test_bench.zig
+++ b/src/test_bench.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const explore = @import("explore.zig");
+const cio = @import("cio.zig");
+
+test "bench: fuzzyScore throughput" {
+    const paths = [_][]const u8{
+        "src/components/authentication/LoginForm.tsx",
+        "packages/core/lib/utils/string-helpers.rs",
+        "internal/server/middleware/rate_limiter.go",
+        "src/database/migrations/20240301_add_users.sql",
+        "frontend/src/hooks/useAuth.ts",
+        "very/deeply/nested/project/structure/with/many/levels/file.zig",
+    };
+    const queries = [_][]const u8{
+        "LoginForm",
+        "string",
+        "rate_limiter",
+        "useAuth",
+        "file.zig",
+        "migrat",
+    };
+
+    const iterations: usize = 50_000;
+    const t0 = cio.nanoTimestamp();
+
+    for (0..iterations) |i| {
+        for (queries) |q| {
+            std.mem.doNotOptimizeAway(explore.fuzzyScore(q, paths[i % paths.len]));
+        }
+    }
+
+    const elapsed: u64 = @intCast(cio.nanoTimestamp() - t0);
+    const total_calls = iterations * queries.len;
+    const per_call_ns = elapsed / total_calls;
+    std.debug.print("\n  fuzzyScore: {d} calls in {d}ms ({d}ns/call)\n", .{
+        total_calls,
+        elapsed / std.time.ns_per_ms,
+        per_call_ns,
+    });
+}
+
+test "bench: detectLanguage + isDocLanguage" {
+    const paths = [_][]const u8{
+        "src/main.zig",
+        "lib/utils.rs",
+        "docs/README.md",
+        "config.json",
+        "app.py",
+        "index.tsx",
+        "style.scss",
+        "Makefile",
+        "server.go",
+        "test.cpp",
+    };
+
+    const iterations: usize = 200_000;
+    const t0 = cio.nanoTimestamp();
+    var doc_count: usize = 0;
+
+    for (0..iterations) |i| {
+        const lang = explore.detectLanguage(paths[i % paths.len]);
+        if (explore.isDocLanguage(lang)) doc_count += 1;
+    }
+
+    const elapsed: u64 = @intCast(cio.nanoTimestamp() - t0);
+    std.debug.print("\n  detectLanguage+isDocLanguage: {d} calls in {d}ms ({d}ns/call, {d} docs)\n", .{
+        iterations,
+        elapsed / std.time.ns_per_ms,
+        elapsed / iterations,
+        doc_count,
+    });
+}


### PR DESCRIPTION
## Summary
- **Pre-lowercase query needle** in `searchInContent` — eliminates redundant per-byte case conversion in `matchAtCaseInsensitive` inner loop
- **Reuse Tier 0 word_hits in Tier 4** instead of re-running `word_index.search(query)` (identical call, wasted work)
- **Pre-compute `is_doc` flag** in Tier 0 sort — `detectLanguage` called once per file during collection, not O(n log n) times in sort comparator
- **Bulk freq table I/O** — read/write 128KB frequency table in 1 syscall instead of 256 (both snapshot read paths + write path)
- **Add `test_bench.zig`** with fuzzyScore and detectLanguage microbenchmarks (`zig build test-bench -Doptimize=ReleaseFast`)

All optimizations were verified against the actual code (not theoretical). The fuzzyScore pointer-swap was benchmarked and **disproven** — `@memcpy` is faster in ReleaseFast (362ms vs 670ms) because the compiler optimizes it to SIMD moves.

## Test plan
- [x] `zig build test` — all 8 test binaries pass
- [x] `zig build -Doptimize=ReleaseFast` — clean build
- [x] `zig build test-bench -Doptimize=ReleaseFast` — benchmarks run
- [x] No accuracy regressions (same search results, same snapshot format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)