### PR TITLE
Fix updater handling for superseded release train typo

### DIFF
--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -272,6 +272,15 @@ test "update: compareVersions orders semantic versions" {
     try testing.expect(try update_mod.compareVersions("0.2.56", "0.2.56.0") == .eq);
 }
 
+test "update: compareVersionsForUpdate allows superseded release train typo" {
+    try testing.expect(try update_mod.compareVersions("0.2.58181", "0.2.5823") == .gt);
+    try testing.expect(try update_mod.compareVersionsForUpdate("0.2.58181", "0.2.5823") == .lt);
+    try testing.expect(try update_mod.compareVersionsForUpdate("v0.2.58181", "v0.2.5823") == .lt);
+    try testing.expect(try update_mod.compareVersionsForUpdate("0.2.58181", "0.2.5824") == .lt);
+    try testing.expect(try update_mod.compareVersionsForUpdate("0.2.58181", "0.2.5822") == .gt);
+    try testing.expect(!try update_mod.targetSupersedesCurrent("0.2.5823", "0.2.5824"));
+}
+
 
 test "update: checksumForBinary parses release manifest" {
     const manifest =

--- a/src/update.zig
+++ b/src/update.zig
@@ -30,6 +30,18 @@ const ResolvedVersion = struct {
     source: VersionSource,
 };
 
+const SupersededRelease = struct {
+    current: []const u8,
+    minimum_target: []const u8,
+};
+
+const superseded_releases = [_]SupersededRelease{
+    // v0.2.58181 was an accidental release-train typo. Pure SemVer ordering
+    // treats its patch component as newer than v0.2.5823, but operationally it
+    // belongs before v0.2.5823 and should update forward normally.
+    .{ .current = "0.2.58181", .minimum_target = "0.2.5823" },
+};
+
 pub fn run(io: std.Io, stdout: cio.File, s: sty.Style, allocator: std.mem.Allocator) void {
     const out = Out{ .file = stdout, .alloc = allocator };
 
@@ -39,7 +51,7 @@ pub fn run(io: std.Io, stdout: cio.File, s: sty.Style, allocator: std.mem.Alloca
     };
     defer allocator.free(resolved.value);
 
-    const version_order = compareVersions(release_info.semver, resolved.value) catch |err| {
+    const version_order = compareVersionsForUpdate(release_info.semver, resolved.value) catch |err| {
         out.p("{s}✗{s} invalid release version: {s}\n", .{ s.red, s.reset, @errorName(err) });
         std.process.exit(1);
     };
@@ -126,6 +138,21 @@ pub fn compareVersions(current: []const u8, target: []const u8) !std.math.Order 
         if (current_num < target_num) return .lt;
         if (current_num > target_num) return .gt;
     }
+}
+
+pub fn compareVersionsForUpdate(current: []const u8, target: []const u8) !std.math.Order {
+    const order = try compareVersions(current, target);
+    if (order == .gt and try targetSupersedesCurrent(current, target)) return .lt;
+    return order;
+}
+
+pub fn targetSupersedesCurrent(current: []const u8, target: []const u8) !bool {
+    const normalized_current = trimVersionPrefix(current);
+    for (superseded_releases) |release| {
+        if (!std.mem.eql(u8, normalized_current, release.current)) continue;
+        return (try compareVersions(target, release.minimum_target)) != .lt;
+    }
+    return false;
 }
 
 pub fn checksumForBinary(manifest: []const u8, binary_name: []const u8) ?[]const u8 {


### PR DESCRIPTION
## Summary
- Keep normal semantic version comparison intact for regular releases.
- Add an updater-specific supersession path so known bad release numbers, starting with `0.2.58181`, can update to `0.2.5823` or newer instead of being treated as newer forever.
- Add a focused regression test proving pure SemVer still says `0.2.58181 > 0.2.5823`, while updater ordering allows the intended forward upgrade.

## Validation
- `zig build test -Dtest-filter=compareVersionsForUpdate`
- `zig build test`
- `zig build`
- `./zig-out/bin/codedb --version`
- local installed `/opt/homebrew/bin/codedb --version` -> `codedb 0.2.5823`
- local installed `/Users/blackfloofie/bin/codedb --version` -> `codedb 0.2.5823`
- `codedb update` -> already up to date
