### PR TITLE
ci: guard PRs targeting main → nudge to the active release branch

### DIFF
--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,35 @@
+name: PR base guard
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+permissions:
+  pull-requests: write
+jobs:
+  guard:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const msg = [
+              "👋 Thanks for the contribution! Quick heads-up: this repo lands changes on the **current `release/*` branch**, not `main`.",
+              "",
+              "Please retarget this PR via **Edit → base branch** to the active release branch (currently `release/0.2.5825`).",
+              "",
+              "_(Automated hint — reply here if you need a hand.)_",
+            ].join("\n");
+            const { data: cs } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (!cs.some((c) => c.body.includes("lands changes on the **current"))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+            }
+            core.setFailed("PR targets main; please retarget to the active release/* branch.");


### PR DESCRIPTION
Adds `.github/workflows/pr-base-guard.yml`. On any PR opened/reopened/edited against `main`, it posts a friendly one-time comment asking the contributor to retarget to the current `release/*` branch, and fails the check (`core.setFailed`) so it's visible.

- Allows any `release/*` target (survives version bumps with no edits).
- Runs under `pull_request_target` for write access on fork PRs, and **does not check out PR code** — so no untrusted-code execution with the elevated token.

Context: contributors keep opening PRs against `main`; we integrate on the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)