### PR TITLE
perf: cut cold-index RSS 4.3GB→1GB and wall-time ~6.5×

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5823",
+    .version = "0.2.5824",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .mcp_zig = .{

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -774,7 +774,7 @@ pub const Explorer = struct {
         }
 
         try self.rebuildDepsFor(stable_path, &persistent_outline);
-        self.rebuildSymbolIndexFor(stable_path, &persistent_outline);
+        self.rebuildSymbolIndexFor(stable_path, &persistent_outline, !is_new);
 
         outline_gop.value_ptr.* = persistent_outline;
         if (prior_outline) |*old_outline| old_outline.deinit();
@@ -1577,7 +1577,7 @@ pub const Explorer = struct {
         }
     }
 
-    fn cloneOutline(src: *const FileOutline, allocator: std.mem.Allocator) !FileOutline {
+    pub fn cloneOutline(src: *const FileOutline, allocator: std.mem.Allocator) !FileOutline {
         const copied_path = try allocator.dupe(u8, src.path);
         // No errdefer here: dst.deinit() below handles freeing copied_path via owns_path.
 
@@ -4075,8 +4075,12 @@ pub const Explorer = struct {
         try self.dep_graph.setDeps(path, deps);
     }
 
-    fn rebuildSymbolIndexFor(self: *Explorer, path: []const u8, outline: *FileOutline) void {
-        self.removeSymbolIndexFor(path);
+    fn rebuildSymbolIndexFor(self: *Explorer, path: []const u8, outline: *FileOutline, had_prior: bool) void {
+        // removeSymbolIndexFor scans the entire global symbol index, so calling
+        // it per file makes a cold scan O(files * total_symbols). A brand-new
+        // path has no prior entries to evict, so skip the scan entirely — only
+        // re-indexed (already-present) files need the removal.
+        if (had_prior) self.removeSymbolIndexFor(path);
         for (outline.symbols.items) |sym| {
             const gop = self.symbol_index.getOrPut(sym.name) catch continue;
             if (!gop.found_existing) {

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -460,11 +460,30 @@ fn parseInitialScanEntry(io: std.Io, root: []const u8, entry: InitialScanEntry, 
 }
 
 fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8, entries: []const InitialScanEntry) void {
-    const arena_alloc = results.arena.allocator();
+    const persist = results.arena.allocator();
+    // Parse each file in a per-file scratch arena that is reset between files,
+    // then copy only the keep-data (content + outline) into the persistent
+    // results arena. parseContentForIndexing allocates large transient parse
+    // state (AST/token buffers) that is not part of the returned content/outline;
+    // without resetting per file, a worker's arena retains every file's
+    // transients chunk-wide (high-water-mark, never reclaimed), which dominated
+    // initial-scan RSS on large repos (~4.3GB -> contents+outline only).
+    // The results arena (and thus the clone) is touched by this worker only, so
+    // the copy is race-free; commit on the main thread re-dups both anyway.
+    var scratch = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer scratch.deinit();
     for (entries) |entry| {
-        const parsed = parseInitialScanEntry(io, root, entry, arena_alloc) catch null;
+        _ = scratch.reset(.retain_capacity);
+        const parsed = parseInitialScanEntry(io, root, entry, scratch.allocator()) catch null;
         if (parsed) |file| {
-            results.items.append(arena_alloc, file) catch return;
+            const content_copy = persist.dupe(u8, file.content) catch continue;
+            const outline_copy = explore_mod.Explorer.cloneOutline(&file.outline, persist) catch continue;
+            results.items.append(persist, .{
+                .path = file.path,
+                .content = content_copy,
+                .outline = outline_copy,
+                .skip_trigram = file.skip_trigram,
+            }) catch continue;
         }
     }
 }


### PR DESCRIPTION
## Summary

Two independent fixes to the initial scan/index path. Measured on a ~16k-file repo with a cold `codedb index`:

| | RSS peak | wall-clock |
|---|---|---|
| before | **4.34 GB** | ~24 s |
| after | **1.01 GB** | **3.7 s** |

−77% memory, ~6.5× faster — no functional change.

## 1. Memory — per-file scratch arena (`src/watcher.zig`)

Each parse worker held **one long-lived `page_allocator` arena for its entire chunk**. `parseContentForIndexing` throws off large transient parse state (AST/token buffers) that isn't part of the returned content/outline; an arena never reclaims freed memory, so each worker's arena ballooned to the high-water-mark of *every file's transients across its whole chunk* (~3.5 GB total).

Now each file is parsed in a **per-file scratch arena that resets between files**; only keep-data (content dupe + `Explorer.cloneOutline`, made `pub`) is copied into the persistent results arena. The threading model is unchanged — parse parallel, commit serial on the main thread — so the per-worker copy is race-free.

## 2. Speed — symbol-index O(n²) (`src/explore.zig`)

`commit` called `removeSymbolIndexFor` per file, which **scans the entire global symbol index** to evict the path's old entries. On a cold scan every file is brand-new (nothing to evict), so the whole pass was **O(files × total_symbols)** — billions of comparisons. Skip the scan when the path has no prior entry (`had_prior=false`).

Commit phase: **23,713 ms → 1,517 ms** (14×).

### Phase breakdown (after)
```
walk:                70 ms
parse (parallel x8): 495 ms
commit (serial):  1,517 ms   (was 23,713 ms)
trigram-build:      628 ms
snapshot:           261 ms
```
The parse was already fast (0.5s), so the win came from the commit, not from adding parallel workers.

## Verification
- `zig build test` → **670/670 pass**
- Rebuilt the index and confirmed `search` (50 hits) and symbol lookup (`find`) return correct results.

Also bumps `build.zig.zon` to `0.2.5824`.