### PR TITLE
mcp/snapshot: secret-filter drift guard + per-session edit locks (#528 audit)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -506,7 +506,7 @@ pub const BenchContext = struct {
         explorer: *Explorer,
         agents: *AgentRegistry,
     ) void {
-        dispatch(io, alloc, tool, args, out, store, explorer, agents, &self.cache, null);
+        dispatch(io, alloc, tool, args, out, store, explorer, agents, &self.cache, null, 1);
     }
 
     pub fn runHandleCall(
@@ -521,7 +521,7 @@ pub const BenchContext = struct {
         agents: *AgentRegistry,
         telem: *telemetry_mod.Telemetry,
     ) void {
-        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null);
+        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null, 1);
     }
 
     pub fn runToolCall(
@@ -540,7 +540,7 @@ pub const BenchContext = struct {
         defer out.deinit(alloc);
 
         const t0 = cio.nanoTimestamp();
-        dispatch(io, alloc, tool, args, &out, store, explorer, agents, &self.cache, null);
+        dispatch(io, alloc, tool, args, &out, store, explorer, agents, &self.cache, null, 1);
         const elapsed = cio.nanoTimestamp() - t0;
 
         const is_error = std.mem.startsWith(u8, out.items, "error:");
@@ -825,6 +825,10 @@ const Session = struct {
     pending_roots_id: ?i64 = null,
     roots: std.ArrayList(Root) = .empty,
     deferred_scan: ?*DeferredScan = null,
+    /// Per-session advisory-lock owner for codedb_edit (#528 audit). Set to a
+    /// distinct registered agent id at session start; defaults to 1 so any path
+    /// that constructs a Session without registering still uses __filesystem__.
+    edit_agent_id: u64 = 1,
 
     fn freeRoots(self: *Session) void {
         for (self.roots.items) |r| {
@@ -895,6 +899,11 @@ pub fn run(
         .stdout = stdout,
         .deferred_scan = deferred_scan,
     };
+    // #528 audit: give this MCP session a distinct advisory-lock owner so that
+    // concurrent edits from separate connections (if a multi-connection MCP
+    // transport is added) serialize correctly instead of all sharing the
+    // startup __filesystem__ agent. Falls back to 1 (__filesystem__).
+    session.edit_agent_id = agents.register("mcp-session") catch 1;
     defer session.deinit();
 
     var read_buf: [4096]u8 = undefined;
@@ -953,7 +962,7 @@ pub fn run(
         } else if (mcpj.eql(method, "tools/list")) {
             if (!is_notification) writeResult(alloc, stdout, id, tools_list_response);
         } else if (mcpj.eql(method, "tools/call")) {
-            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan);
+            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, session.edit_agent_id);
         } else if (mcpj.eql(method, "ping")) {
             if (!is_notification) writeResult(alloc, stdout, id, "{}");
         } else {
@@ -1115,6 +1124,7 @@ fn handleCall(
     cache: *ProjectCache,
     telem: *telemetry_mod.Telemetry,
     deferred_scan: ?*DeferredScan,
+    edit_agent_id: u64,
 ) void {
     const is_notification = id == null;
 
@@ -1153,7 +1163,7 @@ fn handleCall(
     defer out.deinit(alloc);
 
     const t0 = cio.nanoTimestamp();
-    dispatch(io, alloc, tool, args, &out, store, explorer, agents, cache, deferred_scan);
+    dispatch(io, alloc, tool, args, &out, store, explorer, agents, cache, deferred_scan, edit_agent_id);
     const elapsed = cio.nanoTimestamp() - t0;
 
     const is_error = std.mem.startsWith(u8, out.items, "error:");
@@ -1293,6 +1303,7 @@ fn dispatch(
     agents: *AgentRegistry,
     cache: *ProjectCache,
     deferred_scan: ?*DeferredScan,
+    edit_agent_id: u64,
 ) void {
     const project_path = getStr(args, "project");
     const ctx = if (project_path) |path|
@@ -1347,11 +1358,11 @@ fn dispatch(
         .codedb_hot => handleHot(alloc, args, out, ctx.store, ctx.explorer),
         .codedb_deps => handleDeps(alloc, args, out, ctx.explorer),
         .codedb_read => handleRead(io, alloc, args, out, ctx.explorer),
-        .codedb_edit => handleEdit(io, alloc, args, out, default_store, default_explorer, agents, cache),
+        .codedb_edit => handleEdit(io, alloc, args, out, default_store, default_explorer, agents, cache, edit_agent_id),
         .codedb_changes => handleChanges(alloc, args, out, default_store),
         .codedb_status => handleStatus(alloc, out, ctx.store, ctx.explorer),
         .codedb_snapshot => handleSnapshot(alloc, out, ctx.explorer, ctx.store, ctx.snapshot_cache),
-        .codedb_bundle => handleBundle(io, alloc, args, out, ctx.store, ctx.explorer, agents, cache, deferred_scan),
+        .codedb_bundle => handleBundle(io, alloc, args, out, ctx.store, ctx.explorer, agents, cache, deferred_scan, edit_agent_id),
         .codedb_remote => handleRemote(alloc, args, out),
         .codedb_projects => handleProjects(io, alloc, out),
         .codedb_index => handleIndex(io, alloc, args, out, cache, default_store, default_explorer, deferred_scan),
@@ -2594,7 +2605,7 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
     }
 }
 
-fn handleEdit(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer, agents: *AgentRegistry, cache: *ProjectCache) void {
+fn handleEdit(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer, agents: *AgentRegistry, cache: *ProjectCache, edit_agent_id: u64) void {
     const path = getStr(args, "path") orelse {
         out.appendSlice(alloc, "error: missing 'path'") catch {};
         return;
@@ -2625,13 +2636,14 @@ fn handleEdit(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
     const range_end = getInt(args, "range_end");
     const after = getInt(args, "after");
 
-    // Use agent 1 (the __filesystem__ agent registered at startup).
-    // TODO: agent_id is hardcoded to 1 — two MCP clients share the same agent_id and
-    // could both acquire locks on different files without conflict, but cannot detect
-    // concurrent edits to the same file from separate connections.
+    // Per-session advisory-lock owner. The server threads a distinct agent id
+    // per MCP connection (Session.edit_agent_id), so concurrent edits to the
+    // same file from separate connections are detected instead of all sharing
+    // the startup __filesystem__ agent (#528 audit). Defaults to 1 (the
+    // __filesystem__ agent) for the single-connection stdio path.
     var req = edit_mod.EditRequest{
         .path = path,
-        .agent_id = 1,
+        .agent_id = edit_agent_id,
         .op = op,
         .content = content,
         .old_string = getStr(args, "old_string"),
@@ -2976,6 +2988,7 @@ fn handleBundle(
     agents: *AgentRegistry,
     cache: *ProjectCache,
     deferred_scan: ?*DeferredScan,
+    edit_agent_id: u64,
 ) void {
     const ops_val = args.get("ops") orelse {
         out.appendSlice(alloc, "error: missing 'ops' argument") catch {};
@@ -3093,7 +3106,7 @@ fn handleBundle(
         };
         sub_out.ensureTotalCapacity(alloc, sub_reserve) catch {};
 
-        dispatch(io, alloc, tool, sub_args, &sub_out, default_store, default_explorer, agents, cache, deferred_scan);
+        dispatch(io, alloc, tool, sub_args, &sub_out, default_store, default_explorer, agents, cache, deferred_scan, edit_agent_id);
 
         // Check size BEFORE appending to prevent blowout
         if (out.items.len + sub_out.items.len > 200 * 1024) {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1218,9 +1218,11 @@ fn parseJsonU64(json: []const u8, key: []const u8) ?u64 {
     return null;
 }
 
-/// Returns true if a file path looks like it may contain secrets.
-/// These files are excluded from snapshots to prevent accidental exposure.
-fn isSensitivePath(path: []const u8) bool {
+/// Returns true for secret/credential paths that must never be persisted to a
+/// snapshot or live-indexed. Kept in lockstep with `watcher.isSensitivePath`;
+/// the two are parity-tested in test_snapshot.zig ("issue-528: isSensitivePath
+/// parity") so any future drift in this security filter fails CI.
+pub fn isSensitivePath(path: []const u8) bool {
     const sensitive_names = [_][]const u8{
         ".env",
         ".env.local",
@@ -1267,7 +1269,6 @@ fn isSensitivePath(path: []const u8) bool {
 
     return false;
 }
-
 fn endsWith(s: []const u8, suffix: []const u8) bool {
     if (s.len < suffix.len) return false;
     return std.mem.eql(u8, s[s.len - suffix.len ..], suffix);

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -256,6 +256,31 @@ test "issue-411: tryLock grants new locks to a crashed agent" {
     try testing.expect(got == false);
 }
 
+test "issue-528: each MCP session registers a distinct edit-lock owner (not shared agent 1)" {
+    // Bug 2 from the #528 audit: codedb_edit hardcoded agent_id=1, so concurrent
+    // edits from separate connections all shared the startup __filesystem__ agent
+    // and re-entrantly "won" the same-file lock. The MCP server now registers a
+    // distinct agent per session and threads it into handleEdit. This guards that
+    // registration yields distinct, non-1 owners that mutually exclude on a path.
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+
+    const fs = try agents.register("__filesystem__"); // startup agent (id 1)
+    const session_a = try agents.register("mcp-session");
+    const session_b = try agents.register("mcp-session");
+
+    try testing.expect(session_a != fs);
+    try testing.expect(session_b != fs);
+    try testing.expect(session_a != session_b);
+
+    // Distinct session owners serialize same-file edits (vs the old shared-id
+    // re-entrant grant that let two connections clobber each other).
+    try testing.expect(try agents.tryLock(session_a, "x.zig", 60_000));
+    try testing.expect(!(try agents.tryLock(session_b, "x.zig", 60_000)));
+    agents.releaseLock(session_a, "x.zig");
+    try testing.expect(try agents.tryLock(session_b, "x.zig", 60_000));
+}
+
 
 test "issue-401: insert with after=null is a no-op but consumes seq and writes file" {
     var tmp = testing.tmpDir(.{});

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -960,3 +960,61 @@ test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
     try testing.expect(!snapshot_mod.isSensitivePath("main.zig"));
     try testing.expect(!snapshot_mod.isSensitivePath("package.json"));
 }
+
+test "issue-528: codedb_edit applies via a per-session agent id (not the first/__filesystem__ agent)" {
+    // Bug 2 wiring (runtime): handleEdit now uses Session.edit_agent_id — a
+    // per-connection agent registered AFTER __filesystem__, so its id != 1.
+    // applyEdit's advisory lock returns error.FileLocked if that id is not a
+    // live registered agent, so this proves an edit through a non-first session
+    // agent actually acquires the lock and writes the file.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const rel_path = try std.fmt.allocPrint(testing.allocator, ".zig-cache/tmp/{s}/per-session-edit.zig", .{tmp.sub_path});
+    defer testing.allocator.free(rel_path);
+
+    var file = try tmp.dir.createFile(io, "per-session-edit.zig", .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, "const foo = 1;\n");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try explorer.indexFile(rel_path, "const foo = 1;\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    const fs = try agents.register("__filesystem__"); // startup agent (id 1)
+    const session = try agents.register("mcp-session"); // per-session owner (id 2)
+    try testing.expect(session != fs);
+
+    // Edit through the per-session id — must acquire the lock and apply.
+    const r1 = try edit_mod.applyEdit(io, testing.allocator, &store, &agents, &explorer, .{
+        .path = rel_path,
+        .agent_id = session,
+        .op = .replace,
+        .range = .{ 1, 1 },
+        .content = "const bar = 1;",
+    });
+    defer if (r1.health) |h| testing.allocator.free(h);
+    defer if (r1.preview) |p| testing.allocator.free(p);
+    try testing.expect(r1.changed);
+
+    // The lock was released on success, so another session can edit immediately.
+    const r2 = try edit_mod.applyEdit(io, testing.allocator, &store, &agents, &explorer, .{
+        .path = rel_path,
+        .agent_id = fs,
+        .op = .replace,
+        .range = .{ 1, 1 },
+        .content = "const baz = 1;",
+    });
+    defer if (r2.health) |h| testing.allocator.free(h);
+    defer if (r2.preview) |p| testing.allocator.free(p);
+
+    const content = try tmp.dir.readFileAlloc(io, "per-session-edit.zig", testing.allocator, .limited(64 * 1024));
+    defer testing.allocator.free(content);
+    try testing.expect(std.mem.indexOf(u8, content, "baz") != null);
+}

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -922,3 +922,41 @@ test "issue-379: snapshot loader returns true with zero outlines for empty-explo
     }
 }
 
+
+test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
+    // The secret/credential filter is duplicated (snapshot persistence vs live
+    // indexing). The #528 audit flagged a possible divergence; the two are
+    // verified equal today, and this test fails CI if they ever drift apart —
+    // which in this security filter would mean a secret silently leaking into
+    // one path but not the other.
+    const cases = [_][]const u8{
+        // secrets — both copies must block
+        ".env",                  ".env.local",          ".env.production",
+        ".env.development",      ".env.staging",        ".env.test",
+        ".dev.vars",             ".npmrc",              ".pypirc",
+        ".netrc",                "credentials.json",    "service-account.json",
+        "secrets.json",          "secrets.yaml",        "secrets.yml",
+        "id_rsa",                "id_ed25519",          "server.key",
+        "cert.pem",              "keystore.jks",        "identity.pfx",
+        "bundle.p12",            "config/.env.local",   "a/b/secrets.yaml",
+        "deep/nested/.ssh/known_hosts", ".gnupg/secring.gpg", "x/.aws/credentials",
+        // non-secrets — both copies must allow (esp. the .env-prefix edge cases)
+        ".envoy.json",           ".environment",        ".envrc",
+        ".envconfig.yaml",       "main.zig",            "src/server.zig",
+        "README.md",             "package.json",        "id_rsa.pub",
+        "envvars.ts",            "Makefile",            "Dockerfile",
+    };
+    for (cases) |p| {
+        try testing.expectEqual(watcher.isSensitivePath(p), snapshot_mod.isSensitivePath(p));
+    }
+    // Anchor the contract so parity can't be satisfied by both copies being
+    // wrong in the same direction.
+    try testing.expect(snapshot_mod.isSensitivePath(".env"));
+    try testing.expect(snapshot_mod.isSensitivePath("credentials.json"));
+    try testing.expect(snapshot_mod.isSensitivePath("deep/.ssh/id_rsa"));
+    try testing.expect(snapshot_mod.isSensitivePath("keystore.jks")); // fast-path ext
+    try testing.expect(!snapshot_mod.isSensitivePath(".envoy.json")); // issue-409
+    try testing.expect(!snapshot_mod.isSensitivePath(".environment"));
+    try testing.expect(!snapshot_mod.isSensitivePath("main.zig"));
+    try testing.expect(!snapshot_mod.isSensitivePath("package.json"));
+}


### PR DESCRIPTION
Two correctness/security items surfaced by the #528 capability audit. Both were verified against the actual code — and notably, **both turned out to be latent rather than live**, which the fixes reflect honestly.

## 1. `isSensitivePath` secret-filter — drift guard (not a live bug)
`snapshot.zig` and `watcher.zig` keep duplicate copies of the secret/credential exclusion filter (snapshot persistence vs live indexing). The audit flagged "divergent logic causing coverage gaps" — but tracing every input class shows they're **functionally equivalent today** (watcher's first-char fast-path gate `{'.','c','s','i'}` covers every sensitive name; both have the `.env` boundary check from issue-409).

So there's no live coverage gap — but it *is* a real future-leak hazard in security code (edit one copy, not the other → a secret silently slips into one path). Fix: make `snapshot.isSensitivePath` `pub` and add a **parity test** over a ~40-path battery (`.env`, `id_rsa`, `.ssh/known_hosts`, `keystore.jks`, … and the non-secret `.envoy.json`/`.environment` edge cases) that fails CI on any drift. **No runtime behavior change.**

## 2. `codedb_edit` `agent_id = 1` — per-session edit-lock owner (forward-looking)
`handleEdit` hardcoded `EditRequest.agent_id = 1` (the startup `__filesystem__` agent). The advisory lock is **re-entrant per agent id**, so multiple MCP connections sharing one process would both "win" the same file's lock and miss a concurrent edit.

On inspection this is **latent, not live**: stdio MCP is one connection per process, and `server.zig` (HTTP serve) already takes a per-client `agent` id from the request. So it'd only bite if a multi-connection MCP transport is added. The fix threads a distinct per-session id (`Session.edit_agent_id`, registered at session start) through `handleCall → dispatch → handleEdit` (+ the bundle recursion), removing the documented `TODO`. **Behavior-preserving for today's single-connection path** (the single client just owns a distinct registered id instead of the shared `1`).

## Tests / validation
- `test_snapshot.zig`: `isSensitivePath` parity battery (snapshot ≡ watcher) + explicit secret/non-secret anchors.
- `test_core.zig`: distinct session ids register non-`1` and mutually exclude on a path (the registry's contention semantics were already covered).
- `zig build` and `zig build test` are green.

This came out of a multi-agent capability audit of codedb; the larger roadmap (callpath+PageRank from the already-computed edges, token-budget context packing, `format=json`, prefix/kind symbol search, git-churn ranking) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)