### PR TITLE
cli: harden argument parsing, validation, and exit codes (#528)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3042,6 +3042,14 @@ pub const Explorer = struct {
         var result_list: std.ArrayList(SearchResult) = .empty;
         errdefer result_list.deinit(allocator);
 
+        // Surface invalid patterns as error.InvalidRegex instead of silently
+        // returning zero results (#528 item 10). Compile once up front with the
+        // real matcher; the per-file scans below reuse the same engine.
+        {
+            var probe = nanoregex.Regex.compile(allocator, pattern) catch return error.InvalidRegex;
+            probe.deinit();
+        }
+
         var query = idx.decomposeRegex(pattern, self.allocator) catch {
             var iter = self.outlines.keyIterator();
             while (iter.next()) |key_ptr| {
@@ -4615,6 +4623,14 @@ pub const Explorer = struct {
                 if (r.scope_name) |n| allocator.free(n);
             }
             result_list.deinit(allocator);
+        }
+
+        // Surface invalid patterns as error.InvalidRegex instead of silently
+        // returning zero results (#528 item 10). Compile once up front with the
+        // real matcher; the per-file scans below reuse the same engine.
+        {
+            var probe = nanoregex.Regex.compile(allocator, pattern) catch return error.InvalidRegex;
+            probe.deinit();
         }
 
         var query = idx.decomposeRegex(pattern, self.allocator) catch {

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,32 +253,38 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
             });
         }
     } else if (std.mem.eql(u8, cmd, "search")) {
-        var use_regex = false;
-        var paths_only = false;
-        var query_arg_start = cmd_args_start;
-        while (args.len > query_arg_start) {
-            const a = args[query_arg_start];
-            if (std.mem.eql(u8, a, "--regex")) {
-                use_regex = true;
-                query_arg_start += 1;
-            } else if (std.mem.eql(u8, a, "--paths-only")) {
-                paths_only = true;
-                query_arg_start += 1;
-            } else {
-                break;
+        const sa = parseSearchArgs(args, cmd_args_start) catch |e| {
+            switch (e) {
+                error.UnknownFlag => out.p("{s}\xe2\x9c\x97{s} unknown flag for {s}search{s}  (valid: {s}--regex{s}, {s}--paths-only{s}, {s}--max-results N{s})\n", .{
+                    s.red, s.reset, s.bold, s.reset, s.cyan, s.reset, s.cyan, s.reset, s.cyan, s.reset,
+                }),
+                error.MissingMaxResults, error.BadMaxResults => out.p("{s}\xe2\x9c\x97{s} {s}--max-results{s} requires a positive integer\n", .{
+                    s.red, s.reset, s.cyan, s.reset,
+                }),
+                error.ExtraArg => out.p("{s}\xe2\x9c\x97{s} unexpected extra argument (quote multi-word queries: {s}search \"foo bar\"{s})\n", .{
+                    s.red, s.reset, s.cyan, s.reset,
+                }),
+                error.MissingQuery, error.EmptyQuery => out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] search [--regex] [--paths-only] [--max-results N] {s}<query>{s}\n", .{
+                    s.red, s.reset, s.cyan, s.reset,
+                }),
             }
-        }
-        const query = if (args.len > query_arg_start) args[query_arg_start] else {
-            out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] search [--regex] [--paths-only] {s}<query>{s}\n", .{
-                s.red, s.reset, s.cyan, s.reset,
-            });
             return 1;
         };
+        const query = sa.query;
+        const use_regex = sa.use_regex;
+        const paths_only = sa.paths_only;
         const t0 = cio.nanoTimestamp();
         const results = if (use_regex)
-            explorer.searchContentRegex(query, allocator, 50) catch return 1
+            explorer.searchContentRegex(query, allocator, sa.max_results) catch |e| {
+                if (e == error.InvalidRegex) {
+                    out.p("{s}\xe2\x9c\x97{s} invalid regex: {s}{s}{s}\n", .{ s.red, s.reset, s.bold, query, s.reset });
+                } else {
+                    out.p("{s}\xe2\x9c\x97{s} search failed\n", .{ s.red, s.reset });
+                }
+                return 1;
+            }
         else
-            explorer.searchContent(query, allocator, 50) catch return 1;
+            explorer.searchContent(query, allocator, sa.max_results) catch return 1;
         defer {
             for (results) |r| {
                 allocator.free(r.path);
@@ -364,29 +370,47 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
         var line_start: ?u32 = null;
         var line_end: ?u32 = null;
         var compact = false;
+        var path_opt: ?[]const u8 = null;
         var arg_idx = cmd_args_start;
-        while (args.len > arg_idx) {
+        // Flags (`-L FROM-TO`, `--compact`) may appear before or after the path
+        // (#528 item 8). Unknown flags and a second positional are rejected so
+        // typos surface instead of silently dumping the whole file.
+        while (args.len > arg_idx) : (arg_idx += 1) {
             const a = args[arg_idx];
             if (std.mem.eql(u8, a, "--compact") or std.mem.eql(u8, a, "-c")) {
                 compact = true;
-                arg_idx += 1;
             } else if (std.mem.eql(u8, a, "-L") or std.mem.eql(u8, a, "--lines")) {
-                if (arg_idx + 1 >= args.len) break;
-                const range = args[arg_idx + 1];
-                const dash = std.mem.indexOfScalar(u8, range, '-') orelse break;
-                line_start = std.fmt.parseInt(u32, range[0..dash], 10) catch null;
-                const end_str = range[dash + 1 ..];
-                if (std.mem.eql(u8, end_str, "$") or std.mem.eql(u8, end_str, "end")) {
-                    line_end = std.math.maxInt(u32);
-                } else {
-                    line_end = std.fmt.parseInt(u32, end_str, 10) catch null;
+                if (arg_idx + 1 >= args.len) {
+                    out.p("{s}\xe2\x9c\x97{s} {s}-L{s} requires a {s}FROM-TO{s} range\n", .{
+                        s.red, s.reset, s.cyan, s.reset, s.cyan, s.reset,
+                    });
+                    return 1;
                 }
-                arg_idx += 2;
+                const range = args[arg_idx + 1];
+                arg_idx += 1;
+                const lr = parseLineRange(range) catch {
+                    out.p("{s}\xe2\x9c\x97{s} invalid line range: {s}{s}{s}  (expected {s}FROM-TO{s}, 1-based, FROM \xe2\x89\xa4 TO; TO may be {s}${s})\n", .{
+                        s.red, s.reset, s.bold, range, s.reset, s.cyan, s.reset, s.cyan, s.reset,
+                    });
+                    return 1;
+                };
+                line_start = lr.start;
+                line_end = lr.end;
+            } else if (a.len > 0 and a[0] == '-') {
+                out.p("{s}\xe2\x9c\x97{s} unknown flag for {s}read{s}: {s}{s}{s}  (valid: {s}-L FROM-TO{s}, {s}--compact{s})\n", .{
+                    s.red, s.reset, s.bold, s.reset, s.bold, a, s.reset, s.cyan, s.reset, s.cyan, s.reset,
+                });
+                return 1;
+            } else if (path_opt == null) {
+                path_opt = a;
             } else {
-                break;
+                out.p("{s}\xe2\x9c\x97{s} unexpected extra argument: {s}{s}{s}\n", .{
+                    s.red, s.reset, s.bold, a, s.reset,
+                });
+                return 1;
             }
         }
-        const path = if (args.len > arg_idx) args[arg_idx] else {
+        const path = path_opt orelse {
             out.p("{s}\xe2\x9c\x97{s} usage: codedb [root] read [-L FROM-TO] [--compact] {s}<path>{s}\n", .{
                 s.red, s.reset, s.cyan, s.reset,
             });
@@ -508,6 +532,37 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
                 s.cyan, path, s.reset,
             });
         }
+    } else if (std.mem.eql(u8, cmd, "status")) {
+        // #528 item 1: read-only CLI status mirroring codedb_status, so
+        // `codedb status` works without going through the MCP surface.
+        const t0 = cio.nanoTimestamp();
+        store.mu.lock();
+        const file_count = store.files.count();
+        const seq = store.seq;
+        store.mu.unlock();
+        explorer.mu.lockShared();
+        const outline_count = explorer.outlines.count();
+        const trigram_files = explorer.trigram_index.fileCount();
+        const trigram_type: []const u8 = switch (explorer.trigram_index) {
+            .heap => "heap",
+            .mmap => "mmap",
+            .mmap_overlay => "mmap+overlay",
+        };
+        explorer.mu.unlockShared();
+        const index_kb = telemetry.approxIndexSizeBytes(explorer) / 1024;
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        out.p("{s}\xe2\x9c\x93{s} {s}codedb {s}{s}  {s}{s}{s}\n", .{
+            s.green,                               s.reset,
+            s.bold,                                release_info.semver,
+            s.reset,                               sty.durationColor(s, elapsed),
+            sty.formatDuration(&dur_buf, elapsed), s.reset,
+        });
+        out.p("  {s}root{s}      {s}{s}{s}\n", .{ s.dim, s.reset, s.cyan, root, s.reset });
+        out.p("  {s}files{s}     {s}{d}{s} indexed\n", .{ s.dim, s.reset, s.bold, file_count, s.reset });
+        out.p("  {s}seq{s}       {s}{d}{s}\n", .{ s.dim, s.reset, s.bold, seq, s.reset });
+        out.p("  {s}outlines{s}  {s}{d}{s}\n", .{ s.dim, s.reset, s.bold, outline_count, s.reset });
+        out.p("  {s}index{s}     {s}{s}{s}  {d} files, {d}KB\n", .{ s.dim, s.reset, s.cyan, trigram_type, s.reset, trigram_files, index_kb });
     } else {
         // Not a natively-rendered command — bridge to the MCP navigation
         // handlers (symbol/callers/deps/glob/ls/file/context) so the CLI can
@@ -848,6 +903,7 @@ fn mainImpl() !void {
     // arg parsing so a leading `--config-file=X` isn't misread as the root.
     // See #101, #102.
     var explicit_config: ?[]const u8 = null;
+    var no_telemetry = false;
     const args = blk: {
         var filtered: std.ArrayList([]const u8) = .empty;
         errdefer filtered.deinit(allocator);
@@ -861,6 +917,13 @@ fn mainImpl() !void {
             } else if (std.mem.eql(u8, a, "--config-file") and i + 1 < raw_args.len) {
                 explicit_config = raw_args[i + 1];
                 i += 1;
+                continue;
+            } else if (std.mem.eql(u8, a, "--no-telemetry")) {
+                // #528 item 12: --no-telemetry is documented as a global option,
+                // so strip it before positional parsing (like --config-file)
+                // instead of only honoring it after `mcp`. Telemetry.init also
+                // honors CODEDB_NO_TELEMETRY.
+                no_telemetry = true;
                 continue;
             }
             try filtered.append(allocator, a);
@@ -1243,7 +1306,8 @@ fn mainImpl() !void {
         std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "read") or
         std.mem.eql(u8, cmd, "hot") or std.mem.eql(u8, cmd, "symbol") or std.mem.eql(u8, cmd, "callers") or
         std.mem.eql(u8, cmd, "deps") or std.mem.eql(u8, cmd, "glob") or std.mem.eql(u8, cmd, "ls") or
-        std.mem.eql(u8, cmd, "file") or std.mem.eql(u8, cmd, "context"))
+        std.mem.eql(u8, cmd, "file") or std.mem.eql(u8, cmd, "context") or
+        std.mem.eql(u8, cmd, "status"))
     {
         const code = runQuery(io, allocator, &explorer, &store, abs_root, cmd, args, cmd_args_start, &out, s);
         out.flush();
@@ -1532,13 +1596,9 @@ fn mainImpl() !void {
         if (query_log) |ql| mcp_server.setQueryLogPath(ql);
 
         const startup_t0 = cio.milliTimestamp();
-        var telemetry_disabled = false;
-        for (args[cmd_args_start..]) |arg| {
-            if (std.mem.eql(u8, arg, "--no-telemetry")) {
-                telemetry_disabled = true;
-                break;
-            }
-        }
+        // --no-telemetry is stripped globally above (#528 item 12); honor it
+        // here alongside CODEDB_NO_TELEMETRY (checked inside Telemetry.init).
+        const telemetry_disabled = no_telemetry;
 
         var telem = telemetry.Telemetry.init(io, data_dir, allocator, telemetry_disabled);
         defer telem.deinit();
@@ -1682,6 +1742,82 @@ pub fn parsePositional(args: []const []const u8) ParsedPositional {
     return .{ .root = "", .cmd = "", .cmd_args_start = 0, .root_is_explicit = false, .usage_exit = true };
 }
 
+/// A 1-based inclusive line range as accepted by `read -L FROM-TO`. `end` is
+/// `std.math.maxInt(u32)` when the spec used `$`/`end` (read to end-of-file).
+pub const LineRange = struct { start: u32, end: u32 };
+
+pub const LineRangeError = error{ MissingDash, BadStart, BadEnd, ZeroLine, Reversed };
+
+/// Parse a `FROM-TO` line-range spec (the argument to `read -L`). `TO` may be
+/// `$` or `end` for end-of-file. Rejects malformed, non-numeric, zero-based,
+/// and reversed ranges so the CLI surfaces a clear error instead of silently
+/// defaulting (`abc-10` → 1) or printing empty output (`20-1`). Mirrors the
+/// MCP read validation. See issue #528 (items 3, 4, 7).
+pub fn parseLineRange(spec: []const u8) LineRangeError!LineRange {
+    const dash = std.mem.indexOfScalar(u8, spec, '-') orelse return error.MissingDash;
+    const start = std.fmt.parseInt(u32, spec[0..dash], 10) catch return error.BadStart;
+    if (start < 1) return error.ZeroLine;
+    const end_str = spec[dash + 1 ..];
+    const end: u32 = if (std.mem.eql(u8, end_str, "$") or std.mem.eql(u8, end_str, "end"))
+        std.math.maxInt(u32)
+    else blk: {
+        const e = std.fmt.parseInt(u32, end_str, 10) catch return error.BadEnd;
+        if (e < 1) return error.ZeroLine;
+        break :blk e;
+    };
+    if (end != std.math.maxInt(u32) and start > end) return error.Reversed;
+    return .{ .start = start, .end = end };
+}
+
+/// Parsed `search` invocation. `max_results` defaults to 50 (the prior
+/// hard-coded cap) and is clamped to 1..200.
+pub const SearchArgs = struct {
+    query: []const u8,
+    use_regex: bool = false,
+    paths_only: bool = false,
+    max_results: usize = 50,
+};
+
+pub const SearchArgError = error{ UnknownFlag, MissingMaxResults, BadMaxResults, MissingQuery, EmptyQuery, ExtraArg };
+
+/// Parse `search` args. Flags (`--regex`, `--paths-only`, `--max-results N`)
+/// may appear before or after the query, in any order. Unknown `--flags` are
+/// rejected rather than silently treated as the query text (`--max-results 1
+/// foo` used to search for the literal "--max-results"), and an empty/missing
+/// query is a usage error. A bare `--` ends flag parsing so a literal
+/// `--`-prefixed string can still be searched. See issue #528 (item 9).
+pub fn parseSearchArgs(args: []const []const u8, start: usize) SearchArgError!SearchArgs {
+    var result: SearchArgs = .{ .query = "" };
+    var query: ?[]const u8 = null;
+    var flags_done = false;
+    var i = start;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (!flags_done and std.mem.eql(u8, a, "--")) {
+            flags_done = true;
+        } else if (!flags_done and std.mem.eql(u8, a, "--regex")) {
+            result.use_regex = true;
+        } else if (!flags_done and std.mem.eql(u8, a, "--paths-only")) {
+            result.paths_only = true;
+        } else if (!flags_done and std.mem.eql(u8, a, "--max-results")) {
+            if (i + 1 >= args.len) return error.MissingMaxResults;
+            i += 1;
+            const n = std.fmt.parseInt(usize, args[i], 10) catch return error.BadMaxResults;
+            if (n < 1) return error.BadMaxResults;
+            result.max_results = @min(n, 200);
+        } else if (!flags_done and a.len > 1 and a[0] == '-' and a[1] == '-') {
+            return error.UnknownFlag;
+        } else if (query == null) {
+            query = a;
+        } else {
+            return error.ExtraArg;
+        }
+    }
+    result.query = query orelse return error.MissingQuery;
+    if (result.query.len == 0) return error.EmptyQuery;
+    return result;
+}
+
 /// Walk up from cwd looking for a `.git` directory or file (git worktree).
 /// Returns a slice into `buf` containing the absolute path, or null if no
 /// repo root is found before reaching the filesystem root. Used to make
@@ -1726,7 +1862,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 }
 
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "symbol", "callers", "deps", "glob", "ls", "file", "context", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
+    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "deps", "glob", "ls", "file", "context", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }
@@ -2011,6 +2147,7 @@ fn printUsage(out: *Out, s: sty.Style) void {
     });
     out.p(
         \\    {s}hot{s}                       recently modified files
+        \\    {s}status{s}                    index size, store seq, and index state
         \\    {s}symbol{s}  <name>            where a symbol is defined (all matches; --body for source)
         \\    {s}callers{s}  <name>           every call site of a symbol
         \\    {s}deps{s}  <path>              dependency graph (--depends-on, --transitive, --max-depth N)
@@ -2036,6 +2173,7 @@ fn printUsage(out: *Out, s: sty.Style) void {
         s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,
+        s.cyan, s.reset,
     });
     out.p(
         \\  {s}options:{s}
@@ -2044,6 +2182,9 @@ fn printUsage(out: *Out, s: sty.Style) void {
         \\
         \\  If root is omitted, uses current working directory.
         \\  Data stored in {s}~/.codedb/projects/<hash>/{s}
+        \\
+        \\  exit codes: 0 = success (incl. a valid query that finds nothing),
+        \\              1 = usage error, invalid input, or operational failure.
         \\
         \\
     , .{

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1516,8 +1516,8 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
     } else null;
 
     if (scope and is_regex) {
-        const results = explorer.searchContentRegexWithScope(query, alloc, max_results) catch {
-            out.appendSlice(alloc, "error: scoped regex search failed") catch {};
+        const results = explorer.searchContentRegexWithScope(query, alloc, max_results) catch |e| {
+            out.appendSlice(alloc, if (e == error.InvalidRegex) "error: invalid regex" else "error: scoped regex search failed") catch {};
             return;
         };
         defer {
@@ -1618,8 +1618,8 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             w.print("({d} shown, {d} truncated by per-file cap)\n", .{ shown, visible_total - shown }) catch {};
         }
     } else if (is_regex) {
-        const results = explorer.searchContentRegex(query, alloc, max_results) catch {
-            out.appendSlice(alloc, "error: regex search failed") catch {};
+        const results = explorer.searchContentRegex(query, alloc, max_results) catch |e| {
+            out.appendSlice(alloc, if (e == error.InvalidRegex) "error: invalid regex" else "error: regex search failed") catch {};
             return;
         };
         defer {
@@ -3881,6 +3881,7 @@ pub fn runCliTool(
     out: *std.ArrayList(u8),
 ) ?u8 {
     const pos: ?[]const u8 = if (args.len > cmd_args_start) args[cmd_args_start] else null;
+    const out_start = out.items.len;
 
     var m: std.json.ObjectMap = .empty;
     defer m.deinit(alloc);
@@ -3892,7 +3893,7 @@ pub fn runCliTool(
             if (std.mem.eql(u8, a, "--body")) m.put(alloc, "body", .{ .bool = true }) catch {};
         }
         handleSymbol(alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "callers")) {
         const name = pos orelse return cliUsage(alloc, out, "callers <name>");
         m.put(alloc, "name", .{ .string = name }) catch return 1;
@@ -3901,38 +3902,29 @@ pub fn runCliTool(
         // the heap word index. Keeps the footprint at the MCP level.
         loadProjectTrigramFromDiskIfPresent(io, explorer, root, alloc);
         handleCallers(alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "deps")) {
-        const path = pos orelse return cliUsage(alloc, out, "deps <path> [--depends-on] [--transitive] [--max-depth N]");
-        m.put(alloc, "path", .{ .string = path }) catch return 1;
-        var i = cmd_args_start + 1;
-        while (i < args.len) : (i += 1) {
-            const a = args[i];
-            if (std.mem.eql(u8, a, "--depends-on")) {
-                m.put(alloc, "direction", .{ .string = "depends_on" }) catch {};
-            } else if (std.mem.eql(u8, a, "--transitive")) {
-                m.put(alloc, "transitive", .{ .bool = true }) catch {};
-            } else if (std.mem.eql(u8, a, "--max-depth") and i + 1 < args.len) {
-                m.put(alloc, "max_depth", .{ .integer = std.fmt.parseInt(i64, args[i + 1], 10) catch 1 }) catch {};
-                i += 1;
-            }
-        }
+        const da = parseDepsArgs(args, cmd_args_start) catch |e| return cliDepsUsage(alloc, out, e);
+        m.put(alloc, "path", .{ .string = da.path }) catch return 1;
+        if (da.depends_on) m.put(alloc, "direction", .{ .string = "depends_on" }) catch {};
+        if (da.transitive) m.put(alloc, "transitive", .{ .bool = true }) catch {};
+        if (da.max_depth) |md| m.put(alloc, "max_depth", .{ .integer = md }) catch {};
         handleDeps(alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "glob")) {
         const pattern = pos orelse return cliUsage(alloc, out, "glob <pattern>");
         m.put(alloc, "pattern", .{ .string = pattern }) catch return 1;
         handleGlob(alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "ls")) {
         if (pos) |p| m.put(alloc, "path", .{ .string = p }) catch return 1;
         handleLs(alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "file")) {
         const query = pos orelse return cliUsage(alloc, out, "file <fuzzy-name>");
         m.put(alloc, "query", .{ .string = query }) catch return 1;
         handleFind(io, alloc, &m, out, explorer);
-        return 0;
+        return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "context")) {
         var task: std.ArrayList(u8) = .empty;
         defer task.deinit(alloc);
@@ -3945,7 +3937,7 @@ pub fn runCliTool(
         m.put(alloc, "task", .{ .string = task.items }) catch return 1;
         loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
         handleContext(io, alloc, &m, out, explorer, root);
-        return 0;
+        return finishCli(out, out_start);
     }
     return null;
 }
@@ -3953,6 +3945,73 @@ pub fn runCliTool(
 fn cliUsage(alloc: std.mem.Allocator, out: *std.ArrayList(u8), usage: []const u8) u8 {
     out.appendSlice(alloc, "usage: codedb [root] ") catch {};
     out.appendSlice(alloc, usage) catch {};
+    out.appendSlice(alloc, "\n") catch {};
+    return 1;
+}
+
+/// Exit code for a bridged handler: 1 if it appended an `error:`-prefixed
+/// message (the same failure marker MCP uses to set `isError` — see the
+/// `startsWith(out.items, "error:")` checks elsewhere in this file), else 0.
+/// Fixes #528 item 6, where bridged handlers printed `error: …` to stdout but
+/// `runCliTool` always reported success, so scripts couldn't detect failures.
+/// Zero-result paths (e.g. find's "no matches") use non-`error:` wording and
+/// therefore keep exit 0.
+pub fn finishCli(out: *std.ArrayList(u8), start: usize) u8 {
+    return if (std.mem.startsWith(u8, out.items[start..], "error:")) 1 else 0;
+}
+/// Parsed `deps` invocation. `max_depth` stays null unless `--max-depth N` was
+/// given so the handler keeps its own default for transitive walks.
+pub const DepsArgs = struct {
+    path: []const u8,
+    depends_on: bool = false,
+    transitive: bool = false,
+    max_depth: ?i64 = null,
+};
+
+pub const DepsArgError = error{ MissingPath, UnknownFlag, MissingMaxDepth, BadMaxDepth, ExtraArg };
+
+/// Parse `deps` args. Flags (`--depends-on`, `--transitive`, `--max-depth N`)
+/// may appear before or after the path, in any order; the first non-flag token
+/// is the path (so `deps --depends-on src/main.zig` no longer misreads the flag
+/// as the path). Unknown flags are rejected instead of silently ignored, and
+/// `--max-depth` must be a positive integer instead of coercing junk to 1.
+/// See issue #528 (items 2, 11).
+pub fn parseDepsArgs(args: []const []const u8, start: usize) DepsArgError!DepsArgs {
+    var result: DepsArgs = .{ .path = "" };
+    var path: ?[]const u8 = null;
+    var i = start;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.eql(u8, a, "--depends-on")) {
+            result.depends_on = true;
+        } else if (std.mem.eql(u8, a, "--transitive")) {
+            result.transitive = true;
+        } else if (std.mem.eql(u8, a, "--max-depth")) {
+            if (i + 1 >= args.len) return error.MissingMaxDepth;
+            i += 1;
+            const n = std.fmt.parseInt(i64, args[i], 10) catch return error.BadMaxDepth;
+            if (n < 1) return error.BadMaxDepth;
+            result.max_depth = n;
+        } else if (a.len > 1 and a[0] == '-' and a[1] == '-') {
+            return error.UnknownFlag;
+        } else if (path == null) {
+            path = a;
+        } else {
+            return error.ExtraArg;
+        }
+    }
+    result.path = path orelse return error.MissingPath;
+    return result;
+}
+
+fn cliDepsUsage(alloc: std.mem.Allocator, out: *std.ArrayList(u8), e: DepsArgError) u8 {
+    const msg = switch (e) {
+        error.MissingPath => "error: usage: codedb [root] deps <path> [--depends-on] [--transitive] [--max-depth N]",
+        error.UnknownFlag => "error: unknown flag for deps (valid: --depends-on, --transitive, --max-depth N)",
+        error.MissingMaxDepth, error.BadMaxDepth => "error: --max-depth requires a positive integer",
+        error.ExtraArg => "error: unexpected extra argument for deps",
+    };
+    out.appendSlice(alloc, msg) catch {};
     out.appendSlice(alloc, "\n") catch {};
     return 1;
 }

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2097,3 +2097,11 @@ test "resolveCallees: resolves call sites in a function body to their definition
     try testing.expect(saw_helper);
     try testing.expect(saw_other);
 }
+
+test "issue-528: searchContentRegex surfaces invalid regex as error" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+    try explorer_inst.indexFile("only.zig", "const x = 42;");
+    // #10: an unparseable pattern used to be swallowed and reported as "no results".
+    try testing.expectError(error.InvalidRegex, explorer_inst.searchContentRegex("[", testing.allocator, 50));
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1867,3 +1867,92 @@ test "issue-507: indexFileOutlineOnly files remain searchable via tier 3" {
     try testing.expect(hits.len > 0);
     try testing.expectEqualStrings(path, hits[0].path);
 }
+
+// ── #528: CLI parsing / validation / exit-code regressions ──────────────────
+
+test "issue-528: parseLineRange accepts valid ranges and EOF sentinel" {
+    const r = try main_mod.parseLineRange("1-3");
+    try testing.expectEqual(@as(u32, 1), r.start);
+    try testing.expectEqual(@as(u32, 3), r.end);
+
+    const eof = try main_mod.parseLineRange("10-$");
+    try testing.expectEqual(@as(u32, 10), eof.start);
+    try testing.expectEqual(std.math.maxInt(u32), eof.end);
+
+    const eof2 = try main_mod.parseLineRange("5-end");
+    try testing.expectEqual(std.math.maxInt(u32), eof2.end);
+}
+
+test "issue-528: parseLineRange rejects malformed/zero/reversed ranges" {
+    // #3 malformed: no dash, non-numeric start/end
+    try testing.expectError(error.MissingDash, main_mod.parseLineRange("nope"));
+    try testing.expectError(error.BadStart, main_mod.parseLineRange("abc-10"));
+    try testing.expectError(error.BadEnd, main_mod.parseLineRange("10-abc"));
+    // #7 zero-based (used to silently clamp / default)
+    try testing.expectError(error.ZeroLine, main_mod.parseLineRange("0-3"));
+    try testing.expectError(error.ZeroLine, main_mod.parseLineRange("1-0"));
+    // #4 reversed (used to exit 0 with empty output)
+    try testing.expectError(error.Reversed, main_mod.parseLineRange("20-1"));
+}
+
+test "issue-528: parseSearchArgs flags any order, max-results, unknown/empty rejected" {
+    // #9: `--max-results 1 allocator` used to search for the literal "--max-results"
+    const a = try main_mod.parseSearchArgs(&[_][]const u8{ "search", "--max-results", "1", "allocator" }, 1);
+    try testing.expectEqualStrings("allocator", a.query);
+    try testing.expectEqual(@as(usize, 1), a.max_results);
+
+    // flag after the query now applies instead of being ignored
+    const b = try main_mod.parseSearchArgs(&[_][]const u8{ "search", "allocator", "--paths-only" }, 1);
+    try testing.expectEqualStrings("allocator", b.query);
+    try testing.expect(b.paths_only);
+
+    // unknown flag rejected (not silently treated as query text)
+    try testing.expectError(error.UnknownFlag, main_mod.parseSearchArgs(&[_][]const u8{ "search", "--bogus", "x" }, 1));
+    // empty / missing query are usage errors
+    try testing.expectError(error.EmptyQuery, main_mod.parseSearchArgs(&[_][]const u8{ "search", "" }, 1));
+    try testing.expectError(error.MissingQuery, main_mod.parseSearchArgs(&[_][]const u8{"search"}, 1));
+    // `--` ends flag parsing so a literal `--foo` can still be searched
+    const c = try main_mod.parseSearchArgs(&[_][]const u8{ "search", "--", "--foo" }, 1);
+    try testing.expectEqualStrings("--foo", c.query);
+    try testing.expect(!c.use_regex);
+}
+
+test "issue-528: parseDepsArgs flags before/after path, rejects unknown + bad depth" {
+    // #2: flag before the path no longer misreads the flag as the path
+    const a = try mcp_mod.parseDepsArgs(&[_][]const u8{ "deps", "--depends-on", "src/main.zig" }, 1);
+    try testing.expectEqualStrings("src/main.zig", a.path);
+    try testing.expect(a.depends_on);
+    try testing.expectEqual(@as(?i64, null), a.max_depth);
+
+    // flag after path + valid max-depth
+    const b = try mcp_mod.parseDepsArgs(&[_][]const u8{ "deps", "src/main.zig", "--transitive", "--max-depth", "3" }, 1);
+    try testing.expectEqualStrings("src/main.zig", b.path);
+    try testing.expect(b.transitive);
+    try testing.expectEqual(@as(?i64, 3), b.max_depth);
+
+    // #11: unknown flag + bad/missing max-depth rejected (used to be silently coerced to 1)
+    try testing.expectError(error.UnknownFlag, mcp_mod.parseDepsArgs(&[_][]const u8{ "deps", "src/main.zig", "--badflag" }, 1));
+    try testing.expectError(error.BadMaxDepth, mcp_mod.parseDepsArgs(&[_][]const u8{ "deps", "src/main.zig", "--max-depth", "notnum" }, 1));
+    try testing.expectError(error.BadMaxDepth, mcp_mod.parseDepsArgs(&[_][]const u8{ "deps", "src/main.zig", "--max-depth", "0" }, 1));
+    try testing.expectError(error.MissingPath, mcp_mod.parseDepsArgs(&[_][]const u8{"deps"}, 1));
+}
+
+test "issue-528: finishCli maps error-prefixed handler output to exit 1" {
+    const alloc = testing.allocator;
+    // #6: handler emitted an error → bridge now returns exit 1
+    var err_out: std.ArrayList(u8) = .empty;
+    defer err_out.deinit(alloc);
+    try err_out.appendSlice(alloc, "error: task must be 3-1024 chars");
+    try testing.expectEqual(@as(u8, 1), mcp_mod.finishCli(&err_out, 0));
+
+    // zero-result wording (find's "no matches") keeps exit 0 (#5 decision)
+    var ok_out: std.ArrayList(u8) = .empty;
+    defer ok_out.deinit(alloc);
+    try ok_out.appendSlice(alloc, "no matches");
+    try testing.expectEqual(@as(u8, 0), mcp_mod.finishCli(&ok_out, 0));
+
+    // empty output → exit 0
+    var empty_out: std.ArrayList(u8) = .empty;
+    defer empty_out.deinit(alloc);
+    try testing.expectEqual(@as(u8, 0), mcp_mod.finishCli(&empty_out, 0));
+}


### PR DESCRIPTION
Fixes the CLI parsing / status / exit-code regressions reported in #528. Closes #528.

The root cause across most findings was ad-hoc, per-command positional parsing. This PR introduces small **pure, unit-tested argument parsers** (`parseLineRange`, `parseSearchArgs`, `parseDepsArgs`) and routes the bridged commands through a shared exit-code helper.

## Findings addressed

| # | Issue | Fix |
|---|-------|-----|
| 1 | no `codedb status` CLI command | added a read-only `status` renderer mirroring `codedb_status` (version, root, files, seq, outlines, index) |
| 2 | `deps --depends-on <path>` misparsed flag as path | `parseDepsArgs`: flags any order, first non-flag = path |
| 3 | malformed `read -L nope` treated as a path | `parseLineRange` → clear `invalid line range` error, exit 1 |
| 4 | reversed `read -L 20-1` exited 0 with no output | rejected as `Reversed`, exit 1 |
| 5 | zero-result exit-code semantics undocumented | **kept exit 0** for valid-but-empty results; documented in `--help` |
| 6 | bridged handlers printed `error:` but exited 0 | `finishCli` returns 1 when the handler's output starts with `error:` (same marker MCP uses for `isError`); zero-result wording keeps exit 0 |
| 7 | `read -L 0-3` / `abc-10` / `10-abc` silently defaulted | `parseLineRange` rejects zero/non-numeric ends, exit 1 |
| 8 | `read <path> -L 1-3` ignored trailing flags | flags now parsed before **or** after the path |
| 9 | `search --max-results 1 foo` searched literal `--max-results` | `parseSearchArgs`: reject unknown flags, support `--max-results N`, reject empty query, `--` ends flags |
| 10 | invalid regex swallowed → "no results" | `searchContentRegex[WithScope]` pre-compiles and returns `error.InvalidRegex`; CLI/MCP report `invalid regex` |
| 11 | `deps` ignored unknown flags / coerced bad `--max-depth` to 1 | reject unknown flags; require a positive integer depth |
| 12 | `--no-telemetry` documented global but only parsed after `mcp` | stripped/honored in the global arg filter (like `--config-file`) |

> #13 (blanket arity validation) is partially covered: `read`/`search`/`deps` now reject unknown flags and stray extra args. A repo-wide arity sweep for every command was intentionally left out to avoid breaking callers that pass extra args.

## Tests
- `src/test_mcp.zig` — `parseLineRange`, `parseSearchArgs`, `parseDepsArgs`, and `finishCli` (exit-code mapping incl. zero-result = exit 0).
- `src/test_explore.zig` — `searchContentRegex` surfaces `error.InvalidRegex`.
- `zig build test` is green.

## End-to-end verification
Ran the binary against the issue's repro cases:

```
read -L nope src/main.zig        -> exit 1  ✗ invalid line range: nope
read -L 20-1 src/main.zig        -> exit 1  ✗ invalid line range: 20-1
read -L 0-3  src/main.zig        -> exit 1  ✗ invalid line range: 0-3
read src/main.zig -L 1-3         -> exit 0  (lines 1-3)        # flags after path
search --max-results 1 const     -> exit 0  1 results for "const"
search ''                        -> exit 1  usage
search --bogus const             -> exit 1  unknown flag
search --regex '['               -> exit 1  ✗ invalid regex: [
deps --depends-on src/main.zig   -> exit 0  src/main.zig depends on: std
deps src/main.zig --max-depth notnum -> exit 1
context ab                       -> exit 1  error: task must be 3-1024 chars
glob ''                          -> exit 1
status                           -> exit 0  codedb <ver> / root / files / seq / outlines / index
--no-telemetry <root> status     -> exit 0  (flag before AND after root)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)