### PR TITLE
Fix multi-line TS/JS imports getting dropped from the dep graph

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3610,6 +3610,22 @@ pub const Explorer = struct {
             if (extractStringLiteral(line)) |path| {
                 try appendImportPath(a, outline, path);
             }
+        } else if (startsWith(line, "} from ") or
+            (startsWith(line, "export ") and containsAny(line, &.{ " from \"", " from '" })))
+        {
+            // Closing line of a multi-line import/export, e.g.
+            //   import {
+            //     a, b,
+            //   } from "../mod.ts";
+            // or a re-export like `export * from "./x.ts"`. The `from "..."`
+            // clause lands on a line that does not contain "import ", so without
+            // this branch the path is dropped (only single-line imports were
+            // captured). Gated on these concrete shapes so arbitrary `from "..."`
+            // inside strings/comments (e.g. SQL `select * from "users"`) is not
+            // mistaken for a dependency.
+            if (extractStringLiteral(line)) |path| {
+                try appendImportPath(a, outline, path);
+            }
         }
     }
 

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -26,6 +26,44 @@ fn expectOutlineImport(outline: *const explore.FileOutline, import_path: []const
 }
 
 
+test "issue-1: multi-line TS/JS import paths captured for dep graph" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("src/role-driver.ts",
+        \\import {
+        \\  existsSync,
+        \\  readdirSync,
+        \\} from "../bus/in-memory-event-bus.ts";
+        \\
+        \\import { join } from "node:path";
+        \\
+        \\export * from "./re-export.ts";
+        \\
+        \\// loads config from "config.json" at boot
+        \\
+        \\export class RoleDriver {}
+    );
+
+    var outline = (try explorer.getOutline("src/role-driver.ts", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+
+    try testing.expectEqual(Language.typescript, outline.language);
+    // Single-line import already worked (regression guard) ...
+    try expectOutlineImport(&outline, "node:path");
+    // ... the multi-line import is the bug: its `from "..."` sits on a line
+    // that does not contain "import ", so it was dropped from the dep graph.
+    try expectOutlineImport(&outline, "../bus/in-memory-event-bus.ts");
+    // re-export deps (export ... from) are also dependencies.
+    try expectOutlineImport(&outline, "./re-export.ts");
+    // A comment (or string) that merely contains `from "..."` must NOT become a
+    // dependency. The old over-broad match grabbed exactly this kind of thing.
+    for (outline.imports.items) |imp| {
+        try testing.expect(!std.mem.eql(u8, imp, "config.json"));
+    }
+}
+
 test "issue-301: Dart / Flutter parser" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
Fixes #540.

`parseTsLine` only grabbed the import path off lines that contained `import `. Multi-line imports put `from "..."` on the closing `}` line, so the dependency got dropped. This adds a continuation branch that pulls the path off `} from "..."` lines, plus `export ... from` re-exports which were dropped the same way.

The branch is gated on those concrete shapes (`} from ` and `export ... from`) rather than any line containing ` from "`, so strings and comments like `select * from "users"` don't get mistaken for dependencies.

Red to green: the new test indexes a multi-line import, a re-export, and a comment containing `from "config.json"`. It checks the real imports land in `outline.imports` and the comment does not. Fails before the change (multi-line path missing), passes after. The rest of the suite stays green.

Files: `src/explore.zig` (parseTsLine), `src/test_parser.zig`.

One function plus a test, no generated artifacts, branch is off current main. Read CONTRIBUTING and followed it.