### PR TITLE
perf: parallelize WordIndex build (cold index 1.49×) + leaner ranked search

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -10,6 +10,22 @@ const MmapTrigramIndex = idx.MmapTrigramIndex;
 const AnyTrigramIndex = idx.AnyTrigramIndex;
 const SparseNgramIndex = idx.SparseNgramIndex;
 
+/// Fast hash context for u32-keyed maps on hot paths (ranked search aggregation).
+/// Zig's AutoHashMap runs the 4 key bytes through Wyhash even for an integer key;
+/// std.hash.int is a couple of multiply/shift/xor ops with full avalanche. Pure
+/// Context swap — identical map semantics, behavior-preserving. (FxHash precedent.)
+const U32Context = struct {
+    pub fn hash(_: U32Context, k: u32) u64 {
+        return std.hash.int(@as(u64, k));
+    }
+    pub fn eql(_: U32Context, a: u32, b: u32) bool {
+        return a == b;
+    }
+};
+fn U32HashMap(comptime V: type) type {
+    return std.HashMap(u32, V, U32Context, std.hash_map.default_max_load_percentage);
+}
+
 pub const SymbolKind = enum(u8) {
     function,
     struct_def,
@@ -588,6 +604,10 @@ pub const Explorer = struct {
     word_index_can_load_from_disk: bool = false,
     word_index_generation: u64 = 0,
     word_index_persisted_generation: u64 = 0,
+    /// When true, commitParsedFileOwnedOutline skips word_index.indexFile — the
+    /// caller is building the word index in parallel per-worker shards and will
+    /// merge them after the commit loop (see watcher.initialScanWithWorkerCount).
+    defer_word_index: bool = false,
     mu: cio.RwLock = .{},
     root_dir: ?std.Io.Dir = null,
     io: ?std.Io = null,
@@ -735,7 +755,7 @@ pub const Explorer = struct {
             if (!self.word_index_complete) {
                 self.word_index_can_load_from_disk = false;
             }
-            try self.word_index.indexFile(stable_path, content);
+            if (!self.defer_word_index) try self.word_index.indexFile(stable_path, content);
             // If trigram indexing fails below, restore word_index to its previous state
             // to prevent word_index and trigram_index from diverging.
             errdefer if (prior_content) |old| {
@@ -2560,7 +2580,7 @@ pub const Explorer = struct {
             best_line: u32,
             best_line_hits: u32,
         };
-        var per_doc = std.AutoHashMap(u32, DocAgg).init(ta);
+        var per_doc = U32HashMap(DocAgg).init(ta);
 
         // For each unique query term, look up its posting list once,
         // compute df and per-doc tf in a single pass.
@@ -2573,8 +2593,8 @@ pub const Explorer = struct {
             // df: distinct doc_ids in this posting list. tf: count of (term,doc)
             // entries (each entry is a distinct line per indexFile dedup).
             // line_hits: per-doc map of line_num → count for best-line picking.
-            var doc_tf = std.AutoHashMap(u32, u32).init(ta);
-            var doc_best_line = std.AutoHashMap(u32, struct { line: u32, count: u32 }).init(ta);
+            var doc_tf = U32HashMap(u32).init(ta);
+            var doc_best_line = U32HashMap(struct { line: u32, count: u32 }).init(ta);
             for (hits) |h| {
                 const tf_gop = try doc_tf.getOrPut(h.doc_id);
                 if (!tf_gop.found_existing) tf_gop.value_ptr.* = 0;
@@ -2643,12 +2663,19 @@ pub const Explorer = struct {
                 .best_line = entry.value_ptr.best_line,
             });
         }
-        std.sort.block(Cand, cands.items, {}, struct {
-            pub fn lt(_: void, a: Cand, b_: Cand) bool {
-                if (a.score != b_.score) return a.score > b_.score;
-                return a.doc_id < b_.doc_id;
+        // Lazy top-k via a max-heap: pop candidates in (score desc, doc_id asc)
+        // order and materialize until max_results survive. Same ordering and
+        // skip-and-continue semantics as a full sort over all candidates, but only
+        // pops ~max_results of them — O(C + (k+skips)·log C) instead of O(C·log C)
+        // for the common case k ≪ C (bm25s-style top-k retrieval).
+        const candLess = struct {
+            fn order(_: void, a: Cand, b_: Cand) std.math.Order {
+                if (a.score != b_.score) return if (a.score > b_.score) .lt else .gt;
+                return std.math.order(a.doc_id, b_.doc_id);
             }
-        }.lt);
+        }.order;
+        var heap = std.PriorityQueue(Cand, void, candLess).fromOwnedSlice(try cands.toOwnedSlice(ta), {});
+        defer heap.deinit(ta);
 
         var result_list: std.ArrayList(SearchResult) = .empty;
         errdefer {
@@ -2658,10 +2685,10 @@ pub const Explorer = struct {
             }
             result_list.deinit(allocator);
         }
-        try result_list.ensureTotalCapacity(allocator, @min(max_results, cands.items.len));
+        try result_list.ensureTotalCapacity(allocator, @min(max_results, heap.count()));
 
-        for (cands.items) |c| {
-            if (result_list.items.len >= max_results) break;
+        while (result_list.items.len < max_results) {
+            const c = heap.pop() orelse break;
             const path = self.word_index.id_to_path.items[c.doc_id];
             if (path.len == 0) continue;
             const ref = self.readContentForSearch(path, allocator) orelse continue;

--- a/src/index.zig
+++ b/src/index.zig
@@ -253,6 +253,50 @@ pub const WordIndex = struct {
         self.total_tokens += doc_token_count;
     }
 
+    /// Fold a shard (a WordIndex built in parallel over a disjoint, contiguous
+    /// set of documents) into self. The shard's local doc_ids [0, shard.len)
+    /// are remapped to global ids [base, base + shard.len), where base is self's
+    /// current doc count — so merging shards in worker order reproduces the exact
+    /// doc_id assignment of the serial (single-worker) path. Keys/paths are
+    /// re-duped into self.allocator since the shard is arena-backed and freed
+    /// after merge. Postings stay doc_id-ascending (shard lists are ascending and
+    /// each shard's global range follows the previous one). See the per-worker
+    /// shard build in watcher.initialScanWithWorkerCount.
+    pub fn mergeShard(self: *WordIndex, shard: *WordIndex) !void {
+        const base: u32 = @intCast(self.id_to_path.items.len);
+
+        // Paths + per-doc lengths.
+        for (shard.id_to_path.items, 0..) |path, local| {
+            const global_id: u32 = base + @as(u32, @intCast(local));
+            const duped = try self.allocator.dupe(u8, path);
+            errdefer self.allocator.free(duped);
+            try self.id_to_path.append(self.allocator, duped);
+            try self.path_to_id.put(duped, global_id);
+            if (shard.doc_lengths.get(@intCast(local))) |len| {
+                try self.doc_lengths.put(global_id, len);
+            }
+        }
+
+        // Postings: append each shard term's hits with doc_id offset by base.
+        var it = shard.index.iterator();
+        while (it.next()) |entry| {
+            const term = entry.key_ptr.*;
+            const shard_hits = entry.value_ptr.items;
+            const gop = try self.index.getOrPut(term);
+            if (!gop.found_existing) {
+                const dterm = try self.allocator.dupe(u8, term);
+                gop.key_ptr.* = dterm;
+                gop.value_ptr.* = .empty;
+            }
+            try gop.value_ptr.ensureUnusedCapacity(self.allocator, shard_hits.len);
+            for (shard_hits) |h| {
+                gop.value_ptr.appendAssumeCapacity(.{ .doc_id = base + h.doc_id, .line_num = h.line_num });
+            }
+        }
+
+        self.total_tokens += shard.total_tokens;
+    }
+
     /// Look up all hits for a word. O(1) lookup + O(hits) iteration.
     /// Query is normalized to lowercase (all index keys are stored lowercase).
     pub fn search(self: *WordIndex, word: []const u8) []const WordHit {
@@ -1165,35 +1209,39 @@ pub const TrigramIndex = struct {
             if (write == 0) break; // early exit if intersection is empty
         }
 
+        // Bloom-filter refinement. Hoist the per-consecutive-pair trigram packing
+        // and posting-list hash probes out of the per-candidate loop — they depend
+        // only on the query, not on doc_id — leaving just the two getByDocId binary
+        // searches per candidate. Result set is bit-identical to the inline version.
+        const Pair = struct { list_a: ?*PostingList, list_b: ?*PostingList, next_bit: u8 };
+        var pairs: []Pair = &.{};
+        defer if (pairs.len > 0) allocator.free(pairs);
+        if (tri_count >= 2) {
+            pairs = allocator.alloc(Pair, tri_count - 1) catch return null;
+            for (pairs, 0..) |*pair, j| {
+                pair.* = .{
+                    .list_a = self.index.getPtr(packTrigram(normalizeChar(query[j]), normalizeChar(query[j + 1]), normalizeChar(query[j + 2]))),
+                    .list_b = self.index.getPtr(packTrigram(normalizeChar(query[j + 1]), normalizeChar(query[j + 2]), normalizeChar(query[j + 3]))),
+                    .next_bit = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8),
+                };
+            }
+        }
+
         var result: std.ArrayList([]const u8) = .empty;
         errdefer result.deinit(allocator);
         result.ensureTotalCapacity(allocator, result_ids.items.len) catch return null;
 
         next_cand: for (result_ids.items) |doc_id| {
-            // Bloom-filter check for consecutive trigram pairs
-            if (tri_count >= 2) {
-                for (0..tri_count - 1) |j| {
-                    const tri_a = packTrigram(
-                        normalizeChar(query[j]),
-                        normalizeChar(query[j + 1]),
-                        normalizeChar(query[j + 2]),
-                    );
-                    const tri_b = packTrigram(
-                        normalizeChar(query[j + 1]),
-                        normalizeChar(query[j + 2]),
-                        normalizeChar(query[j + 3]),
-                    );
-                    const list_a = self.index.getPtr(tri_a) orelse continue;
-                    const list_b = self.index.getPtr(tri_b) orelse continue;
-                    const mask_a = list_a.getByDocId(doc_id) orelse continue;
-                    const mask_b = list_b.getByDocId(doc_id) orelse continue;
+            for (pairs) |pair| {
+                const list_a = pair.list_a orelse continue;
+                const list_b = pair.list_b orelse continue;
+                const mask_a = list_a.getByDocId(doc_id) orelse continue;
+                const mask_b = list_b.getByDocId(doc_id) orelse continue;
 
-                    const next_bit: u8 = @as(u8, 1) << @intCast(normalizeChar(query[j + 3]) % 8);
-                    if ((mask_a.next_mask & next_bit) == 0) continue :next_cand;
+                if ((mask_a.next_mask & pair.next_bit) == 0) continue :next_cand;
 
-                    const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
-                    if ((rotated & mask_b.loc_mask) == 0) continue :next_cand;
-                }
+                const rotated = (mask_a.loc_mask << 1) | (mask_a.loc_mask >> 7);
+                if ((rotated & mask_b.loc_mask) == 0) continue :next_cand;
             }
 
             if (doc_id < self.id_to_path.items.len) {

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -626,6 +626,73 @@ test "watcher: parallel initial scan matches sequential results" {
 }
 
 
+test "watcher: parallel word-index shards match sequential (skip_file_words)" {
+    // Exercises the per-worker WordIndex shard + serial mergeShard path
+    // (use_shards requires word_index.enabled and skip_file_words). Asserts the
+    // sharded parallel build is byte-identical to the single-worker serial build
+    // for both raw word hits and BM25 ranked results.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "src");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/a.zig", .data = "const std = @import(\"std\");\npub fn parseToken() void {}\n// TODO alpha\n" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/b.zig", .data = "pub fn parseToken() void {}\npub fn handleRequest() void {}\n// TODO beta\n" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/c.py", .data = "def parse_token():\n    return handle_request()\n# TODO gamma\n" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/d.md", .data = "# parseToken and handleRequest notes\nTODO delta\n" });
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = "src/e.zig", .data = "pub fn handleRequest() void { parseToken(); }\n" });
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp_dir.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+
+    var store_seq = Store.init(testing.allocator);
+    defer store_seq.deinit();
+    var explorer_seq = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_seq.deinit();
+    explorer_seq.word_index.skip_file_words = true;
+    explorer_seq.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store_seq, &explorer_seq, root, testing.allocator, false, 1);
+
+    var store_par = Store.init(testing.allocator);
+    defer store_par.deinit();
+    var explorer_par = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_par.deinit();
+    explorer_par.word_index.skip_file_words = true;
+    explorer_par.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store_par, &explorer_par, root, testing.allocator, false, 4);
+
+    // Word-index structural parity.
+    try testing.expectEqual(explorer_seq.word_index.id_to_path.items.len, explorer_par.word_index.id_to_path.items.len);
+    try testing.expectEqual(explorer_seq.word_index.total_tokens, explorer_par.word_index.total_tokens);
+    for ([_][]const u8{ "parsetoken", "parse", "token", "handlerequest", "handle", "request", "todo", "std" }) |term| {
+        try testing.expectEqual(explorer_seq.word_index.search(term).len, explorer_par.word_index.search(term).len);
+    }
+
+    // BM25 ranked-search parity: identical ordered result set (path + line).
+    const r_seq = try explorer_seq.searchContentRanked("parseToken handleRequest", testing.allocator, 10);
+    defer {
+        for (r_seq) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(r_seq);
+    }
+    const r_par = try explorer_par.searchContentRanked("parseToken handleRequest", testing.allocator, 10);
+    defer {
+        for (r_par) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(r_par);
+    }
+    try testing.expectEqual(r_seq.len, r_par.len);
+    for (r_seq, r_par) |a, b| {
+        try testing.expectEqualStrings(a.path, b.path);
+        try testing.expectEqual(a.line_num, b.line_num);
+    }
+}
+
+
 test "edit: range_start zero is invalid" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -4,6 +4,7 @@ const cio = @import("cio.zig");
 const Store = @import("store.zig").Store;
 const Explorer = @import("explore.zig").Explorer;
 const TrigramIndex = @import("index.zig").TrigramIndex;
+const WordIndex = @import("index.zig").WordIndex;
 const explore_mod = @import("explore.zig");
 const git_mod = @import("git.zig");
 pub const EventKind = enum(u8) {
@@ -459,7 +460,7 @@ fn parseInitialScanEntry(io: std.Io, root: []const u8, entry: InitialScanEntry, 
     };
 }
 
-fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8, entries: []const InitialScanEntry) void {
+fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8, entries: []const InitialScanEntry, word_shard: ?*WordIndex) void {
     const persist = results.arena.allocator();
     // Parse each file in a per-file scratch arena that is reset between files,
     // then copy only the keep-data (content + outline) into the persistent
@@ -470,6 +471,11 @@ fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8
     // initial-scan RSS on large repos (~4.3GB -> contents+outline only).
     // The results arena (and thus the clone) is touched by this worker only, so
     // the copy is race-free; commit on the main thread re-dups both anyway.
+    //
+    // When word_shard is set, also build the WordIndex for this chunk in parallel
+    // here (lock-free, content is hot) instead of on the serial commit thread.
+    // Files are indexed in chunk order, matching the order commit/mergeShard will
+    // assign global doc_ids, so the merged index is identical to the serial path.
     var scratch = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer scratch.deinit();
     for (entries) |entry| {
@@ -484,6 +490,7 @@ fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8
                 .outline = outline_copy,
                 .skip_trigram = file.skip_trigram,
             }) catch continue;
+            if (word_shard) |ws| ws.indexFile(file.path, content_copy) catch {};
         }
     }
 }
@@ -524,6 +531,18 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
     const threads = try allocator.alloc(std.Thread, n_workers);
     defer allocator.free(threads);
 
+    // When the word index is enabled (cold `index`/`mcp` path), build it in
+    // parallel per-worker shards backed by each worker's arena, then merge the
+    // shards on the main thread after commit. This moves the word-index build —
+    // the dominant cost of the otherwise-serial commit loop — into the parallel
+    // region. Gated on skip_file_words because shards intentionally omit the
+    // per-file word set (file_words), so they only fit the bulk cold-index build
+    // (which never needs incremental removeFile); main.zig always sets it. Other
+    // paths keep the old serial behavior with zero overhead.
+    const use_shards = explorer.word_index.enabled and explorer.word_index.skip_file_words;
+    const shards: ?[]WordIndex = if (use_shards) try allocator.alloc(WordIndex, n_workers) else null;
+    defer if (shards) |sh| allocator.free(sh);
+
     const chunk_size = entries.items.len / n_workers;
     const remainder = entries.items.len % n_workers;
     var offset: usize = 0;
@@ -533,16 +552,29 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
         const count = chunk_size + extra;
         const chunk = entries.items[offset .. offset + count];
         offset += count;
-        threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk });
+        var shard_ptr: ?*WordIndex = null;
+        if (shards) |sh| {
+            sh[i] = WordIndex.init(worker.arena.allocator());
+            sh[i].skip_file_words = true;
+            shard_ptr = &sh[i];
+        }
+        threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk, shard_ptr });
     }
     for (threads) |thread| thread.join();
 
-    for (workers) |*worker| {
+    // Commit outlines/contents/deps/symbol serially (those mutate shared maps);
+    // word indexing is deferred and folded in per worker via mergeShard, so the
+    // global doc_ids land in chunk order — identical to the single-worker path.
+    if (use_shards) explorer.defer_word_index = true;
+    defer explorer.defer_word_index = false;
+    for (workers, 0..) |*worker, wi| {
         for (worker.items.items) |file| {
             try explorer.commitParsedFileOwnedOutline(file.path, file.content, file.outline, true, file.skip_trigram);
         }
+        if (shards) |sh| try explorer.word_index.mergeShard(&sh[wi]);
         // Free this worker's arena immediately — releases pages to OS,
-        // prevents holding all workers' content simultaneously.
+        // prevents holding all workers' content simultaneously. (This also
+        // frees the worker's word shard, which mergeShard has copied out.)
         worker.deinit(allocator);
         workers_committed += 1;
     }
@@ -845,7 +877,7 @@ pub fn initialScanWithTrigrams(
             const count = chunk_size + extra;
             const chunk = entries.items[offset .. offset + count];
             offset += count;
-            threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk });
+            threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk, null });
         }
         for (threads) |thread| thread.join();
 


### PR DESCRIPTION
## Summary

Research-backed cold-index and search-path optimizations (from a 13-agent profile+literature workflow). Headline: the cold-index `commit` phase was dominated by the serial `WordIndex.indexFile`; this parallelizes it.

## #1 — Parallel WordIndex shards (Lucene DocumentsWriterPerThread)

Each parse worker builds a **private `WordIndex` shard** (reusing `indexFile`, backed by its arena); after join, the new **`WordIndex.mergeShard`** folds them in worker order. Global doc-ids land in chunk ranges that **exactly reproduce the serial assignment**, so postings stay doc-id-ascending and BM25 results are byte-identical.

Gated on `skip_file_words` — shards omit the per-file word set, so they only fit the bulk cold-index build (which never needs incremental `removeFile`); `main.zig` always sets it. Threading model unchanged (parse parallel, commit serial → `self.allocator` stays single-threaded).

**Controlled interleaved A/B (same binary, shards on/off, ~16k-file repo, 6 iters, medians):**

| | cold index (real) | commit phase | user (CPU work) |
|---|---|---|---|
| before (serial) | 3.96 s | 1517 ms | 5.96 s |
| after (shards) | **2.66 s** | **206 ms** | 6.20 s |
| | **1.49×** | **7.4×** | ~flat |

`user`-time staying flat confirms it's the *same* total work, parallelized rather than reduced.

## Search-path wins (behavior-preserving)

- **`searchContentRanked`**: lazy top-k max-heap (`std.PriorityQueue`) instead of full-sorting every matched doc — identical ordering + skip-and-continue semantics, `O(C + (k+skips)·logC)` (bm25s top-k).
- **`TrigramIndex.candidates`**: hoist per-pair `packTrigram` + `getPtr` hash probes out of the per-candidate bloom loop (bit-identical result set).
- **`searchContentRanked`**: `U32Context` (`std.hash.int`) for the three u32-keyed aggregation maps instead of Wyhash-over-4-bytes.

## Tests

`zig build test` → **671/671**. Adds a `workers=1`-vs-`workers=4` parity test asserting identical word hits **and** BM25 ranked results (locks down the shard doc-id/merge correctness).

## Note on measurement

Absolute cold-index wall-time is noisy on Apple Silicon (efficiency-core placement under load — same binary measured 2.5s vs 37s), so the A/B above is **interleaved on the same binary** to cancel that out; the `user`-time invariant is the reliable cross-check.