### PR TITLE
feat: register codedb in Windsurf + Devin via mcpsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 | Structural outlines (functions, structs, imports)      | mmap-backed trigram index                |
 | Reverse dependency graph                               |                                          |
 | Fallback editor: atomic line-range edits + version tracking          |                                          |
-| Auto-registration in Claude, Codex, Gemini, Cursor     |                                          |
+| Auto-registration in Claude, Codex, Gemini, Cursor, Windsurf, Devin |                                |
 | Polling file watcher with filtered directory walker    |                                          |
 | Portable snapshot for instant MCP startup              |                                          |
 | Singleton MCP with PID lock + 1h idle timeout          |                                          |
@@ -74,7 +74,7 @@
 curl -fsSL https://codedb.codegraff.com/install.sh | bash
 ```
 
-Downloads the binary for your platform and auto-registers codedb as an MCP server in **Claude Code**, **Codex**, **Gemini CLI**, and **Cursor**. The installer prints the exact `codedb mcp` command it registered plus hook setup pointers for Codex and Claude Code.
+Downloads the binary for your platform and auto-registers codedb as an MCP server in **Claude Code**, **Codex**, **Gemini CLI**, and **Cursor** directly, plus **Windsurf** and **Devin** via [mcpsync](https://github.com/justrach/mcpsync) (auto-installed if missing; tools that aren't installed are skipped). The installer prints the exact `codedb mcp` command it registered plus hook setup pointers for Codex and Claude Code.
 
 ### Or via npm/npx (zero-install for MCP clients)
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -168,6 +168,67 @@ PYEOF
   printf "  ${G}✓${N} cursor       ${D}→ $config${N}\n"
 }
 
+register_windsurf_devin() {
+  local codedb_bin="$1"
+  # Windsurf and Devin are registered via mcpsync (a codegraff product that keeps
+  # MCP servers in sync across AI tools). Only these two are delegated to mcpsync;
+  # the tools above are registered directly. mcpsync skips tools that aren't
+  # installed, so this is a no-op for users without Windsurf or Devin.
+  local mcpsync_bin
+  mcpsync_bin="$(command -v mcpsync 2>/dev/null || true)"
+  if [ -z "$mcpsync_bin" ]; then
+    for p in "$HOME/.local/bin/mcpsync" "$HOME/bin/mcpsync" "/usr/local/bin/mcpsync"; do
+      [ -x "$p" ] && mcpsync_bin="$p" && break
+    done
+  fi
+  # Auto-install mcpsync if missing (same trust domain as codedb). Never fail the
+  # codedb install if this is unavailable.
+  if [ -z "$mcpsync_bin" ]; then
+    curl -fsSL https://mcpsync.codegraff.com | bash >/dev/null 2>&1 || true
+    mcpsync_bin="$(command -v mcpsync 2>/dev/null || true)"
+    if [ -z "$mcpsync_bin" ]; then
+      for p in "$HOME/.local/bin/mcpsync" "$HOME/bin/mcpsync" "/usr/local/bin/mcpsync"; do
+        [ -x "$p" ] && mcpsync_bin="$p" && break
+      done
+    fi
+  fi
+  if [ -z "$mcpsync_bin" ]; then
+    printf "  ${D}windsurf/devin: skip (mcpsync unavailable)${N}\n"
+    return
+  fi
+
+  # Add codedb to mcpsync's source of truth (~/.mcpconfig.json), then sync ONLY
+  # windsurf + devin (named) so we don't re-touch the tools registered above.
+  # Writing the source-of-truth directly (rather than `mcpsync add`, which
+  # auto-syncs to every detected tool) keeps mcpsync's footprint to these two.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$HOME/.mcpconfig.json" "$codedb_bin" << 'PYEOF'
+import json, sys
+config_path, codedb_bin = sys.argv[1], sys.argv[2]
+try:
+    with open(config_path) as f:
+        data = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+servers = data.setdefault("mcpServers", {})
+servers["codedb"] = {"command": codedb_bin, "args": ["mcp"], "transport": "stdio"}
+with open(config_path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PYEOF
+  else
+    # No python3: fall back to `mcpsync add` (also syncs other detected tools,
+    # additively and idempotently — same codedb entry).
+    "$mcpsync_bin" add codedb --cmd "$codedb_bin" --args mcp >/dev/null 2>&1 || true
+  fi
+
+  if "$mcpsync_bin" sync windsurf devin >/dev/null 2>&1; then
+    printf "  ${G}✓${N} windsurf/devin ${D}→ via mcpsync (~/.mcpconfig.json)${N}\n"
+  else
+    printf "  ${D}windsurf/devin: skip (mcpsync sync failed)${N}\n"
+  fi
+}
+
 register_hooks() {
   if ! command -v python3 >/dev/null 2>&1; then
     printf "  ${D}hooks:   skip (python3 not found)${N}\n"
@@ -350,6 +411,7 @@ main() {
   register_codex "$dest"
   register_gemini "$dest"
   register_cursor "$dest"
+  register_windsurf_devin "$dest"
   register_hooks
   print_hook_notes "$dest"
 

--- a/src/nuke.zig
+++ b/src/nuke.zig
@@ -193,6 +193,16 @@ fn deregisterInstalledIntegrations(io: std.Io, allocator: std.mem.Allocator, hom
     defer allocator.free(codex_config);
     if (deregisterCodexIntegrationFile(io, allocator, codex_config) catch false) removed += 1;
 
+    // Windsurf and Devin are registered via mcpsync; both store servers under a
+    // standard `mcpServers` object, so the JSON deregister handles them too.
+    const windsurf_config = std.fmt.allocPrint(allocator, "{s}/.codeium/windsurf/mcp_config.json", .{home}) catch return removed;
+    defer allocator.free(windsurf_config);
+    if (deregisterJsonIntegrationFile(io, allocator, windsurf_config) catch false) removed += 1;
+
+    const devin_config = std.fmt.allocPrint(allocator, "{s}/.config/devin/config.json", .{home}) catch return removed;
+    defer allocator.free(devin_config);
+    if (deregisterJsonIntegrationFile(io, allocator, devin_config) catch false) removed += 1;
+
     return removed;
 }
 


### PR DESCRIPTION
## What & why

codedb's installer auto-registers the MCP server in **Claude Code, Codex, Gemini CLI, Cursor** — but not Windsurf or Devin. This PR adds those two, delegating them to [**mcpsync**](https://github.com/justrach/mcpsync) (the codegraff tool that keeps MCP servers in sync across AI tools, and already targets both).

**Design: augment, not replace.** The four existing per-client registrations are untouched; mcpsync's footprint is scoped to exactly Windsurf + Devin. Net diff is **+74/−2 across 3 files**, no Zig logic rewritten.

---

## Changes, part by part

### 1. `install/install.sh` — new `register_windsurf_devin()` (+62)

Called from `main()` immediately after `register_cursor "$dest"`. Flow:

1. **Locate mcpsync** — `command -v mcpsync`, then fall back to `~/.local/bin`, `~/bin`, `/usr/local/bin`.
2. **Auto-install if missing** — `curl -fsSL https://mcpsync.codegraff.com | bash` (same trust domain as codedb's own installer). Wrapped in `|| true` and followed by a re-probe; if mcpsync still isn't found it prints `windsurf/devin: skip (mcpsync unavailable)` and returns — **it never fails the codedb install.**
3. **Write the source of truth** — adds codedb to `~/.mcpconfig.json` (mcpsync's single owned config) via `python3`:
   ```json
   "codedb": { "command": "<bin>", "args": ["mcp"], "transport": "stdio" }
   ```
   We write this file directly rather than calling `mcpsync add`, because `mcpsync add` **auto-syncs to every detected tool** — writing the file ourselves keeps the sync scoped to the two named tools below, so Claude/Codex/Gemini/Cursor (registered above) are not re-touched. A `python3`-less fallback uses `mcpsync add`.
4. **Sync only the two new tools** — `mcpsync sync windsurf devin`. This is **additive** (existing servers untouched) and mcpsync **skips tools that aren't installed**, so it's a no-op for users without Windsurf/Devin.

### 2. `src/nuke.zig` — deregister Windsurf + Devin (+10)

`deregisterInstalledIntegrations` now also strips codedb from:
- Windsurf — `~/.codeium/windsurf/mcp_config.json`
- Devin — `~/.config/devin/config.json`

Both store servers under a standard `mcpServers` object, so the existing `deregisterJsonIntegrationFile` handles them unchanged — other servers and Devin's non-`mcpServers` keys are preserved. `codedb nuke` stays a complete uninstall.

### 3. `README.md` — docs (+2/−2)

Feature table and the Install section now list Windsurf + Devin and link mcpsync, noting it's auto-installed and that uninstalled tools are skipped.

---

## Config paths (reference)

| Tool | Path | Layout |
|---|---|---|
| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `{ mcpServers: {...} }` |
| Devin | `~/.config/devin/config.json` | `mcpServers` is a peer of other keys |
| (source of truth) | `~/.mcpconfig.json` | owned by mcpsync |

---

## Testing

**End-to-end, against the real `install.sh` function.** Sourced `register_windsurf_devin()` into a sandboxed `HOME` with Windsurf + Devin present (each pre-seeded with an unrelated server / extra key):

```
✓ windsurf/devin → via mcpsync (~/.mcpconfig.json)
```
- codedb added to **both** configs;
- **additive** — pre-existing `keep-me` server and Devin's `other` key both preserved;
- separately verified: with neither tool installed, `mcpsync sync windsurf devin` reports `not installed, skipped` and writes nothing.

**Other checks:**
- `bash -n install/install.sh` — clean.
- `zig build test` — **670/670** (the nuke change is covered by the existing `deregisterJsonIntegrationFile` tests; no new test needed).

No real user configs were modified during testing (all in a throwaway `HOME`).

---

## Safety properties

- Never breaks the codedb install (mcpsync failures degrade to a skip line).
- No litter — uninstalled tools are skipped, not created.
- Additive everywhere — never removes a user's other MCP servers.
- Idempotent — re-running the installer re-writes the same codedb entry.
- Complete uninstall — `codedb nuke` removes codedb from Windsurf/Devin too.