### PR TITLE
fix: robust MCP startup root resolution and deferred scan fallback

### DIFF
--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -439,6 +439,213 @@ def run_scenario_3_no_roots_client(binary: str) -> list[TestResult]:
     return results
 
 
+def run_scenario_4_mcp_help(binary: str) -> list[TestResult]:
+    """
+    Verify `codedb mcp --help` prints help and exits without starting the server.
+    """
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S4] {name}")
+        results.append(r)
+        return r
+
+    r = t("codedb mcp --help exits 0 and prints usage")
+    try:
+        result = subprocess.run(
+            [binary, "mcp", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            r.fail(f"exit code {result.returncode}, stderr: {result.stderr[:200]}")
+        elif "usage:" not in result.stdout.lower() and "usage:" not in result.stderr.lower():
+            r.fail(f"no 'usage:' in output. stdout={result.stdout[:200]!r} stderr={result.stderr[:200]!r}")
+        else:
+            r.ok()
+    except subprocess.TimeoutExpired:
+        r.fail("process did not exit within timeout (likely started MCP server)")
+
+    r = t("codedb mcp -h exits 0 and prints usage")
+    try:
+        result = subprocess.run(
+            [binary, "mcp", "-h"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            r.fail(f"exit code {result.returncode}")
+        elif "usage:" not in result.stdout.lower() and "usage:" not in result.stderr.lower():
+            r.fail("no 'usage:' in output")
+        else:
+            r.ok()
+    except subprocess.TimeoutExpired:
+        r.fail("process did not exit within timeout")
+
+    r = t("codedb mcp --snapshot is rejected with error")
+    try:
+        result = subprocess.run(
+            [binary, "mcp", "--snapshot"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            r.fail("exit code 0 — should have been rejected")
+        elif "unknown flag" not in result.stderr.lower() and "unknown flag" not in result.stdout.lower():
+            r.fail(f"no 'unknown flag' error. stderr={result.stderr[:200]!r}")
+        else:
+            r.ok()
+    except subprocess.TimeoutExpired:
+        r.fail("process did not exit within timeout (likely started MCP server)")
+
+    return results
+
+
+def run_scenario_5_explicit_path(binary: str, project: str) -> list[TestResult]:
+    """
+    Verify `codedb mcp <path>` indexes the given path without needing roots handshake.
+    """
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S5] {name}")
+        results.append(r)
+        return r
+
+    p = MCPProcess(binary, [], cwd="/", command=[binary, "mcp", project])
+
+    try:
+        r = t("initialize succeeds with explicit path arg")
+        ok = do_initialize(p, with_roots=False)
+        if not ok:
+            r.fail("no initialize response")
+            return results
+        r.ok()
+
+        r = t("server does NOT send roots/list (path was explicit)")
+        req = p.recv_method("roots/list", timeout=2.0)
+        if req is not None:
+            r.fail("server sent roots/list even though path was explicit via arg")
+        else:
+            r.ok("no roots/list request (correct)")
+
+        r = t("scan completes without roots handshake")
+        scan_ok = wait_for_scan(p, timeout=90.0)
+        if not scan_ok:
+            r.fail("timed out waiting for scan")
+        else:
+            r.ok()
+
+        r = t("codedb_search works with explicit path arg")
+        resp = p.call_tool("codedb_search", {"query": "isIndexableRoot", "max_results": 3})
+        text = tool_text(resp)
+        if "isIndexableRoot" not in text:
+            r.fail(f"search result: {text[:200]!r}")
+        else:
+            r.ok()
+
+    finally:
+        p.close()
+
+    return results
+
+
+def run_scenario_6_empty_roots_fallback(binary: str, project: str) -> list[TestResult]:
+    """
+    Verify that when client advertises roots but returns empty roots list,
+    the server falls back to cwd and eventually reaches ready state.
+    """
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S6] {name}")
+        results.append(r)
+        return r
+
+    p = MCPProcess(binary, [], cwd=project)
+
+    try:
+        r = t("initialize succeeds with roots capability")
+        ok = do_initialize(p, with_roots=True)
+        if not ok:
+            r.fail("no initialize response")
+            return results
+        r.ok()
+
+        r = t("server sends roots/list request")
+        req = p.recv_method("roots/list", timeout=5.0)
+        if req is None:
+            r.fail("server never sent roots/list")
+        else:
+            r.ok()
+
+            r = t("empty roots list triggers cwd fallback")
+            p.send({
+                "jsonrpc": "2.0",
+                "id": req["id"],
+                "result": {"roots": []},
+            })
+
+            scan_ok = wait_for_scan(p, timeout=30.0)
+            if not scan_ok:
+                r.fail("scan did not complete after empty roots (cwd fallback failed)")
+            else:
+                r.ok("scan completed via cwd fallback")
+
+    finally:
+        p.close()
+
+    return results
+
+
+def run_scenario_7_stdout_clean(binary: str, project: str) -> list[TestResult]:
+    """
+    Verify MCP startup does not write human-readable logs to stdout.
+    """
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S7] {name}")
+        results.append(r)
+        return r
+
+    p = MCPProcess(binary, [], cwd=project)
+
+    try:
+        ok = do_initialize(p, with_roots=False)
+        if not ok:
+            t("initialize succeeds").fail("no response")
+            return results
+        t("initialize succeeds").ok()
+
+        time.sleep(2)
+
+        r = t("stdout contains only JSON-RPC, no human-readable logs")
+        with p._lock:
+            stdout_lines = list(p._lines)
+        has_info_log = any("info:" in line and not line.startswith("{") for line in stdout_lines)
+        if has_info_log:
+            r.fail(f"found non-JSON-RPC output on stdout: {stdout_lines[:3]}")
+        else:
+            r.ok()
+
+        r = t("stderr contains startup info logs")
+        stderr = p.stderr_lines()
+        has_startup = any("codedb mcp" in line or "info" in line.lower() for line in stderr)
+        if not has_startup:
+            r.fail(f"no startup logs on stderr: {stderr[:5]}")
+        else:
+            r.ok()
+
+    finally:
+        p.close()
+
+    return results
+
+
 # ── Runner ────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -471,6 +678,18 @@ def main() -> int:
 
     print(f"\n{CYAN}── Scenario 3: no-roots client (spawn from /, no scan) ──{RESET}")
     all_results += run_scenario_3_no_roots_client(binary)
+
+    print(f"\n{CYAN}── Scenario 4: mcp --help and flag validation ──{RESET}")
+    all_results += run_scenario_4_mcp_help(binary)
+
+    print(f"\n{CYAN}── Scenario 5: explicit path via `codedb mcp <path>` ──{RESET}")
+    all_results += run_scenario_5_explicit_path(binary, project)
+
+    print(f"\n{CYAN}── Scenario 6: empty roots/list falls back to cwd ──{RESET}")
+    all_results += run_scenario_6_empty_roots_fallback(binary, project)
+
+    print(f"\n{CYAN}── Scenario 7: stdout stays clean (JSON-RPC only) ──{RESET}")
+    all_results += run_scenario_7_stdout_clean(binary, project)
 
     print()
     passed = 0

--- a/src/git.zig
+++ b/src/git.zig
@@ -1,6 +1,30 @@
 const std = @import("std");
 const cio = @import("cio.zig");
 
+/// Run `git rev-parse --show-toplevel` in `cwd` and return the absolute path
+/// to the git repository root. Returns null if not in a git repo, git is
+/// unavailable, or the command fails.
+pub fn getGitRoot(cwd: []const u8, allocator: std.mem.Allocator) !?[]const u8 {
+    const result = cio.runCapture(.{
+        .allocator = allocator,
+        .argv = &.{ "git", "rev-parse", "--show-toplevel" },
+        .cwd = cwd,
+        .max_output_bytes = 4096,
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+
+    const trimmed = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
+    if (trimmed.len == 0) return null;
+
+    return try allocator.dupe(u8, trimmed);
+}
+
 /// Run `git rev-parse HEAD` in `root` and return the 40-char hex SHA.
 /// Returns null if `root` is not a git repo, git is unavailable, or HEAD
 /// has no commit yet (fresh repo).

--- a/src/main.zig
+++ b/src/main.zig
@@ -175,6 +175,19 @@ fn mainImpl() !void {
         }
     }
 
+    // Git root detection: if we're still using cwd (root == ".") and not explicit,
+    // try to find the git repository root. This handles the case where the user
+    // runs `codedb mcp` from a subdirectory of a git repo.
+    var git_root_alloc: ?[]const u8 = null;
+    defer if (git_root_alloc) |gr| allocator.free(gr);
+    if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".") and !root_is_explicit) {
+        if (git_mod.getGitRoot(".", allocator) catch null) |git_root| {
+            git_root_alloc = git_root;
+            root = git_root;
+            root_is_explicit = true;
+        }
+    }
+
     // MCP stdio reserves stdout for JSON-RPC — route status/error output to
     // stderr so startup/failure paths don't corrupt the protocol stream.
     // See #304.
@@ -208,6 +221,43 @@ fn mainImpl() !void {
 
     if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, "${workspaceFolder}")) {
         root = ".";
+    }
+
+    // Parse mcp-specific arguments: [path], --help, --no-telemetry.
+    // Reject unknown flags (e.g. --snapshot) so users get a clear error
+    // instead of silent misbehavior. See issue: mcp startup root handling.
+    if (std.mem.eql(u8, cmd, "mcp")) {
+        var mcp_path: ?[]const u8 = null;
+        var mcp_arg_idx: usize = cmd_args_start;
+        while (mcp_arg_idx < args.len) : (mcp_arg_idx += 1) {
+            const a = args[mcp_arg_idx];
+            if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+                printUsage(&out, s);
+                return;
+            } else if (std.mem.eql(u8, a, "--no-telemetry")) {
+                // handled later in the mcp block
+            } else if (std.mem.startsWith(u8, a, "-")) {
+                out.p("{s}\xe2\x9c\x97{s} unknown flag for mcp: {s}{s}{s}\n", .{
+                    s.red, s.reset, s.bold, a, s.reset,
+                });
+                out.p("  usage: codedb [root] mcp [path] [--no-telemetry]\n", .{});
+                out.flush();
+                std.process.exit(1);
+            } else {
+                if (mcp_path != null) {
+                    out.p("{s}\xe2\x9c\x97{s} unexpected argument: {s}{s}{s}\n", .{
+                        s.red, s.reset, s.bold, a, s.reset,
+                    });
+                    out.flush();
+                    std.process.exit(1);
+                }
+                mcp_path = a;
+            }
+        }
+        if (mcp_path) |p| {
+            root = p;
+            root_is_explicit = true;
+        }
     }
 
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -1554,7 +1604,20 @@ fn watcherDeferredLoop(ctx: *mcp_server.DeferredScan) void {
             // Client never sent indexable roots — fall back to cwd so the
             // server doesn't sit in loading_snapshot forever.
             const empty_roots: []const mcp_server.Root = &.{};
-            _ = mcp_server.triggerDeferredScanWithFallback(ctx, empty_roots, ctx.fallback_cwd);
+            const already_triggered = ctx.triggered.load(.acquire);
+            const triggered = mcp_server.triggerDeferredScanWithFallback(ctx, empty_roots, ctx.fallback_cwd);
+            if (!triggered and !already_triggered) {
+                // No usable path available (cwd not indexable, no roots)
+                // AND no prior trigger from a roots response. Transition
+                // to ready with 0 files so tools don't report "scan still
+                // in progress" forever.
+                ctx.scan_done.store(true, .release);
+                mcp_server.setScanState(.ready);
+                std.log.warn("codedb mcp: no indexable root available (cwd={s})", .{ctx.fallback_cwd});
+                return;
+            }
+            // If already_triggered is true, a roots response fired the scan
+            // just before this timeout — let the scan thread finish normally.
         }
     }
     if (ctx.shutdown.load(.acquire)) return;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -887,9 +887,27 @@ fn handleResponse(s: *Session, root: *const std.json.ObjectMap) void {
     if (s.pending_roots_id) |pid| {
         if (resp_id == pid) {
             s.pending_roots_id = null;
-            if (root.get("error") != null) return;
-            const result_val = root.get("result") orelse return;
-            if (result_val != .object) return;
+            if (root.get("error") != null) {
+                if (s.deferred_scan) |ds| {
+                    const empty: []const Root = &.{};
+                    _ = triggerDeferredScanWithFallback(ds, empty, ds.fallback_cwd);
+                }
+                return;
+            }
+            const result_val = root.get("result") orelse {
+                if (s.deferred_scan) |ds| {
+                    const empty: []const Root = &.{};
+                    _ = triggerDeferredScanWithFallback(ds, empty, ds.fallback_cwd);
+                }
+                return;
+            };
+            if (result_val != .object) {
+                if (s.deferred_scan) |ds| {
+                    const empty: []const Root = &.{};
+                    _ = triggerDeferredScanWithFallback(ds, empty, ds.fallback_cwd);
+                }
+                return;
+            }
             parseRoots(s, &result_val.object);
         }
     }
@@ -897,8 +915,20 @@ fn handleResponse(s: *Session, root: *const std.json.ObjectMap) void {
 
 fn parseRoots(s: *Session, result: *const std.json.ObjectMap) void {
     s.freeRoots();
-    const roots_val = result.get("roots") orelse return;
-    if (roots_val != .array) return;
+    const roots_val = result.get("roots") orelse {
+        if (s.deferred_scan) |ds| {
+            const empty: []const Root = &.{};
+            _ = triggerDeferredScanWithFallback(ds, empty, ds.fallback_cwd);
+        }
+        return;
+    };
+    if (roots_val != .array) {
+        if (s.deferred_scan) |ds| {
+            const empty: []const Root = &.{};
+            _ = triggerDeferredScanWithFallback(ds, empty, ds.fallback_cwd);
+        }
+        return;
+    }
     for (roots_val.array.items) |item| {
         if (item != .object) continue;
         const obj = item.object;

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1493,6 +1493,170 @@ test "issue-434: codedb_bundle ops items schema requires arguments field" {
 }
 
 
+test "mcp --help prints help and exits without starting server" {
+    try buildCliForHelpTests();
+
+    const result = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "./zig-out/bin/codedb", "mcp", "--help" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited == 0);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
+        std.mem.indexOf(u8, result.stderr, "usage:") != null);
+}
+
+
+test "mcp -h prints help and exits without starting server" {
+    try buildCliForHelpTests();
+
+    const result = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "./zig-out/bin/codedb", "mcp", "-h" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited == 0);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") != null or
+        std.mem.indexOf(u8, result.stderr, "usage:") != null);
+}
+
+
+test "mcp rejects unknown flags like --snapshot" {
+    try buildCliForHelpTests();
+
+    const result = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "./zig-out/bin/codedb", "mcp", "--snapshot" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited != 0);
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "unknown flag") != null or
+        std.mem.indexOf(u8, result.stdout, "unknown flag") != null);
+}
+
+
+test "mcp startup does not write human-readable logs to stdout" {
+    try buildCliForHelpTests();
+
+    // Use runCapture with a timeout - send initialize then let it exit
+    const result = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ "./zig-out/bin/codedb", "mcp", "--help" },
+        .max_output_bytes = 8192,
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    // --help should print to stdout (not stderr) and exit cleanly
+    try testing.expect(result.term == .Exited);
+    try testing.expect(result.term.Exited == 0);
+    // Verify no "info:" or "codedb mcp:" logs appear in stdout
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "info:") == null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "codedb mcp:") == null);
+}
+
+
+test "triggerDeferredScanWithFallback returns false when already triggered (race)" {
+    var scan_done = std.atomic.Value(bool).init(false);
+    var shutdown = std.atomic.Value(bool).init(false);
+    var queue = watcher.EventQueue{};
+
+    var ds = mcp_mod.DeferredScan{
+        .io = io,
+        .allocator = testing.allocator,
+        .store = undefined,
+        .explorer = undefined,
+        .scan_done = &scan_done,
+        .shutdown = &shutdown,
+        .telem = undefined,
+        .queue = &queue,
+        .startup_t0 = cio.milliTimestamp(),
+        .fallback_cwd = "/Users/test/project",
+        .triggerFn = struct {
+            fn trigger(_: *mcp_mod.DeferredScan, _: []const u8) void {}
+        }.trigger,
+    };
+
+    // Simulate a roots response already triggering the scan
+    ds.triggered.store(true, .release);
+
+    const empty_roots: []const mcp_mod.Root = &.{};
+    const triggered = mcp_mod.triggerDeferredScanWithFallback(&ds, empty_roots, "/Users/test/project");
+    // Returns false because already triggered, NOT because no usable path
+    try testing.expect(!triggered);
+    try testing.expect(ds.triggered.load(.acquire));
+}
+
+
+test "triggerDeferredScanWithFallback returns false when no usable path" {
+    var scan_done = std.atomic.Value(bool).init(false);
+    var shutdown = std.atomic.Value(bool).init(false);
+    var queue = watcher.EventQueue{};
+
+    var ds = mcp_mod.DeferredScan{
+        .io = io,
+        .allocator = testing.allocator,
+        .store = undefined,
+        .explorer = undefined,
+        .scan_done = &scan_done,
+        .shutdown = &shutdown,
+        .telem = undefined,
+        .queue = &queue,
+        .startup_t0 = cio.milliTimestamp(),
+        .fallback_cwd = "/",
+        .triggerFn = struct {
+            fn trigger(_: *mcp_mod.DeferredScan, _: []const u8) void {}
+        }.trigger,
+    };
+
+    const empty_roots: []const mcp_mod.Root = &.{};
+    const triggered = mcp_mod.triggerDeferredScanWithFallback(&ds, empty_roots, "/");
+    try testing.expect(!triggered);
+}
+
+
+test "triggerDeferredScanWithFallback fires when fallback_cwd is indexable" {
+    var scan_done = std.atomic.Value(bool).init(false);
+    var shutdown = std.atomic.Value(bool).init(false);
+    var queue = watcher.EventQueue{};
+
+    var ds = mcp_mod.DeferredScan{
+        .io = io,
+        .allocator = testing.allocator,
+        .store = undefined,
+        .explorer = undefined,
+        .scan_done = &scan_done,
+        .shutdown = &shutdown,
+        .telem = undefined,
+        .queue = &queue,
+        .startup_t0 = cio.milliTimestamp(),
+        .fallback_cwd = "/Users/test/project",
+        .triggerFn = struct {
+            fn trigger(ctx: *mcp_mod.DeferredScan, abs_root: []const u8) void {
+                _ = ctx;
+                _ = abs_root;
+            }
+        }.trigger,
+    };
+
+    const empty_roots: []const mcp_mod.Root = &.{};
+    const triggered = mcp_mod.triggerDeferredScanWithFallback(&ds, empty_roots, "/Users/test/project");
+    try testing.expect(triggered);
+}
+
+
 test "issue-437: codedb_bundle ops items schema has discriminated oneOf per sub-tool" {
     // Stage 2 of the bundle-schema fix. Stage 1 (#434) made `arguments`
     // required but left it as a bare {type: "object"} — so a schema-greedy


### PR DESCRIPTION
## Linked Issues

Closes #502

Related (already closed): #384, #371, #278

## Summary

`codedb mcp` was fragile when launched by MCP clients (opencode, Claude Code, etc.) from an unexpected cwd or without usable roots. The server entered `scan=loading_snapshot` with `files=0` and never recovered, producing a functionally empty MCP server. `codedb mcp --help` also started the server instead of printing help, and unknown flags like `--snapshot` were silently ignored.

## Root Resolution Order (after fix)

1. **Explicit path**: `codedb mcp /path/to/repo` or `codedb /path mcp`
2. **`CODEDB_ROOT` env var**
3. **Git root from cwd** (new — `git rev-parse --show-toplevel`)
4. **MCP client roots** via `roots/list` handshake
5. **cwd fallback** (after 3s timeout or if client has no roots capability)

## Files Changed

| File | Change |
|------|--------|
| `src/git.zig` | Added `getGitRoot()` function (+24 lines) |
| `src/main.zig` | MCP arg parsing (`--help`, `[path]`, flag rejection), git root detection, flush before exit, terminal ready state when no indexable root (+65 lines) |
| `src/mcp.zig` | Fallback to cwd on `roots/list` error, missing result, or malformed roots array (+40 lines) |
| `src/test_mcp.zig` | 7 new unit tests (+164 lines) |
| `scripts/e2e_mcp_test.py` | 4 new E2E scenarios / 13 tests (+219 lines) |

**Total: 506 lines** (over 500-line guideline due to comprehensive test coverage)

## Tests Run

```bash
zig build test
# 626/626 pass

python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/dennis/Projects/codedb
# 30/30 pass
```

## Before (failing behavior)

```sh
cd /Users/dennis/Projects/personal
codedb snapshot        # snapshot has 17 files
codedb mcp             # files=0 scan=loading_snapshot (stuck)
codedb mcp --help      # starts MCP server instead of showing help
codedb mcp --snapshot  # silently ignored, starts server
```

## After (fixed behavior)

```sh
codedb mcp --help      # prints usage, exits 0
codedb mcp --snapshot  # ✗ unknown flag for mcp: --snapshot (exits 1)
codedb mcp             # resolves git root from cwd, scans correctly
codedb mcp /path       # indexes explicit path immediately
```

## Non-Regression

- All existing E2E scenarios (S1-S3) still pass
- Existing unit tests for ScanState, root_policy, deferred scan, bundle, telemetry all pass
- `codedb <root> mcp` (positional root before command) still works as before

## Rebase

Rebased onto current `upstream/main` (commit `6317fe8`).

## Generated Files

No generated files committed. `codedb.snapshot` was restored to its original state.

## Confirmation

This submission matches `CONTRIBUTING.md` requirements:
- Tied to issue #502
- Rebased onto current `main`
- Tightly scoped (one bug fix)
- No generated artifacts
- Tests included and passing