### PR TITLE
cli: warm-CLI daemon — proxy query commands to a per-project warm daemon (MCP-parity latency + RSS)

### DIFF
--- a/src/cio.zig
+++ b/src/cio.zig
@@ -15,6 +15,7 @@ extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 extern "c" fn clock_gettime(id: c_int, ts: *std.c.timespec) c_int;
 extern "c" fn pipe(fds: *[2]c_int) c_int;
 extern "c" fn close(fd: c_int) c_int;
+extern "c" fn open(path: [*:0]const u8, oflag: c_int) c_int;
 
 pub fn ignoreSigpipe() void {
     var act: std.posix.Sigaction = .{
@@ -23,6 +24,24 @@ pub fn ignoreSigpipe() void {
         .flags = 0,
     };
     std.posix.sigaction(std.posix.SIG.PIPE, &act, null);
+}
+
+/// Detach a daemonized child from its controlling terminal: start a new
+/// session (so it survives the spawning shell / parent CLI) and point
+/// stdin/stdout/stderr at /dev/null (so it never holds the terminal open or
+/// writes stray bytes to it). Best-effort — every step ignores errors, since a
+/// failure here only means the daemon keeps an inherited fd, not that it
+/// malfunctions. Called once at cli-daemon startup.
+pub fn detachFromTerminal() void {
+    _ = std.c.setsid();
+    // O_RDWR == 2 on both Darwin and Linux.
+    const fd = open("/dev/null", 2);
+    if (fd >= 0) {
+        _ = std.c.dup2(fd, 0);
+        _ = std.c.dup2(fd, 1);
+        _ = std.c.dup2(fd, 2);
+        if (fd > 2) _ = close(fd);
+    }
 }
 
 const CLOCK_REALTIME: c_int = 0;
@@ -332,6 +351,7 @@ extern "c" fn posix_spawn_file_actions_destroy(fa: *PosixSpawnFileActions) c_int
 extern "c" fn posix_spawn_file_actions_adddup2(fa: *PosixSpawnFileActions, fd: c_int, newfd: c_int) c_int;
 extern "c" fn posix_spawn_file_actions_addclose(fa: *PosixSpawnFileActions, fd: c_int) c_int;
 extern "c" fn posix_spawn_file_actions_addchdir_np(fa: *PosixSpawnFileActions, path: [*:0]const u8) c_int;
+extern "c" fn posix_spawn_file_actions_addopen(fa: *PosixSpawnFileActions, fd: c_int, path: [*:0]const u8, oflag: c_int, mode: c_uint) c_int;
 extern "c" fn waitpid(pid: pid_t, status: *c_int, options: c_int) pid_t;
 
 // posix_spawn_file_actions_t is a struct of unknown size on each libc. We
@@ -475,4 +495,57 @@ pub fn runCapture(opts: RunOptions) !CaptureResult {
         .stderr = try err_ctx.out.toOwnedSlice(alloc),
         .term = term,
     };
+}
+
+/// Fire-and-forget spawn: posix_spawnp `argv` with stdin/stdout/stderr
+/// redirected to /dev/null, and do NOT wait on the child. Used to launch the
+/// warm cli-daemon from a cold CLI invocation. The child is expected to
+/// setsid() itself; once this CLI process exits the child is reparented to
+/// init, so we never reap it (no zombie outlives this short-lived CLI). All
+/// failures are swallowed — auto-spawn is best-effort and the cold path still
+/// produces correct output regardless.
+pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) void {
+    if (argv.len == 0) return;
+
+    const c_argv = allocator.alloc(?[*:0]const u8, argv.len + 1) catch return;
+    defer allocator.free(c_argv);
+    const arg_bufs = allocator.alloc([]u8, argv.len) catch return;
+    var built: usize = 0;
+    defer {
+        for (arg_bufs[0..built]) |b| allocator.free(b);
+        allocator.free(arg_bufs);
+    }
+    for (argv, 0..) |a, i| {
+        const buf = allocator.alloc(u8, a.len + 1) catch return;
+        @memcpy(buf[0..a.len], a);
+        buf[a.len] = 0;
+        arg_bufs[i] = buf;
+        built = i + 1;
+        c_argv[i] = @ptrCast(buf.ptr);
+    }
+    c_argv[argv.len] = null;
+    const c_argv_z: [*:null]const ?[*:0]const u8 = @ptrCast(c_argv.ptr);
+
+    var fa_storage: PosixSpawnFAStorage = undefined;
+    const fa: *PosixSpawnFileActions = @ptrCast(&fa_storage);
+    if (posix_spawn_file_actions_init(fa) != 0) return;
+    defer _ = posix_spawn_file_actions_destroy(fa);
+
+    // Redirect 0/1/2 to /dev/null so the daemon holds no inherited terminal fds.
+    // O_RDWR == 2 on both Darwin and Linux. Errors are non-fatal — the daemon
+    // re-redirects to /dev/null itself after setsid() at startup.
+    const devnull: [*:0]const u8 = "/dev/null";
+    _ = posix_spawn_file_actions_addopen(fa, 0, devnull, 2, 0);
+    _ = posix_spawn_file_actions_addopen(fa, 1, devnull, 2, 0);
+    _ = posix_spawn_file_actions_addopen(fa, 2, devnull, 2, 0);
+
+    const envp: [*:null]const ?[*:0]const u8 = if (builtin.os.tag == .macos)
+        @ptrCast(_NSGetEnviron().*)
+    else
+        @ptrCast(std.c.environ);
+
+    var pid: pid_t = 0;
+    // Fire and forget: no waitpid. The child reparents to init once this CLI
+    // exits, so it never becomes a lingering zombie of ours.
+    _ = posix_spawnp(&pid, c_argv[0].?, fa, null, c_argv_z, envp);
 }

--- a/src/index.zig
+++ b/src/index.zig
@@ -25,6 +25,14 @@ pub const WordIndex = struct {
     doc_lengths: std.AutoHashMap(u32, u32),
     /// Sum of all values in doc_lengths.
     total_tokens: u64 = 0,
+    /// Zero-copy read mode: when non-null, the postings live in this mmap'd
+    /// word.index file and `index` is empty — search/searchPrefix binary-search
+    /// the sorted on-disk words instead. The first write promotes to a heap
+    /// index (promoteIfBorrowed). Cuts warm-daemon RSS from ~4x the file to a
+    /// small word directory + touched pages.
+    mmap_data: ?[]align(std.heap.page_size_min) const u8 = null,
+    /// Byte offset of each sorted word record in mmap_data, for binary search.
+    word_dir: []u32 = &.{},
 
     pub fn hitPath(self: *const WordIndex, hit: WordHit) []const u8 {
         if (hit.doc_id < self.id_to_path.items.len) return self.id_to_path.items[hit.doc_id];
@@ -52,6 +60,22 @@ pub const WordIndex = struct {
     }
 
     pub fn deinit(self: *WordIndex) void {
+        if (self.mmap_data) |m| {
+            // Zero-copy mode: index/path_to_id/file_words are empty; id_to_path
+            // owns the duped paths; word_dir + doc_lengths are heap; the postings
+            // live in the mmap. Free the heap bits and unmap.
+            self.index.deinit();
+            self.path_to_id.deinit();
+            self.file_words.deinit();
+            for (self.id_to_path.items) |path| {
+                if (path.len > 0) self.allocator.free(path);
+            }
+            self.id_to_path.deinit(self.allocator);
+            self.doc_lengths.deinit();
+            self.allocator.free(self.word_dir);
+            std.posix.munmap(m);
+            return;
+        }
         // Free hit lists and duped word keys
         var iter = self.index.iterator();
         while (iter.next()) |entry| {
@@ -156,6 +180,8 @@ pub const WordIndex = struct {
 
     pub fn indexFile(self: *WordIndex, path: []const u8, content: []const u8) !void {
         if (!self.enabled) return;
+        // A write to a zero-copy (mmap) index must first materialize a heap index.
+        try self.promoteIfBorrowed();
         // Clean up old entries first
         self.removeFile(path);
 
@@ -299,14 +325,85 @@ pub const WordIndex = struct {
 
     /// Look up all hits for a word. O(1) lookup + O(hits) iteration.
     /// Query is normalized to lowercase (all index keys are stored lowercase).
-    pub fn search(self: *WordIndex, word: []const u8) []const WordHit {
+    pub fn search(self: *WordIndex, word: []const u8) []align(1) const WordHit {
         var buf: [512]u8 = undefined;
         const lower = if (word.len <= buf.len) blk: {
             for (word, 0..) |c, i| buf[i] = normalizeChar(c);
             break :blk buf[0..word.len];
         } else word;
+        if (self.mmap_data != null) return self.mmapSearch(lower);
         if (self.index.get(lower)) |hits| return hits.items;
         return &.{};
+    }
+
+    /// Binary-search the sorted on-disk words; return the postings as a
+    /// zero-copy slice into the mmap. Unaligned (records sit at arbitrary byte
+    /// offsets), hence align(1) — fields are read with unaligned loads.
+    fn mmapSearch(self: *WordIndex, lower: []const u8) []align(1) const WordHit {
+        const data = self.mmap_data.?;
+        var lo: usize = 0;
+        var hi: usize = self.word_dir.len;
+        while (lo < hi) {
+            const mid = lo + (hi - lo) / 2;
+            const off = self.word_dir[mid];
+            const wlen = std.mem.readInt(u16, data[off..][0..2], .little);
+            const wbytes = data[off + 2 ..][0..wlen];
+            switch (std.mem.order(u8, wbytes, lower)) {
+                .lt => lo = mid + 1,
+                .gt => hi = mid,
+                .eq => {
+                    const hc_off = off + 2 + wlen;
+                    const hit_count = std.mem.readInt(u32, data[hc_off..][0..4], .little);
+                    const posts = data[hc_off + 4 ..][0 .. @as(usize, hit_count) * @sizeOf(WordHit)];
+                    return std.mem.bytesAsSlice(WordHit, posts);
+                },
+            }
+        }
+        return &.{};
+    }
+
+    /// First write to a zero-copy (mmap) index rebuilds a heap index from the
+    /// mmap so the mutation has somewhere to land, then unmaps. Reads stay
+    /// zero-copy; only an actual edit pays this one-time cost.
+    fn promoteIfBorrowed(self: *WordIndex) !void {
+        const data = self.mmap_data orelse return;
+        var new_index = std.StringHashMap(std.ArrayList(WordHit)).init(self.allocator);
+        errdefer {
+            var it = new_index.iterator();
+            while (it.next()) |e| {
+                self.allocator.free(e.key_ptr.*);
+                e.value_ptr.deinit(self.allocator);
+            }
+            new_index.deinit();
+        }
+        try new_index.ensureTotalCapacity(@intCast(self.word_dir.len));
+        for (self.word_dir) |off| {
+            const wlen = std.mem.readInt(u16, data[off..][0..2], .little);
+            const word = try self.allocator.dupe(u8, data[off + 2 ..][0..wlen]);
+            errdefer self.allocator.free(word);
+            const hc_off = off + 2 + wlen;
+            const hit_count = std.mem.readInt(u32, data[hc_off..][0..4], .little);
+            const posts = std.mem.bytesAsSlice(WordHit, data[hc_off + 4 ..][0 .. @as(usize, hit_count) * @sizeOf(WordHit)]);
+            var list: std.ArrayList(WordHit) = .empty;
+            errdefer list.deinit(self.allocator);
+            try list.appendUnalignedSlice(self.allocator, posts);
+            try new_index.put(word, list);
+        }
+        var new_p2i = std.StringHashMap(u32).init(self.allocator);
+        errdefer new_p2i.deinit();
+        try new_p2i.ensureTotalCapacity(@intCast(self.id_to_path.items.len));
+        for (self.id_to_path.items, 0..) |p, i| {
+            if (p.len > 0) try new_p2i.put(p, @intCast(i));
+        }
+        // Commit: drop the (empty) mmap-mode maps + unmap, install heap maps.
+        self.index.deinit();
+        self.path_to_id.deinit();
+        self.allocator.free(self.word_dir);
+        std.posix.munmap(data);
+        self.index = new_index;
+        self.path_to_id = new_p2i;
+        self.word_dir = &.{};
+        self.mmap_data = null;
     }
 
     /// Look up hits, returning results allocated by the caller.
@@ -359,6 +456,38 @@ pub const WordIndex = struct {
         defer seen.deinit();
         try seen.ensureTotalCapacity(@intCast(max_results));
 
+        if (self.mmap_data) |data| {
+            // Sorted on-disk words: binary-search the prefix lower bound, then
+            // walk forward while the word still starts with `prefix`.
+            var lo: usize = 0;
+            var hi: usize = self.word_dir.len;
+            while (lo < hi) {
+                const mid = lo + (hi - lo) / 2;
+                const off = self.word_dir[mid];
+                const wlen = std.mem.readInt(u16, data[off..][0..2], .little);
+                if (std.mem.order(u8, data[off + 2 ..][0..wlen], prefix) == .lt) lo = mid + 1 else hi = mid;
+            }
+            var wi = lo;
+            outer_mmap: while (wi < self.word_dir.len) : (wi += 1) {
+                const off = self.word_dir[wi];
+                const wlen = std.mem.readInt(u16, data[off..][0..2], .little);
+                const wbytes = data[off + 2 ..][0..wlen];
+                if (!std.mem.startsWith(u8, wbytes, prefix)) break; // past the prefix range
+                if (wlen <= prefix.len) continue; // strictly longer; exact is Tier 0
+                const hc_off = off + 2 + wlen;
+                const hit_count = std.mem.readInt(u32, data[hc_off..][0..4], .little);
+                const posts = std.mem.bytesAsSlice(WordHit, data[hc_off + 4 ..][0 .. @as(usize, hit_count) * @sizeOf(WordHit)]);
+                for (posts) |hit| {
+                    const dk = DedupKey{ .doc_id = hit.doc_id, .line_num = hit.line_num };
+                    const gop = try seen.getOrPut(dk);
+                    if (!gop.found_existing) {
+                        result.appendAssumeCapacity(hit);
+                        if (result.items.len >= max_results) break :outer_mmap;
+                    }
+                }
+            }
+            return result.toOwnedSlice(allocator);
+        }
         var key_iter = self.index.keyIterator();
         outer: while (key_iter.next()) |k| {
             if (k.len <= prefix.len) continue; // strictly longer: exact match is Tier 0
@@ -663,6 +792,82 @@ pub const WordIndex = struct {
         return result;
     }
 
+    /// Zero-copy load: mmap the word.index file and build only a small word
+    /// directory + doc-length table; postings stay in the mmap. Returns a
+    /// WordIndex in zero-copy mode (first write promotes to heap). Null on any
+    /// malformation — caller can fall back to readFromDisk.
+    pub fn mmapFromDisk(io: std.Io, dir_path: []const u8, allocator: std.mem.Allocator) ?WordIndex {
+        return mmapFromDiskInner(io, dir_path, allocator) catch null;
+    }
+
+    fn mmapFromDiskInner(io: std.Io, dir_path: []const u8, allocator: std.mem.Allocator) !?WordIndex {
+        const index_path = try std.fmt.allocPrint(allocator, "{s}/word.index", .{dir_path});
+        defer allocator.free(index_path);
+
+        const file = std.Io.Dir.cwd().openFile(io, index_path, .{}) catch return null;
+        defer file.close(io);
+        const size = file.length(io) catch return null;
+        if (size < 51) return null;
+        const data = std.posix.mmap(null, size, .{ .READ = true }, .{ .TYPE = .SHARED }, file.handle, 0) catch return null;
+        errdefer std.posix.munmap(data);
+
+        if (!std.mem.eql(u8, data[0..4], &DISK_MAGIC)) return null;
+        if (std.mem.readInt(u16, data[4..6], .little) != DISK_FORMAT_VERSION) return null;
+        const file_count = std.mem.readInt(u32, data[6..10], .little);
+
+        var result = WordIndex.init(allocator);
+        result.skip_file_words = true;
+        // mmap_data stays null until the hand-off below, so this errdefer takes
+        // the heap deinit path (frees the duped paths); word_dir + mmap have
+        // their own errdefers.
+        errdefer result.deinit();
+
+        try result.id_to_path.ensureTotalCapacity(allocator, file_count);
+        var pos: usize = 51;
+        for (0..file_count) |_| {
+            if (pos + 2 > data.len) return null;
+            const plen = std.mem.readInt(u16, data[pos..][0..2], .little);
+            pos += 2;
+            if (plen == 0 or pos + plen > data.len) return null;
+            const path = try allocator.dupe(u8, data[pos .. pos + plen]);
+            result.id_to_path.appendAssumeCapacity(path);
+            pos += plen;
+        }
+
+        if (pos + 4 > data.len) return null;
+        const word_count = std.mem.readInt(u32, data[pos..][0..4], .little);
+        pos += 4;
+        const word_dir = try allocator.alloc(u32, word_count);
+        errdefer allocator.free(word_dir);
+        for (0..word_count) |i| {
+            if (pos + 2 > data.len) return null;
+            word_dir[i] = @intCast(pos);
+            const wlen = std.mem.readInt(u16, data[pos..][0..2], .little);
+            pos += 2 + wlen;
+            if (pos + 4 > data.len) return null;
+            const hit_count = std.mem.readInt(u32, data[pos..][0..4], .little);
+            pos += 4 + @as(usize, hit_count) * @sizeOf(WordHit);
+            if (pos > data.len) return null;
+        }
+
+        if (pos + 4 > data.len) return null;
+        const dl_count = std.mem.readInt(u32, data[pos..][0..4], .little);
+        pos += 4;
+        if (dl_count != file_count or pos + @as(usize, dl_count) * 4 + 8 > data.len) return null;
+        for (0..dl_count) |i| {
+            const len = std.mem.readInt(u32, data[pos..][0..4], .little);
+            pos += 4;
+            if (len > 0) try result.doc_lengths.put(@intCast(i), len);
+        }
+        result.total_tokens = std.mem.readInt(u64, data[pos..][0..8], .little);
+        pos += 8;
+        if (pos != data.len) return null;
+
+        // Hand off: switch to zero-copy mode. result.deinit now takes the mmap path.
+        result.mmap_data = data;
+        result.word_dir = word_dir;
+        return result;
+    }
     pub fn readDiskHeader(io: std.Io, dir_path: []const u8, allocator: std.mem.Allocator) !?DiskHeader {
         const index_path = try std.fmt.allocPrint(allocator, "{s}/word.index", .{dir_path});
         defer allocator.free(index_path);

--- a/src/index.zig
+++ b/src/index.zig
@@ -557,7 +557,7 @@ pub const WordIndex = struct {
 
         var file_paths = try allocator.alloc([]u8, file_count);
         defer allocator.free(file_paths);
-        var used_paths = try allocator.alloc(bool, file_count);
+        const used_paths = try allocator.alloc(bool, file_count);
         defer allocator.free(used_paths);
         @memset(used_paths, false);
         var parsed_files: u32 = 0;
@@ -585,14 +585,11 @@ pub const WordIndex = struct {
         var result = WordIndex.init(allocator);
         errdefer result.deinit();
 
-        // Temporary HashMap for accumulating file_words during load
-        // (compacted to slices below)
-        var tmp_file_words = std.StringHashMap(std.StringHashMap(void)).init(allocator);
-        defer {
-            var tfw_iter = tmp_file_words.iterator();
-            while (tfw_iter.next()) |entry| entry.value_ptr.deinit();
-            tmp_file_words.deinit();
-        }
+        // Pre-size the maps to the exact counts so they don't overshoot via
+        // incremental doubling while loading (saves tens of MB on big indexes).
+        try result.index.ensureTotalCapacity(word_count);
+        try result.path_to_id.ensureTotalCapacity(file_count);
+        try result.doc_lengths.ensureTotalCapacity(file_count);
 
         for (0..word_count) |_| {
             if (pos + 2 > data.len) return null;
@@ -611,7 +608,6 @@ pub const WordIndex = struct {
             errdefer hits.deinit(allocator);
             try hits.ensureTotalCapacity(allocator, hit_count);
 
-            var last_file_id: ?u32 = null;
             for (0..hit_count) |_| {
                 if (pos + 8 > data.len) return null;
                 const file_id = std.mem.readInt(u32, data[pos..][0..4], .little);
@@ -619,23 +615,7 @@ pub const WordIndex = struct {
                 if (file_id >= file_count) return null;
                 const line_num = std.mem.readInt(u32, data[pos..][0..4], .little);
                 pos += 4;
-
-                hits.appendAssumeCapacity(.{
-                    .doc_id = file_id,
-                    .line_num = line_num,
-                });
-
-                if (last_file_id == null or last_file_id.? != file_id) {
-                    const fw_gop = try tmp_file_words.getOrPut(file_paths[file_id]);
-                    if (!fw_gop.found_existing) {
-                        fw_gop.key_ptr.* = file_paths[file_id];
-                        fw_gop.value_ptr.* = std.StringHashMap(void).init(allocator);
-                        used_paths[file_id] = true;
-                    }
-                    const wgop = try fw_gop.value_ptr.getOrPut(word);
-                    if (!wgop.found_existing) wgop.key_ptr.* = word;
-                    last_file_id = file_id;
-                }
+                hits.appendAssumeCapacity(.{ .doc_id = file_id, .line_num = line_num });
             }
 
             const gop = try result.index.getOrPut(word);
@@ -672,17 +652,13 @@ pub const WordIndex = struct {
         }
         result.total_tokens = total_tokens_loaded;
 
-        // Compact tmp_file_words HashMaps into slices for result.file_words
-        var tfw_iter = tmp_file_words.iterator();
-        while (tfw_iter.next()) |entry| {
-            const compact = try allocator.alloc([]const u8, entry.value_ptr.count());
-            var ki2: usize = 0;
-            var wk_iter2 = entry.value_ptr.keyIterator();
-            while (wk_iter2.next()) |k| : (ki2 += 1) {
-                compact[ki2] = k.*;
-            }
-            try result.file_words.put(entry.key_ptr.*, compact);
-        }
+        // Loaded indexes skip file_words: only incremental removeFile needs it,
+        // and queries / BM25 never do. Same hundreds-of-MB save the bulk scan
+        // already takes (see main.zig). id_to_path owns the path strings now, so
+        // keep them out of the cleanup defer (used_paths=true) and free them via
+        // the skip_file_words deinit path.
+        @memset(used_paths, true);
+        result.skip_file_words = true;
 
         return result;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -608,16 +608,36 @@ fn cliIsQueryCmd(cmd: []const u8) bool {
 /// (CLI calls are infrequent and runQuery already tolerates concurrent reads
 /// from the watcher). On a fatal bind failure it logs and returns — the daemon
 /// keeps working and clients simply fall back to the cold path.
-fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8) void {
+/// Daemon side. Bind a per-project Unix socket and serve framed query requests
+/// against the warm `explorer`/`store`. Runs on its own detached thread so it
+/// never blocks the daemon's primary loop. Connections are handled sequentially
+/// (CLI calls are infrequent and runQuery already tolerates concurrent reads
+/// from the watcher).
+///
+/// `last_activity_ms` is bumped to the current ms timestamp at the start of
+/// every accepted connection so a time-based idle watchdog (cli-daemon) can
+/// tell when the socket has gone quiet. `shutdown` is set to true on a fatal
+/// bind/listen failure: this lets an auto-spawned cli-daemon that lost the bind
+/// race to an already-running daemon exit promptly instead of lingering. The
+/// long-lived serve/mcp daemons pass a `shutdown` flag they never watch, so for
+/// them a bind failure simply disables the proxy (clients fall back to cold).
+fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, last_activity_ms: *std.atomic.Value(i64), shutdown: *std.atomic.Value(bool)) void {
     var path_buf: [128]u8 = undefined;
     const sock_path = cliSocketPath(&path_buf, abs_root) orelse {
         std.log.warn("cli-proxy: could not build socket path", .{});
+        shutdown.store(true, .release);
         return;
     };
     var path_z_buf: [128]u8 = undefined;
-    const sock_path_z = std.fmt.bufPrintZ(&path_z_buf, "{s}", .{sock_path}) catch return;
+    const sock_path_z = std.fmt.bufPrintZ(&path_z_buf, "{s}", .{sock_path}) catch {
+        shutdown.store(true, .release);
+        return;
+    };
 
-    const sa = cliFillSockaddr(sock_path) orelse return;
+    const sa = cliFillSockaddr(sock_path) orelse {
+        shutdown.store(true, .release);
+        return;
+    };
 
     // Try to bind; if the path is stale (a dead daemon left it behind) unlink
     // and retry once. listenfd is owned for the lifetime of the daemon.
@@ -627,6 +647,7 @@ fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer
         const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
         if (fd < 0) {
             std.log.warn("cli-proxy: socket() failed", .{});
+            shutdown.store(true, .release);
             return;
         }
         var sa_mut = sa;
@@ -641,10 +662,16 @@ fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer
             _ = std.c.unlink(sock_path_z.ptr);
             continue;
         }
+        // A live daemon already owns this socket (lost the bind race). Signal
+        // shutdown so a duplicate auto-spawned cli-daemon exits promptly.
         std.log.warn("cli-proxy: bind {s} failed — proxy disabled", .{sock_path});
+        shutdown.store(true, .release);
         return;
     }
-    if (listenfd < 0) return;
+    if (listenfd < 0) {
+        shutdown.store(true, .release);
+        return;
+    }
     defer {
         _ = std.c.close(listenfd);
         _ = std.c.unlink(sock_path_z.ptr);
@@ -657,6 +684,7 @@ fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer
 
     if (std.c.listen(listenfd, 16) != 0) {
         std.log.warn("cli-proxy: listen failed — proxy disabled", .{});
+        shutdown.store(true, .release);
         return;
     }
     std.log.info("cli-proxy: listening on {s}", .{sock_path});
@@ -668,6 +696,8 @@ fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer
             // Listener went bad; stop the loop (daemon still serves its main API).
             return;
         }
+        // Record activity for the cli-daemon idle watchdog before serving.
+        last_activity_ms.store(cio.milliTimestamp(), .release);
         cliServeConn(io, allocator, explorer, store, abs_root, conn);
         _ = std.c.close(conn);
     }
@@ -963,6 +993,20 @@ fn mainImpl() !void {
         if (cliTryProxy(io, allocator, abs_root, args, use_color)) |code| {
             out.flush();
             std.process.exit(code);
+        }
+        // No daemon answered. Auto-spawn a detached cli-daemon so the NEXT call
+        // is warm; this call still falls through to the cold path below. The
+        // daemon is the SAME binary (resolved via the self-exe path) run as
+        // `codedb <abs_root> cli-daemon`, with stdio redirected to /dev/null and
+        // no waitpid (fire-and-forget). Gated by CODEDB_NO_CLI_DAEMON and skipped
+        // for an empty root. cli-daemon is not a query command, so the spawned
+        // process won't recurse into this path.
+        if (cio.posixGetenv("CODEDB_NO_CLI_DAEMON") == null and abs_root.len > 0) {
+            if (std.process.executablePathAlloc(io, allocator)) |self_exe| {
+                defer allocator.free(self_exe);
+                const daemon_argv = [_][]const u8{ self_exe, abs_root, "cli-daemon" };
+                cio.spawnDetached(allocator, &daemon_argv);
+            } else |_| {}
         }
     }
 
@@ -1345,6 +1389,77 @@ fn mainImpl() !void {
             sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
             s.reset,
         });
+    } else if (std.mem.eql(u8, cmd, "cli-daemon")) {
+        // Hidden command: a lightweight warm daemon spawned by a cold CLI query
+        // so the NEXT query is fast. It is `serve` minus the TCP server, agent
+        // registry, and reaper — just the warm explorer/store (loaded by the
+        // section above), an incremental watcher to keep the index fresh, the
+        // per-project CLI socket listener, and a time-based idle watchdog that
+        // exits the process once the socket has been quiet for a while. We do
+        // NOT auto-spawn `serve` here because two `serve` daemons would fight
+        // over the fixed TCP port; the CLI socket is per-project and conflict-free.
+
+        // Detach from the controlling terminal so we outlive the spawning CLI
+        // and never touch its stdio. (spawnDetached already pointed 0/1/2 at
+        // /dev/null; this also starts a fresh session.)
+        cio.detachFromTerminal();
+
+        const idle_ms: i64 = blk: {
+            const raw = cio.posixGetenv("CODEDB_CLI_DAEMON_IDLE_MS") orelse break :blk 5 * 60 * 1000;
+            break :blk std.fmt.parseInt(i64, raw, 10) catch (5 * 60 * 1000);
+        };
+
+        var shutdown = std.atomic.Value(bool).init(false);
+        defer shutdown.store(true, .release);
+        // The load section above already loaded/scanned the index, so the
+        // watcher starts in the "scan done" state and only does incremental
+        // upkeep from here.
+        var scan_already_done = std.atomic.Value(bool).init(true);
+
+        // Grace period: treat startup as activity so a freshly-spawned daemon
+        // gets the full idle window before the watchdog can fire.
+        var last_activity_ms = std.atomic.Value(i64).init(cio.milliTimestamp());
+
+        const queue = try allocator.create(watcher.EventQueue);
+        defer allocator.destroy(queue);
+        queue.* = watcher.EventQueue{};
+        const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, &store, &explorer, queue, root, &shutdown, &scan_already_done });
+        watch_thread.detach();
+
+        std.log.info("cli-daemon: {d} files indexed, idle_timeout={d}ms", .{ store.currentSeq(), idle_ms });
+
+        // CLI socket listener. Pass the REAL shutdown flag: if another daemon
+        // already owns the socket (we lost the bind race), cliDaemonListen sets
+        // shutdown and the watchdog below returns at once, so the redundant
+        // daemon exits instead of lingering idle.
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root, &last_activity_ms, &shutdown })) |cli_t| {
+            cli_t.detach();
+        } else |err| {
+            std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
+            return;
+        }
+
+        // Block here until idle (or a bind-race shutdown). On return the process
+        // exits immediately — std.process.exit reclaims everything and avoids
+        // racing the detached listener thread against freed explorer/store.
+        const idle_exit = cliIdleWatchdog(&shutdown, &last_activity_ms, idle_ms);
+        shutdown.store(true, .release);
+        // If WE owned the socket (exited on idle, not a bind-race loss), unlink
+        // it on the way out. The listener thread's own `defer unlink` never runs
+        // because std.process.exit kills it mid-accept; do it here so we don't
+        // leave a stale node behind. On a bind-race loss the socket belongs to
+        // the winning daemon, so idle_exit is false and we leave it alone.
+        if (idle_exit) {
+            var sock_buf: [128]u8 = undefined;
+            if (cliSocketPath(&sock_buf, abs_root)) |sock_path| {
+                var sock_z_buf: [128]u8 = undefined;
+                if (std.fmt.bufPrintZ(&sock_z_buf, "{s}", .{sock_path})) |sock_z| {
+                    _ = std.c.unlink(sock_z.ptr);
+                } else |_| {}
+            }
+        }
+        out.flush();
+        std.process.exit(0);
     } else if (std.mem.eql(u8, cmd, "serve")) {
         const port: u16 = blk: {
             const raw = cio.posixGetenv("CODEDB_PORT") orelse break :blk 6767;
@@ -1372,7 +1487,13 @@ fn mainImpl() !void {
         // Thin-CLI proxy listener: lets `codedb <root> <query>` invocations
         // reuse this warm explorer/store over a per-project Unix socket instead
         // of paying a cold snapshot reload. Detached so it never blocks serve().
-        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root })) |cli_t| {
+        // serve has no idle timeout: it passes throwaway activity/shutdown
+        // atomics that nobody watches (a bind failure just disables the proxy).
+        // These outlive the detached thread because server.serve() below blocks
+        // on this same stack frame for the whole process lifetime.
+        var cli_activity = std.atomic.Value(i64).init(cio.milliTimestamp());
+        var cli_listener_dead = std.atomic.Value(bool).init(false);
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root, &cli_activity, &cli_listener_dead })) |cli_t| {
             cli_t.detach();
         } else |err| {
             std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
@@ -1465,8 +1586,13 @@ fn mainImpl() !void {
         // Thin-CLI proxy listener (same as the serve branch): serve read-only
         // query commands from this warm explorer/store over a per-project Unix
         // socket so plain `codedb <root> <query>` calls skip a cold reload.
-        // Detached so it never blocks mcp_server.run().
-        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root })) |cli_t| {
+        // Detached so it never blocks mcp_server.run(). Like serve, mcp has no
+        // idle timeout — throwaway activity/shutdown atomics that nobody watches.
+        // They outlive the detached thread because mcp_server.run() below blocks
+        // on this same stack frame for the whole process lifetime.
+        var cli_activity = std.atomic.Value(i64).init(cio.milliTimestamp());
+        var cli_listener_dead = std.atomic.Value(bool).init(false);
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root, &cli_activity, &cli_listener_dead })) |cli_t| {
             cli_t.detach();
         } else |err| {
             std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
@@ -1586,7 +1712,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 }
 
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "snapshot", "serve", "mcp", "update", "nuke" };
+    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }
@@ -2118,4 +2244,34 @@ fn idleWatchdog(shutdown: *std.atomic.Value(bool)) void {
 
         cio.sleepMs(mcp.dead_client_poll_ms);
     }
+}
+
+/// Time-based idle watchdog for the `cli-daemon` background process. Unlike
+/// `idleWatchdog` (which watches stdin for POLLHUP on an MCP stdio transport),
+/// this exits the daemon after `idle_ms` elapse with no CLI socket activity.
+/// "Activity" is the last_activity_ms timestamp bumped by cliDaemonListen at
+/// the start of each accepted connection. It also returns promptly if
+/// `shutdown` is set externally — e.g. cliDaemonListen sets it when this daemon
+/// lost the bind race to an already-running daemon, so the redundant daemon
+/// tears down immediately instead of idling for the full timeout.
+///
+/// Returns true when it exited because the idle window elapsed (this daemon
+/// owned the socket and the caller should clean it up), or false when it
+/// returned because `shutdown` was already set by someone else (a bind-race
+/// loss — the socket belongs to the winning daemon, so the caller must NOT
+/// unlink it).
+fn cliIdleWatchdog(shutdown: *std.atomic.Value(bool), last_activity_ms: *std.atomic.Value(i64), idle_ms: i64) bool {
+    while (!shutdown.load(.acquire)) {
+        // Poll in 250ms slices so a bind-race shutdown (set by cliDaemonListen)
+        // is honored quickly rather than after a full idle window.
+        cio.sleepMs(250);
+        if (shutdown.load(.acquire)) return false;
+        const idle = cio.milliTimestamp() - last_activity_ms.load(.acquire);
+        if (idle >= idle_ms) {
+            std.log.info("cli-daemon: idle {d}ms >= {d}ms — exiting", .{ idle, idle_ms });
+            shutdown.store(true, .release);
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -142,6 +142,364 @@ fn mainInner() void {
         std.process.exit(1);
     };
 }
+/// Read-only query command dispatch, extracted from mainImpl so the same
+/// rendering code can run inside the warm daemon (writing to a socket)
+/// without exiting the daemon process. Returns a u8 exit code; the caller
+/// is responsible for flushing `out`. Covers: tree, outline, find, search,
+/// word, read, hot. Unknown commands return 1.
+fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, root: []const u8, cmd: []const u8, args: []const []const u8, cmd_args_start: usize, out: *Out, s: sty.Style) u8 {
+    const use_color = s.reset.len != 0;
+    if (std.mem.eql(u8, cmd, "tree")) {
+        const t0 = cio.nanoTimestamp();
+        const tree = explorer.getTree(allocator, use_color) catch return 1;
+        defer allocator.free(tree);
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        out.p("{s}", .{tree});
+        out.p("{s}{s}{s}\n", .{
+            sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed), s.reset,
+        });
+    } else if (std.mem.eql(u8, cmd, "outline")) {
+        const path = if (args.len > cmd_args_start) args[cmd_args_start] else {
+            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] outline {s}<path>{s}\n", .{
+                s.red, s.reset, s.cyan, s.reset,
+            });
+            return 1;
+        };
+        const t0 = cio.nanoTimestamp();
+        var outline = explorer.getOutline(path, allocator) catch {
+            out.p("{s}\xe2\x9c\x97{s} {s}{s}{s} \xe2\x80\x94 failed to load outline\n", .{
+                s.red, s.reset, s.bold, path, s.reset,
+            });
+            return 1;
+        } orelse {
+            out.p("{s}\xe2\x9c\x97{s} not indexed: {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, path, s.reset,
+            });
+            return 0;
+        };
+        defer outline.deinit();
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        const lang = @tagName(outline.language);
+        out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  {s}{d} lines{s}  {s}{s}{s}\n", .{
+            s.green,                               s.reset,
+            s.bold,                                path,
+            s.reset,                               s.langColor(lang),
+            lang,                                  s.reset,
+            s.dim,                                 outline.line_count,
+            s.reset,                               sty.durationColor(s, elapsed),
+            sty.formatDuration(&dur_buf, elapsed), s.reset,
+        });
+        for (outline.symbols.items) |sym| {
+            const kind = @tagName(sym.kind);
+            out.p("  {s}L{d:<5}{s}  {s}{s:<14}{s}  {s}{s}{s}", .{
+                s.dim,             sym.line_start, s.reset,
+                s.kindColor(kind), kind,           s.reset,
+                s.bold,            sym.name,       s.reset,
+            });
+            if (sym.detail) |d| {
+                out.p("  {s}{s}{s}", .{ s.dim, d, s.reset });
+            }
+            out.p("\n", .{});
+        }
+    } else if (std.mem.eql(u8, cmd, "find")) {
+        const name = if (args.len > cmd_args_start) args[cmd_args_start] else {
+            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] find {s}<symbol>{s}\n", .{
+                s.red, s.reset, s.cyan, s.reset,
+            });
+            return 1;
+        };
+        const t0 = cio.nanoTimestamp();
+        if (explorer.findSymbol(name, allocator) catch return 1) |r| {
+            defer {
+                allocator.free(r.path);
+                allocator.free(r.symbol.name);
+                if (r.symbol.detail) |d| allocator.free(d);
+            }
+            const elapsed = cio.nanoTimestamp() - t0;
+            var dur_buf: [64]u8 = undefined;
+            const kind = @tagName(r.symbol.kind);
+            out.p("{s}\xe2\x9c\x93{s} {s}{s}{s} {s}{s}{s}  {s}{s}{s}:{s}{d}{s}  {s}{s}{s}\n", .{
+                s.green,                       s.reset,
+                s.kindColor(kind),             kind,
+                s.reset,                       s.bold,
+                name,                          s.reset,
+                s.dim,                         r.path,
+                s.reset,                       s.cyan,
+                r.symbol.line_start,           s.reset,
+                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+                s.reset,
+            });
+            if (r.symbol.detail) |d| {
+                out.p("  {s}{s}{s}\n", .{ s.dim, d, s.reset });
+            }
+        } else {
+            out.p("{s}\xe2\x9c\x97{s} not found: {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, name, s.reset,
+            });
+        }
+    } else if (std.mem.eql(u8, cmd, "search")) {
+        var use_regex = false;
+        var paths_only = false;
+        var query_arg_start = cmd_args_start;
+        while (args.len > query_arg_start) {
+            const a = args[query_arg_start];
+            if (std.mem.eql(u8, a, "--regex")) {
+                use_regex = true;
+                query_arg_start += 1;
+            } else if (std.mem.eql(u8, a, "--paths-only")) {
+                paths_only = true;
+                query_arg_start += 1;
+            } else {
+                break;
+            }
+        }
+        const query = if (args.len > query_arg_start) args[query_arg_start] else {
+            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] search [--regex] [--paths-only] {s}<query>{s}\n", .{
+                s.red, s.reset, s.cyan, s.reset,
+            });
+            return 1;
+        };
+        const t0 = cio.nanoTimestamp();
+        const results = if (use_regex)
+            explorer.searchContentRegex(query, allocator, 50) catch return 1
+        else
+            explorer.searchContent(query, allocator, 50) catch return 1;
+        defer {
+            for (results) |r| {
+                allocator.free(r.path);
+                allocator.free(r.line_text);
+            }
+            allocator.free(results);
+        }
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        const quiet = cio.posixGetenv("CODEDB_QUIET") != null;
+        if (results.len == 0) {
+            if (!quiet) {
+                out.p("{s}\xe2\x9c\x97{s} no results for {s}\"{s}\"{s}\n", .{
+                    s.yellow, s.reset, s.bold, query, s.reset,
+                });
+            }
+        } else {
+            if (!quiet) {
+                const mode_label: []const u8 = if (use_regex) " (regex)" else "";
+                out.p("{s}\xe2\x9c\x93{s} {s}{d}{s} results for {s}\"{s}\"{s}{s}  {s}{s}{s}\n", .{
+                    s.green,                               s.reset,
+                    s.bold,                                results.len,
+                    s.reset,                               s.bold,
+                    query,                                 s.reset,
+                    mode_label,                            sty.durationColor(s, elapsed),
+                    sty.formatDuration(&dur_buf, elapsed), s.reset,
+                });
+            }
+            for (results) |r| {
+                if (paths_only) {
+                    out.p("  {s}{s}{s}:{s}{d}{s}\n", .{
+                        s.cyan, r.path, s.reset,
+                        s.dim,  r.line_num, s.reset,
+                    });
+                } else {
+                    out.p("  {s}{s}{s}:{s}{d}{s}  {s}\n", .{
+                        s.cyan,      r.path,     s.reset,
+                        s.dim,       r.line_num, s.reset,
+                        r.line_text,
+                    });
+                }
+            }
+        }
+    } else if (std.mem.eql(u8, cmd, "word")) {
+        const word = if (args.len > cmd_args_start) args[cmd_args_start] else {
+            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] word {s}<identifier>{s}\n", .{
+                s.red, s.reset, s.cyan, s.reset,
+            });
+            return 1;
+        };
+        const t0 = cio.nanoTimestamp();
+        const hits = explorer.searchWord(word, allocator) catch return 1;
+        defer allocator.free(hits);
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        if (hits.len == 0) {
+            out.p("{s}\xe2\x9c\x97{s} no hits for {s}'{s}'{s}\n", .{
+                s.yellow, s.reset, s.bold, word, s.reset,
+            });
+        } else {
+            out.p("{s}\xe2\x9c\x93{s} {s}{d}{s} hits for {s}'{s}'{s}  {s}{s}{s}\n", .{
+                s.green,                       s.reset,
+                s.bold,                        hits.len,
+                s.reset,                       s.bold,
+                word,                          s.reset,
+                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+                s.reset,
+            });
+            explorer.mu.lockShared();
+            defer explorer.mu.unlockShared();
+            for (hits) |h| {
+                out.p("  {s}{s}{s}:{s}{d}{s}\n", .{
+                    s.cyan, explorer.word_index.hitPath(h), s.reset,
+                    s.dim,  h.line_num,                     s.reset,
+                });
+            }
+        }
+    } else if (std.mem.eql(u8, cmd, "read")) {
+        // CLI counterpart of codedb_read MCP tool. Closes the agentic-eval
+        // gap where the CLI surface lacked a file-read primitive — agents
+        // restricted to `codedb` CLI had to reconstruct file bodies from
+        // 20+ `search` invocations.
+        var line_start: ?u32 = null;
+        var line_end: ?u32 = null;
+        var compact = false;
+        var arg_idx = cmd_args_start;
+        while (args.len > arg_idx) {
+            const a = args[arg_idx];
+            if (std.mem.eql(u8, a, "--compact") or std.mem.eql(u8, a, "-c")) {
+                compact = true;
+                arg_idx += 1;
+            } else if (std.mem.eql(u8, a, "-L") or std.mem.eql(u8, a, "--lines")) {
+                if (arg_idx + 1 >= args.len) break;
+                const range = args[arg_idx + 1];
+                const dash = std.mem.indexOfScalar(u8, range, '-') orelse break;
+                line_start = std.fmt.parseInt(u32, range[0..dash], 10) catch null;
+                const end_str = range[dash + 1 ..];
+                if (std.mem.eql(u8, end_str, "$") or std.mem.eql(u8, end_str, "end")) {
+                    line_end = std.math.maxInt(u32);
+                } else {
+                    line_end = std.fmt.parseInt(u32, end_str, 10) catch null;
+                }
+                arg_idx += 2;
+            } else {
+                break;
+            }
+        }
+        const path = if (args.len > arg_idx) args[arg_idx] else {
+            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] read [-L FROM-TO] [--compact] {s}<path>{s}\n", .{
+                s.red, s.reset, s.cyan, s.reset,
+            });
+            return 1;
+        };
+        // Same safety guards as codedb_read MCP — path must be project-relative
+        // (no leading `/`, no `..` traversal, no null bytes / backslashes) and
+        // must not target sensitive files like .env / id_rsa / .ssh/*. Without
+        // these guards the CLI happily reads /etc/passwd, secrets, or any file
+        // the codedb process can see.
+        if (!mcp_server.isPathSafe(path)) {
+            out.p("{s}\xe2\x9c\x97{s} path must be relative to the project root (no leading `/`, no `..` traversal): {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, path, s.reset,
+            });
+            return 1;
+        }
+        if (watcher.isSensitivePath(path)) {
+            out.p("{s}\xe2\x9c\x97{s} access to sensitive file blocked: {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, path, s.reset,
+            });
+            return 1;
+        }
+        const t0 = cio.nanoTimestamp();
+        // Prefer indexed content (matches the indexed view), fall back to disk
+        // reads anchored at the resolved project root — NOT cwd. Pre-fix, an
+        // explicit `codedb /path/to/proj read foo.zig` would read `./foo.zig`
+        // from wherever the user happened to invoke it.
+        const cached = explorer.getContent(path, allocator) catch null;
+        const content_owned = if (cached) |c| c else blk: {
+            var root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
+                out.p("{s}\xe2\x9c\x97{s} cannot open project root: {s}{s}{s}\n", .{
+                    s.red, s.reset, s.bold, root, s.reset,
+                });
+                return 1;
+            };
+            defer root_dir.close(io);
+            break :blk root_dir.readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch {
+                out.p("{s}\xe2\x9c\x97{s} not indexed and disk read failed: {s}{s}{s}\n", .{
+                    s.red, s.reset, s.bold, path, s.reset,
+                });
+                return 1;
+            };
+        };
+        defer allocator.free(content_owned);
+        // Binary detection (NUL byte in first 8KB) — stub instead of dumping raw bytes
+        const probe_len = @min(content_owned.len, 8 * 1024);
+        if (std.mem.indexOfScalar(u8, content_owned[0..probe_len], 0) != null) {
+            out.p("{s}\xe2\x9c\x97{s} binary file: {d} bytes\n", .{ s.yellow, s.reset, content_owned.len });
+            return 0;
+        }
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        const has_range = line_start != null or line_end != null;
+        const lang = explore_mod.detectLanguage(path);
+        if (has_range or compact) {
+            const start: u32 = line_start orelse 1;
+            const end: u32 = line_end orelse std.math.maxInt(u32);
+            const extracted = explore_mod.extractLines(content_owned, start, end, true, compact, lang, allocator) catch {
+                out.p("{s}\xe2\x9c\x97{s} line extraction failed\n", .{ s.red, s.reset });
+                return 1;
+            };
+            defer allocator.free(extracted);
+            const unbounded = end == std.math.maxInt(u32);
+            if (unbounded) {
+                out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  L{d}-EOF  {s}{s}{s}\n", .{
+                    s.green,                       s.reset,
+                    s.bold,                        path,
+                    s.reset,                       s.langColor(@tagName(lang)),
+                    @tagName(lang),                s.reset,
+                    start,                         sty.durationColor(s, elapsed),
+                    sty.formatDuration(&dur_buf, elapsed), s.reset,
+                });
+            } else {
+                out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  L{d}-{d}  {s}{s}{s}\n", .{
+                    s.green,                       s.reset,
+                    s.bold,                        path,
+                    s.reset,                       s.langColor(@tagName(lang)),
+                    @tagName(lang),                s.reset,
+                    start,                         end,
+                    sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+                    s.reset,
+                });
+            }
+            out.p("{s}", .{extracted});
+        } else {
+            out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  {s}{s}{s}\n", .{
+                s.green,                       s.reset,
+                s.bold,                        path,
+                s.reset,                       s.langColor(@tagName(lang)),
+                @tagName(lang),                s.reset,
+                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+                s.reset,
+            });
+            var line_num: u32 = 0;
+            var lines = std.mem.splitScalar(u8, content_owned, '\n');
+            while (lines.next()) |line| {
+                line_num += 1;
+                out.p("{d:>5} | {s}\n", .{ line_num, line });
+            }
+        }
+    } else if (std.mem.eql(u8, cmd, "hot")) {
+        const t0 = cio.nanoTimestamp();
+        const hot = explorer.getHotFiles(store, allocator, 10) catch return 1;
+        defer {
+            for (hot) |path| allocator.free(path);
+            allocator.free(hot);
+        }
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        out.p("{s}\xe2\x9c\x93{s} {s}recently modified{s}  {s}{s}{s}\n", .{
+            s.green,                       s.reset,
+            s.bold,                        s.reset,
+            sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+            s.reset,
+        });
+        for (hot, 1..) |path, i| {
+            out.p("  {s}{d}{s}  {s}{s}{s}\n", .{
+                s.dim,  i,    s.reset,
+                s.cyan, path, s.reset,
+            });
+        }
+    } else {
+        return 1;
+    }
+    return 0;
+}
 fn mainImpl() !void {
     // Use c_allocator (libc malloc) — better page reclamation than GPA
     const allocator = std.heap.c_allocator;
@@ -529,356 +887,13 @@ fn mainImpl() !void {
         } // end else (no snapshot)
     }
 
-    if (std.mem.eql(u8, cmd, "tree")) {
-        const t0 = cio.nanoTimestamp();
-        const tree = try explorer.getTree(allocator, use_color);
-        defer allocator.free(tree);
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        out.p("{s}", .{tree});
-        out.p("{s}{s}{s}\n", .{
-            sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed), s.reset,
-        });
-    } else if (std.mem.eql(u8, cmd, "outline")) {
-        const path = if (args.len > cmd_args_start) args[cmd_args_start] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] outline {s}<path>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
-            std.process.exit(1);
-        };
-        const t0 = cio.nanoTimestamp();
-        var outline = explorer.getOutline(path, allocator) catch {
-            out.p("{s}\xe2\x9c\x97{s} {s}{s}{s} \xe2\x80\x94 failed to load outline\n", .{
-                s.red, s.reset, s.bold, path, s.reset,
-            });
-            std.process.exit(1);
-        } orelse {
-            out.p("{s}\xe2\x9c\x97{s} not indexed: {s}{s}{s}\n", .{
-                s.red, s.reset, s.bold, path, s.reset,
-            });
-            return;
-        };
-        defer outline.deinit();
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        const lang = @tagName(outline.language);
-        out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  {s}{d} lines{s}  {s}{s}{s}\n", .{
-            s.green,                               s.reset,
-            s.bold,                                path,
-            s.reset,                               s.langColor(lang),
-            lang,                                  s.reset,
-            s.dim,                                 outline.line_count,
-            s.reset,                               sty.durationColor(s, elapsed),
-            sty.formatDuration(&dur_buf, elapsed), s.reset,
-        });
-        for (outline.symbols.items) |sym| {
-            const kind = @tagName(sym.kind);
-            out.p("  {s}L{d:<5}{s}  {s}{s:<14}{s}  {s}{s}{s}", .{
-                s.dim,             sym.line_start, s.reset,
-                s.kindColor(kind), kind,           s.reset,
-                s.bold,            sym.name,       s.reset,
-            });
-            if (sym.detail) |d| {
-                out.p("  {s}{s}{s}", .{ s.dim, d, s.reset });
-            }
-            out.p("\n", .{});
-        }
-    } else if (std.mem.eql(u8, cmd, "find")) {
-        const name = if (args.len > cmd_args_start) args[cmd_args_start] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] find {s}<symbol>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
-            std.process.exit(1);
-        };
-        const t0 = cio.nanoTimestamp();
-        if (try explorer.findSymbol(name, allocator)) |r| {
-            defer {
-                allocator.free(r.path);
-                allocator.free(r.symbol.name);
-                if (r.symbol.detail) |d| allocator.free(d);
-            }
-            const elapsed = cio.nanoTimestamp() - t0;
-            var dur_buf: [64]u8 = undefined;
-            const kind = @tagName(r.symbol.kind);
-            out.p("{s}\xe2\x9c\x93{s} {s}{s}{s} {s}{s}{s}  {s}{s}{s}:{s}{d}{s}  {s}{s}{s}\n", .{
-                s.green,                       s.reset,
-                s.kindColor(kind),             kind,
-                s.reset,                       s.bold,
-                name,                          s.reset,
-                s.dim,                         r.path,
-                s.reset,                       s.cyan,
-                r.symbol.line_start,           s.reset,
-                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-                s.reset,
-            });
-            if (r.symbol.detail) |d| {
-                out.p("  {s}{s}{s}\n", .{ s.dim, d, s.reset });
-            }
-        } else {
-            out.p("{s}\xe2\x9c\x97{s} not found: {s}{s}{s}\n", .{
-                s.red, s.reset, s.bold, name, s.reset,
-            });
-        }
-    } else if (std.mem.eql(u8, cmd, "search")) {
-        var use_regex = false;
-        var paths_only = false;
-        var query_arg_start = cmd_args_start;
-        while (args.len > query_arg_start) {
-            const a = args[query_arg_start];
-            if (std.mem.eql(u8, a, "--regex")) {
-                use_regex = true;
-                query_arg_start += 1;
-            } else if (std.mem.eql(u8, a, "--paths-only")) {
-                paths_only = true;
-                query_arg_start += 1;
-            } else {
-                break;
-            }
-        }
-        const query = if (args.len > query_arg_start) args[query_arg_start] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] search [--regex] [--paths-only] {s}<query>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
-            std.process.exit(1);
-        };
-        const t0 = cio.nanoTimestamp();
-        const results = if (use_regex)
-            try explorer.searchContentRegex(query, allocator, 50)
-        else
-            try explorer.searchContent(query, allocator, 50);
-        defer {
-            for (results) |r| {
-                allocator.free(r.path);
-                allocator.free(r.line_text);
-            }
-            allocator.free(results);
-        }
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        const quiet = cio.posixGetenv("CODEDB_QUIET") != null;
-        if (results.len == 0) {
-            if (!quiet) {
-                out.p("{s}\xe2\x9c\x97{s} no results for {s}\"{s}\"{s}\n", .{
-                    s.yellow, s.reset, s.bold, query, s.reset,
-                });
-            }
-        } else {
-            if (!quiet) {
-                const mode_label: []const u8 = if (use_regex) " (regex)" else "";
-                out.p("{s}\xe2\x9c\x93{s} {s}{d}{s} results for {s}\"{s}\"{s}{s}  {s}{s}{s}\n", .{
-                    s.green,                               s.reset,
-                    s.bold,                                results.len,
-                    s.reset,                               s.bold,
-                    query,                                 s.reset,
-                    mode_label,                            sty.durationColor(s, elapsed),
-                    sty.formatDuration(&dur_buf, elapsed), s.reset,
-                });
-            }
-            for (results) |r| {
-                if (paths_only) {
-                    out.p("  {s}{s}{s}:{s}{d}{s}\n", .{
-                        s.cyan, r.path, s.reset,
-                        s.dim,  r.line_num, s.reset,
-                    });
-                } else {
-                    out.p("  {s}{s}{s}:{s}{d}{s}  {s}\n", .{
-                        s.cyan,      r.path,     s.reset,
-                        s.dim,       r.line_num, s.reset,
-                        r.line_text,
-                    });
-                }
-            }
-        }
-    } else if (std.mem.eql(u8, cmd, "word")) {
-        const word = if (args.len > cmd_args_start) args[cmd_args_start] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] word {s}<identifier>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
-            std.process.exit(1);
-        };
-        const t0 = cio.nanoTimestamp();
-        const hits = try explorer.searchWord(word, allocator);
-        defer allocator.free(hits);
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        if (hits.len == 0) {
-            out.p("{s}\xe2\x9c\x97{s} no hits for {s}'{s}'{s}\n", .{
-                s.yellow, s.reset, s.bold, word, s.reset,
-            });
-        } else {
-            out.p("{s}\xe2\x9c\x93{s} {s}{d}{s} hits for {s}'{s}'{s}  {s}{s}{s}\n", .{
-                s.green,                       s.reset,
-                s.bold,                        hits.len,
-                s.reset,                       s.bold,
-                word,                          s.reset,
-                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-                s.reset,
-            });
-            explorer.mu.lockShared();
-            defer explorer.mu.unlockShared();
-            for (hits) |h| {
-                out.p("  {s}{s}{s}:{s}{d}{s}\n", .{
-                    s.cyan, explorer.word_index.hitPath(h), s.reset,
-                    s.dim,  h.line_num,                     s.reset,
-                });
-            }
-        }
-    } else if (std.mem.eql(u8, cmd, "read")) {
-        // CLI counterpart of codedb_read MCP tool. Closes the agentic-eval
-        // gap where the CLI surface lacked a file-read primitive — agents
-        // restricted to `codedb` CLI had to reconstruct file bodies from
-        // 20+ `search` invocations.
-        var line_start: ?u32 = null;
-        var line_end: ?u32 = null;
-        var compact = false;
-        var arg_idx = cmd_args_start;
-        while (args.len > arg_idx) {
-            const a = args[arg_idx];
-            if (std.mem.eql(u8, a, "--compact") or std.mem.eql(u8, a, "-c")) {
-                compact = true;
-                arg_idx += 1;
-            } else if (std.mem.eql(u8, a, "-L") or std.mem.eql(u8, a, "--lines")) {
-                if (arg_idx + 1 >= args.len) break;
-                const range = args[arg_idx + 1];
-                const dash = std.mem.indexOfScalar(u8, range, '-') orelse break;
-                line_start = std.fmt.parseInt(u32, range[0..dash], 10) catch null;
-                const end_str = range[dash + 1 ..];
-                if (std.mem.eql(u8, end_str, "$") or std.mem.eql(u8, end_str, "end")) {
-                    line_end = std.math.maxInt(u32);
-                } else {
-                    line_end = std.fmt.parseInt(u32, end_str, 10) catch null;
-                }
-                arg_idx += 2;
-            } else {
-                break;
-            }
-        }
-        const path = if (args.len > arg_idx) args[arg_idx] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] read [-L FROM-TO] [--compact] {s}<path>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
-            std.process.exit(1);
-        };
-        // Same safety guards as codedb_read MCP — path must be project-relative
-        // (no leading `/`, no `..` traversal, no null bytes / backslashes) and
-        // must not target sensitive files like .env / id_rsa / .ssh/*. Without
-        // these guards the CLI happily reads /etc/passwd, secrets, or any file
-        // the codedb process can see.
-        if (!mcp_server.isPathSafe(path)) {
-            out.p("{s}\xe2\x9c\x97{s} path must be relative to the project root (no leading `/`, no `..` traversal): {s}{s}{s}\n", .{
-                s.red, s.reset, s.bold, path, s.reset,
-            });
-            out.flush();
-            std.process.exit(1);
-        }
-        if (watcher.isSensitivePath(path)) {
-            out.p("{s}\xe2\x9c\x97{s} access to sensitive file blocked: {s}{s}{s}\n", .{
-                s.red, s.reset, s.bold, path, s.reset,
-            });
-            out.flush();
-            std.process.exit(1);
-        }
-        const t0 = cio.nanoTimestamp();
-        // Prefer indexed content (matches the indexed view), fall back to disk
-        // reads anchored at the resolved project root — NOT cwd. Pre-fix, an
-        // explicit `codedb /path/to/proj read foo.zig` would read `./foo.zig`
-        // from wherever the user happened to invoke it.
-        const cached = explorer.getContent(path, allocator) catch null;
-        const content_owned = if (cached) |c| c else blk: {
-            var root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
-                out.p("{s}\xe2\x9c\x97{s} cannot open project root: {s}{s}{s}\n", .{
-                    s.red, s.reset, s.bold, root, s.reset,
-                });
-                out.flush();
-                std.process.exit(1);
-            };
-            defer root_dir.close(io);
-            break :blk root_dir.readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch {
-                out.p("{s}\xe2\x9c\x97{s} not indexed and disk read failed: {s}{s}{s}\n", .{
-                    s.red, s.reset, s.bold, path, s.reset,
-                });
-                out.flush();
-                std.process.exit(1);
-            };
-        };
-        defer allocator.free(content_owned);
-        // Binary detection (NUL byte in first 8KB) — stub instead of dumping raw bytes
-        const probe_len = @min(content_owned.len, 8 * 1024);
-        if (std.mem.indexOfScalar(u8, content_owned[0..probe_len], 0) != null) {
-            out.p("{s}\xe2\x9c\x97{s} binary file: {d} bytes\n", .{ s.yellow, s.reset, content_owned.len });
-            return;
-        }
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        const has_range = line_start != null or line_end != null;
-        const lang = explore_mod.detectLanguage(path);
-        if (has_range or compact) {
-            const start: u32 = line_start orelse 1;
-            const end: u32 = line_end orelse std.math.maxInt(u32);
-            const extracted = explore_mod.extractLines(content_owned, start, end, true, compact, lang, allocator) catch {
-                out.p("{s}\xe2\x9c\x97{s} line extraction failed\n", .{ s.red, s.reset });
-                std.process.exit(1);
-            };
-            defer allocator.free(extracted);
-            const unbounded = end == std.math.maxInt(u32);
-            if (unbounded) {
-                out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  L{d}-EOF  {s}{s}{s}\n", .{
-                    s.green,                       s.reset,
-                    s.bold,                        path,
-                    s.reset,                       s.langColor(@tagName(lang)),
-                    @tagName(lang),                s.reset,
-                    start,                         sty.durationColor(s, elapsed),
-                    sty.formatDuration(&dur_buf, elapsed), s.reset,
-                });
-            } else {
-                out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  L{d}-{d}  {s}{s}{s}\n", .{
-                    s.green,                       s.reset,
-                    s.bold,                        path,
-                    s.reset,                       s.langColor(@tagName(lang)),
-                    @tagName(lang),                s.reset,
-                    start,                         end,
-                    sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-                    s.reset,
-                });
-            }
-            out.p("{s}", .{extracted});
-        } else {
-            out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  {s}{s}{s}\n", .{
-                s.green,                       s.reset,
-                s.bold,                        path,
-                s.reset,                       s.langColor(@tagName(lang)),
-                @tagName(lang),                s.reset,
-                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-                s.reset,
-            });
-            var line_num: u32 = 0;
-            var lines = std.mem.splitScalar(u8, content_owned, '\n');
-            while (lines.next()) |line| {
-                line_num += 1;
-                out.p("{d:>5} | {s}\n", .{ line_num, line });
-            }
-        }
-    } else if (std.mem.eql(u8, cmd, "hot")) {
-        const t0 = cio.nanoTimestamp();
-        const hot = try explorer.getHotFiles(&store, allocator, 10);
-        defer {
-            for (hot) |path| allocator.free(path);
-            allocator.free(hot);
-        }
-        const elapsed = cio.nanoTimestamp() - t0;
-        var dur_buf: [64]u8 = undefined;
-        out.p("{s}\xe2\x9c\x93{s} {s}recently modified{s}  {s}{s}{s}\n", .{
-            s.green,                       s.reset,
-            s.bold,                        s.reset,
-            sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-            s.reset,
-        });
-        for (hot, 1..) |path, i| {
-            out.p("  {s}{d}{s}  {s}{s}{s}\n", .{
-                s.dim,  i,    s.reset,
-                s.cyan, path, s.reset,
-            });
-        }
+    if (std.mem.eql(u8, cmd, "tree") or std.mem.eql(u8, cmd, "outline") or std.mem.eql(u8, cmd, "find") or
+        std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "read") or
+        std.mem.eql(u8, cmd, "hot"))
+    {
+        const code = runQuery(io, allocator, &explorer, &store, root, cmd, args, cmd_args_start, &out, s);
+        out.flush();
+        std.process.exit(code);
     } else if (std.mem.eql(u8, cmd, "bench-engine")) {
         // Engine-vs-engine microbenchmark — bypasses MCP envelope, response
         // formatting, and most of the CLI display path. Lets us compare

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,6 +32,11 @@ const Out = struct {
     alloc: std.mem.Allocator,
     buf: [65536]u8 = undefined,
     used: usize = 0,
+    // When set, flush() appends here instead of writing to `file`. Lets a warm
+    // daemon capture a command's full rendered output (run via runQuery) and frame
+    // it back to a CLI client over a socket — reusing the exact rendering the cold
+    // CLI uses. null for the normal stdout path.
+    sink: ?*std.ArrayList(u8) = null,
 
     fn p(self: *Out, comptime fmt: []const u8, args: anytype) void {
         // Fast path: format directly into the remaining buffer window.
@@ -49,12 +54,20 @@ const Out = struct {
         // Single message larger than 64KB — fall back to one-shot heap alloc.
         const big = std.fmt.allocPrint(self.alloc, fmt, args) catch return;
         defer self.alloc.free(big);
-        self.file.writeAll(big) catch {};
+        if (self.sink) |snk| {
+            snk.appendSlice(self.alloc, big) catch {};
+        } else {
+            self.file.writeAll(big) catch {};
+        }
     }
 
     fn flush(self: *Out) void {
         if (self.used == 0) return;
-        self.file.writeAll(self.buf[0..self.used]) catch {};
+        if (self.sink) |snk| {
+            snk.appendSlice(self.alloc, self.buf[0..self.used]) catch {};
+        } else {
+            self.file.writeAll(self.buf[0..self.used]) catch {};
+        }
         self.used = 0;
     }
 
@@ -500,6 +513,277 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
     }
     return 0;
 }
+
+// ── Thin CLI client → warm daemon ──────────────────────────────────────────
+// When a `codedb <root> serve` or `codedb <root> mcp` daemon is already running
+// for a project, a fresh `codedb <root> <query>` invocation can skip the
+// per-process snapshot reload by proxying the command to that daemon over a
+// per-project Unix-domain socket. The daemon runs the exact same `runQuery`
+// rendering against its already-warm Explorer/Store and streams the rendered
+// bytes back. If no daemon is listening, the client transparently falls back to
+// the cold in-process path.
+//
+// Transport: blocking std.c (libc) Unix sockets. std.posix dropped the socket
+// syscalls in 0.16 and the std.Io.net UnixAddress Reader/Writer surface is
+// awkward for a tiny framed request/response, so we go straight to libc here.
+// runQuery itself still receives the daemon's real `io` (it reads files through
+// it); only the socket bytes move over libc.
+//
+// Wire protocol (little-endian, length-framed):
+//   request  (client→daemon): [u8 color][u32 blob_len][blob]
+//       blob = argv[1..] NUL-joined, e.g. "/proj\0find\0foo"
+//   response (daemon→client): [u8 exit_code][u32 out_len][out_bytes]
+const cli_blob_max: u32 = 64 * 1024;
+
+/// Build the per-project socket path into `buf`. Stays well under sun_path
+/// (104 bytes on macOS / 108 on Linux): "/tmp/codedb-<uid>-<hash16>.sock" is
+/// at most ~40 bytes. Returns null only if formatting somehow overflows `buf`.
+fn cliSocketPath(buf: []u8, abs_root: []const u8) ?[]const u8 {
+    const uid = std.c.getuid();
+    const hash = std.hash.Wyhash.hash(0xc0de, abs_root);
+    return std.fmt.bufPrint(buf, "/tmp/codedb-{d}-{x:0>16}.sock", .{ uid, hash }) catch null;
+}
+
+/// Fill a sockaddr.un for `path` (which must be NUL-terminatable into sun_path).
+/// Returns the struct plus the byte length to pass to bind/connect. Path is
+/// guaranteed short by cliSocketPath, but we guard the copy regardless.
+fn cliFillSockaddr(path: []const u8) ?struct { addr: std.c.sockaddr.un, len: std.c.socklen_t } {
+    var addr: std.c.sockaddr.un = .{ .family = std.c.AF.UNIX, .path = undefined };
+    if (path.len + 1 > addr.path.len) return null;
+    @memcpy(addr.path[0..path.len], path);
+    addr.path[path.len] = 0;
+    // sun_len/sun_family + the NUL-terminated path. sizeof works on every
+    // platform we ship; the extra trailing bytes are harmless for AF_UNIX.
+    const len: std.c.socklen_t = @intCast(@sizeOf(std.c.sockaddr.un));
+    return .{ .addr = addr, .len = len };
+}
+
+/// Read exactly `buf.len` bytes from a blocking fd, looping over short reads.
+/// Returns false on EOF-before-full or a hard error (EINTR is retried).
+fn cliReadFull(fd: c_int, buf: []u8) bool {
+    var off: usize = 0;
+    while (off < buf.len) {
+        const n = std.c.read(fd, buf.ptr + off, buf.len - off);
+        if (n > 0) {
+            off += @intCast(n);
+            continue;
+        }
+        if (n == 0) return false; // peer closed early
+        if (std.c.errno(n) == .INTR) continue;
+        return false;
+    }
+    return true;
+}
+
+/// Write all of `data` to a blocking fd, looping over short/partial writes.
+/// Returns false on a hard error (EINTR is retried).
+fn cliWriteFull(fd: c_int, data: []const u8) bool {
+    var off: usize = 0;
+    while (off < data.len) {
+        const n = std.c.write(fd, data.ptr + off, data.len - off);
+        if (n > 0) {
+            off += @intCast(n);
+            continue;
+        }
+        if (n < 0 and std.c.errno(n) == .INTR) continue;
+        return false;
+    }
+    return true;
+}
+
+/// True for the read-only query commands the daemon will serve / the client
+/// will proxy. Everything else (serve, mcp, snapshot, index, ...) is handled
+/// only by the cold path.
+fn cliIsQueryCmd(cmd: []const u8) bool {
+    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot" };
+    for (cmds) |c| {
+        if (std.mem.eql(u8, cmd, c)) return true;
+    }
+    return false;
+}
+
+/// Daemon side. Bind a per-project Unix socket and serve framed query requests
+/// against the warm `explorer`/`store`. Runs on its own detached thread so it
+/// never blocks the daemon's primary loop. Connections are handled sequentially
+/// (CLI calls are infrequent and runQuery already tolerates concurrent reads
+/// from the watcher). On a fatal bind failure it logs and returns — the daemon
+/// keeps working and clients simply fall back to the cold path.
+fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8) void {
+    var path_buf: [128]u8 = undefined;
+    const sock_path = cliSocketPath(&path_buf, abs_root) orelse {
+        std.log.warn("cli-proxy: could not build socket path", .{});
+        return;
+    };
+    var path_z_buf: [128]u8 = undefined;
+    const sock_path_z = std.fmt.bufPrintZ(&path_z_buf, "{s}", .{sock_path}) catch return;
+
+    const sa = cliFillSockaddr(sock_path) orelse return;
+
+    // Try to bind; if the path is stale (a dead daemon left it behind) unlink
+    // and retry once. listenfd is owned for the lifetime of the daemon.
+    var listenfd: c_int = -1;
+    var attempt: u8 = 0;
+    while (attempt < 2) : (attempt += 1) {
+        const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
+        if (fd < 0) {
+            std.log.warn("cli-proxy: socket() failed", .{});
+            return;
+        }
+        var sa_mut = sa;
+        const rc = std.c.bind(fd, @ptrCast(&sa_mut.addr), sa_mut.len);
+        if (rc == 0) {
+            listenfd = fd;
+            break;
+        }
+        _ = std.c.close(fd);
+        if (attempt == 0) {
+            // Stale socket from a previous (now dead) daemon — clear and retry.
+            _ = std.c.unlink(sock_path_z.ptr);
+            continue;
+        }
+        std.log.warn("cli-proxy: bind {s} failed — proxy disabled", .{sock_path});
+        return;
+    }
+    if (listenfd < 0) return;
+    defer {
+        _ = std.c.close(listenfd);
+        _ = std.c.unlink(sock_path_z.ptr);
+    }
+
+    // Owner-only perms on the socket (0600). Must chmod the path, not fchmod the
+    // fd: Darwin ignores fchmod() on a socket fd, leaving the node world-rwx.
+    // Safe to do before listen() — no client can connect+use it yet. Non-fatal.
+    _ = std.c.chmod(sock_path_z.ptr, 0o600);
+
+    if (std.c.listen(listenfd, 16) != 0) {
+        std.log.warn("cli-proxy: listen failed — proxy disabled", .{});
+        return;
+    }
+    std.log.info("cli-proxy: listening on {s}", .{sock_path});
+
+    while (true) {
+        const conn = std.c.accept(listenfd, null, null);
+        if (conn < 0) {
+            if (std.c.errno(conn) == .INTR) continue;
+            // Listener went bad; stop the loop (daemon still serves its main API).
+            return;
+        }
+        cliServeConn(io, allocator, explorer, store, abs_root, conn);
+        _ = std.c.close(conn);
+    }
+}
+
+/// Handle one client connection: read the framed request, run the query into a
+/// sink buffer via runQuery, and write the framed response.
+fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, conn: c_int) void {
+    // Header: [u8 color][u32 blob_len]
+    var hdr: [5]u8 = undefined;
+    if (!cliReadFull(conn, &hdr)) return;
+    const color = hdr[0] != 0;
+    const blob_len = std.mem.readInt(u32, hdr[1..5], .little);
+    if (blob_len == 0 or blob_len > cli_blob_max) {
+        cliRespond(conn, 1, "");
+        return;
+    }
+
+    const blob = allocator.alloc(u8, blob_len) catch {
+        cliRespond(conn, 1, "");
+        return;
+    };
+    defer allocator.free(blob);
+    if (!cliReadFull(conn, blob)) return;
+
+    // Rebuild argv = ["codedb"] ++ split(blob, '\0'), skipping empty fields.
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    argv.append(allocator, "codedb") catch {
+        cliRespond(conn, 1, "");
+        return;
+    };
+    var it = std.mem.splitScalar(u8, blob, 0);
+    while (it.next()) |field| {
+        if (field.len == 0) continue;
+        argv.append(allocator, field) catch {
+            cliRespond(conn, 1, "");
+            return;
+        };
+    }
+
+    const parsed = parsePositional(argv.items);
+    if (parsed.usage_exit or !cliIsQueryCmd(parsed.cmd)) {
+        cliRespond(conn, 1, "");
+        return;
+    }
+
+    var sink: std.ArrayList(u8) = .empty;
+    defer sink.deinit(allocator);
+    var out = Out{ .file = cio.File.stdout(), .alloc = allocator, .sink = &sink };
+    const s = sty.style(color);
+    const code = runQuery(io, allocator, explorer, store, abs_root, parsed.cmd, argv.items, parsed.cmd_args_start, &out, s);
+    out.flush();
+
+    cliRespond(conn, code, sink.items);
+}
+
+/// Write the framed response [u8 code][u32 out_len][out_bytes] to `conn`.
+fn cliRespond(conn: c_int, code: u8, out_bytes: []const u8) void {
+    var hdr: [5]u8 = undefined;
+    hdr[0] = code;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(out_bytes.len), .little);
+    if (!cliWriteFull(conn, &hdr)) return;
+    if (out_bytes.len > 0) _ = cliWriteFull(conn, out_bytes);
+}
+
+/// Client side. If a daemon is listening for this project, proxy the command to
+/// it and stream the rendered output to stdout, returning the daemon's exit
+/// code. On ANY failure (no daemon, connect refused, short read, oversized
+/// response) returns null so the caller falls back to the cold in-process path.
+/// `args` is mainImpl's filtered argv (args[0] = program name); we send args[1..].
+fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, args: []const []const u8, color: bool) ?u8 {
+    _ = io;
+    if (args.len < 2) return null;
+
+    var path_buf: [128]u8 = undefined;
+    const sock_path = cliSocketPath(&path_buf, abs_root) orelse return null;
+    const sa = cliFillSockaddr(sock_path) orelse return null;
+
+    const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
+    if (fd < 0) return null;
+    defer _ = std.c.close(fd);
+
+    var sa_mut = sa;
+    if (std.c.connect(fd, @ptrCast(&sa_mut.addr), sa_mut.len) != 0) return null;
+
+    // Build the NUL-joined blob from args[1..].
+    var blob: std.ArrayList(u8) = .empty;
+    defer blob.deinit(allocator);
+    for (args[1..], 0..) |a, i| {
+        if (i != 0) blob.append(allocator, 0) catch return null;
+        blob.appendSlice(allocator, a) catch return null;
+    }
+    if (blob.items.len == 0 or blob.items.len > cli_blob_max) return null;
+
+    // Request header: [u8 color][u32 blob_len]
+    var hdr: [5]u8 = undefined;
+    hdr[0] = if (color) 1 else 0;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(blob.items.len), .little);
+    if (!cliWriteFull(fd, &hdr)) return null;
+    if (!cliWriteFull(fd, blob.items)) return null;
+
+    // Response header: [u8 code][u32 out_len]
+    var resp_hdr: [5]u8 = undefined;
+    if (!cliReadFull(fd, &resp_hdr)) return null;
+    const code = resp_hdr[0];
+    const out_len = std.mem.readInt(u32, resp_hdr[1..5], .little);
+
+    if (out_len > 0) {
+        const out_bytes = allocator.alloc(u8, out_len) catch return null;
+        defer allocator.free(out_bytes);
+        if (!cliReadFull(fd, out_bytes)) return null;
+        cio.File.stdout().writeAll(out_bytes) catch {};
+    }
+    return code;
+}
 fn mainImpl() !void {
     // Use c_allocator (libc malloc) — better page reclamation than GPA
     const allocator = std.heap.c_allocator;
@@ -668,6 +952,18 @@ fn mainImpl() !void {
             s.red, s.reset, s.bold, abs_root, s.reset,
         });
         out.exitWithFlush(1);
+    }
+
+    // Thin-client fast path: if a warm daemon (codedb <root> serve / mcp) is
+    // already listening for this project, proxy read-only query commands to it
+    // and skip the per-invocation snapshot reload entirely. Falls through to
+    // the cold in-process path below when no daemon answers. Must run before
+    // getDataDir + the load section so the proxied call pays none of that cost.
+    if (cliIsQueryCmd(cmd)) {
+        if (cliTryProxy(io, allocator, abs_root, args, use_color)) |code| {
+            out.flush();
+            std.process.exit(code);
+        }
     }
 
     const data_dir = try getDataDir(io, allocator, abs_root);
@@ -1072,6 +1368,15 @@ fn mainImpl() !void {
         defer reap_thread.join();
 
         std.log.info("codedb: {d} files indexed, listening on :{d}", .{ store.currentSeq(), port });
+
+        // Thin-CLI proxy listener: lets `codedb <root> <query>` invocations
+        // reuse this warm explorer/store over a per-project Unix socket instead
+        // of paying a cold snapshot reload. Detached so it never blocks serve().
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root })) |cli_t| {
+            cli_t.detach();
+        } else |err| {
+            std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
+        }
         try server.serve(io, allocator, &store, &agents, &explorer, queue, port);
     } else if (std.mem.eql(u8, cmd, "mcp")) {
         // Background auto-update check (no-op when CODEDB_NO_AUTO_UPDATE is set
@@ -1157,6 +1462,15 @@ fn mainImpl() !void {
 
         std.log.info("codedb mcp: root={s} files={d} data={s} scan={s}", .{ abs_root, store.currentSeq(), data_dir, mcp_server.getScanState().name() });
 
+        // Thin-CLI proxy listener (same as the serve branch): serve read-only
+        // query commands from this warm explorer/store over a per-project Unix
+        // socket so plain `codedb <root> <query>` calls skip a cold reload.
+        // Detached so it never blocks mcp_server.run().
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, &explorer, &store, abs_root })) |cli_t| {
+            cli_t.detach();
+        } else |err| {
+            std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
+        }
         mcp_server.run(io, allocator, &store, &explorer, &agents, abs_root, cfg.max_cached, &telem, maybe_deferred, &shutdown);
 
         shutdown.store(true, .release);

--- a/src/main.zig
+++ b/src/main.zig
@@ -509,6 +509,15 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
             });
         }
     } else {
+        // Not a natively-rendered command — bridge to the MCP navigation
+        // handlers (symbol/callers/deps/glob/ls/file/context) so the CLI can
+        // reach the same warm tools the MCP surface exposes.
+        var nav: std.ArrayList(u8) = .empty;
+        defer nav.deinit(allocator);
+        if (mcp_server.runCliTool(io, allocator, explorer, root, cmd, args, cmd_args_start, &nav)) |code| {
+            out.p("{s}", .{nav.items});
+            return code;
+        }
         return 1;
     }
     return 0;
@@ -595,7 +604,7 @@ fn cliWriteFull(fd: c_int, data: []const u8) bool {
 /// will proxy. Everything else (serve, mcp, snapshot, index, ...) is handled
 /// only by the cold path.
 fn cliIsQueryCmd(cmd: []const u8) bool {
-    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot" };
+    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "symbol", "callers", "deps", "glob", "ls", "file", "context" };
     for (cmds) |c| {
         if (std.mem.eql(u8, cmd, c)) return true;
     }
@@ -1229,9 +1238,11 @@ fn mainImpl() !void {
 
     if (std.mem.eql(u8, cmd, "tree") or std.mem.eql(u8, cmd, "outline") or std.mem.eql(u8, cmd, "find") or
         std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "read") or
-        std.mem.eql(u8, cmd, "hot"))
+        std.mem.eql(u8, cmd, "hot") or std.mem.eql(u8, cmd, "symbol") or std.mem.eql(u8, cmd, "callers") or
+        std.mem.eql(u8, cmd, "deps") or std.mem.eql(u8, cmd, "glob") or std.mem.eql(u8, cmd, "ls") or
+        std.mem.eql(u8, cmd, "file") or std.mem.eql(u8, cmd, "context"))
     {
-        const code = runQuery(io, allocator, &explorer, &store, root, cmd, args, cmd_args_start, &out, s);
+        const code = runQuery(io, allocator, &explorer, &store, abs_root, cmd, args, cmd_args_start, &out, s);
         out.flush();
         std.process.exit(code);
     } else if (std.mem.eql(u8, cmd, "bench-engine")) {
@@ -1712,7 +1723,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 }
 
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
+    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "symbol", "callers", "deps", "glob", "ls", "file", "context", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }
@@ -1997,12 +2008,26 @@ fn printUsage(out: *Out, s: sty.Style) void {
     });
     out.p(
         \\    {s}hot{s}                       recently modified files
+        \\    {s}symbol{s}  <name>            where a symbol is defined (all matches; --body for source)
+        \\    {s}callers{s}  <name>           every call site of a symbol
+        \\    {s}deps{s}  <path>              dependency graph (--depends-on, --transitive, --max-depth N)
+        \\    {s}glob{s}  <pattern>           match indexed paths by glob
+        \\    {s}ls{s}  [path]                list a directory's indexed children
+        \\    {s}file{s}  <fuzzy-name>        fuzzy file-name search
+        \\    {s}context{s}  <task...>        task-shaped orientation bundle
         \\    {s}serve{s}                     HTTP daemon on :7719
         \\    {s}mcp{s}                       JSON-RPC/MCP server over stdio
         \\    {s}update{s}                    self-update to the latest verified release
         \\    {s}nuke{s}                      uninstall codedb, clear caches, and deregister integrations
         \\
     , .{
+        s.cyan, s.reset,
+        s.cyan, s.reset,
+        s.cyan, s.reset,
+        s.cyan, s.reset,
+        s.cyan, s.reset,
+        s.cyan, s.reset,
+        s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1074,16 +1074,19 @@ fn mainImpl() !void {
         const needs_word_index = std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "bench-engine") or
             std.mem.eql(u8, cmd, "index") or std.mem.eql(u8, cmd, "mcp");
         if (snapshot_loaded) {
-            if (std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "bench-engine")) {
+            if (std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "bench-engine") or std.mem.eql(u8, cmd, "cli-daemon")) {
+                // The cli-daemon serves proxied `search`/`callers`; warm the
+                // trigram up front (mmap-backed — cheap RSS) so it doesn't scan
+                // all content per query. Matches the serve/mcp daemon.
                 loadTrigramFromDiskIfPresent(io, &explorer, data_dir, allocator);
             }
-            if (std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "bench-engine")) {
+            if (std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "bench-engine") or std.mem.eql(u8, cmd, "cli-daemon")) {
                 loadWordIndexFromDiskIfPresent(io, &explorer, data_dir, git_head, allocator);
-                // If the on-disk word index wasn't usable (missing or stale vs
-                // the loaded snapshot), eagerly rebuild + persist here so the
-                // next `codedb word X` invocation loads in ~1ms instead of
-                // re-paying the ~200ms rebuild cost every time.
-                if (!explorer.wordIndexIsComplete()) {
+                // word/bench-engine want a guaranteed-ready index — rebuild + persist
+                // if the on-disk one was missing/stale. The cli-daemon stays lean: if
+                // the mmap load missed, let the first `word`/`context` query rebuild
+                // lazily rather than hold a heap rebuild at startup.
+                if (!std.mem.eql(u8, cmd, "cli-daemon") and !explorer.wordIndexIsComplete()) {
                     explorer.rebuildWordIndex() catch {};
                     persistWordIndexToDisk(io, &explorer, data_dir, git_head);
                 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1855,7 +1855,7 @@ fn loadWordIndexFromDiskIfPresent(
         return;
     }
 
-    if (WordIndex.readFromDisk(io, data_dir, allocator)) |loaded| {
+    if (WordIndex.mmapFromDisk(io, data_dir, allocator) orelse WordIndex.readFromDisk(io, data_dir, allocator)) |loaded| {
         explorer.replaceWordIndex(loaded);
     } else {
         explorer.disableWordIndexDiskLoad();

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -270,7 +270,7 @@ fn loadProjectWordIndexFromDiskIfPresent(io: std.Io, explorer: *Explorer, projec
         return;
     }
 
-    if (idx.WordIndex.readFromDisk(io, data_dir, allocator)) |loaded| {
+    if (idx.WordIndex.mmapFromDisk(io, data_dir, allocator) orelse idx.WordIndex.readFromDisk(io, data_dir, allocator)) |loaded| {
         explorer.replaceWordIndex(loaded);
     } else {
         explorer.disableWordIndexDiskLoad();

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3826,6 +3826,101 @@ fn handleLs(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std
     }
 }
 
+/// CLI⇄MCP parity bridge. Serves the read-only navigation tools that `runQuery`
+/// doesn't render natively — symbol / callers / deps / glob / ls / context and
+/// the fuzzy file-name `file` lookup — by building the MCP argument map and
+/// reusing the same handlers against the warm Explorer. Returns the exit code,
+/// or null if `cmd` isn't one we handle (caller falls through to its own usage
+/// error). The rendered data block is appended to `out`. `root` must be the
+/// resolved absolute project root (used to locate the on-disk word index for
+/// callers/context).
+pub fn runCliTool(
+    io: std.Io,
+    alloc: std.mem.Allocator,
+    explorer: *Explorer,
+    root: []const u8,
+    cmd: []const u8,
+    args: []const []const u8,
+    cmd_args_start: usize,
+    out: *std.ArrayList(u8),
+) ?u8 {
+    const pos: ?[]const u8 = if (args.len > cmd_args_start) args[cmd_args_start] else null;
+
+    var m: std.json.ObjectMap = .empty;
+    defer m.deinit(alloc);
+
+    if (std.mem.eql(u8, cmd, "symbol")) {
+        const name = pos orelse return cliUsage(alloc, out, "symbol <name> [--body]");
+        m.put(alloc, "name", .{ .string = name }) catch return 1;
+        for (args[cmd_args_start..]) |a| {
+            if (std.mem.eql(u8, a, "--body")) m.put(alloc, "body", .{ .bool = true }) catch {};
+        }
+        handleSymbol(alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "callers")) {
+        const name = pos orelse return cliUsage(alloc, out, "callers <name>");
+        m.put(alloc, "name", .{ .string = name }) catch return 1;
+        // handleCallers does a content search (searchContentWithScope), so it
+        // needs the trigram — load the MMAP'd trigram (cheap, reclaimable), NOT
+        // the heap word index. Keeps the footprint at the MCP level.
+        loadProjectTrigramFromDiskIfPresent(io, explorer, root, alloc);
+        handleCallers(alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "deps")) {
+        const path = pos orelse return cliUsage(alloc, out, "deps <path> [--depends-on] [--transitive] [--max-depth N]");
+        m.put(alloc, "path", .{ .string = path }) catch return 1;
+        var i = cmd_args_start + 1;
+        while (i < args.len) : (i += 1) {
+            const a = args[i];
+            if (std.mem.eql(u8, a, "--depends-on")) {
+                m.put(alloc, "direction", .{ .string = "depends_on" }) catch {};
+            } else if (std.mem.eql(u8, a, "--transitive")) {
+                m.put(alloc, "transitive", .{ .bool = true }) catch {};
+            } else if (std.mem.eql(u8, a, "--max-depth") and i + 1 < args.len) {
+                m.put(alloc, "max_depth", .{ .integer = std.fmt.parseInt(i64, args[i + 1], 10) catch 1 }) catch {};
+                i += 1;
+            }
+        }
+        handleDeps(alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "glob")) {
+        const pattern = pos orelse return cliUsage(alloc, out, "glob <pattern>");
+        m.put(alloc, "pattern", .{ .string = pattern }) catch return 1;
+        handleGlob(alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "ls")) {
+        if (pos) |p| m.put(alloc, "path", .{ .string = p }) catch return 1;
+        handleLs(alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "file")) {
+        const query = pos orelse return cliUsage(alloc, out, "file <fuzzy-name>");
+        m.put(alloc, "query", .{ .string = query }) catch return 1;
+        handleFind(io, alloc, &m, out, explorer);
+        return 0;
+    } else if (std.mem.eql(u8, cmd, "context")) {
+        var task: std.ArrayList(u8) = .empty;
+        defer task.deinit(alloc);
+        var i = cmd_args_start;
+        while (i < args.len) : (i += 1) {
+            if (i > cmd_args_start) task.append(alloc, ' ') catch {};
+            task.appendSlice(alloc, args[i]) catch {};
+        }
+        if (task.items.len == 0) return cliUsage(alloc, out, "context <task...>");
+        m.put(alloc, "task", .{ .string = task.items }) catch return 1;
+        loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
+        handleContext(io, alloc, &m, out, explorer, root);
+        return 0;
+    }
+    return null;
+}
+
+fn cliUsage(alloc: std.mem.Allocator, out: *std.ArrayList(u8), usage: []const u8) u8 {
+    out.appendSlice(alloc, "usage: codedb [root] ") catch {};
+    out.appendSlice(alloc, usage) catch {};
+    out.appendSlice(alloc, "\n") catch {};
+    return 1;
+}
+
 const COMBO_WINDOW_MS: i64 = 5000; // 5 second window between query and file open
 const COMBO_BOOST_PER_HIT: f32 = 5.0; // score boost per historical open
 

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -724,12 +724,14 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
         outline.byte_size = try readSectionInt(u64, bytes, &cursor);
 
         const import_count = try readSectionInt(u32, bytes, &cursor);
+        try outline.imports.ensureTotalCapacity(allocator, import_count);
         for (0..import_count) |_| {
             const imp = try readSectionStringBorrowed(bytes, &cursor, 4096);
-            try outline.imports.append(allocator, imp);
+            outline.imports.appendAssumeCapacity(imp);
         }
 
         const symbol_count = try readSectionInt(u32, bytes, &cursor);
+        try outline.symbols.ensureTotalCapacity(allocator, symbol_count);
         for (0..symbol_count) |_| {
             const name = try readSectionStringBorrowed(bytes, &cursor, std.math.maxInt(u16));
             if (name.len == 0) return error.InvalidData;
@@ -745,7 +747,7 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
                 else => return error.InvalidData,
             };
 
-            try outline.symbols.append(allocator, Symbol{
+            outline.symbols.appendAssumeCapacity(Symbol{
                 .name = name,
                 .kind = kind,
                 .line_start = line_start,
@@ -767,10 +769,11 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
 fn rebuildDepsFromOutline(explorer: *Explorer, path: []const u8, outline: *const FileOutline, allocator: std.mem.Allocator) !void {
     var deps: std.ArrayList([]const u8) = .empty;
     errdefer deps.deinit(allocator);
+    try deps.ensureTotalCapacity(allocator, outline.imports.items.len);
 
     for (outline.imports.items) |imp| {
         if (std.mem.indexOf(u8, imp, "..") != null) continue;
-        try deps.append(allocator, imp);
+        deps.appendAssumeCapacity(imp);
     }
 
     try explorer.dep_graph.setDeps(path, deps);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -185,7 +185,8 @@ pub fn writeSnapshot(
             var import_count_buf: [4]u8 = undefined;
             std.mem.writeInt(u32, &import_count_buf, @intCast(outline.imports.items.len), .little);
             try writer.writeAll(&import_count_buf);
-            for (outline.imports.items) |imp| {
+            for (outline.imports.items) |imp_full| {
+                const imp = imp_full[0..@min(imp_full.len, std.math.maxInt(u16))];
                 var import_len_buf: [2]u8 = undefined;
                 std.mem.writeInt(u16, &import_len_buf, @intCast(imp.len), .little);
                 try writer.writeAll(&import_len_buf);
@@ -196,10 +197,13 @@ pub fn writeSnapshot(
             std.mem.writeInt(u32, &symbol_count_buf, @intCast(outline.symbols.items.len), .little);
             try writer.writeAll(&symbol_count_buf);
             for (outline.symbols.items) |sym| {
+                // Names from minified/generated files can exceed u16 (65535) —
+                // truncate the stored name instead of panicking on @intCast (P0).
+                const sym_name = sym.name[0..@min(sym.name.len, std.math.maxInt(u16))];
                 var name_len_buf: [2]u8 = undefined;
-                std.mem.writeInt(u16, &name_len_buf, @intCast(sym.name.len), .little);
+                std.mem.writeInt(u16, &name_len_buf, @intCast(sym_name.len), .little);
                 try writer.writeAll(&name_len_buf);
-                try writer.writeAll(sym.name);
+                try writer.writeAll(sym_name);
 
                 try writer.writeByte(@intFromEnum(sym.kind));
 
@@ -211,7 +215,8 @@ pub fn writeSnapshot(
                 std.mem.writeInt(u32, &line_end_buf, sym.line_end, .little);
                 try writer.writeAll(&line_end_buf);
 
-                if (sym.detail) |detail| {
+                if (sym.detail) |detail_full| {
+                    const detail = detail_full[0..@min(detail_full.len, std.math.maxInt(u16))];
                     try writer.writeByte(1);
                     var detail_len_buf: [2]u8 = undefined;
                     std.mem.writeInt(u16, &detail_len_buf, @intCast(detail.len), .little);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11684,3 +11684,79 @@ test "issue-471b: codedb_find error message enumerates accepted aliases" {
     try testing.expect(std.mem.indexOf(u8, out.items, "path") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "pattern") != null);
 }
+
+test "cli-mcp-parity: runCliTool bridges navigation commands to MCP handlers" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var exp = Explorer.init(aa, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try exp.indexFile("src/store.zig", "pub const Store = struct {};\n");
+    try exp.indexFile("src/main.zig", "const Store = @import(\"store.zig\").Store;\npub fn main() void {}\n");
+
+    // glob: pattern -> matching indexed paths (reuses handleGlob)
+    {
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(aa);
+        const code = mcp_mod.runCliTool(io, aa, &exp, ".", "glob", &.{ "codedb", ".", "glob", "src/*.zig" }, 3, &out);
+        try testing.expectEqual(@as(?u8, 0), code);
+        try testing.expect(std.mem.indexOf(u8, out.items, "src/store.zig") != null);
+        try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
+    }
+
+    // symbol: name -> definition site (reuses handleSymbol)
+    {
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(aa);
+        const code = mcp_mod.runCliTool(io, aa, &exp, ".", "symbol", &.{ "codedb", ".", "symbol", "Store" }, 3, &out);
+        try testing.expectEqual(@as(?u8, 0), code);
+        try testing.expect(std.mem.indexOf(u8, out.items, "src/store.zig") != null);
+    }
+
+    // unknown command -> null so runQuery falls through to its own usage error
+    {
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(aa);
+        try testing.expectEqual(@as(?u8, null), mcp_mod.runCliTool(io, aa, &exp, ".", "bogus", &.{ "codedb", ".", "bogus" }, 3, &out));
+    }
+
+    // missing required arg -> usage line, exit 1
+    {
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(aa);
+        try testing.expectEqual(@as(?u8, 1), mcp_mod.runCliTool(io, aa, &exp, ".", "glob", &.{ "codedb", ".", "glob" }, 3, &out));
+        try testing.expect(std.mem.indexOf(u8, out.items, "usage") != null);
+    }
+}
+
+test "p0: writeSnapshot tolerates over-long symbol names (u16 length overflow)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var exp = Explorer.init(aa, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    // An identifier longer than u16 max (65535) — minified/generated files produce
+    // these, and the old code paniced casting the length to u16 in writeSnapshot.
+    const long = try aa.alloc(u8, 70000);
+    @memset(long, 'a');
+    const content = try std.fmt.allocPrint(aa, "pub const {s} = 1;\n", .{long});
+    try exp.indexFile("src/min.zig", content);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = pb[0..try tmp.dir.realPathFile(io, ".", &pb)];
+    const snap = try std.fmt.allocPrint(testing.allocator, "{s}/min.codedb", .{dir});
+    defer testing.allocator.free(snap);
+
+    // Pre-fix: this paniced ("integer does not fit in destination type").
+    try snapshot_mod.writeSnapshot(io, &exp, dir, snap, testing.allocator);
+
+    // And the truncated record must round-trip back without crashing.
+    var exp2 = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap, &exp2, &store, testing.allocator));
+    try testing.expectEqual(@as(usize, 1), exp2.outlines.count());
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11760,3 +11760,60 @@ test "p0: writeSnapshot tolerates over-long symbol names (u16 length overflow)" 
     try testing.expect(snapshot_mod.loadSnapshot(io, snap, &exp2, &store, testing.allocator));
     try testing.expectEqual(@as(usize, 1), exp2.outlines.count());
 }
+
+test "mmap word index: zero-copy load matches heap load and promotes on write" {
+    const alloc = testing.allocator;
+    var wi = WordIndex.init(alloc);
+    defer wi.deinit();
+    wi.skip_file_words = true;
+    try wi.indexFile("src/a.zig", "pub fn alphaToken() void { betaToken(); }\n");
+    try wi.indexFile("src/b.zig", "pub fn betaToken() void { alphaToken(); alphaToken(); }\n");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = pb[0..try tmp.dir.realPathFile(io, ".", &pb)];
+    try wi.writeToDisk(io, dir, null);
+
+    var heap = WordIndex.readFromDisk(io, dir, alloc).?;
+    defer heap.deinit();
+    var mm = WordIndex.mmapFromDisk(io, dir, alloc).?;
+    defer mm.deinit(); // picks the right path (mmap, or heap after promote)
+    try testing.expect(mm.mmap_data != null);
+
+    // search parity (exact)
+    try testing.expectEqual(heap.search("alphaToken").len, mm.search("alphaToken").len);
+    try testing.expect(mm.search("alphaToken").len >= 1);
+
+    // searchDeduped parity + hitPath resolves through the mmap file table
+    {
+        const h = try mm.searchDeduped("betaToken", alloc);
+        defer alloc.free(h);
+        const r = try heap.searchDeduped("betaToken", alloc);
+        defer alloc.free(r);
+        try testing.expectEqual(r.len, h.len);
+        try testing.expect(h.len >= 1);
+        try testing.expectEqualStrings(heap.hitPath(r[0]), mm.hitPath(h[0]));
+    }
+
+    // searchPrefix parity (sorted-range walk vs linear scan)
+    {
+        const h = try mm.searchPrefix("alpha", alloc, 10);
+        defer alloc.free(h);
+        const r = try heap.searchPrefix("alpha", alloc, 10);
+        defer alloc.free(r);
+        try testing.expectEqual(r.len, h.len);
+    }
+
+    // BM25 helpers parity
+    try testing.expectEqual(heap.rankedDocCount(), mm.rankedDocCount());
+    try testing.expectEqual(heap.total_tokens, mm.total_tokens);
+    try testing.expectEqual(heap.docLength(0), mm.docLength(0));
+    try testing.expectEqual(heap.docLength(1), mm.docLength(1));
+
+    // Promote on write: a mutation materializes a heap index, then stays queryable.
+    try mm.indexFile("src/c.zig", "pub fn gammaToken() void {}\n");
+    try testing.expect(mm.mmap_data == null);
+    try testing.expectEqual(@as(usize, 1), (try mm.searchDeduped("gammaToken", alloc)).len);
+    try testing.expect(mm.search("alphaToken").len >= 1); // pre-promote postings survived
+}


### PR DESCRIPTION
## Summary

Makes the `codedb` CLI as fast as the warm `codedb mcp` daemon for read-only queries, without the per-invocation snapshot reload. Agents reach for the CLI over the `codedb_*` MCP tools, but the CLI used to reload the snapshot every call (~10–130 ms). This branch adds a **per-project warm daemon** that CLI query commands proxy to over a Unix socket, plus the index/RSS work needed to make the daemon match the MCP's footprint.

## What's in it

**Warm daemon + proxy (2bbc413, 37faafe, 3d631c8)**
- Factored read-only query commands into `runQuery(...) u8` (returns an exit code, never `std.process.exit`); `Out.sink` lets the daemon capture and reuse the identical rendering.
- CLI query commands connect to `/tmp/codedb-<uid>-<wyhash(abs_root)>.sock` (0600), send `[u8 color][u32 len][NUL-joined argv]`, daemon runs `runQuery` and frames back `[u8 code][u32 len][bytes]`. Connect-fail → cold fallback.
- A cold query with no daemon auto-spawns a detached `cli-daemon` (serve minus the TCP server) so the next call is warm. Idle watchdog self-cleans (`CODEDB_CLI_DAEMON_IDLE_MS`, default 5 min); `CODEDB_NO_CLI_DAEMON` suppresses.

**CLI⇄MCP parity bridge (9e38633, 976c50f)**
- 7 read-only navigation commands now reachable from the CLI (`symbol`, `callers`, `deps`, `glob`, `ls`, `file`, `context`) via `runCliTool` in mcp.zig, which builds the MCP arg map and calls the existing handlers — zero logic duplication.

**P0 crash fix (e211659)**
- `writeSnapshot` panicked ("integer does not fit") casting symbol-name / import / detail lengths to u16 on minified/generated files. Truncate each to `maxInt(u16)` before the length write. Repro repo (crawlspherev11) now exits 0. Regression test indexes a 70k-char identifier.

**RSS: match the MCP footprint (efd01d1, 747e342, 8d4d3f0, fb8be04)**
- Word-index disk load skips the `file_words` map (queries/BM25 never use it) and is now a **zero-copy mmap** (`mmapFromDisk`): a small sorted `word_dir` + doc-length table; postings stay in the mmap and are returned as `[]align(1) const WordHit`. First write calls `promoteIfBorrowed`. Pre-size per-file symbol/import lists on snapshot load.
- The cli-daemon now warms the trigram **and** word index at startup (both mmap-backed) so proxied `search` no longer rescans content per call (was ~31 ms) and `word`/`context` don't pay a heap rebuild on first use. The cli-daemon is excluded from the rebuild-if-incomplete branch so it stays lean (defers to a lazy first-query rebuild on a miss).

## Verified (openclaw 670-file index, interleaved A/B vs a warm `codedb mcp`, medians of 21)

| cmd | MCP | CLI | gap |
|---|---|---|---|
| search | 1.7 ms | 5.2 ms | +3.5 |
| callers | 7.2 ms | 11.0 ms | +3.9 |
| context | 88.5 ms | 92.1 ms | +3.6 |
| word | 0.15 ms | 3.0 ms | +2.8 |
| symbol | 9.1 ms | 12.2 ms | +3.2 |
| find | 262 ms | 5.1 ms | CLI faster |

Every command is **MCP query-cost + a flat ~3 ms irreducible process-launch floor** — the only gap is the exec the persistent MCP never pays. **RSS:** fresh cli-daemon 207→214 MB across 120 mixed queries vs MCP 211 MB — matched and bounded (mmap working-set fault-in plateaus, no unbounded leak).

## Tests
699/699 green (`zig build test`). New tests: cli-mcp parity bridge, p0 u16-overflow snapshot, zero-copy mmap word-index parity (mmap == heap load + promote-on-write).

## Follow-up (separate PR)
MCP `codedb_find` runs `fuzzyScore` over all ~25k symbols (~262 ms on openclaw) while the CLI `find` path returns in ~5 ms — a 30–50× win available by porting the fast path into `handleFind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)