### PR TITLE
explore: ReScript (.res/.resi) language support (#532)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -141,6 +141,7 @@ pub const Language = enum(u8) {
     llvm_ir,
     mlir,
     tablegen,
+    rescript,
 };
 
 pub fn detectLanguage(path: []const u8) Language {
@@ -179,6 +180,7 @@ pub fn detectLanguage(path: []const u8) Language {
     if (std.mem.endsWith(u8, path, ".ll")) return .llvm_ir;
     if (std.mem.endsWith(u8, path, ".mlir")) return .mlir;
     if (std.mem.endsWith(u8, path, ".td")) return .tablegen;
+    if (std.mem.endsWith(u8, path, ".res") or std.mem.endsWith(u8, path, ".resi")) return .rescript;
     return .unknown;
 }
 
@@ -1141,7 +1143,7 @@ pub const Explorer = struct {
                 outline.language == .vue or outline.language == .astro or
                 outline.language == .css or outline.language == .scss or
                 outline.language == .protobuf or outline.language == .mlir or
-                outline.language == .tablegen)
+                outline.language == .tablegen or outline.language == .rescript)
             {
                 if (in_block_comment) {
                     if (std.mem.indexOf(u8, trimmed, "*/")) |close_pos| {
@@ -1220,6 +1222,8 @@ pub const Explorer = struct {
                 try parser.parseMlirLine(trimmed, line_num, &outline);
             } else if (outline.language == .tablegen) {
                 try parser.parseTableGenLine(trimmed, line_num, &outline);
+            } else if (outline.language == .rescript) {
+                try parser.parseRescriptLine(trimmed, line_num, &outline);
             }
 
             prev_line_trimmed = trimmed;
@@ -4429,6 +4433,68 @@ pub const Explorer = struct {
         }
     }
 
+    /// ReScript (.res/.resi). `let`/`and` bindings become functions when the RHS has an
+    /// arrow (`=>`) and constants otherwise; `type` → type_alias; `module` → struct_def
+    /// (`module type` → interface_def); `external` → function; `open`/`include` → import.
+    /// Leading @decorators are stripped first. Line-based like the sibling parsers, so
+    /// nested module members are flattened into the top-level outline.
+    fn parseRescriptLine(self: *Explorer, line: []const u8, line_num: u32, outline: *FileOutline) !void {
+        const a = self.allocator;
+        const code = stripLeadingResDecorators(line);
+        if (code.len == 0 or startsWith(code, "//")) return;
+
+        if (startsWith(code, "open ")) {
+            const name = resModulePath(std.mem.trimStart(u8, code[5..], " \t"));
+            if (name.len > 0) {
+                try appendImportPath(a, outline, name);
+                try appendOutlineSymbol(a, outline, name, .import, line_num, null);
+            }
+            return;
+        }
+        if (startsWith(code, "include ")) {
+            const name = resModulePath(std.mem.trimStart(u8, code[8..], " \t"));
+            if (name.len > 0) {
+                try appendImportPath(a, outline, name);
+                try appendOutlineSymbol(a, outline, name, .import, line_num, null);
+            }
+            return;
+        }
+        if (startsWith(code, "module ")) {
+            var rest = std.mem.trimStart(u8, code[7..], " \t");
+            var kind: SymbolKind = .struct_def;
+            if (startsWith(rest, "type ")) {
+                kind = .interface_def;
+                rest = std.mem.trimStart(u8, rest[5..], " \t");
+            }
+            const name = resIdent(rest);
+            if (name.len > 0) try appendOutlineSymbol(a, outline, name, kind, line_num, line);
+            return;
+        }
+        if (startsWith(code, "type ")) {
+            var rest = std.mem.trimStart(u8, code[5..], " \t");
+            if (startsWith(rest, "rec ")) rest = std.mem.trimStart(u8, rest[4..], " \t");
+            const name = resIdent(rest);
+            if (name.len > 0) try appendOutlineSymbol(a, outline, name, .type_alias, line_num, line);
+            return;
+        }
+        if (startsWith(code, "external ")) {
+            const name = resIdent(std.mem.trimStart(u8, code[9..], " \t"));
+            if (name.len > 0) try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+            return;
+        }
+        var rest: []const u8 = undefined;
+        if (startsWith(code, "let ")) {
+            rest = std.mem.trimStart(u8, code[4..], " \t");
+            if (startsWith(rest, "rec ")) rest = std.mem.trimStart(u8, rest[4..], " \t");
+        } else if (startsWith(code, "and ")) {
+            rest = std.mem.trimStart(u8, code[4..], " \t");
+        } else return;
+        const name = resIdent(rest);
+        if (name.len == 0) return; // destructuring binding (let (a, b) = …) — skip
+        const kind: SymbolKind = if (std.mem.indexOf(u8, code, "=>") != null) .function else .constant;
+        try appendOutlineSymbol(a, outline, name, kind, line_num, line);
+    }
+
     fn rebuildDepsFor(self: *Explorer, path: []const u8, outline: *FileOutline) !void {
         var deps: std.ArrayList([]const u8) = .empty;
         errdefer deps.deinit(self.allocator);
@@ -4831,6 +4897,7 @@ pub fn isCommentOrBlank(line: []const u8, language: Language) bool {
         .sql => std.mem.startsWith(u8, trimmed, "--") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
         .fortran => std.mem.startsWith(u8, trimmed, "!"),
         .llvm_ir => std.mem.startsWith(u8, trimmed, ";"),
+        .rescript => std.mem.startsWith(u8, trimmed, "//") or std.mem.startsWith(u8, trimmed, "/*") or std.mem.startsWith(u8, trimmed, "*"),
         else => false,
     };
 }
@@ -5210,6 +5277,54 @@ fn appendOutlineSymbol(
         .line_end = line_num,
         .detail = detail_copy,
     });
+}
+
+inline fn resIsIdentStart(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or c == '_';
+}
+inline fn resIsIdentChar(c: u8) bool {
+    return resIsIdentStart(c) or (c >= '0' and c <= '9') or c == '\'';
+}
+/// Leading ReScript identifier (letter/_/digit/prime), or "" if none.
+fn resIdent(s: []const u8) []const u8 {
+    if (s.len == 0 or !resIsIdentStart(s[0])) return "";
+    var i: usize = 1;
+    while (i < s.len and resIsIdentChar(s[i])) i += 1;
+    return s[0..i];
+}
+/// Leading dotted module path (Foo.Bar.Baz), trailing dots trimmed, or "".
+fn resModulePath(s: []const u8) []const u8 {
+    if (s.len == 0 or !resIsIdentStart(s[0])) return "";
+    var i: usize = 1;
+    while (i < s.len and (resIsIdentChar(s[i]) or s[i] == '.')) i += 1;
+    var end = i;
+    while (end > 0 and s[end - 1] == '.') end -= 1;
+    return s[0..end];
+}
+/// Strip leading `@decorator` / `@decorator(args)` tokens (and trailing space) so a
+/// decorated `external`/`let` on the same line still parses. Returns the remainder.
+fn stripLeadingResDecorators(line: []const u8) []const u8 {
+    var s = std.mem.trimStart(u8, line, " \t");
+    while (s.len > 0 and s[0] == '@') {
+        var i: usize = 1;
+        while (i < s.len and (resIsIdentChar(s[i]) or s[i] == '.')) i += 1;
+        if (i < s.len and s[i] == '(') {
+            var depth: usize = 0;
+            while (i < s.len) : (i += 1) {
+                if (s[i] == '(') {
+                    depth += 1;
+                } else if (s[i] == ')') {
+                    depth -= 1;
+                    if (depth == 0) {
+                        i += 1;
+                        break;
+                    }
+                }
+            }
+        }
+        s = std.mem.trimStart(u8, s[i..], " \t");
+    }
+    return s;
 }
 
 fn appendImportSymbol(

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -1174,6 +1174,11 @@ test "issue-215: detectLanguage handles .r and .R" {
     try testing.expectEqual(Language.r, explore.detectLanguage("analysis.R"));
 }
 
+test "issue-532: detectLanguage handles .res and .resi" {
+    try testing.expectEqualStrings("rescript", @tagName(explore.detectLanguage("src/User.res")));
+    try testing.expectEqualStrings("rescript", @tagName(explore.detectLanguage("src/User.resi")));
+}
+
 
 test "dep-graph: reverse index gives O(1) imported_by lookup" {
     var graph = DependencyGraph.init(testing.allocator);

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -1678,3 +1678,50 @@ test "issue-392: Swift parser" {
     try testing.expect(found_method);
 }
 
+test "issue-532: ReScript parser" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("src/User.res",
+        \\open Belt
+        \\
+        \\module User = {
+        \\    type t = {
+        \\        name: string,
+        \\        age: int,
+        \\    }
+        \\
+        \\    let make = (name, age) => {name, age}
+        \\
+        \\    let greet = user => "Hi " ++ user.name
+        \\}
+        \\
+        \\type status = Active | Inactive
+        \\
+        \\let defaultName = "anon"
+        \\
+        \\let rec fib = n => if n < 2 { n } else { fib(n - 1) + fib(n - 2) }
+        \\
+        \\external getEnv: string => string = "%identity"
+    );
+
+    var outline = (try explorer.getOutline("src/User.res", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+
+    // .res must detect as rescript; without it the file is .unknown and no parser runs.
+    try testing.expectEqualStrings("rescript", @tagName(outline.language));
+
+    // Module → struct_def, type → type_alias, arrow-let → function, value-let → constant,
+    // external → function. `open` is recorded as an import.
+    try expectOutlineSymbol(&outline, "User", .struct_def);
+    try expectOutlineSymbol(&outline, "t", .type_alias);
+    try expectOutlineSymbol(&outline, "status", .type_alias);
+    try expectOutlineSymbol(&outline, "make", .function);
+    try expectOutlineSymbol(&outline, "greet", .function);
+    try expectOutlineSymbol(&outline, "fib", .function);
+    try expectOutlineSymbol(&outline, "getEnv", .function);
+    try expectOutlineSymbol(&outline, "defaultName", .constant);
+    try expectOutlineImport(&outline, "Belt");
+}
+


### PR DESCRIPTION
Closes #532.

Adds ReScript as a first-class indexed language, following the existing per-language line-parser pattern (mirrors how `.r` #215 and `.tf` #108 were added).

## What

- **Detection:** `.res` and `.resi` → new `rescript` language.
- **`parseRescriptLine`** extracts:
  | ReScript | Symbol kind |
  |---|---|
  | `let f = (…) => …` / `let rec` / `and f = … =>` | `function` |
  | `let x = value` (no arrow) | `constant` |
  | `type t = …` | `type_alias` |
  | `module M = { … }` | `struct_def` |
  | `module type S = { … }` | `interface_def` |
  | `external name: T = "…"` | `function` |
  | `open M` / `include M` | `import` |
- Leading `@decorator` / `@decorator(args)` are stripped first, so a decorated `@val external …` or `@react.component\nlet make` still resolves.
- `//` and `/* */` comments are skipped (ReScript joins the C-style block-comment group + `isCommentOrBlank`). `langHasCallSites`/`isCheckableCode` fall through their `else` arms correctly (call-sites: yes, delimiter-balance check: no).

## Tests (failing-first, per CLAUDE.md)

Commit 1 adds `issue-532` tests that fail on the base branch (`.res` → `.unknown`, empty outline); commit 2 implements support and turns them green:
- `test_parser.zig` — full outline of a `.res` file (module/type/let/external/open).
- `test_explore.zig` — `detectLanguage` for `.res`/`.resi`.

`zig build test` passes clean (0 failures).

## End-to-end (`codedb outline` on a real `.res`)

```
✓ src/User.res  rescript  25 lines  ⚡ 4.0µs
  L1   import      Belt
  L3   struct_def  User
  L4   type_alias  t
  L9   function    make
  L11  function    greet
  L14  type_alias  status
  L18  constant    defaultName
  L20  function    fib
  L22  function    setTimeout   (decorated @val external)
  L24  function    helper       (and-binding)
```

## Known limitations (v1, additive)

Line-based like the sibling parsers: nested module members are flattened into the top-level outline, and `exception`/variant constructors are not yet emitted as symbols. These can be follow-ups; nothing here is a filter, so recall is never reduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)