### PR TITLE
Release 0.2.5823

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -91,14 +91,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          codesign_arg=()
           if [[ "${{ runner.os }}" == "macOS" ]] &&
              [[ "${{ matrix.zig_target }}" != "x86_64-macos" ]] &&
              [[ -n "${CODEDB_CODESIGN_IDENTITY:-}" ]] &&
              grep -q 'codesign-identity' build.zig; then
-            codesign_arg=(-Dcodesign-identity="$CODEDB_CODESIGN_IDENTITY")
+            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} -Dcodesign-identity="$CODEDB_CODESIGN_IDENTITY"
+          else
+            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
           fi
-          zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} "${codesign_arg[@]}"
           cp zig-out/bin/codedb "${{ matrix.asset_name }}"
 
       - name: Upload build artifact

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,6 +39,11 @@ jobs:
             asset_name: codedb-linux-x86_64
             zig_archive: zig-x86_64-linux-0.16.0.tar.xz
             zig_dir: zig-x86_64-linux-0.16.0
+          - runner: ubuntu-24.04
+            zig_target: aarch64-linux
+            asset_name: codedb-linux-arm64
+            zig_archive: zig-x86_64-linux-0.16.0.tar.xz
+            zig_dir: zig-x86_64-linux-0.16.0
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
       APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,62 @@
 # Changelog
 
 
+## 0.2.5823 - 2026-05-29
+
+`0.2.5823` is an MCP compatibility hotfix for direct `tools/call` requests.
+It ships the issue #512 fix and adds a wire-level stdio backtest so future
+releases catch this exact client-wrapper failure mode.
+
+### MCP direct tool-call compatibility
+
+- **#512 — direct calls no longer drop inline args when `arguments` is empty.**
+  Some clients send canonical MCP `params.name` and `params.arguments`, but a
+  wrapper layer may also emit `arguments: {}` while placing the real fields
+  inline on `params`, for example `{"name":"codedb_outline","arguments":{},
+  "path":"src/mcp.zig"}`. Direct `tools/call` previously treated the empty
+  `arguments` object as authoritative, dispatched `codedb_outline` with no
+  `path`, and returned `missing 'path'` / `received keys: []` even though the
+  request contained a path.
+- **Canonical MCP behavior is preserved.** Non-empty `params.arguments` remains
+  authoritative. When `arguments` is empty or absent, direct calls now copy
+  non-administrative inline fields into a clean argument map before dispatch.
+  A legacy `params.args` object is accepted only as a compatibility fallback
+  when canonical args are absent or empty. Malformed non-object `arguments`
+  still returns the protocol error `arguments must be object`.
+- **Diagnostics now match direct calls.** Missing-arg guidance no longer says
+  "sub-op" for direct `tools/call`; it explains the canonical direct shape and
+  separately mentions the bundled inline fallback.
+
+### Backtesting
+
+- Added `test "issue-512: direct tools call accepts inline args when arguments
+  is empty"` to exercise the direct call handler.
+- Extended `scripts/e2e_mcp_test.py` with Scenario 4, which sends the malformed
+  direct stdio MCP request through the real server process. The fixed binary
+  passes **20/20** E2E checks; the pre-fix binary fails Scenario 4 with the old
+  `missing 'path'` / `received keys: []` response.
+- A subagent also validated the change with codedb MCP available. Its MCP
+  snapshot was stale, so it used codedb MCP to inspect what was available and
+  then confirmed the current disk state plus the focused and stdio E2E tests.
+
+### Release metadata
+
+- `src/release_info.zig`, `build.zig.zon`, and `npm/package.json` are aligned
+  on `0.2.5823`.
+
+### Validation
+
+- `zig build test -Dtest-filter=issue-512`
+- `zig build test`
+- `zig build`
+- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/codedb-release-0.2.5823`
+  — **20/20 passed**
+- GitHub PR bench-regression for #513: **success**
+
+See [`benchmarks/v0.2.5823-validation.md`](benchmarks/v0.2.5823-validation.md)
+for the release validation notes.
+
+
 ## 0.2.5822 - 2026-05-29
 
 `0.2.5822` is a hot-path performance and release-reliability follow-up to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ releases catch this exact client-wrapper failure mode.
 - `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/codedb-release-0.2.5823`
   — **20/20 passed**
 - GitHub PR bench-regression for #513: **success**
+- Release asset workflow now builds the expected Linux ARM64 asset in addition
+  to macOS ARM64, macOS x86_64, and Linux x86_64.
 
 See [`benchmarks/v0.2.5823-validation.md`](benchmarks/v0.2.5823-validation.md)
 for the release validation notes.

--- a/benchmarks/v0.2.5823-validation.md
+++ b/benchmarks/v0.2.5823-validation.md
@@ -1,0 +1,74 @@
+# codedb v0.2.5823 validation
+
+**Date:** 2026-05-29
+**Branch:** `release/0.2.5823`
+**Version:** `codedb 0.2.5823`
+
+This file records the release validation for the issue #512 direct
+`tools/call` compatibility hotfix.
+
+## Fix Scope
+
+`0.2.5823` includes the merged PR #513 changes:
+
+- `src/mcp.zig` now normalizes direct `tools/call` params before dispatch.
+  Non-empty `params.arguments` remains canonical. If `arguments` is empty or
+  absent, inline non-administrative params are copied into a clean argument map.
+  `params.args` is accepted only as a fallback when canonical args are absent
+  or empty.
+- `src/test_mcp.zig` and `src/tests.zig` include the issue #512 direct handler
+  regression test.
+- `scripts/e2e_mcp_test.py` includes Scenario 4, which sends a malformed direct
+  stdio MCP request with `arguments: {}` and inline `path`.
+
+## Backtest
+
+The new stdio E2E Scenario 4 was run against both fixed and pre-fix binaries.
+
+| Binary | Result |
+| --- | --- |
+| Fixed `release/0.2.5823` build | E2E **20/20 passed** |
+| Pre-fix `e5e25b9` build | E2E **19/20 passed**; Scenario 4 failed with `missing 'path' argument`, `received keys: []`, and the old `no sub-op args reached the handler` hint |
+
+This proves the added E2E scenario catches the old bug and passes after the
+fix.
+
+## codedb MCP Subagent Check
+
+A validation subagent was asked to use codedb MCP first against
+`/Users/blackfloofie/codedb-fix-mcp-inline-args`.
+
+Results:
+
+- `codedb_status` worked and reported a ready index.
+- `codedb_tree` and some `codedb_outline` calls worked, but the project
+  snapshot was stale.
+- `codedb_search issue-512` and related searches did not find the new release
+  code because of the stale snapshot.
+- The subagent did not run `codedb_index` because the task was read-only.
+- It then confirmed the current disk state and ran the focused and stdio E2E
+  checks successfully.
+
+## Commands
+
+```bash
+zig build test -Dtest-filter=issue-512
+zig build test
+zig build
+python3 scripts/e2e_mcp_test.py \
+  --binary zig-out/bin/codedb \
+  --project /Users/blackfloofie/codedb-release-0.2.5823
+```
+
+Expected E2E result:
+
+```text
+Results: 20/20 passed
+All tests passed.
+```
+
+## PR / CI
+
+- PR #513 merged to `main`.
+- Issue #512 closed.
+- GitHub `bench-regression` check passed for PR #513.

--- a/benchmarks/v0.2.5823-validation.md
+++ b/benchmarks/v0.2.5823-validation.md
@@ -72,3 +72,6 @@ All tests passed.
 - PR #513 merged to `main`.
 - Issue #512 closed.
 - GitHub `bench-regression` check passed for PR #513.
+- The release asset workflow includes all installer/npm platforms:
+  `codedb-darwin-arm64`, `codedb-darwin-x86_64`, `codedb-linux-x86_64`, and
+  `codedb-linux-arm64`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5822",
+    .version = "0.2.5823",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .mcp_zig = .{

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5822",
+  "version": "0.2.5823",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5822";
+pub const semver = "0.2.5823";


### PR DESCRIPTION
## Summary
- Bump codedb to 0.2.5823 across release metadata and npm package metadata.
- Document the issue #512 MCP inline tools/call compatibility fix and validation results.
- Add Linux ARM64 release asset publishing and fix the release workflow's empty bash array behavior under `set -u`.

## Validation
- `zig build test -Dtest-filter=issue-512`
- `zig build test`
- `zig build`
- `./zig-out/bin/codedb --version` -> `codedb 0.2.5823`
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/codedb-release-0.2.5823` -> `20/20`
- GitHub release workflow `release-binaries` run 26624318253 passed
- Release assets published for darwin/linux x86_64/arm64 with checksum manifest

## Deployment note
- GitHub release `v0.2.5823` is published.
- npm publish is still pending registry authentication; local dry-run passed for `codedeebee@0.2.5823`.
