### PR TITLE
Snapshot load performance (~3×) + parallel freshness + #518 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,36 @@ the query hot path.
   `next`, …) are filtered out — guessing would assert a false edge in an
   LLM-facing block, so ambiguous calls are omitted rather than mis-resolved.
 
+### Snapshot load performance (~3× faster load, ~338 MB lower RSS)
+
+A series of load-path changes, each A/B-measured on openclaw/openclaw (~39k
+files; interleaved warm loads, zero overlap between arms), found with a new gated
+`CODEDB_LOAD_PROFILE` phase profiler (near-zero cost when off). Cumulatively the
+load went from ~380 ms to ~125 ms and peak RSS from ~795 MB to ~457 MB.
+
+- **Borrow restored outline strings + pre-size the load maps.** Imports / symbol
+  names / details are now slices into the retained `OUTLINE_STATE` section instead
+  of ~170k (millions on a dense repo) per-string dupes, and the load's hashmaps are
+  pre-sized to the known file count. ~34% faster.
+- **`statFile` instead of `openFile` + `stat` + `close` in the freshness check.**
+  Only the mtime is needed, so one syscall per file instead of three. ~36% faster,
+  and far more resilient to machine load.
+- **mmap the content section.** Records are parsed from one memory mapping instead
+  of ~4 `readPositionalAll` syscalls per file (~156k on a 39k-file repo); file-
+  backed and demand-paged, with a heap bulk-read fallback. ~23% faster.
+- **Borrow content from the mmap.** Drops the transient per-file content copy — a
+  full pass over all content plus ~39k alloc/free pairs. ~8% faster.
+- **Zero-copy `ContentCache`.** Cache values are borrowed (`putBorrowed`,
+  `value_owned=false`) directly from the retained mmap instead of duped into owned
+  heap; the Explorer munmaps at deinit, and a later re-index safely replaces a
+  borrowed entry with an owned one. ~17% faster load and ~237 MB lower RSS — the
+  ~268 MB owned content dupe is gone; content lives in the reclaimable mmap.
+- **Stored content hashes (`CONTENT_HASHES` section).** Per-file content hashes are
+  computed once at write time and read back at load, so the loader no longer
+  re-hashes every file's content (which also faulted in every content page). ~14%
+  faster and ~100 MB lower RSS; an absent section makes the loader recompute
+  (backward compatible).
+
 ### Validation
 
 - `zig build test` — all pass, including new codegraph unit tests, `resolveCallees`
@@ -57,6 +87,11 @@ the query hot path.
 - `codedb_context` verified end-to-end through the MCP server on codedb itself
   (e.g. `searchContentRanked` → `lockShared` / `posixGetenv` / `ensureCallCentrality`
   / `normalizeChar` / `splitIdentifier`, all correctly resolved).
+- Snapshot load + RSS A/B'd on openclaw/openclaw (~39k files), two binaries on the
+  same snapshot, interleaved warm loads: load ~380 ms → ~125 ms, peak RSS
+  ~795 MB → ~457 MB, with no overlap between arms on any step. New ContentCache
+  borrow tests and a `CONTENT_HASHES` order-alignment test pass under the
+  DebugAllocator.
 
 ## 0.2.5823 - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,63 @@
 # Changelog
 
 
+## 0.2.5824 - 2026-06-02
+
+`0.2.5824` adds a deterministic, no-LLM **code-graph** layer. codedb now builds a
+resolved call graph from the indexed symbols and uses it to rank search results
+more precisely and to assemble richer first-touch context. The graph is computed
+locally with no model calls and persisted in the snapshot, so it costs nothing on
+the query hot path.
+
+### Graph-aware ranking (call-graph centrality)
+
+- **New `src/codegraph.zig` builds a resolved call graph.** For each function
+  body it extracts call sites (`extractCallees` — identifier-before-`(`, keyword
+  filtered, de-duped), resolves each callee name through the function/method
+  symbol table, and accumulates a weighted in-degree centrality per file
+  (ambiguous names split their weight 1/N across candidates).
+- **`searchContentRanked` folds centrality into the score.** Each candidate is
+  multiplied by `1 + 0.15·log(1 + centrality)` — purely additive, never a filter,
+  so recall is unchanged. Set `CODEDB_NO_CENTRALITY` to disable.
+- **MRR-gated on the codedb repo** (18 labelled multi-word queries):
+  MRR 0.819 → 0.944 (+15%), P@1 12 → 16, recall@5 unchanged, four queries' correct
+  file jumped to rank 1, none regressed.
+
+### Persisted call-graph centrality
+
+- **The centrality map is stored in the snapshot** (new `CALL_CENTRALITY` section)
+  and restored on load, instead of being rebuilt lazily on the first ranked query.
+  The index/scan path builds it once via `Explorer.buildCallCentrality` before
+  persisting; the loader restores it keyed off the stable outline paths, so
+  `ensureCallCentrality` short-circuits.
+- **Removes a large first-query stall.** On openclaw/openclaw (~39k files) the lazy
+  build measured ~960 ms; it is now paid once at index time, and restoring it at
+  load adds ~3 ms. Snapshots without the section fall back to the lazy build
+  (backward compatible).
+
+### Edge-aware codedb_context (callees)
+
+- **`codedb_context` now surfaces a "Calls" section** alongside the existing
+  callers section: for each key symbol it walks the symbol's call sites through
+  the call graph and lists where each callee is defined, so an agent sees both who
+  calls a symbol and what it calls without a follow-up `codedb_outline` /
+  `codedb_read`.
+- **High-precision by design.** Resolution is name-based (no type info), so a
+  callee is shown only when it resolves to exactly one non-test function/method,
+  and ubiquitous std/container method names (`init`, `get`, `append`, `lock`,
+  `next`, …) are filtered out — guessing would assert a false edge in an
+  LLM-facing block, so ambiguous calls are omitted rather than mis-resolved.
+
+### Validation
+
+- `zig build test` — all pass, including new codegraph unit tests, `resolveCallees`
+  resolution, and snapshot round-trip + centrality-persistence tests under the
+  DebugAllocator.
+- Graph ranking MRR-gated on the codedb query set (0.819 → 0.944, zero regressions).
+- `codedb_context` verified end-to-end through the MCP server on codedb itself
+  (e.g. `searchContentRanked` → `lockShared` / `posixGetenv` / `ensureCallCentrality`
+  / `normalizeChar` / `splitIdentifier`, all correctly resolved).
+
 ## 0.2.5823 - 2026-05-29
 
 `0.2.5823` is an MCP compatibility hotfix for direct `tools/call` requests.

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1889,6 +1889,15 @@ pub const Explorer = struct {
         const callees = codegraph.extractCallees(allocator, body) catch return &.{};
 
         var refs: std.ArrayList(CalleeRef) = .empty;
+        // Resolve each callee straight off the symbol index: we only need to know
+        // whether exactly one non-test function/method defines the name, which is
+        // O(defs-of-that-name). findAllSymbols would instead run an O(all-symbols)
+        // safety scan over every outline and allocate a full result list per name —
+        // ~18 such scans per codedb_context made it ~20% slower on a multi-thousand-
+        // file repo (the #524 bench regression). The index is rebuilt on every
+        // commit, so for this high-precision/best-effort feature it is authoritative.
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
         for (callees) |name| {
             if (refs.items.len >= max) break;
             // Skip ubiquitous std/container/builtin method names. They are almost
@@ -1897,33 +1906,30 @@ pub const Explorer = struct {
             // based resolution would assert a false edge even when there's a
             // single user definition.
             if (isUbiquitousName(name)) continue;
-            const defs = self.findAllSymbols(name, allocator) catch continue;
-            // Only surface UNAMBIGUOUS edges: a callee is shown only if exactly
-            // one non-test function/method defines that name. Resolution here is
-            // name-based (no type info), so common method names (init, lock, get,
-            // next, ...) resolve to many candidates — guessing one would assert a
-            // false edge. Skipping them keeps this high-precision: distinctive
-            // names (extractCallees, readContentForSearch, ...) resolve cleanly;
-            // ambiguous ones are simply omitted. (Centrality tolerates ambiguity
-            // via 1/N weighting + aggregation; a per-edge display cannot.)
-            var cand: ?SymbolResult = null;
+            const locs = self.symbol_index.get(name) orelse continue;
+            // Only surface UNAMBIGUOUS edges: a callee is shown only if exactly one
+            // non-test function/method defines that name. Resolution is name-based
+            // (no type info), so common method names (init, lock, get, next, ...)
+            // resolve to many candidates — guessing one would assert a false edge.
+            // Skipping them keeps this high-precision; ambiguous names are omitted.
+            var cand: ?SymbolLocation = null;
             var n_cand: usize = 0;
-            for (defs) |d| {
-                if (d.symbol.kind != .function and d.symbol.kind != .method) continue;
-                if (isLikelyTestPath(d.path)) continue;
+            for (locs.items) |loc| {
+                if (loc.kind != .function and loc.kind != .method) continue;
+                if (isLikelyTestPath(loc.path)) continue;
                 // Skip the defining function itself (self-edge / recursion).
-                if (d.symbol.line_start == line_start and std.mem.eql(u8, d.path, path)) continue;
+                if (loc.line_start == line_start and std.mem.eql(u8, loc.path, path)) continue;
                 n_cand += 1;
                 if (n_cand > 1) break; // ambiguous — stop, will be skipped
-                cand = d;
+                cand = loc;
             }
             if (n_cand == 1) {
-                const d = cand.?;
+                const loc = cand.?;
                 try refs.append(allocator, .{
                     .name = name,
-                    .path = d.path,
-                    .line = d.symbol.line_start,
-                    .kind = d.symbol.kind,
+                    .path = try allocator.dupe(u8, loc.path),
+                    .line = loc.line_start,
+                    .kind = loc.kind,
                 });
             }
         }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -63,6 +63,11 @@ pub const FileOutline = struct {
     imports: std.ArrayList([]const u8) = .empty,
     allocator: std.mem.Allocator,
     owns_path: bool = false,
+    /// When true, `imports` and each `symbols[].name`/`.detail` are borrowed
+    /// slices into an externally-owned buffer (the snapshot outline_state
+    /// section, retained by the Explorer) rather than individual allocations,
+    /// so deinit must not free them. The ArrayLists themselves are still owned.
+    borrows_strings: bool = false,
 
     pub fn init(allocator: std.mem.Allocator, path: []const u8) FileOutline {
         return .{
@@ -75,12 +80,14 @@ pub const FileOutline = struct {
     }
     pub fn deinit(self: *FileOutline) void {
         if (self.owns_path) self.allocator.free(self.path);
-        for (self.symbols.items) |sym| {
-            self.allocator.free(sym.name);
-            if (sym.detail) |d| self.allocator.free(d);
+        if (!self.borrows_strings) {
+            for (self.symbols.items) |sym| {
+                self.allocator.free(sym.name);
+                if (sym.detail) |d| self.allocator.free(d);
+            }
+            for (self.imports.items) |imp| self.allocator.free(imp);
         }
         self.symbols.deinit(self.allocator);
-        for (self.imports.items) |imp| self.allocator.free(imp);
         self.imports.deinit(self.allocator);
     }
 };
@@ -628,6 +635,11 @@ pub const Explorer = struct {
     /// Production code does not read this field.
     search_tier5_count: u64 = 0,
     last_search_breakdown: SearchBreakdown = .{},
+    /// Buffers adopted from snapshot loads (the raw outline_state section).
+    /// Restored FileOutlines borrow their import/symbol strings as slices into
+    /// these (see FileOutline.borrows_strings), so they must outlive every
+    /// restored outline; freed once here at Explorer.deinit.
+    outline_section_bufs: std.ArrayList([]const u8) = .empty,
 
     /// Default file-content cache capacity. Was 16384, but on typical
     /// projects (≤2000 files) the cache only ever holds a few hundred
@@ -677,9 +689,18 @@ pub const Explorer = struct {
         self.word_index.deinit();
         self.trigram_index.deinit();
         self.skip_trigram_files.deinit();
+        // Freed after outlines (above) since restored outlines borrow into these.
+        for (self.outline_section_bufs.items) |b| self.allocator.free(b);
+        self.outline_section_bufs.deinit(self.allocator);
         if (self.root_dir) |d| {
             if (self.io) |io| d.close(io);
         }
+    }
+
+    /// Take ownership of a snapshot outline_state section buffer that restored
+    /// FileOutlines borrow their import/symbol strings from. Freed at deinit.
+    pub fn adoptOutlineSection(self: *Explorer, buf: []const u8) !void {
+        try self.outline_section_bufs.append(self.allocator, buf);
     }
 
     /// Number of slots in the heap trigram index id_to_path array (benchmark helper).

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2554,6 +2554,17 @@ pub const Explorer = struct {
         return 1.0 + alpha * @log(1.0 + c);
     }
 
+    /// Public, lock-acquiring entry point for single-threaded callers (the
+    /// index/scan path) to pre-build call_centrality before persisting a snapshot,
+    /// so a later load can restore it instead of paying the lazy first-query build.
+    /// ensureCallCentrality assumes the caller already holds a shared lock (it is
+    /// normally reached from searchContentRanked); this wrapper takes that lock.
+    pub fn buildCallCentrality(self: *Explorer, allocator: std.mem.Allocator) void {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        self.ensureCallCentrality(allocator);
+    }
+
     /// Build `call_centrality` once (idempotent, mutex-guarded). Must be called
     /// while holding at least a shared lock on `mu` (it reads outlines/contents
     /// via readContentForSearch, which assumes the lock is held). The resolved

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3483,7 +3483,7 @@ pub const Explorer = struct {
             }
         } else if (startsWith(line, "class ")) {
             if (extractIdent(line[6..])) |name| {
-                try appendOutlineSymbol(a, outline, name, .struct_def, line_num, line);
+                try appendOutlineSymbol(a, outline, name, .class_def, line_num, line);
             }
         } else if (startsWith(line, "import ") or startsWith(line, "from ")) {
             try appendOutlineSymbol(a, outline, line, .import, line_num, null);
@@ -5157,7 +5157,10 @@ fn extractIdent(s: []const u8) ?[]const u8 {
     var end: usize = 0;
     for (s) |ch| {
         if (end >= max_ident_len) break;
-        if (std.ascii.isAlphanumeric(ch) or ch == '_') {
+        // Accept ASCII identifier chars plus any non-ASCII UTF-8 byte (>= 0x80) so
+        // identifiers in non-Latin scripts (Korean, Japanese, accented Latin, ...)
+        // are captured rather than truncated to empty. See issue #518.
+        if (std.ascii.isAlphanumeric(ch) or ch == '_' or ch >= 0x80) {
             end += 1;
         } else break;
     }
@@ -5648,7 +5651,10 @@ fn extractRubyMethodName(s: []const u8) ?[]const u8 {
     var end: usize = 0;
     for (s) |ch| {
         if (end >= max_len) break;
-        if (std.ascii.isAlphanumeric(ch) or ch == '_') {
+        // Accept ASCII identifier chars plus any non-ASCII UTF-8 byte (>= 0x80) so
+        // identifiers in non-Latin scripts (Korean, Japanese, accented Latin, ...)
+        // are captured rather than truncated to empty. See issue #518.
+        if (std.ascii.isAlphanumeric(ch) or ch == '_' or ch >= 0x80) {
             end += 1;
         } else break;
     }
@@ -5826,6 +5832,30 @@ fn getFilename(path: []const u8) []const u8 {
     return path;
 }
 
+// Length of the longest common subsequence of two strings, case-insensitive.
+// Used as a fuzzy-match floor: how many of the query's characters actually align,
+// in order, somewhere in the path. See issue #518.
+fn lcsLenIgnoreCase(query: []const u8, path: []const u8) usize {
+    const MAXB = 512;
+    var row: [MAXB + 1]usize = undefined;
+    const pn = @min(path.len, MAXB);
+    for (0..pn + 1) |j| row[j] = 0;
+    for (query) |qc| {
+        const lq = toLowerByte(qc);
+        var prev_diag: usize = 0;
+        for (0..pn) |j| {
+            const tmp = row[j + 1];
+            if (lq == toLowerByte(path[j])) {
+                row[j + 1] = prev_diag + 1;
+            } else if (row[j] > row[j + 1]) {
+                row[j + 1] = row[j];
+            }
+            prev_diag = tmp;
+        }
+    }
+    return row[pn];
+}
+
 pub fn fuzzyScore(query: []const u8, path: []const u8) ?f32 {
     if (query.len == 0 or path.len == 0) return null;
     if (query.len > 128 or path.len > 512) return null;
@@ -5927,6 +5957,14 @@ pub fn fuzzyScore(query: []const u8, path: []const u8) ?f32 {
     // Minimum score threshold based on query length
     const min_threshold = @as(f32, @floatFromInt(query.len)) * MATCH_SCORE * 0.3;
     if (best_score < min_threshold) return null;
+
+    // Issue #518: a local alignment can clear the score floor on a handful of
+    // incidental matches even when most of the query never appears in the path
+    // (e.g. a 16-char query hitting 5 stray filename chars). Require the query and
+    // path to share a real in-order subsequence — at least 60% of the query's
+    // characters. Computed only for candidates past the score floor, so it adds
+    // no cost to the overwhelming majority of non-matching files.
+    if (lcsLenIgnoreCase(query, path) * 5 < query.len * 3) return null;
 
     // Special entry point bonus (like fff: main.go, index.ts, lib.rs rank higher)
     const fname = getFilename(path);

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -640,6 +640,10 @@ pub const Explorer = struct {
     /// these (see FileOutline.borrows_strings), so they must outlive every
     /// restored outline; freed once here at Explorer.deinit.
     outline_section_bufs: std.ArrayList([]const u8) = .empty,
+    /// mmap'd snapshot content sections adopted at load. The ContentCache stores
+    /// borrowed (value_owned=false) slices into these for restored files, so they
+    /// must outlive the cache; munmap'd once here at Explorer.deinit.
+    content_section_maps: std.ArrayList([]align(std.heap.page_size_min) const u8) = .empty,
 
     /// Default file-content cache capacity. Was 16384, but on typical
     /// projects (≤2000 files) the cache only ever holds a few hundred
@@ -692,6 +696,11 @@ pub const Explorer = struct {
         // Freed after outlines (above) since restored outlines borrow into these.
         for (self.outline_section_bufs.items) |b| self.allocator.free(b);
         self.outline_section_bufs.deinit(self.allocator);
+        // munmap'd after contents.deinit (above): the cache holds borrowed slices
+        // into these maps, but deinit skips freeing borrowed values, so the maps
+        // are still valid through it and only released here.
+        for (self.content_section_maps.items) |m| std.posix.munmap(m);
+        self.content_section_maps.deinit(self.allocator);
         if (self.root_dir) |d| {
             if (self.io) |io| d.close(io);
         }
@@ -701,6 +710,12 @@ pub const Explorer = struct {
     /// FileOutlines borrow their import/symbol strings from. Freed at deinit.
     pub fn adoptOutlineSection(self: *Explorer, buf: []const u8) !void {
         try self.outline_section_bufs.append(self.allocator, buf);
+    }
+
+    /// Take ownership of an mmap'd snapshot content section that the ContentCache
+    /// borrows (value_owned=false) slices from. munmap'd at deinit.
+    pub fn adoptContentSection(self: *Explorer, map: []align(std.heap.page_size_min) const u8) !void {
+        try self.content_section_maps.append(self.allocator, map);
     }
 
     /// Number of slots in the heap trigram index id_to_path array (benchmark helper).

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1845,6 +1845,133 @@ pub const Explorer = struct {
         return result_list.toOwnedSlice(allocator);
     }
 
+    pub const CalleeRef = struct {
+        name: []const u8, // callee identifier (borrows the resolved body content)
+        path: []const u8, // file the callee is defined in (borrows a stable outlines key)
+        line: u32,
+        kind: SymbolKind,
+    };
+
+    /// Resolve the call sites inside the function defined at `path` spanning
+    /// [line_start, line_end] to their definitions — the dependency side of the
+    /// call-graph neighborhood, using the same extraction as centrality. Deduped
+    /// by callee name, capped at `max`, function/method targets only, and the
+    /// defining function itself is skipped. Best-effort. Everything is allocated
+    /// in / borrowed from `allocator` (intended to be a per-request arena); the
+    /// returned slice and each `.name` live as long as that allocator.
+    pub fn resolveCallees(
+        self: *Explorer,
+        path: []const u8,
+        line_start: u32,
+        line_end: u32,
+        allocator: std.mem.Allocator,
+        max: usize,
+    ) ![]CalleeRef {
+        if (max == 0 or line_end < line_start) return &.{};
+        const content = (self.getContent(path, allocator) catch return &.{}) orelse return &.{};
+        const body = sliceLineRange(content, line_start, line_end);
+        if (body.len == 0) return &.{};
+        const callees = codegraph.extractCallees(allocator, body) catch return &.{};
+
+        var refs: std.ArrayList(CalleeRef) = .empty;
+        for (callees) |name| {
+            if (refs.items.len >= max) break;
+            // Skip ubiquitous std/container/builtin method names. They are almost
+            // always calls on some receiver (ArrayList.append, HashMap.get, ...),
+            // not the rare user-defined free function of the same name, so name-
+            // based resolution would assert a false edge even when there's a
+            // single user definition.
+            if (isUbiquitousName(name)) continue;
+            const defs = self.findAllSymbols(name, allocator) catch continue;
+            // Only surface UNAMBIGUOUS edges: a callee is shown only if exactly
+            // one non-test function/method defines that name. Resolution here is
+            // name-based (no type info), so common method names (init, lock, get,
+            // next, ...) resolve to many candidates — guessing one would assert a
+            // false edge. Skipping them keeps this high-precision: distinctive
+            // names (extractCallees, readContentForSearch, ...) resolve cleanly;
+            // ambiguous ones are simply omitted. (Centrality tolerates ambiguity
+            // via 1/N weighting + aggregation; a per-edge display cannot.)
+            var cand: ?SymbolResult = null;
+            var n_cand: usize = 0;
+            for (defs) |d| {
+                if (d.symbol.kind != .function and d.symbol.kind != .method) continue;
+                if (isLikelyTestPath(d.path)) continue;
+                // Skip the defining function itself (self-edge / recursion).
+                if (d.symbol.line_start == line_start and std.mem.eql(u8, d.path, path)) continue;
+                n_cand += 1;
+                if (n_cand > 1) break; // ambiguous — stop, will be skipped
+                cand = d;
+            }
+            if (n_cand == 1) {
+                const d = cand.?;
+                try refs.append(allocator, .{
+                    .name = name,
+                    .path = d.path,
+                    .line = d.symbol.line_start,
+                    .kind = d.symbol.kind,
+                });
+            }
+        }
+        return refs.toOwnedSlice(allocator);
+    }
+
+    /// Heuristic: does this path look like a test/spec/fixture file? Mirrors the
+    /// filter used by the codedb_context callers section.
+    fn isLikelyTestPath(path: []const u8) bool {
+        return std.mem.startsWith(u8, path, "tests/") or
+            std.mem.startsWith(u8, path, "test/") or
+            std.mem.indexOf(u8, path, "/test") != null or
+            std.mem.indexOf(u8, path, "_test.") != null or
+            std.mem.indexOf(u8, path, ".test.") != null or
+            std.mem.indexOf(u8, path, ".spec.") != null or
+            std.mem.indexOf(u8, path, "/__tests__/") != null or
+            std.mem.indexOf(u8, path, "/spec/") != null or
+            std.mem.indexOf(u8, path, "/fixtures/") != null;
+    }
+
+    /// Names so commonly used as stdlib/container/builtin methods across
+    /// languages that a `name(` call site almost never refers to a user-defined
+    /// free function of that name. Used to suppress false callee edges from
+    /// name-only resolution. Conservative: only the highest-collision names.
+    fn isUbiquitousName(name: []const u8) bool {
+        const common = [_][]const u8{
+            "init",        "deinit",   "append",   "get",       "set",
+            "put",         "getOrPut", "remove",   "contains",  "has",
+            "count",       "len",      "items",    "alloc",     "free",
+            "create",      "destroy",  "lock",     "unlock",    "tryLock",
+            "next",        "iterator", "clone",    "dupe",      "slice",
+            "reset",       "clear",    "format",   "hash",      "eql",
+            "write",       "writeAll", "print",    "read",      "close",
+            "open",        "value",    "key",      "toOwnedSlice", "pop",
+            "push",        "find",     "add",      "new",       "build",
+            "run",         "deinit",   "toString", "valueOf",   "of",
+        };
+        for (common) |c| {
+            if (std.mem.eql(u8, name, c)) return true;
+        }
+        return false;
+    }
+
+    /// Return the slice of `content` covering source lines [line_start, line_end]
+    /// (1-based, inclusive), excluding the trailing newline. Empty if out of range.
+    fn sliceLineRange(content: []const u8, line_start: u32, line_end: u32) []const u8 {
+        if (line_start == 0 or line_end < line_start) return content[0..0];
+        var line: u32 = 1;
+        var i: usize = 0;
+        while (i < content.len and line < line_start) : (i += 1) {
+            if (content[i] == '\n') line += 1;
+        }
+        if (i >= content.len) return content[0..0];
+        const start = i;
+        var cur: u32 = line_start;
+        while (i < content.len) : (i += 1) {
+            if (content[i] == '\n') {
+                if (cur >= line_end) break;
+                cur += 1;
+            }
+        }
+        return content[start..i];
+    }
     pub fn renderSymbols(self: *Explorer, name: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8)) !bool {
         self.mu.lockShared();
         defer self.mu.unlockShared();

--- a/src/hot_cache.zig
+++ b/src/hot_cache.zig
@@ -1,9 +1,13 @@
 const std = @import("std");
 
 /// Fixed-capacity CLOCK eviction cache for file contents.
-/// Keys are owned (duped on put, freed on eviction/remove/clear).
-/// Values are owned (duped on put, freed on eviction/remove/clear).
-/// Zero dynamic allocation past init.
+/// Keys are always owned (duped on put, freed on eviction/remove/clear/deinit).
+/// Values are owned by default (duped on put), but `putBorrowed` stores a value
+/// that aliases externally-owned memory (e.g. a retained mmap of the snapshot
+/// content section): `value_owned=false` so it is never freed by the cache —
+/// the borrowed bytes must outlive the cache (the Explorer munmaps at deinit).
+/// Zero dynamic allocation past init (for owned-value puts; borrowed puts don't
+/// allocate the value at all).
 pub const ContentCache = struct {
     slots: []Slot,
     capacity: u32,
@@ -22,6 +26,9 @@ pub const ContentCache = struct {
         value: []const u8,
         ref_bit: bool,
         present: bool,
+        /// When false, `value` aliases externally-owned memory and the cache
+        /// must not free it (the key is always cache-owned regardless).
+        value_owned: bool,
     };
 
     const empty_slot = Slot{
@@ -30,6 +37,7 @@ pub const ContentCache = struct {
         .value = &.{},
         .ref_bit = false,
         .present = false,
+        .value_owned = false,
     };
 
     pub const Stats = struct {
@@ -78,7 +86,7 @@ pub const ContentCache = struct {
         for (self.slots) |*slot| {
             if (slot.present) {
                 self.allocator.free(slot.key);
-                self.allocator.free(slot.value);
+                if (slot.value_owned) self.allocator.free(slot.value);
             }
         }
         self.allocator.free(self.slots);
@@ -102,9 +110,22 @@ pub const ContentCache = struct {
         return null;
     }
 
-    /// Insert key/value. Dups both into the cache allocator.
-    /// On collision past probe limit, evicts a cold slot via CLOCK sweep and frees its memory.
+    /// Insert key/value, duping both into the cache allocator. On collision past
+    /// the probe limit, evicts a cold slot via CLOCK sweep and frees its memory.
     pub fn put(self: *ContentCache, key: []const u8, value: []const u8) !void {
+        return self.putImpl(key, value, true);
+    }
+
+    /// Like `put`, but `value` aliases externally-owned memory that outlives the
+    /// cache (a retained mmap of the snapshot content section). The value is
+    /// stored as-is (no dupe) and is never freed by the cache; the key is still
+    /// duped/owned as usual. The caller guarantees `value`'s backing stays valid
+    /// for as long as the entry can live (until Explorer.deinit munmaps it).
+    pub fn putBorrowed(self: *ContentCache, key: []const u8, value: []const u8) !void {
+        return self.putImpl(key, value, false);
+    }
+
+    fn putImpl(self: *ContentCache, key: []const u8, value: []const u8, own: bool) !void {
         const h = hashKey(key);
         const base = @as(u32, @truncate(h)) % self.capacity;
 
@@ -113,19 +134,22 @@ pub const ContentCache = struct {
             const slot_idx = (base +% i) % self.capacity;
             const slot = &self.slots[slot_idx];
             if (slot.present and slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
-                const old_value = slot.value;
-                slot.value = try self.allocator.dupe(u8, value);
+                // Compute the new value first so a failed dupe leaves the slot intact.
+                const new_value = if (own) try self.allocator.dupe(u8, value) else value;
+                if (slot.value_owned) self.allocator.free(slot.value);
+                slot.value = new_value;
+                slot.value_owned = own;
                 slot.ref_bit = true;
-                self.allocator.free(old_value);
                 return;
             }
             if (!slot.present) {
                 const duped_key = try self.allocator.dupe(u8, key);
                 errdefer self.allocator.free(duped_key);
-                const duped_val = try self.allocator.dupe(u8, value);
+                const new_value = if (own) try self.allocator.dupe(u8, value) else value;
                 slot.key_hash = h;
                 slot.key = duped_key;
-                slot.value = duped_val;
+                slot.value = new_value;
+                slot.value_owned = own;
                 slot.ref_bit = true;
                 slot.present = true;
                 self.count_ += 1;
@@ -138,16 +162,17 @@ pub const ContentCache = struct {
         const slot = &self.slots[evict_idx];
         if (slot.present) {
             self.allocator.free(slot.key);
-            self.allocator.free(slot.value);
+            if (slot.value_owned) self.allocator.free(slot.value);
             self.count_ -= 1;
             _ = self.evictions_.fetchAdd(1, .monotonic);
         }
         const duped_key = try self.allocator.dupe(u8, key);
         errdefer self.allocator.free(duped_key);
-        const duped_val = try self.allocator.dupe(u8, value);
+        const new_value = if (own) try self.allocator.dupe(u8, value) else value;
         slot.key_hash = h;
         slot.key = duped_key;
-        slot.value = duped_val;
+        slot.value = new_value;
+        slot.value_owned = own;
         slot.ref_bit = true;
         slot.present = true;
         self.count_ += 1;
@@ -162,7 +187,7 @@ pub const ContentCache = struct {
             const slot = &self.slots[slot_idx];
             if (slot.present and slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
                 self.allocator.free(slot.key);
-                self.allocator.free(slot.value);
+                if (slot.value_owned) self.allocator.free(slot.value);
                 slot.* = empty_slot;
                 self.count_ -= 1;
                 return;
@@ -175,7 +200,7 @@ pub const ContentCache = struct {
         for (self.slots) |*slot| {
             if (slot.present) {
                 self.allocator.free(slot.key);
-                self.allocator.free(slot.value);
+                if (slot.value_owned) self.allocator.free(slot.value);
                 slot.* = empty_slot;
             }
         }
@@ -325,4 +350,50 @@ test "ContentCache: eviction fires under capacity pressure" {
     try std.testing.expect(cache.len() <= cap);
     const s = cache.stats();
     try std.testing.expect(s.evictions > 0);
+}
+
+test "ContentCache: putBorrowed is zero-copy and never frees the value" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 64);
+    defer cache.deinit();
+
+    // A string literal lives in static memory — if the cache ever tried to free
+    // it, the DebugAllocator would detect a bad free / crash.
+    const borrowed: []const u8 = "borrowed content not owned by the cache";
+    try cache.putBorrowed("k", borrowed);
+    const got = cache.get("k").?;
+    try std.testing.expectEqual(borrowed.ptr, got.ptr); // aliases, not a copy
+    try std.testing.expectEqualStrings(borrowed, got);
+
+    // remove frees the owned key but must leave the borrowed value alone.
+    cache.remove("k");
+    try std.testing.expect(cache.get("k") == null);
+}
+
+test "ContentCache: mixed owned/borrowed — transitions and eviction free correctly" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 8);
+    defer cache.deinit();
+
+    const lit: []const u8 = "literal-borrowed-value";
+    try cache.put("a", "heap-duped");       // owned
+    try cache.putBorrowed("b", lit);        // borrowed
+    try std.testing.expectEqualStrings("heap-duped", cache.get("a").?);
+    try std.testing.expectEqual(lit.ptr, cache.get("b").?.ptr);
+
+    // owned -> borrowed: the old heap value must be freed, new aliases lit.
+    try cache.putBorrowed("a", lit);
+    try std.testing.expectEqual(lit.ptr, cache.get("a").?.ptr);
+    // borrowed -> owned: the old borrowed (literal) must NOT be freed.
+    try cache.put("b", "now-owned");
+    try std.testing.expectEqualStrings("now-owned", cache.get("b").?);
+
+    // Capacity pressure with both kinds interleaved: evicting a borrowed slot
+    // must skip the free (would crash on the literal); evicting owned frees it.
+    var kb: [16]u8 = undefined;
+    var i: usize = 0;
+    while (i < 64) : (i += 1) {
+        const k = std.fmt.bufPrint(&kb, "f{d}", .{i}) catch unreachable;
+        if (i % 2 == 0) try cache.putBorrowed(k, lit) else try cache.put(k, "v");
+    }
+    try std.testing.expect(cache.len() <= 8);
+    // No leak (DebugAllocator) and no bad free => the owned/borrowed split holds.
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -513,6 +513,12 @@ fn mainImpl() !void {
             }
 
             if (!std.mem.eql(u8, cmd, "snapshot")) {
+                // Pre-build call-graph centrality so it's persisted in the snapshot
+                // and a later load restores it instead of paying the lazy
+                // first-query rebuild. Same env gate as the search path.
+                if (cio.posixGetenv("CODEDB_NO_CENTRALITY") == null) {
+                    explorer.buildCallCentrality(allocator);
+                }
                 snapshot_mod.writeProjectCacheSnapshot(io, &explorer, abs_root, allocator) catch |err| {
                     std.log.warn("could not persist project-cache snapshot: {}", .{err});
                 };

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2266,6 +2266,31 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                 }
             }
         }
+
+        // Callees section (graph-resolved): walk each ≤3 key symbol's call sites
+        // through the resolved call graph and surface where each callee is
+        // defined. This is the dependency side of the neighborhood — pairs with
+        // the Callers section above so the agent sees both who calls a symbol and
+        // what it calls, without a follow-up codedb_outline/read on the callees.
+        if (inline_bodies) {
+            var any_callees = false;
+            var done_sym = std.StringHashMap(void).init(A);
+            for (sym_refs.items) |sr| {
+                const sym_key = std.fmt.allocPrint(A, "{s}:{d}", .{ sr.path, sr.line }) catch continue;
+                if (done_sym.contains(sym_key)) continue;
+                done_sym.put(sym_key, {}) catch {};
+                const callees = explorer.resolveCallees(sr.path, sr.line, sr.line_end, A, 6) catch continue;
+                if (callees.len == 0) continue;
+                if (!any_callees) {
+                    w.print("\n## Calls (graph-resolved callees of these symbols)\n", .{}) catch {};
+                    any_callees = true;
+                }
+                w.print("- {s} ({s}) calls:\n", .{ sr.kw, sr.kind }) catch {};
+                for (callees) |c| {
+                    w.print("    \xe2\x86\x92 {s} ({s})  {s}:{d}\n", .{ c.name, @tagName(c.kind), c.path, c.line }) catch {};
+                }
+            }
+        }
     }
 
     if (top_n == 0) {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -812,53 +812,65 @@ fn loadSnapshotFast(
     const file_stat = content_file.stat(io) catch return false;
     if (content_entry.offset + content_entry.length > file_stat.size) return false;
 
-    var read_pos: u64 = content_entry.offset;
     const snap_mtime: i128 = @intCast(file_stat.mtime.nanoseconds);
-    var bytes_read: u64 = 0;
     var file_count: u32 = 0;
     var word_index_can_load_from_disk = true;
-    while (bytes_read < content_entry.length) {
-        var pl_buf: [2]u8 = undefined;
-        const pln = content_file.readPositionalAll(io, &pl_buf, read_pos) catch return false;
-        if (pln != 2) break;
-        read_pos += 2;
-        const path_len = std.mem.readInt(u16, &pl_buf, .little);
+
+    // Read the content section as one block, then parse records from memory.
+    // This replaces ~4 readPositionalAll syscalls per file (path_len, path,
+    // content_len, content — ~156k syscalls on a 39k-file repo) with in-memory
+    // slicing. Prefer a file-backed mmap (no heap spike — pages are demand-paged
+    // and reclaimable); fall back to a heap bulk-read if mmap is unavailable.
+    const sec_len: usize = std.math.cast(usize, content_entry.length) orelse return false;
+    const sec_base: usize = std.math.cast(usize, content_entry.offset) orelse return false;
+    var map: ?[]align(std.heap.page_size_min) const u8 = null;
+    var heap_section: ?[]u8 = null;
+    defer if (map) |m| std.posix.munmap(m);
+    defer if (heap_section) |h| allocator.free(h);
+    const section: []const u8 = section_blk: {
+        const fsize: usize = std.math.cast(usize, file_stat.size) orelse return false;
+        if (std.posix.mmap(null, fsize, .{ .READ = true }, .{ .TYPE = .SHARED }, content_file.handle, 0)) |m| {
+            map = m;
+            break :section_blk m[sec_base..][0..sec_len];
+        } else |_| {}
+        const h = allocator.alloc(u8, sec_len) catch return false;
+        if ((content_file.readPositionalAll(io, h, content_entry.offset) catch 0) != sec_len) {
+            allocator.free(h);
+            return false;
+        }
+        heap_section = h;
+        break :section_blk h;
+    };
+
+    var sc: usize = 0; // cursor into `section`
+    while (sc < section.len) {
+        if (sc + 2 > section.len) break;
+        const path_len = std.mem.readInt(u16, section[sc..][0..2], .little);
+        sc += 2;
         if (path_len == 0 or path_len > 4096) break;
-        bytes_read += 2;
+        if (sc + path_len > section.len) break;
 
         const path_buf = allocator.alloc(u8, path_len) catch return false;
-        const prn = content_file.readPositionalAll(io, path_buf, read_pos) catch return false;
-        if (prn != path_len) {
-            allocator.free(path_buf);
-            break;
-        }
-        read_pos += path_len;
-        bytes_read += path_len;
+        @memcpy(path_buf, section[sc..][0..path_len]);
+        sc += path_len;
 
-        var cl_buf: [4]u8 = undefined;
-        const cln = content_file.readPositionalAll(io, &cl_buf, read_pos) catch return false;
-        if (cln != 4) {
+        if (sc + 4 > section.len) {
             allocator.free(path_buf);
             break;
         }
-        read_pos += 4;
-        const content_len = std.mem.readInt(u32, &cl_buf, .little);
-        if (content_len > 64 * 1024 * 1024) {
+        const content_len = std.mem.readInt(u32, section[sc..][0..4], .little);
+        sc += 4;
+        if (content_len > 64 * 1024 * 1024 or sc + content_len > section.len) {
             allocator.free(path_buf);
             break;
         }
-        bytes_read += 4;
 
-        const content = allocator.alloc(u8, content_len) catch return false;
-        const crn = content_file.readPositionalAll(io, content, read_pos) catch return false;
-        if (crn != content_len) {
+        const content = allocator.alloc(u8, content_len) catch {
             allocator.free(path_buf);
-            allocator.free(content);
-            break;
-        }
-        read_pos += content_len;
-        bytes_read += content_len;
-
+            return false;
+        };
+        @memcpy(content, section[sc..][0..content_len]);
+        sc += content_len;
         var disk_content: ?[]u8 = null;
         if (snap_mtime > 0) blk: {
             // statFile (no open/close) — we only need the mtime to detect edits

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -614,21 +614,50 @@ fn readSectionString(buf: []const u8, cursor: *usize, allocator: std.mem.Allocat
     return out;
 }
 
-fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem.Allocator) !std.StringHashMap(FileOutline) {
-    const bytes = (try readSectionBytes(io, snapshot_path, .outline_state, allocator)) orelse return error.InvalidData;
-    defer allocator.free(bytes);
+/// Like readSectionString but returns a slice that aliases `buf` (no copy, no
+/// allocation). Valid only while `buf` is alive — callers that retain the
+/// result must keep `buf` alive at least as long (see loadOutlineStateMap).
+fn readSectionStringBorrowed(buf: []const u8, cursor: *usize, max_len: usize) ![]const u8 {
+    const len = try readSectionInt(u16, buf, cursor);
+    if (len > max_len) return error.InvalidData;
+    if (cursor.* + len > buf.len) return error.InvalidData;
+    const out = buf[cursor.* .. cursor.* + len];
+    cursor.* += len;
+    return out;
+}
+/// On success, `backing_out.*` is set to the raw outline_state section buffer
+/// and ownership transfers to the caller (the restored FileOutlines borrow
+/// their import/symbol strings as slices into it — see FileOutline.borrows_strings).
+/// On any error the buffer is freed here and `backing_out.*` is left null.
+///
+/// The backing buffer is allocated from `backing_allocator` (the Explorer's
+/// allocator), NOT `allocator` (the per-load allocator): it is retained by the
+/// Explorer and must share its lifetime/allocator. Everything else (the map,
+/// keys/paths) uses `allocator` exactly as before.
+fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem.Allocator, backing_allocator: std.mem.Allocator, expected: ?u32, backing_out: *?[]const u8) !std.StringHashMap(FileOutline) {
+    backing_out.* = null;
+    const bytes = (try readSectionBytes(io, snapshot_path, .outline_state, backing_allocator)) orelse return error.InvalidData;
+    // Kept alive on success (handed to backing_out); freed here on any error.
+    var release_bytes = true;
+    defer if (release_bytes) backing_allocator.free(bytes);
 
     var result = std.StringHashMap(FileOutline).init(allocator);
     errdefer deinitOutlineStateMap(&result, allocator);
+    // Pre-size to the known file count: the map otherwise grows 0 -> ~N with
+    // ~log2(N) rehashes, each re-hashing every entry inserted so far.
+    if (expected) |e| result.ensureTotalCapacity(e) catch {};
 
     var cursor: usize = 0;
     const file_count = try readSectionInt(u32, bytes, &cursor);
     for (0..file_count) |_| {
+        // `path` is the map key and stays individually owned (deinitOutlineStateMap
+        // / Explorer.deinit free it). Only the import/symbol strings are borrowed.
         const path = try readSectionString(bytes, &cursor, allocator, 4096);
         if (path.len == 0) return error.InvalidData;
         errdefer allocator.free(path);
 
         var outline = FileOutline.init(allocator, path);
+        outline.borrows_strings = true;
         errdefer outline.deinit();
 
         const language_raw = try readSectionByte(bytes, &cursor);
@@ -638,16 +667,14 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
 
         const import_count = try readSectionInt(u32, bytes, &cursor);
         for (0..import_count) |_| {
-            const imp = try readSectionString(bytes, &cursor, allocator, 4096);
-            errdefer allocator.free(imp);
+            const imp = try readSectionStringBorrowed(bytes, &cursor, 4096);
             try outline.imports.append(allocator, imp);
         }
 
         const symbol_count = try readSectionInt(u32, bytes, &cursor);
         for (0..symbol_count) |_| {
-            const name = try readSectionString(bytes, &cursor, allocator, std.math.maxInt(u16));
+            const name = try readSectionStringBorrowed(bytes, &cursor, std.math.maxInt(u16));
             if (name.len == 0) return error.InvalidData;
-            errdefer allocator.free(name);
 
             const kind_raw = try readSectionByte(bytes, &cursor);
             const kind = std.enums.fromInt(SymbolKind, kind_raw) orelse return error.InvalidData;
@@ -656,10 +683,9 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
             const has_detail = try readSectionByte(bytes, &cursor);
             const detail = switch (has_detail) {
                 0 => null,
-                1 => try readSectionString(bytes, &cursor, allocator, std.math.maxInt(u16)),
+                1 => try readSectionStringBorrowed(bytes, &cursor, std.math.maxInt(u16)),
                 else => return error.InvalidData,
             };
-            errdefer if (detail) |d| allocator.free(d);
 
             try outline.symbols.append(allocator, Symbol{
                 .name = name,
@@ -674,6 +700,9 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
     }
 
     if (cursor != bytes.len) return error.InvalidData;
+    // Success: transfer the backing buffer to the caller.
+    backing_out.* = bytes;
+    release_bytes = false;
     return result;
 }
 
@@ -717,8 +746,32 @@ fn loadSnapshotFast(
     store: *Store,
     allocator: std.mem.Allocator,
 ) !bool {
-    var outline_states = loadOutlineStateMap(io, snapshot_path, allocator) catch std.StringHashMap(FileOutline).init(allocator);
+    var section_backing: ?[]const u8 = null;
+    // backing_allocator = explorer.allocator: the section buffer is retained by
+    // the Explorer (outline_section_bufs) and freed via explorer.allocator, so it
+    // must be allocated from the same allocator (matters when the per-load
+    // allocator differs from the Explorer's, e.g. arena-backed Explorers).
+    var outline_states = loadOutlineStateMap(io, snapshot_path, allocator, explorer.allocator, expected_file_count, &section_backing) catch std.StringHashMap(FileOutline).init(allocator);
     defer deinitOutlineStateMap(&outline_states, allocator);
+
+    // Restored outlines borrow their import/symbol strings as slices into this
+    // buffer; hand it to the Explorer so it outlives them. If the Explorer can't
+    // retain it the borrows would dangle, so free it and abort to a full re-index.
+    if (section_backing) |b| {
+        explorer.adoptOutlineSection(b) catch {
+            explorer.allocator.free(b);
+            return false;
+        };
+    }
+
+    // Pre-size the explorer maps the restore loop fills. Without this they grow
+    // 0 -> ~N with ~log2(N) rehashes apiece, each re-inserting every prior entry
+    // (an O(N log N) churn over the whole load). The file count is known up front.
+    if (expected_file_count) |fc| {
+        explorer.outlines.ensureTotalCapacity(fc) catch {};
+        explorer.dep_graph.forward.ensureTotalCapacity(fc) catch {};
+        explorer.dep_graph.reverse.ensureTotalCapacity(fc) catch {};
+    }
 
     var sections = (try readSections(io, snapshot_path, allocator)) orelse return false;
     defer sections.deinit();

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -558,9 +558,8 @@ pub fn loadSnapshotValidated(
         // Re-index from disk if file was modified after the snapshot
         var disk_content: ?[]u8 = null;
         if (snap_mtime > 0) blk: {
-            const df = std.Io.Dir.cwd().openFile(io, path_buf, .{}) catch break :blk;
-            defer df.close(io);
-            const ds = df.stat(io) catch break :blk;
+            // statFile (no open/close): only the mtime is needed here.
+            const ds = std.Io.Dir.cwd().statFile(io, path_buf, .{}) catch break :blk;
             const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
             if (ds_mtime <= snap_mtime) break :blk;
             disk_content = std.Io.Dir.cwd().readFileAlloc(io, path_buf, allocator, .limited(16 * 1024 * 1024)) catch break :blk;
@@ -862,9 +861,11 @@ fn loadSnapshotFast(
 
         var disk_content: ?[]u8 = null;
         if (snap_mtime > 0) blk: {
-            const df = std.Io.Dir.cwd().openFile(io, path_buf, .{}) catch break :blk;
-            defer df.close(io);
-            const ds = df.stat(io) catch break :blk;
+            // statFile (no open/close) — we only need the mtime to detect edits
+            // made since the snapshot. Saves 2 syscalls/file vs openFile+stat+close
+            // across the whole tree; the file is only opened (readFileAlloc below)
+            // when it's actually newer, which is the rare case.
+            const ds = std.Io.Dir.cwd().statFile(io, path_buf, .{}) catch break :blk;
             const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
             if (ds_mtime <= snap_mtime) break :blk;
             disk_content = std.Io.Dir.cwd().readFileAlloc(io, path_buf, allocator, .limited(16 * 1024 * 1024)) catch break :blk;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -43,6 +43,7 @@ pub const SectionId = enum(u32) {
     freq_table = 5,
     meta = 6,
     outline_state = 7,
+    call_centrality = 8,
 };
 
 const SectionEntry = struct {
@@ -282,6 +283,35 @@ pub fn writeSnapshot(
         try sections.append(allocator, .{ .id = @intFromEnum(SectionId.freq_table), .offset = offset, .length = end - offset });
     }
 
+    // ── Section: CALL_CENTRALITY ──
+    // Per-file weighted call-graph in-degree (path -> f32), so a loaded snapshot
+    // can skip the lazy first-query rebuild in ensureCallCentrality. Written only
+    // if already built (non-null); an absent/empty section makes the loader fall
+    // back to the lazy build — backward compatible with older snapshots. Read
+    // under the shared lock held above; never builds here.
+    {
+        const offset = file_writer.logicalPos();
+        const count: u32 = if (explorer.call_centrality) |cm| @intCast(cm.count()) else 0;
+        var count_buf: [4]u8 = undefined;
+        std.mem.writeInt(u32, &count_buf, count, .little);
+        try fw.writeAll(&count_buf);
+        if (explorer.call_centrality) |cm| {
+            var it = cm.iterator();
+            while (it.next()) |e| {
+                const key = e.key_ptr.*;
+                var plen_buf: [2]u8 = undefined;
+                std.mem.writeInt(u16, &plen_buf, @intCast(@min(key.len, std.math.maxInt(u16))), .little);
+                try fw.writeAll(&plen_buf);
+                try fw.writeAll(key[0..@min(key.len, std.math.maxInt(u16))]);
+                const bits: u32 = @bitCast(e.value_ptr.*);
+                var f_buf: [4]u8 = undefined;
+                std.mem.writeInt(u32, &f_buf, bits, .little);
+                try fw.writeAll(&f_buf);
+            }
+        }
+        const end = file_writer.logicalPos();
+        try sections.append(allocator, .{ .id = @intFromEnum(SectionId.call_centrality), .offset = offset, .length = end - offset });
+    }
     // ── Write header + section table at file start ──
     try file_writer.seekTo(0);
 
@@ -920,7 +950,63 @@ fn loadSnapshotFast(
         }
     }
 
+    // Restore persisted call-graph centrality, if present, so the first ranked
+    // search skips the lazy rebuild (ensureCallCentrality's null-check returns
+    // early once this is set). Best-effort: any failure just leaves it unbuilt.
+    if (sections.get(@intFromEnum(SectionId.call_centrality))) |cc_entry| {
+        restoreCallCentrality(io, snapshot_path, cc_entry, explorer, allocator) catch {};
+    }
+
     return true;
+}
+
+/// Reconstruct Explorer.call_centrality from a persisted CALL_CENTRALITY section.
+/// Keys are taken from the (now-populated) outlines map so they share the same
+/// stable, borrowed lifetime as ensureCallCentrality's keys — Explorer.deinit
+/// frees them via outlines, never via call_centrality. Files no longer in the
+/// outlines (changed/removed since the snapshot) are simply skipped.
+fn restoreCallCentrality(
+    io: std.Io,
+    snapshot_path: []const u8,
+    entry: SectionEntry,
+    explorer: *Explorer,
+    allocator: std.mem.Allocator,
+) !void {
+    if (entry.length < 4 or entry.length > 256 * 1024 * 1024) return;
+    const bytes = try allocator.alloc(u8, entry.length);
+    defer allocator.free(bytes);
+    const f = try std.Io.Dir.cwd().openFile(io, snapshot_path, .{});
+    defer f.close(io);
+    if ((try f.readPositionalAll(io, bytes, entry.offset)) != entry.length) return;
+
+    var cursor: usize = 0;
+    if (cursor + 4 > bytes.len) return;
+    const count = std.mem.readInt(u32, bytes[cursor..][0..4], .little);
+    cursor += 4;
+    if (count == 0) return;
+
+    var cmap = std.StringHashMap(f32).init(explorer.allocator);
+    errdefer cmap.deinit();
+    cmap.ensureTotalCapacity(count) catch {};
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (cursor + 2 > bytes.len) break;
+        const plen = std.mem.readInt(u16, bytes[cursor..][0..2], .little);
+        cursor += 2;
+        if (plen == 0 or cursor + plen + 4 > bytes.len) break;
+        const path = bytes[cursor .. cursor + plen];
+        cursor += plen;
+        const bits = std.mem.readInt(u32, bytes[cursor..][0..4], .little);
+        cursor += 4;
+        const centrality: f32 = @bitCast(bits);
+        // Borrow the stable outlines key (don't allocate a new one).
+        if (explorer.outlines.getEntry(path)) |e| {
+            cmap.put(e.key_ptr.*, centrality) catch {};
+        }
+    }
+
+    explorer.call_centrality = cmap;
 }
 
 fn parseJsonU32(json: []const u8, key: []const u8) ?u32 {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -798,6 +798,51 @@ fn insertRestoredFile(
     try rebuildDepsFromOutline(explorer, path, &restored_outline, allocator);
 }
 
+// Below this many files the per-file freshness stats run on the loading thread:
+// spawning workers for a small tree costs more than the stats they save. Setting
+// CODEDB_LOAD_WORKERS overrides the worker count (and forces parallelism below the
+// threshold) for A/B measurement. Public so a test can size a fixture that
+// deterministically exercises the multi-worker path.
+pub const FRESHNESS_PARALLEL_THRESHOLD: usize = 256;
+
+// Worker cap for the parallel freshness scan. statFile is dominated by kernel VFS
+// work, not CPU, so throughput saturates at low concurrency: a worker sweep over a
+// 16k-file tree (20 P-core M3 Ultra, files across 200 dirs) measured freshness
+// 14.1ms@1 -> 5.7ms@4 -> 9.5ms@8 -> 13.3ms@12 — a U-curve bottoming at ~4 regardless
+// of core count. More workers past that regress (syscall/cache contention), so cap
+// low rather than at the CPU count. CODEDB_LOAD_WORKERS overrides for re-tuning.
+const FRESHNESS_MAX_WORKERS: usize = 4;
+
+// One parsed CONTENT-section record. `path` and `content` are borrowed slices into
+// the mapped content section (alive for the whole load) — never owned here; the
+// insert pass copies whatever it keeps.
+const LoadRecord = struct {
+    path: []const u8,
+    content: []const u8,
+    stored_hash: ?u64,
+};
+
+// Outcome of one file's freshness check. `content` is non-null only when the file
+// on disk was modified after the snapshot: the fresh bytes, allocated from the page
+// allocator (the scan may run on a worker thread) and freed by the insert pass.
+// null = unchanged, or the stat/read failed (treated as unchanged).
+const LoadFreshness = struct {
+    content: ?[]u8 = null,
+};
+
+// Freshness scan for one chunk of records: statFile each path (one syscall, no
+// open/close) and, only when its mtime is newer than the snapshot, re-read the
+// fresh content. Independent per file, so workers run this over disjoint chunks
+// concurrently; each writes only its own slice of `out`.
+fn freshnessScan(io: std.Io, snap_mtime: i128, recs: []const LoadRecord, out: []LoadFreshness) void {
+    for (recs, out) |record, *fr| {
+        const ds = std.Io.Dir.cwd().statFile(io, record.path, .{}) catch continue;
+        const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
+        if (ds_mtime <= snap_mtime) continue;
+        fr.content = std.Io.Dir.cwd().readFileAlloc(io, record.path, std.heap.page_allocator, .limited(16 * 1024 * 1024)) catch continue;
+    }
+}
+
 fn loadSnapshotFast(
     io: std.Io,
     snapshot_path: []const u8,
@@ -859,7 +904,6 @@ fn loadSnapshotFast(
     // (which would also fault in all content pages). Absent => recompute.
     const content_hashes_buf: ?[]u8 = readSectionBytes(io, snapshot_path, .content_hashes, allocator) catch null;
     defer if (content_hashes_buf) |b| allocator.free(b);
-    var rec: usize = 0; // 0-based content-record index, matches content_hashes order
 
     // Read the content section as one block, then parse records from memory.
     // This replaces ~4 readPositionalAll syscalls per file (path_len, path,
@@ -894,94 +938,136 @@ fn loadSnapshotFast(
         break :section_blk h;
     };
 
-    var sc: usize = 0; // cursor into `section`
-    while (sc < section.len) {
-        if (sc + 2 > section.len) break;
-        const path_len = std.mem.readInt(u16, section[sc..][0..2], .little);
-        sc += 2;
-        if (path_len == 0 or path_len > 4096) break;
-        if (sc + path_len > section.len) break;
+    // ── Pass A: parse the CONTENT section into records (borrowed slices). ──
+    // Pure slicing over the mapped section — no per-file allocation. The path and
+    // content of each record are slices into `section` (alive for the whole load).
+    // The insert pass (Pass C) copies whatever it retains — indexFile*/recordSnapshot
+    // dupe the path, the restored branch reuses the OUTLINE_STATE map key — so this
+    // drops the old per-record path_buf alloc+memcpy+free (one pair per file).
+    var records: std.ArrayList(LoadRecord) = .empty;
+    defer records.deinit(allocator);
+    if (expected_file_count) |fc| records.ensureTotalCapacity(allocator, fc) catch {};
+    {
+        var sc: usize = 0; // cursor into `section`
+        var rec_idx: usize = 0;
+        while (sc < section.len) {
+            if (sc + 2 > section.len) break;
+            const path_len = std.mem.readInt(u16, section[sc..][0..2], .little);
+            sc += 2;
+            if (path_len == 0 or path_len > 4096) break;
+            if (sc + path_len > section.len) break;
+            const path = section[sc..][0..path_len];
+            sc += path_len;
 
-        const path_buf = allocator.alloc(u8, path_len) catch return false;
-        @memcpy(path_buf, section[sc..][0..path_len]);
-        sc += path_len;
+            if (sc + 4 > section.len) break;
+            const content_len = std.mem.readInt(u32, section[sc..][0..4], .little);
+            sc += 4;
+            if (content_len > 64 * 1024 * 1024 or sc + content_len > section.len) break;
+            const content = section[sc..][0..content_len];
+            sc += content_len;
 
-        if (sc + 4 > section.len) {
-            allocator.free(path_buf);
-            break;
+            // Precomputed hash of this record's content, if the snapshot carries it
+            // (content order). Lets the restored/outline-only branches record a Store
+            // baseline without re-hashing + faulting every page; the changed-file
+            // branch re-hashes fresh disk content instead.
+            const stored_hash: ?u64 = if (content_hashes_buf) |hb| blk: {
+                const off = rec_idx * 8;
+                break :blk if (off + 8 <= hb.len) std.mem.readInt(u64, hb[off..][0..8], .little) else null;
+            } else null;
+            records.append(allocator, .{ .path = path, .content = content, .stored_hash = stored_hash }) catch break;
+            rec_idx += 1;
         }
-        const content_len = std.mem.readInt(u32, section[sc..][0..4], .little);
-        sc += 4;
-        if (content_len > 64 * 1024 * 1024 or sc + content_len > section.len) {
-            allocator.free(path_buf);
-            break;
-        }
+    }
 
-        // `content` borrows the mapped section directly — no transient copy.
-        // The consumers below (insertRestoredFile/indexFile*/recordSnapshot)
-        // only read it or dupe it into the content cache, and the mapping is
-        // alive for the whole loop, so the slice never outlives its backing.
-        const content = section[sc..][0..content_len];
-        sc += content_len;
-        const rec_idx = rec;
-        rec += 1;
-        // Precomputed hash of this record's content, if the snapshot carries it.
-        // Used for the restored/outline-only branches (content == snapshot content)
-        // so we don't re-hash + fault every page. The changed-file branch below
-        // re-hashes the fresh disk content instead.
-        const stored_hash: ?u64 = if (content_hashes_buf) |hb| blk: {
-            const off = rec_idx * 8;
-            break :blk if (off + 8 <= hb.len) std.mem.readInt(u64, hb[off..][0..8], .little) else null;
-        } else null;
-        var disk_content: ?[]u8 = null;
-        const t_fresh0: i128 = if (prof) cio.nanoTimestamp() else 0;
-        if (snap_mtime > 0) blk: {
-            // statFile (no open/close) — we only need the mtime to detect edits
-            // made since the snapshot. Saves 2 syscalls/file vs openFile+stat+close
-            // across the whole tree; the file is only opened (readFileAlloc below)
-            // when it's actually newer, which is the rare case.
-            const ds = std.Io.Dir.cwd().statFile(io, path_buf, .{}) catch break :blk;
-            const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
-            if (ds_mtime <= snap_mtime) break :blk;
-            disk_content = std.Io.Dir.cwd().readFileAlloc(io, path_buf, allocator, .limited(16 * 1024 * 1024)) catch break :blk;
-        }
-        if (prof) fresh_ns += cio.nanoTimestamp() - t_fresh0;
-        defer if (disk_content) |dc| allocator.free(dc);
+    // ── Pass B: freshness check (parallelized for large trees). ──
+    // statFile every record to detect edits made since the snapshot, re-reading
+    // fresh content for any that changed. These are independent per-file syscalls —
+    // the dominant load cost once the borrow/mmap work removed the copies — so fan
+    // them out across workers writing disjoint result slices. The mutating insert
+    // pass (Pass C) consumes the results single-threaded.
+    const fresh_results = allocator.alloc(LoadFreshness, records.items.len) catch return false;
+    defer allocator.free(fresh_results);
+    for (fresh_results) |*fr| fr.* = .{};
 
-        if (disk_content) |dc| {
+    const t_fresh0: i128 = if (prof) cio.nanoTimestamp() else 0;
+    if (snap_mtime > 0 and records.items.len > 0) {
+        const want_workers = blk: {
+            if (cio.posixGetenv("CODEDB_LOAD_WORKERS")) |raw| {
+                const parsed = std.fmt.parseInt(usize, raw, 10) catch 0;
+                if (parsed > 0) break :blk parsed;
+            }
+            if (records.items.len < FRESHNESS_PARALLEL_THRESHOLD) break :blk 1;
+            const cpu_count = std.Thread.getCpuCount() catch 1;
+            break :blk @min(@as(usize, @intCast(cpu_count)), FRESHNESS_MAX_WORKERS);
+        };
+        const n_workers = @max(@as(usize, 1), @min(want_workers, records.items.len));
+        if (n_workers <= 1) {
+            freshnessScan(io, snap_mtime, records.items, fresh_results);
+        } else if (allocator.alloc(std.Thread, n_workers)) |threads| {
+            defer allocator.free(threads);
+            const chunk = records.items.len / n_workers;
+            const rem = records.items.len % n_workers;
+            var off: usize = 0;
+            var spawned: usize = 0;
+            var spawn_failed = false;
+            for (0..n_workers) |i| {
+                const extra: usize = if (i < rem) 1 else 0;
+                const start = off;
+                off += chunk + extra;
+                const recs = records.items[start..off];
+                const out = fresh_results[start..off];
+                if (spawn_failed) {
+                    freshnessScan(io, snap_mtime, recs, out);
+                    continue;
+                }
+                if (std.Thread.spawn(.{}, freshnessScan, .{ io, snap_mtime, recs, out })) |t| {
+                    threads[spawned] = t;
+                    spawned += 1;
+                } else |_| {
+                    // Out of threads: scan this chunk (and any remaining) inline.
+                    freshnessScan(io, snap_mtime, recs, out);
+                    spawn_failed = true;
+                }
+            }
+            for (threads[0..spawned]) |t| t.join();
+        } else |_| {
+            freshnessScan(io, snap_mtime, records.items, fresh_results);
+        }
+    }
+    if (prof) fresh_ns += cio.nanoTimestamp() - t_fresh0;
+
+    // ── Pass C: insert restored / changed / outline-only files (sequential). ──
+    for (records.items, fresh_results) |record, fr| {
+        const path = record.path;
+        const content = record.content;
+        // Non-null fr.content => the file was edited after the snapshot (fresh disk
+        // bytes from the page allocator); free it once this record is consumed.
+        defer if (fr.content) |dc| std.heap.page_allocator.free(dc);
+
+        if (fr.content) |dc| {
             word_index_can_load_from_disk = false;
-            if (outline_states.fetchRemove(path_buf)) |removed| {
+            if (outline_states.fetchRemove(path)) |removed| {
                 allocator.free(removed.key);
                 var stale_outline = removed.value;
                 stale_outline.deinit();
             }
-
-            explorer.indexFile(path_buf, dc) catch {
-                allocator.free(path_buf);
-                continue;
-            };
+            explorer.indexFile(path, dc) catch continue;
             const hash = std.hash.Wyhash.hash(0, dc);
-            _ = store.recordSnapshot(path_buf, dc.len, hash) catch {};
-            allocator.free(path_buf);
-        } else if (outline_states.fetchRemove(path_buf)) |removed| {
-            allocator.free(path_buf);
+            _ = store.recordSnapshot(path, dc.len, hash) catch {};
+        } else if (outline_states.fetchRemove(path)) |removed| {
             insertRestoredFile(explorer, removed.key, content, removed.value, allocator, content_borrowed) catch {
                 allocator.free(removed.key);
                 var bad_outline = removed.value;
                 bad_outline.deinit();
                 continue;
             };
-            const hash = stored_hash orelse std.hash.Wyhash.hash(0, content);
+            const hash = record.stored_hash orelse std.hash.Wyhash.hash(0, content);
             _ = store.recordSnapshot(removed.key, content.len, hash) catch {};
         } else {
             word_index_can_load_from_disk = false;
-            explorer.indexFileOutlineOnly(path_buf, content) catch {
-                allocator.free(path_buf);
-                continue;
-            };
-            const hash = stored_hash orelse std.hash.Wyhash.hash(0, content);
-            _ = store.recordSnapshot(path_buf, content.len, hash) catch {};
-            allocator.free(path_buf);
+            explorer.indexFileOutlineOnly(path, content) catch continue;
+            const hash = record.stored_hash orelse std.hash.Wyhash.hash(0, content);
+            _ = store.recordSnapshot(path, content.len, hash) catch {};
         }
 
         file_count += 1;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -865,11 +865,11 @@ fn loadSnapshotFast(
             break;
         }
 
-        const content = allocator.alloc(u8, content_len) catch {
-            allocator.free(path_buf);
-            return false;
-        };
-        @memcpy(content, section[sc..][0..content_len]);
+        // `content` borrows the mapped section directly — no transient copy.
+        // The consumers below (insertRestoredFile/indexFile*/recordSnapshot)
+        // only read it or dupe it into the content cache, and the mapping is
+        // alive for the whole loop, so the slice never outlives its backing.
+        const content = section[sc..][0..content_len];
         sc += content_len;
         var disk_content: ?[]u8 = null;
         if (snap_mtime > 0) blk: {
@@ -894,36 +894,30 @@ fn loadSnapshotFast(
 
             explorer.indexFile(path_buf, dc) catch {
                 allocator.free(path_buf);
-                allocator.free(content);
                 continue;
             };
             const hash = std.hash.Wyhash.hash(0, dc);
             _ = store.recordSnapshot(path_buf, dc.len, hash) catch {};
             allocator.free(path_buf);
-            allocator.free(content);
         } else if (outline_states.fetchRemove(path_buf)) |removed| {
             allocator.free(path_buf);
             insertRestoredFile(explorer, removed.key, content, removed.value, allocator) catch {
                 allocator.free(removed.key);
                 var bad_outline = removed.value;
                 bad_outline.deinit();
-                allocator.free(content);
                 continue;
             };
             const hash = std.hash.Wyhash.hash(0, content);
             _ = store.recordSnapshot(removed.key, content.len, hash) catch {};
-            allocator.free(content);
         } else {
             word_index_can_load_from_disk = false;
             explorer.indexFileOutlineOnly(path_buf, content) catch {
                 allocator.free(path_buf);
-                allocator.free(content);
                 continue;
             };
             const hash = std.hash.Wyhash.hash(0, content);
             _ = store.recordSnapshot(path_buf, content.len, hash) catch {};
             allocator.free(path_buf);
-            allocator.free(content);
         }
 
         file_count += 1;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -822,24 +822,23 @@ const LoadRecord = struct {
     stored_hash: ?u64,
 };
 
-// Outcome of one file's freshness check. `content` is non-null only when the file
-// on disk was modified after the snapshot: the fresh bytes, allocated from the page
-// allocator (the scan may run on a worker thread) and freed by the insert pass.
-// null = unchanged, or the stat/read failed (treated as unchanged).
+// Outcome of one file's freshness check: was the on-disk file modified after the
+// snapshot? The scan only stats — no content read, no allocation — so workers stay
+// pure and trivially thread-safe; the insert pass reads fresh content (sequentially,
+// one file at a time) for the rare stale ones.
 const LoadFreshness = struct {
-    content: ?[]u8 = null,
+    stale: bool = false,
 };
 
 // Freshness scan for one chunk of records: statFile each path (one syscall, no
-// open/close) and, only when its mtime is newer than the snapshot, re-read the
-// fresh content. Independent per file, so workers run this over disjoint chunks
+// open/close) and flag it stale when its mtime is newer than the snapshot. Pure
+// read-only and allocation-free, so workers run this over disjoint chunks
 // concurrently; each writes only its own slice of `out`.
 fn freshnessScan(io: std.Io, snap_mtime: i128, recs: []const LoadRecord, out: []LoadFreshness) void {
     for (recs, out) |record, *fr| {
         const ds = std.Io.Dir.cwd().statFile(io, record.path, .{}) catch continue;
         const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
-        if (ds_mtime <= snap_mtime) continue;
-        fr.content = std.Io.Dir.cwd().readFileAlloc(io, record.path, std.heap.page_allocator, .limited(16 * 1024 * 1024)) catch continue;
+        if (ds_mtime > snap_mtime) fr.stale = true;
     }
 }
 
@@ -980,11 +979,11 @@ fn loadSnapshotFast(
     }
 
     // ── Pass B: freshness check (parallelized for large trees). ──
-    // statFile every record to detect edits made since the snapshot, re-reading
-    // fresh content for any that changed. These are independent per-file syscalls —
-    // the dominant load cost once the borrow/mmap work removed the copies — so fan
-    // them out across workers writing disjoint result slices. The mutating insert
-    // pass (Pass C) consumes the results single-threaded.
+    // statFile every record to detect edits made since the snapshot. These are
+    // independent, allocation-free per-file syscalls — the dominant load cost once
+    // the borrow/mmap work removed the copies — so fan them out across workers, each
+    // flagging its own disjoint slice. The insert pass (Pass C) reads fresh content
+    // for the flagged files and mutates Explorer/Store single-threaded.
     const fresh_results = allocator.alloc(LoadFreshness, records.items.len) catch return false;
     defer allocator.free(fresh_results);
     for (fresh_results) |*fr| fr.* = .{};
@@ -1040,11 +1039,16 @@ fn loadSnapshotFast(
     for (records.items, fresh_results) |record, fr| {
         const path = record.path;
         const content = record.content;
-        // Non-null fr.content => the file was edited after the snapshot (fresh disk
-        // bytes from the page allocator); free it once this record is consumed.
-        defer if (fr.content) |dc| std.heap.page_allocator.free(dc);
+        // A file flagged stale was edited after the snapshot: re-read its fresh
+        // content from disk and re-index it. Read here (not in the parallel scan) so
+        // peak memory is one file's content, not every changed file's at once.
+        var disk_content: ?[]u8 = null;
+        if (fr.stale) {
+            disk_content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(16 * 1024 * 1024)) catch null;
+        }
+        defer if (disk_content) |dc| allocator.free(dc);
 
-        if (fr.content) |dc| {
+        if (disk_content) |dc| {
             word_index_can_load_from_disk = false;
             if (outline_states.fetchRemove(path)) |removed| {
                 allocator.free(removed.key);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -753,6 +753,7 @@ fn insertRestoredFile(
     content: []const u8,
     outline: FileOutline,
     allocator: std.mem.Allocator,
+    borrow_content: bool,
 ) !void {
     var restored_outline = outline;
     restored_outline.path = path;
@@ -762,7 +763,13 @@ fn insertRestoredFile(
     outline_gop.key_ptr.* = path;
     outline_gop.value_ptr.* = restored_outline;
 
-    try explorer.contents.put(path, content);
+    // When the content was read from an mmap the Explorer has adopted, store a
+    // borrowed (zero-copy) cache value; otherwise dupe it as usual.
+    if (borrow_content) {
+        try explorer.contents.putBorrowed(path, content);
+    } else {
+        try explorer.contents.put(path, content);
+    }
 
     try rebuildDepsFromOutline(explorer, path, &restored_outline, allocator);
 }
@@ -823,15 +830,22 @@ fn loadSnapshotFast(
     // and reclaimable); fall back to a heap bulk-read if mmap is unavailable.
     const sec_len: usize = std.math.cast(usize, content_entry.length) orelse return false;
     const sec_base: usize = std.math.cast(usize, content_entry.offset) orelse return false;
-    var map: ?[]align(std.heap.page_size_min) const u8 = null;
     var heap_section: ?[]u8 = null;
-    defer if (map) |m| std.posix.munmap(m);
     defer if (heap_section) |h| allocator.free(h);
+    // When the content comes from an mmap, the Explorer adopts it (munmap'd at its
+    // deinit) and the ContentCache borrows zero-copy slices into it — no per-file
+    // content dupe. The heap fallback is transient (freed below), so in that case
+    // the content is duped into the cache as usual.
+    var content_borrowed = false;
     const section: []const u8 = section_blk: {
         const fsize: usize = std.math.cast(usize, file_stat.size) orelse return false;
         if (std.posix.mmap(null, fsize, .{ .READ = true }, .{ .TYPE = .SHARED }, content_file.handle, 0)) |m| {
-            map = m;
-            break :section_blk m[sec_base..][0..sec_len];
+            if (explorer.adoptContentSection(m)) {
+                content_borrowed = true;
+                break :section_blk m[sec_base..][0..sec_len];
+            } else |_| {
+                std.posix.munmap(m);
+            }
         } else |_| {}
         const h = allocator.alloc(u8, sec_len) catch return false;
         if ((content_file.readPositionalAll(io, h, content_entry.offset) catch 0) != sec_len) {
@@ -901,7 +915,7 @@ fn loadSnapshotFast(
             allocator.free(path_buf);
         } else if (outline_states.fetchRemove(path_buf)) |removed| {
             allocator.free(path_buf);
-            insertRestoredFile(explorer, removed.key, content, removed.value, allocator) catch {
+            insertRestoredFile(explorer, removed.key, content, removed.value, allocator, content_borrowed) catch {
                 allocator.free(removed.key);
                 var bad_outline = removed.value;
                 bad_outline.deinit();

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -44,6 +44,7 @@ pub const SectionId = enum(u32) {
     meta = 6,
     outline_state = 7,
     call_centrality = 8,
+    content_hashes = 9,
 };
 
 const SectionEntry = struct {
@@ -228,6 +229,12 @@ pub fn writeSnapshot(
     }
 
     // ── Section: CONTENT ──
+    // Per-file content hashes, collected in lockstep with the records below and
+    // written as a separate CONTENT_HASHES section. The loader records these in
+    // the Store version log instead of re-hashing every file's content at load
+    // (which also faults in the whole mmap'd content section).
+    var content_hashes: std.ArrayList(u64) = .empty;
+    defer content_hashes.deinit(allocator);
     {
         const offset = file_writer.logicalPos();
         var root_dir = std.Io.Dir.cwd().openDir(io, root_path, .{}) catch null;
@@ -248,6 +255,7 @@ pub fn writeSnapshot(
                 std.mem.writeInt(u32, &cl_buf, @intCast(content.len), .little);
                 try fw.writeAll(&cl_buf);
                 try fw.writeAll(content);
+                try content_hashes.append(allocator, std.hash.Wyhash.hash(0, content));
             } else if (root_dir) |*dir| {
                 const disk_content = dir.readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
                 errdefer allocator.free(disk_content);
@@ -260,11 +268,27 @@ pub fn writeSnapshot(
                 std.mem.writeInt(u32, &cl_buf, @intCast(disk_content.len), .little);
                 try fw.writeAll(&cl_buf);
                 try fw.writeAll(disk_content);
+                try content_hashes.append(allocator, std.hash.Wyhash.hash(0, disk_content));
                 allocator.free(disk_content);
             }
         }
         const end = file_writer.logicalPos();
         try sections.append(allocator, .{ .id = @intFromEnum(SectionId.content), .offset = offset, .length = end - offset });
+    }
+
+    // ── Section: CONTENT_HASHES ──
+    // u64 Wyhash per content record, in the exact order of the CONTENT section,
+    // so the loader can record Store baselines without re-hashing content. An
+    // absent section just makes the loader recompute (older snapshots).
+    {
+        const offset = file_writer.logicalPos();
+        for (content_hashes.items) |h| {
+            var hbuf: [8]u8 = undefined;
+            std.mem.writeInt(u64, &hbuf, h, .little);
+            try fw.writeAll(&hbuf);
+        }
+        const end = file_writer.logicalPos();
+        try sections.append(allocator, .{ .id = @intFromEnum(SectionId.content_hashes), .offset = offset, .length = end - offset });
     }
 
     // ── Section: FREQ TABLE ──
@@ -782,6 +806,12 @@ fn loadSnapshotFast(
     store: *Store,
     allocator: std.mem.Allocator,
 ) !bool {
+    // Optional phase profiler (CODEDB_LOAD_PROFILE): prints a load breakdown to
+    // stderr. Near-zero cost when off (one getenv + a few timestamps).
+    const prof = cio.posixGetenv("CODEDB_LOAD_PROFILE") != null;
+    const t_load0: i128 = if (prof) cio.nanoTimestamp() else 0;
+    var fresh_ns: i128 = 0;
+
     var section_backing: ?[]const u8 = null;
     // backing_allocator = explorer.allocator: the section buffer is retained by
     // the Explorer (outline_section_bufs) and freed via explorer.allocator, so it
@@ -809,6 +839,7 @@ fn loadSnapshotFast(
         explorer.dep_graph.reverse.ensureTotalCapacity(fc) catch {};
     }
 
+    const t_outline: i128 = if (prof) cio.nanoTimestamp() else 0;
     var sections = (try readSections(io, snapshot_path, allocator)) orelse return false;
     defer sections.deinit();
 
@@ -822,6 +853,13 @@ fn loadSnapshotFast(
     const snap_mtime: i128 = @intCast(file_stat.mtime.nanoseconds);
     var file_count: u32 = 0;
     var word_index_can_load_from_disk = true;
+
+    // Precomputed per-record content hashes (CONTENT_HASHES section), in content
+    // order. Lets the restored branch record Store baselines without re-hashing
+    // (which would also fault in all content pages). Absent => recompute.
+    const content_hashes_buf: ?[]u8 = readSectionBytes(io, snapshot_path, .content_hashes, allocator) catch null;
+    defer if (content_hashes_buf) |b| allocator.free(b);
+    var rec: usize = 0; // 0-based content-record index, matches content_hashes order
 
     // Read the content section as one block, then parse records from memory.
     // This replaces ~4 readPositionalAll syscalls per file (path_len, path,
@@ -885,7 +923,18 @@ fn loadSnapshotFast(
         // alive for the whole loop, so the slice never outlives its backing.
         const content = section[sc..][0..content_len];
         sc += content_len;
+        const rec_idx = rec;
+        rec += 1;
+        // Precomputed hash of this record's content, if the snapshot carries it.
+        // Used for the restored/outline-only branches (content == snapshot content)
+        // so we don't re-hash + fault every page. The changed-file branch below
+        // re-hashes the fresh disk content instead.
+        const stored_hash: ?u64 = if (content_hashes_buf) |hb| blk: {
+            const off = rec_idx * 8;
+            break :blk if (off + 8 <= hb.len) std.mem.readInt(u64, hb[off..][0..8], .little) else null;
+        } else null;
         var disk_content: ?[]u8 = null;
+        const t_fresh0: i128 = if (prof) cio.nanoTimestamp() else 0;
         if (snap_mtime > 0) blk: {
             // statFile (no open/close) — we only need the mtime to detect edits
             // made since the snapshot. Saves 2 syscalls/file vs openFile+stat+close
@@ -896,6 +945,7 @@ fn loadSnapshotFast(
             if (ds_mtime <= snap_mtime) break :blk;
             disk_content = std.Io.Dir.cwd().readFileAlloc(io, path_buf, allocator, .limited(16 * 1024 * 1024)) catch break :blk;
         }
+        if (prof) fresh_ns += cio.nanoTimestamp() - t_fresh0;
         defer if (disk_content) |dc| allocator.free(dc);
 
         if (disk_content) |dc| {
@@ -921,7 +971,7 @@ fn loadSnapshotFast(
                 bad_outline.deinit();
                 continue;
             };
-            const hash = std.hash.Wyhash.hash(0, content);
+            const hash = stored_hash orelse std.hash.Wyhash.hash(0, content);
             _ = store.recordSnapshot(removed.key, content.len, hash) catch {};
         } else {
             word_index_can_load_from_disk = false;
@@ -929,7 +979,7 @@ fn loadSnapshotFast(
                 allocator.free(path_buf);
                 continue;
             };
-            const hash = std.hash.Wyhash.hash(0, content);
+            const hash = stored_hash orelse std.hash.Wyhash.hash(0, content);
             _ = store.recordSnapshot(path_buf, content.len, hash) catch {};
             allocator.free(path_buf);
         }
@@ -976,6 +1026,21 @@ fn loadSnapshotFast(
     // early once this is set). Best-effort: any failure just leaves it unbuilt.
     if (sections.get(@intFromEnum(SectionId.call_centrality))) |cc_entry| {
         restoreCallCentrality(io, snapshot_path, cc_entry, explorer, allocator) catch {};
+    }
+
+    if (prof) {
+        const now = cio.nanoTimestamp();
+        const ms = struct {
+            fn f(ns: i128) f64 {
+                return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+            }
+        }.f;
+        const outline_ns = t_outline - t_load0;
+        const loop_ns = now - t_outline;
+        std.debug.print(
+            "[load-profile] {d} files  total={d:.1}ms  outline={d:.1}ms  loop={d:.1}ms (freshness={d:.1}ms, rest={d:.1}ms)\n",
+            .{ file_count, ms(now - t_load0), ms(outline_ns), ms(loop_ns), ms(fresh_ns), ms(loop_ns - fresh_ns) },
+        );
     }
 
     return true;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2065,3 +2065,35 @@ test "explorer: multi-line signature gets correct line_end (findBraceEnd paren-a
     // on line 2 ended the scope early (line_end ~2); paren-awareness fixes it.
     try testing.expect(f_end >= 6);
 }
+
+test "resolveCallees: resolves call sites in a function body to their definitions" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var exp = Explorer.init(a, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try exp.indexFile("util.zig", "pub fn helper() void {}\npub fn other() void {}\n");
+    try exp.indexFile("main.zig",
+        \\pub fn run() void {
+        \\    helper();
+        \\    other();
+        \\}
+        \\
+    );
+
+    // run() spans lines 1-4; both calls resolve to definitions in util.zig.
+    const callees = try exp.resolveCallees("main.zig", 1, 4, a, 8);
+    var saw_helper = false;
+    var saw_other = false;
+    for (callees) |c| {
+        if (std.mem.eql(u8, c.name, "helper")) {
+            saw_helper = true;
+            try testing.expectEqualStrings("util.zig", c.path);
+            try testing.expect(c.kind == .function);
+        }
+        if (std.mem.eql(u8, c.name, "other")) saw_other = true;
+        // The defining function must not appear as its own callee.
+        try testing.expect(!std.mem.eql(u8, c.name, "run"));
+    }
+    try testing.expect(saw_helper);
+    try testing.expect(saw_other);
+}

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -896,6 +896,32 @@ test "issue-179: Python docstring with text does not leak symbols" {
     try testing.expect(!found_fake);
 }
 
+test "issue-518: non-ASCII (Korean) function identifier is captured in the outline" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // "def 한():" — 한 (U+D55C) is a valid Python 3 identifier that ast parses;
+    // the ASCII-only ident scanner used to drop it, returning 0 symbols.
+    try explorer.indexFile("uni.py", "def \xed\x95\x9c():\n    return 1\n");
+
+    var outline = (try explorer.getOutline("uni.py", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    try expectOutlineSymbol(&outline, "\xed\x95\x9c", .function);
+}
+
+test "issue-518: Python class is labeled class_def, not struct_def" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("widget.py", "class Widget:\n    pass\n");
+
+    var outline = (try explorer.getOutline("widget.py", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    try expectOutlineSymbol(&outline, "Widget", .class_def);
+}
+
 
 test "issue-108: HCL resource block parsed" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);

--- a/src/test_query.zig
+++ b/src/test_query.zig
@@ -183,6 +183,19 @@ test "issue-163: fuzzy no match returns null" {
     try testing.expect(score == null);
 }
 
+test "issue-518: fuzzy find has a subsequence floor — garbage queries return null" {
+    // Long queries whose characters only incidentally overlap a path must not
+    // score as confident hits. Before the LCS-ratio floor, the local alignment
+    // let a few stray filename matches clear the threshold, so codedb_find
+    // returned ranked results for queries that match no filename.
+    try testing.expect(fuzzyScore("zzznosuchfilexyz", "notrail.py") == null);
+    try testing.expect(fuzzyScore("Widget", "empty.py") == null);
+    // Typo-tolerant matches that share most of the query in order still score.
+    try testing.expect(fuzzyScore("authmid", "src/auth_middleware.py") != null);
+    try testing.expect(fuzzyScore("mian", "src/main.zig") != null);
+    try testing.expect(fuzzyScore("auth_midlware", "src/auth_middleware.py") != null);
+}
+
 
 test "issue-163: fuzzyFindFiles via Explorer" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -260,6 +260,57 @@ test "snapshot: restored outlines borrow strings (round-trip intact + clean dein
     try testing.expect(saw_beta);
 }
 
+// Call-graph centrality (the ranking boost) is persisted in a snapshot section
+// and restored on load, so the first ranked search skips the lazy rebuild. This
+// pins: (1) the value round-trips exactly, and (2) restore happens at load time
+// with no search having run, keyed off the restored outlines.
+test "snapshot: call-graph centrality persists and restores (no lazy rebuild)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var exp = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    // util.zig defines helper(); main.zig calls it twice -> util.zig has in-degree.
+    // Paths don't exist on disk, so the load takes the restore path.
+    try exp.indexFile("cc_pkg/util.zig",
+        \\pub fn helper() void {}
+        \\
+    );
+    try exp.indexFile("cc_pkg/main.zig",
+        \\const util = @import("util.zig");
+        \\pub fn run() void {
+        \\    helper();
+        \\    helper();
+        \\}
+        \\
+    );
+
+    exp.buildCallCentrality(testing.allocator);
+    try testing.expect(exp.call_centrality != null);
+    const want = exp.call_centrality.?.get("cc_pkg/util.zig") orelse 0.0;
+    try testing.expect(want > 0.0);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/cc.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    var exp2 = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    const loaded = snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, testing.allocator);
+    try testing.expect(loaded);
+
+    // Restored at load time — no ranked search ran to build it.
+    try testing.expect(exp2.call_centrality != null);
+    const got = exp2.call_centrality.?.get("cc_pkg/util.zig") orelse 0.0;
+    try testing.expectEqual(want, got);
+}
+
 
 test "issue-220: snapshot fast load restores outlines and lazily rebuilds word index" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -203,6 +203,63 @@ test "issue-46: empty-repo snapshot rejected on load" {
     try testing.expect(exp2.outlines.count() == 0);
 }
 
+// Restored FileOutlines borrow their import/symbol strings as slices into a
+// section buffer the Explorer retains (FileOutline.borrows_strings). This test
+// pins two things the borrow optimization must preserve:
+//   1. the strings survive the round-trip intact (slices point at the right bytes)
+//   2. explorer.deinit() frees the adopted section buffer exactly once and does
+//      NOT double-free the borrowed strings (DebugAllocator flags either).
+test "snapshot: restored outlines borrow strings (round-trip intact + clean deinit)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var exp = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    // A path that does not exist on disk, so the load takes the restore path
+    // (the freshness check can't find a newer file) rather than re-indexing.
+    try exp.indexFile("borrow_test_pkg/main.zig",
+        \\const std = @import("std");
+        \\const helper = @import("helper.zig");
+        \\pub fn alphaFn() void {}
+        \\pub fn betaFn(x: u32) u32 {
+        \\    return x + 1;
+        \\}
+        \\
+    );
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/borrow.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    // Fresh Explorer, loaded with the same allocator and explicitly deinit'd —
+    // the production pattern. This verifies explorer.deinit() cleanly frees the
+    // adopted section backing AND that the borrowed import/symbol strings are
+    // not double-freed (DebugAllocator would flag either).
+    var exp2 = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    const loaded = snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, testing.allocator);
+    try testing.expect(loaded);
+
+    const outline = exp2.outlines.get("borrow_test_pkg/main.zig") orelse return error.MissingOutline;
+    try testing.expect(outline.borrows_strings);
+    try testing.expect(outline.imports.items.len >= 1);
+
+    var saw_alpha = false;
+    var saw_beta = false;
+    for (outline.symbols.items) |s| {
+        if (std.mem.eql(u8, s.name, "alphaFn")) saw_alpha = true;
+        if (std.mem.eql(u8, s.name, "betaFn")) saw_beta = true;
+    }
+    try testing.expect(saw_alpha);
+    try testing.expect(saw_beta);
+}
+
 
 test "issue-220: snapshot fast load restores outlines and lazily rebuilds word index" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -311,6 +311,43 @@ test "snapshot: call-graph centrality persists and restores (no lazy rebuild)" {
     try testing.expectEqual(want, got);
 }
 
+// The CONTENT_HASHES section lets the loader record Store baselines without
+// re-hashing content. This pins that the stored hash equals Wyhash of the
+// content for each file — i.e. the section is read in the correct (content)
+// order, so hashes are not misaligned across files.
+test "snapshot: CONTENT_HASHES records the correct per-file hash (order-aligned)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var exp = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    const Pair = struct { p: []const u8, c: []const u8 };
+    const files = [_]Pair{
+        .{ .p = "ch_pkg/alpha.zig", .c = "pub fn alpha() void { beta(); }\n" },
+        .{ .p = "ch_pkg/beta.zig", .c = "pub fn beta() void {}\npub fn extra() void {}\n" },
+        .{ .p = "ch_pkg/gamma.zig", .c = "const value = 123456;\n" },
+    };
+    for (files) |f| try exp.indexFile(f.p, f.c);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/ch.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    var exp2 = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, testing.allocator));
+
+    for (files) |f| {
+        const v = store.getLatest(f.p) orelse return error.MissingVersion;
+        try testing.expectEqual(std.hash.Wyhash.hash(0, f.c), v.hash);
+    }
+}
+
 
 test "issue-220: snapshot fast load restores outlines and lazily rebuilds word index" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -399,6 +399,71 @@ test "issue-220: snapshot fast load restores outlines and lazily rebuilds word i
     try testing.expect(exp2.wordIndexNeedsPersist());
 }
 
+test "snapshot: parallel freshness load re-indexes changed files, restores the rest" {
+    // Forces loadSnapshotFast's multi-worker freshness path with a fixture larger
+    // than FRESHNESS_PARALLEL_THRESHOLD: files edited after the snapshot must come
+    // back with fresh content (changed branch) while the rest restore unchanged.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    const total = snapshot_mod.FRESHNESS_PARALLEL_THRESHOLD + 32;
+
+    // Build `total` files on disk, indexing each by ABSOLUTE path so the load's
+    // cwd-relative statFile resolves them regardless of the test's working dir.
+    var exp = Explorer.init(aa, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    const abs_paths = try aa.alloc([]const u8, total);
+    for (0..total) |i| {
+        const rel = try std.fmt.allocPrint(aa, "f{d}.zig", .{i});
+        const content = try std.fmt.allocPrint(aa, "pub fn oldfn_{d}() void {{}}\n", .{i});
+        try tmp.dir.writeFile(io, .{ .sub_path = rel, .data = content });
+        abs_paths[i] = try std.fmt.allocPrint(aa, "{s}/{s}", .{ dir_path, rel });
+        try exp.indexFileOutlineOnly(abs_paths[i], content);
+    }
+
+    const snap_path = try std.fmt.allocPrint(aa, "{s}/parallel.codedb", .{dir_path});
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, aa);
+
+    // Edit a spread of files AFTER the snapshot so their mtime is strictly newer.
+    cio.sleepMs(10);
+    const changed = [_]usize{ 1, total / 4, total / 2, (total * 3) / 4, total - 2 };
+    for (changed) |i| {
+        const rel = try std.fmt.allocPrint(aa, "f{d}.zig", .{i});
+        const content = try std.fmt.allocPrint(aa, "pub fn newfn_{d}() void {{}}\n", .{i});
+        try tmp.dir.writeFile(io, .{ .sub_path = rel, .data = content });
+    }
+
+    // Reload into a fresh explorer: the parallel scan must spot the edited files.
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    var exp2 = Explorer.init(arena2.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, arena2.allocator()));
+    try testing.expectEqual(total, exp2.outlines.count());
+
+    var is_changed = [_]bool{false} ** total;
+    for (changed) |i| is_changed[i] = true;
+
+    // Changed files carry fresh content (changed branch); the rest keep snapshot
+    // content (restored branch) — verified directly via the content cache.
+    for (0..total) |i| {
+        const cached = exp2.contents.get(abs_paths[i]) orelse return error.MissingContent;
+        const want = if (is_changed[i])
+            try std.fmt.allocPrint(aa, "pub fn newfn_{d}() void {{}}\n", .{i})
+        else
+            try std.fmt.allocPrint(aa, "pub fn oldfn_{d}() void {{}}\n", .{i});
+        try testing.expectEqualStrings(want, cached);
+    }
+}
+
 
 test "snapshot: writer streams uncached file contents for large repos" {
     var tmp = testing.tmpDir(.{});


### PR DESCRIPTION
## Summary

`feat/code-graph` → `release/0.2.5824` — 13 commits. The most recent three are from this session; the rest is the snapshot load-performance arc and the code-graph snapshot persistence.

### Snapshot load performance (~380ms → ~125ms, ~3× on a 39k-file repo; ~338MB lower RSS)
The full load-path arc, measured end-to-end on an `openclaw`-sized index:
- Borrowed restored outline strings + pre-sized load maps (~34%) — `d5a8ad1`
- `statFile` freshness instead of open+stat+close (~36%) — `1a3e2c5`
- Single mmap of the content section instead of ~4 preads/file (~23%) — `5143cb2`
- Borrowed content from the mmap'd section (~8%) — `0c7c523`
- Zero-copy `ContentCache` over the retained mmap (~17%, ~237MB lower RSS) — `9c00f8f`
- Stored content hashes, skipping re-hash at load (~14%, ~100MB lower RSS) — `df941eb`
- **Parallel freshness scan (this session)** — fan the per-file `statFile` check across workers. `statFile` is kernel/VFS-bound, not CPU-bound: a worker sweep on a 16k-file tree measured a U-curve bottoming at ~4 workers regardless of core count, so the count is capped at `FRESHNESS_MAX_WORKERS=4`. ~2.3× freshness, ~43% faster 16k load. Workers are pure read-only stat; the insert pass reads changed content sequentially so peak memory stays at one file. — `109775c`, `42e67f6`

### Code-graph snapshot persistence
- Persist call-graph centrality in the snapshot, skipping the ~960ms first-query rebuild — `8e6a950`
- Graph-resolved callees in `codedb_context` (edge-aware) — `b5389f6`

### #518 correctness fixes (this session) — `210966e`
- **Non-ASCII identifiers** captured in outlines — `extractIdent`/`extractRubyMethodName` accepted only ASCII, so `def 한():` was dropped from `codedb_outline`/`codedb_symbol`.
- **Python `class`** labeled `.class_def` (was `.struct_def`; every other language already used `.class_def`).
- **`codedb_find` subsequence floor** — query and path must share an in-order LCS of ≥60% of the query's chars, so `find` no longer returns confident hits for queries that match no filename.

## Testing
`zig build test` — **699/699 tests passing** (23/23 build steps).

## Related issues
- #518 (non-ASCII outline, `codedb_find` false hits, Python class kind) — addressed here.
- #504 (Intel x64 segfault on bare `codedb`) — fixed earlier on this line (infallible `main` + synchronous fast path).
- #508 (`codedb_remote` 530 / code 1033) — client emits an actionable hint for the Cloudflare-origin outage; the 530 itself is server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
