### PR TITLE
Fix relative TS/JS imports never showing up in deps/imported_by

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -225,13 +225,35 @@ pub const DependencyGraph = struct {
     forward: std.StringHashMap(std.ArrayList([]const u8)),
     reverse: std.StringHashMap(std.StringHashMap(void)),
     allocator: std.mem.Allocator,
+    /// Owns the resolved dependency strings the graph creates (e.g. relative
+    /// imports normalized to repo paths). Raw specifiers handed in by callers
+    /// are still borrowed; only graph-minted strings live here. Freed after the
+    /// maps in deinit, so map keys/values never outlive their backing bytes.
+    str_arena: std.heap.ArenaAllocator,
+    /// Dedup map for interned strings: resolved path -> its single arena-owned
+    /// copy. Re-resolving the same import (e.g. on every watcher reindex) reuses
+    /// that copy instead of growing the arena by a fresh allocation each time.
+    interned: std.StringHashMap([]const u8),
 
     pub fn init(allocator: std.mem.Allocator) DependencyGraph {
         return .{
             .forward = std.StringHashMap(std.ArrayList([]const u8)).init(allocator),
             .reverse = std.StringHashMap(std.StringHashMap(void)).init(allocator),
             .allocator = allocator,
+            .str_arena = std.heap.ArenaAllocator.init(allocator),
+            .interned = std.StringHashMap([]const u8).init(allocator),
         };
+    }
+
+    /// Intern a string into the graph-owned arena, returning a slice valid for
+    /// the lifetime of the graph. Repeated calls with the same content return
+    /// the same slice, so re-indexing a file does not leak a fresh copy per
+    /// import. Use for resolved paths that have no other owner.
+    pub fn internString(self: *DependencyGraph, s: []const u8) ![]const u8 {
+        if (self.interned.get(s)) |existing| return existing;
+        const owned = try self.str_arena.allocator().dupe(u8, s);
+        try self.interned.put(owned, owned);
+        return owned;
     }
 
     pub fn deinit(self: *DependencyGraph) void {
@@ -246,6 +268,11 @@ pub const DependencyGraph = struct {
             entry.value_ptr.deinit();
         }
         self.reverse.deinit();
+
+        // The interned map's keys/values live in str_arena; free the map
+        // structure, then the arena (which forward/reverse also borrow from).
+        self.interned.deinit();
+        self.str_arena.deinit();
     }
 
     pub fn setDeps(self: *DependencyGraph, path: []const u8, deps: std.ArrayList([]const u8)) !void {
@@ -4507,10 +4534,10 @@ pub const Explorer = struct {
         defer seen.deinit();
 
         for (outline.imports.items) |imp| {
-            if (std.mem.indexOf(u8, imp, "..") != null) continue;
-            const gop = try seen.getOrPut(imp);
+            const dep = (try resolveDependencyKey(&self.dep_graph, outline.path, imp, self.allocator)) orelse continue;
+            const gop = try seen.getOrPut(dep);
             if (gop.found_existing) continue;
-            try deps.append(self.allocator, imp);
+            try deps.append(self.allocator, dep);
         }
 
         try self.dep_graph.setDeps(path, deps);
@@ -5903,7 +5930,9 @@ fn extractStringLiteral(s: []const u8) ?[]const u8 {
 
 fn normalizePath(path: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
     var parts: std.ArrayList([]const u8) = .empty;
-    errdefer parts.deinit(allocator);
+    // `parts` holds borrowed slices into `path`; free the list on every path
+    // (success included). Previously errdefer-only, which leaked on success.
+    defer parts.deinit(allocator);
 
     var it = std.mem.splitSequence(u8, path, "/");
     while (it.next()) |part| {
@@ -5927,6 +5956,70 @@ fn normalizePath(path: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
         buf.appendSlice(allocator, part) catch return null;
     }
     return buf.toOwnedSlice(allocator) catch null;
+}
+
+fn isRelativeImport(spec: []const u8) bool {
+    return std.mem.startsWith(u8, spec, "./") or std.mem.startsWith(u8, spec, "../");
+}
+
+/// File extension of a path including the leading dot (".ts"), or null if the
+/// final segment has none. A leading-dot file (".env") counts as no extension.
+fn pathExtension(path: []const u8) ?[]const u8 {
+    const base = if (std.mem.lastIndexOfScalar(u8, path, '/')) |s| path[s + 1 ..] else path;
+    if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| {
+        if (dot > 0) return base[dot..];
+    }
+    return null;
+}
+
+/// Resolve a relative import specifier (`./` or `../`) against the importing
+/// file's path into a repo-rooted path, e.g.
+///   ("daemon/src/role/role-driver.ts", "../bus/x.ts") -> "daemon/src/bus/x.ts"
+/// Returns null if the path escapes the repo root or allocation fails. The
+/// caller owns the returned slice (allocated with `allocator`).
+fn resolveRelativeImportPath(file_path: []const u8, raw: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
+    const dir = if (std.mem.lastIndexOfScalar(u8, file_path, '/')) |sep|
+        file_path[0..sep]
+    else
+        ".";
+    const joined = std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, raw }) catch return null;
+    defer allocator.free(joined);
+    return normalizePath(joined, allocator);
+}
+
+/// Map a raw import specifier to the dependency key the graph should store:
+///   - relative (./ ../) specifiers resolve to repo paths, interned in the
+///     graph arena (so they outlive the call without mutating outline.imports);
+///   - any other specifier containing ".." can't map to a repo path -> null (skip);
+///   - everything else is returned as-is (borrowed from the caller).
+/// Shared by Explorer.rebuildDepsFor and the snapshot restore path so the two
+/// never diverge. `tmp_allocator` is only used for transient resolution scratch.
+pub fn resolveDependencyKey(
+    dep_graph: *DependencyGraph,
+    importer_path: []const u8,
+    spec: []const u8,
+    tmp_allocator: std.mem.Allocator,
+) !?[]const u8 {
+    if (isRelativeImport(spec)) {
+        const tmp = resolveRelativeImportPath(importer_path, spec, tmp_allocator) orelse return null;
+        defer tmp_allocator.free(tmp);
+        // Extensionless imports ("../foo") are common in TS/JS. The resolved
+        // path then has no extension and won't match the indexed file
+        // ("dir/foo.ts"). Assume the importer's own extension (TS importing TS,
+        // JS importing JS) so the key lines up with the real file. Specifiers
+        // that already carry an extension are left as-is.
+        if (pathExtension(tmp) == null) {
+            if (pathExtension(importer_path)) |ext| {
+                const with_ext = std.fmt.allocPrint(tmp_allocator, "{s}{s}", .{ tmp, ext }) catch
+                    return try dep_graph.internString(tmp);
+                defer tmp_allocator.free(with_ext);
+                return try dep_graph.internString(with_ext);
+            }
+        }
+        return try dep_graph.internString(tmp);
+    }
+    if (std.mem.indexOf(u8, spec, "..") != null) return null;
+    return spec;
 }
 
 fn resolveDartImport(raw: []const u8, file_path: []const u8, allocator: std.mem.Allocator) ?[]const u8 {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -771,9 +771,19 @@ fn rebuildDepsFromOutline(explorer: *Explorer, path: []const u8, outline: *const
     errdefer deps.deinit(allocator);
     try deps.ensureTotalCapacity(allocator, outline.imports.items.len);
 
+    // Dedup like Explorer.rebuildDepsFor: a file importing the same module more
+    // than once (e.g. ../foo for both a type and a value) must not produce
+    // duplicate forward edges, so a snapshot-restored graph matches a fresh one.
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+
     for (outline.imports.items) |imp| {
-        if (std.mem.indexOf(u8, imp, "..") != null) continue;
-        deps.appendAssumeCapacity(imp);
+        // Same resolution as Explorer.rebuildDepsFor: relative specifiers
+        // resolve to repo paths so restored deps match a freshly-indexed graph.
+        const dep = (try explore_mod.resolveDependencyKey(&explorer.dep_graph, outline.path, imp, allocator)) orelse continue;
+        const gop = try seen.getOrPut(dep);
+        if (gop.found_existing) continue;
+        deps.appendAssumeCapacity(dep);
     }
 
     try explorer.dep_graph.setDeps(path, deps);

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -26,6 +26,91 @@ fn expectOutlineImport(outline: *const explore.FileOutline, import_path: []const
 }
 
 
+test "issue-2: relative imports resolve to repo paths in the dep graph" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("daemon/src/role/role-driver.ts",
+        \\import { foo } from "../bus/event-bus.ts";
+        \\import { join } from "node:path";
+    );
+
+    const deps = explorer.dep_graph.getForwardDeps("daemon/src/role/role-driver.ts") orelse
+        return error.TestUnexpectedResult;
+    var found_resolved = false;
+    var found_raw = false;
+    var found_bare = false;
+    for (deps) |d| {
+        if (std.mem.eql(u8, d, "daemon/src/bus/event-bus.ts")) found_resolved = true;
+        if (std.mem.eql(u8, d, "../bus/event-bus.ts")) found_raw = true;
+        if (std.mem.eql(u8, d, "node:path")) found_bare = true;
+    }
+    // the relative import resolves to a repo-rooted path ...
+    try testing.expect(found_resolved);
+    // ... the raw "../" form no longer appears in the graph (was dropped before) ...
+    try testing.expect(!found_raw);
+    // ... and bare specifiers are unaffected.
+    try testing.expect(found_bare);
+
+    // imported_by must now resolve to the importer.
+    const importers = try explorer.dep_graph.getImportedBy("daemon/src/bus/event-bus.ts", testing.allocator);
+    defer {
+        for (importers) |imp| testing.allocator.free(imp);
+        testing.allocator.free(importers);
+    }
+    var found_importer = false;
+    for (importers) |imp| {
+        if (std.mem.eql(u8, imp, "daemon/src/role/role-driver.ts")) found_importer = true;
+    }
+    try testing.expect(found_importer);
+}
+
+test "issue-2: extensionless relative imports resolve using the importer's extension" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // Common TS/JS form: the import omits the ".ts" extension.
+    try explorer.indexFile("daemon/src/role/role-driver.ts",
+        \\import { foo } from "../bus/event-bus";
+    );
+
+    const deps = explorer.dep_graph.getForwardDeps("daemon/src/role/role-driver.ts") orelse
+        return error.TestUnexpectedResult;
+    var found = false;
+    for (deps) |d| {
+        if (std.mem.eql(u8, d, "daemon/src/bus/event-bus.ts")) found = true;
+    }
+    // Resolved to the indexed file path, with the importer's .ts extension added.
+    try testing.expect(found);
+
+    const importers = try explorer.dep_graph.getImportedBy("daemon/src/bus/event-bus.ts", testing.allocator);
+    defer {
+        for (importers) |imp| testing.allocator.free(imp);
+        testing.allocator.free(importers);
+    }
+    var found_importer = false;
+    for (importers) |imp| {
+        if (std.mem.eql(u8, imp, "daemon/src/role/role-driver.ts")) found_importer = true;
+    }
+    try testing.expect(found_importer);
+}
+
+test "issue-2: interned dependency keys are reused, not re-allocated per reindex" {
+    var dg = DependencyGraph.init(testing.allocator);
+    defer dg.deinit();
+
+    const a = try dg.internString("daemon/src/bus/event-bus.ts");
+    const b = try dg.internString("daemon/src/bus/event-bus.ts");
+    // Same content -> same backing allocation, so re-indexing a file with the
+    // same relative imports does not grow the arena on every rebuild.
+    try testing.expect(a.ptr == b.ptr);
+
+    const c = try dg.internString("daemon/src/other.ts");
+    try testing.expect(a.ptr != c.ptr);
+}
+
 test "issue-301: Dart / Flutter parser" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
Fixes #541.

Every import with `..` in it got thrown out before it hit the dep graph, so all the intra-repo `../foo` deps were invisible and `imported_by` on an internal file came back empty. This resolves relative specifiers against the importing file into real repo paths instead of dropping them.

The skip lived in two places that had drifted: `rebuildDepsFor` (fresh index) and `rebuildDepsFromOutline` (snapshot restore). The binary always reloads from a snapshot, so the restore copy is the one that broke it in real use. You could write an in-process test that passed and still have it broken from the CLI. Both now go through one shared `resolveDependencyKey`, including the same dedup, so a file importing `../foo` as both a type and a value doesn't double up after reload.

`outline.imports` stays raw, the resolved strings are interned in a dep-graph-owned arena, so `issue-114` and the other import tests don't change. Also fixes a pre-existing leak in `normalizePath` that this newly hits under a leak-checking allocator (`parts` was errdefer-only, so it leaked on the success path).

Red to green: the new test checks depends-on and imported_by for a `../` import. Fails before (relative dep dropped), passes after. Verified through the built binary too, not just in-process. On a two-file repo where `role/driver.ts` does `import type { Bus } from "../bus/event-bus.ts"`:

Before:
```
role/driver.ts depends on:
  node:path
bus/event-bus.ts is imported by:
  (none)
```
After:
```
role/driver.ts depends on:
  bus/event-bus.ts
  node:path
bus/event-bus.ts is imported by:
  role/driver.ts
```

Files: `src/explore.zig` (resolveDependencyKey, rebuildDepsFor, normalizePath), `src/snapshot.zig` (rebuildDepsFromOutline), `src/test_parser.zig`.

Off current main, no generated files. Read CONTRIBUTING and followed it.