### PR TITLE
fix(mcp): accept inline args for direct tool calls

### DIFF
--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -9,6 +9,8 @@ Scenarios covered:
      and tools return data without needing a roots handshake.
   3. No-roots client: spawn from cwd=/, client declares no roots capability, MCP
      stays alive and tools respond gracefully (0 files, no crash).
+  4. issue-512 regression: direct tools/call accepts inline params when
+     arguments is empty, matching codedb_bundle's compatibility fallback.
 
 Usage:
   python3 scripts/e2e_mcp_test.py [--binary /path/to/codedb] [--project /path/to/project]
@@ -129,12 +131,16 @@ class MCPProcess:
 
     def call_tool(self, name: str, args: dict[str, Any], timeout: float = 30.0) -> dict[str, Any] | None:
         """Send a tools/call request and return the response."""
+        return self.call_tool_params({"name": name, "arguments": args}, timeout=timeout)
+
+    def call_tool_params(self, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any] | None:
+        """Send a tools/call request with raw params and return the response."""
         req_id = self.next_id()
         self.send({
             "jsonrpc": "2.0",
             "id": req_id,
             "method": "tools/call",
-            "params": {"name": name, "arguments": args},
+            "params": params,
         })
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -439,6 +445,57 @@ def run_scenario_3_no_roots_client(binary: str) -> list[TestResult]:
     return results
 
 
+def run_scenario_4_issue512_direct_inline_args(binary: str, project: str) -> list[TestResult]:
+    """
+    issue-512: direct tools/call must recover when a client sends arguments: {}
+    but places real tool fields inline in params.
+    """
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S4] {name}")
+        results.append(r)
+        return r
+
+    p = MCPProcess(binary, [], cwd="/", command=[binary, project, "mcp"])
+
+    try:
+        r = t("initialize succeeds")
+        ok = do_initialize(p, with_roots=False)
+        if not ok:
+            r.fail("no initialize response")
+            return results
+        r.ok()
+
+        r = t("scan completes before inline-arg backtest")
+        scan_ok = wait_for_scan(p, timeout=90.0)
+        if not scan_ok:
+            r.fail("timed out waiting for scan")
+            return results
+        r.ok()
+
+        r = t("direct tools/call accepts inline path with empty arguments")
+        resp = p.call_tool_params({
+            "name": "codedb_outline",
+            "arguments": {},
+            "path": "src/mcp.zig",
+        })
+        text = tool_text(resp)
+        if resp is None:
+            r.fail("no response to inline-arg tools/call")
+        elif "missing 'path'" in text or "received keys: []" in text:
+            r.fail(f"inline path was dropped: {text[:220]!r}")
+        elif "src/mcp.zig" not in text and "handleCall" not in text:
+            r.fail(f"outline response missing expected file/symbol: {text[:220]!r}")
+        else:
+            r.ok()
+
+    finally:
+        p.close()
+
+    return results
+
+
 # ── Runner ────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -471,6 +528,9 @@ def main() -> int:
 
     print(f"\n{CYAN}── Scenario 3: no-roots client (spawn from /, no scan) ──{RESET}")
     all_results += run_scenario_3_no_roots_client(binary)
+
+    print(f"\n{CYAN}── Scenario 4: issue-512 direct inline args ──{RESET}")
+    all_results += run_scenario_4_issue512_direct_inline_args(binary, project)
 
     print()
     passed = 0

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1111,12 +1111,17 @@ fn handleCall(
         if (!is_notification) writeError(alloc, stdout, id, -32602, "Missing tool name");
         return;
     };
-    var args_value = params.get("arguments") orelse std.json.Value{ .object = .empty };
-    if (args_value != .object) {
-        if (!is_notification) writeError(alloc, stdout, id, -32602, "arguments must be object");
+    var args_value: std.json.Value = .{ .object = .empty };
+    var inline_args: std.json.ObjectMap = .empty;
+    defer inline_args.deinit(alloc);
+    const args = selectDirectCallArgs(alloc, params, &args_value, &inline_args) catch |err| {
+        if (!is_notification) writeError(alloc, stdout, id, -32602, switch (err) {
+            error.ArgumentsMustBeObject => "arguments must be object",
+            error.ArgsMustBeObject => "args must be object",
+            error.OutOfMemory => "out of memory",
+        });
         return;
-    }
-    const args = &args_value.object;
+    };
 
     const tool = std.meta.stringToEnum(Tool, name) orelse {
         if (!is_notification) writeError(alloc, stdout, id, -32602, "Unknown tool");
@@ -1203,6 +1208,57 @@ fn handleCall(
 
     result.appendSlice(alloc, if (is_error) "],\"isError\":true}" else "],\"isError\":false}") catch return;
     writeResult(alloc, stdout, id, result.items);
+}
+
+fn isDirectCallAdminKey(key: []const u8) bool {
+    return std.mem.eql(u8, key, "name") or
+        std.mem.eql(u8, key, "arguments") or
+        std.mem.eql(u8, key, "args") or
+        std.mem.eql(u8, key, "_meta") or
+        std.mem.eql(u8, key, "task");
+}
+
+fn copyDirectInlineArgs(
+    alloc: std.mem.Allocator,
+    params: *const std.json.ObjectMap,
+    inline_args: *std.json.ObjectMap,
+) !bool {
+    var copied = false;
+    var it = params.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (isDirectCallAdminKey(key)) continue;
+        try inline_args.put(alloc, key, entry.value_ptr.*);
+        copied = true;
+    }
+    return copied;
+}
+
+fn selectDirectCallArgs(
+    alloc: std.mem.Allocator,
+    params: *const std.json.ObjectMap,
+    args_value: *std.json.Value,
+    inline_args: *std.json.ObjectMap,
+) (error{ ArgumentsMustBeObject, ArgsMustBeObject } || std.mem.Allocator.Error)!*const std.json.ObjectMap {
+    if (params.get("arguments")) |arguments_val| {
+        if (arguments_val != .object) return error.ArgumentsMustBeObject;
+        if (arguments_val.object.count() > 0) {
+            args_value.* = arguments_val;
+            return &args_value.object;
+        }
+        if (try copyDirectInlineArgs(alloc, params, inline_args)) return inline_args;
+    } else {
+        if (try copyDirectInlineArgs(alloc, params, inline_args)) return inline_args;
+    }
+
+    if (params.get("args")) |args_val| {
+        if (args_val != .object) return error.ArgsMustBeObject;
+        args_value.* = args_val;
+        return &args_value.object;
+    }
+
+    args_value.* = .{ .object = .empty };
+    return &args_value.object;
 }
 
 fn dispatch(
@@ -2668,21 +2724,20 @@ fn appendBundleArgKeysDiagnostic(
         out.appendSlice(alloc, entry.key_ptr.*) catch return;
     }
     out.appendSlice(alloc, "]") catch return;
-    // Issue #424: if the args we saw contain ONLY administrative keys
-    // (`tool`, `arguments`) — or are empty entirely — there were no real
-    // sub-op fields at all. That's almost always a client wrapper bug.
-    // Suggest the inline shape so the caller can route around it.
+    // Issue #424/#512: if the args we saw contain only administrative keys
+    // or are empty entirely, there were no real tool fields at all. That's
+    // almost always a client wrapper bug.
     var has_real_arg = false;
     var it2 = args.iterator();
     while (it2.next()) |entry| {
         const k = entry.key_ptr.*;
-        if (!std.mem.eql(u8, k, "tool") and !std.mem.eql(u8, k, "arguments")) {
+        if (!std.mem.eql(u8, k, "tool") and !isDirectCallAdminKey(k)) {
             has_real_arg = true;
             break;
         }
     }
     if (!has_real_arg) {
-        out.appendSlice(alloc, "\nhint: no sub-op args reached the handler — your client may be stripping fields. Try inline shape: {\"tool\":\"...\",\"path\":\"...\"} (no `arguments` wrapper)") catch return;
+        out.appendSlice(alloc, "\nhint: no tool args reached the handler — your client may be stripping fields. Direct tools/call expects {\"name\":\"...\",\"arguments\":{\"path\":\"...\"}}; bundled ops may use inline shape: {\"tool\":\"...\",\"path\":\"...\"}.") catch return;
     }
 }
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -493,6 +493,21 @@ pub const BenchContext = struct {
         dispatch(io, alloc, tool, args, out, store, explorer, agents, &self.cache, null);
     }
 
+    pub fn runHandleCall(
+        self: *BenchContext,
+        io: std.Io,
+        alloc: std.mem.Allocator,
+        root: *const std.json.ObjectMap,
+        stdout: cio.File,
+        id: ?std.json.Value,
+        store: *Store,
+        explorer: *Explorer,
+        agents: *AgentRegistry,
+        telem: *telemetry_mod.Telemetry,
+    ) void {
+        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null);
+    }
+
     pub fn runToolCall(
         self: *BenchContext,
         io: std.Io,
@@ -4569,6 +4584,7 @@ pub fn mcpGenerateGuidance(
         buf.appendSlice(alloc, MCP_DIM ++ MCP_ARROW ++ "next: codedb_outline on a hot file to see recent changes" ++ MCP_RESET) catch {};
     }
 }
+
 test "issue-258: cached project reads use the project root after contents are released" {
     const io = testing.io;
     var tmp = testing.tmpDir(.{});

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1250,6 +1250,53 @@ test "issue-424-B: bundle falls through to inline args when arguments is empty o
 }
 
 
+test "issue-512: direct tools call accepts inline args when arguments is empty" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+    var telem = telemetry_mod.Telemetry.init(io, ".", testing.allocator, true);
+    defer telem.deinit();
+
+    const call_json =
+        \\{"params":{"name":"codedb_outline","arguments":{},"path":"src/main.zig"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, call_json, .{});
+    defer parsed.deinit();
+
+    const pipe = try cio.makePipe();
+    defer _ = std.c.close(pipe[0]);
+    defer _ = std.c.close(pipe[1]);
+
+    bench_ctx.runHandleCall(
+        io,
+        testing.allocator,
+        &parsed.value.object,
+        .{ .handle = pipe[1] },
+        std.json.Value{ .integer = 1 },
+        &store,
+        &explorer,
+        &agents,
+        &telem,
+    );
+
+    var response_buf: [16 * 1024]u8 = undefined;
+    const n = try std.posix.read(pipe[0], &response_buf);
+    const response = response_buf[0..n];
+
+    try testing.expect(std.mem.indexOf(u8, response, "src/main.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, response, "missing 'path'") == null);
+}
+
+
 test "issue-424-D: received-keys diagnostic hints at inline-args workaround when empty" {
     // When a sub-op fails with truly-empty args, the diagnostic should
     // point users at the inline-args fallback so a broken client wrapper

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10430,6 +10430,52 @@ test "issue-424-B: bundle falls through to inline args when arguments is empty o
     try testing.expect(std.mem.indexOf(u8, out.items, "received keys: []") == null);
 }
 
+test "issue-512: direct tools call accepts inline args when arguments is empty" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+    var telem = telemetry_mod.Telemetry.init(io, ".", testing.allocator, true);
+    defer telem.deinit();
+
+    const call_json =
+        \\{"params":{"name":"codedb_outline","arguments":{},"path":"src/main.zig"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, call_json, .{});
+    defer parsed.deinit();
+
+    const pipe = try cio.makePipe();
+    defer _ = std.c.close(pipe[0]);
+    defer _ = std.c.close(pipe[1]);
+
+    bench_ctx.runHandleCall(
+        io,
+        testing.allocator,
+        &parsed.value.object,
+        .{ .handle = pipe[1] },
+        std.json.Value{ .integer = 1 },
+        &store,
+        &explorer,
+        &agents,
+        &telem,
+    );
+
+    var response_buf: [16 * 1024]u8 = undefined;
+    const n = try std.posix.read(pipe[0], &response_buf);
+    const response = response_buf[0..n];
+
+    try testing.expect(std.mem.indexOf(u8, response, "src/main.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, response, "missing 'path'") == null);
+}
+
 test "issue-424-D: received-keys diagnostic hints at inline-args workaround when empty" {
     // When a sub-op fails with truly-empty args, the diagnostic should
     // point users at the inline-args fallback so a broken client wrapper


### PR DESCRIPTION
## Summary

- Closes #512.
- Adds a direct `tools/call` regression test for `arguments: {}` with inline `path`.
- Normalizes direct call args so non-empty `params.arguments` remains canonical, while empty/missing `arguments` can fall back to inline fields or an `args` compatibility object.
- Updates the empty-args diagnostic so direct calls no longer get a misleading sub-op hint.

## Verification

- `zig build test -Dtest-filter=issue-512`
- `zig build test`
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/codedb-fix-mcp-inline-args`