### PR TITLE
fix(#548): TS/JS parser no longer captures "import " inside strings as a dependency

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3929,7 +3929,7 @@ pub const Explorer = struct {
                 try appendOutlineSymbol(a, outline, name, kind, line_num, line);
             }
         }
-        if (containsAny(line, &.{ "import ", "require(" })) {
+        if (startsWith(line, "import ") or containsAny(line, &.{ "require(" })) {
             try appendOutlineSymbol(a, outline, line, .import, line_num, null);
             if (extractStringLiteral(line)) |path| {
                 try appendImportPath(a, outline, path);

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -149,6 +149,27 @@ test "issue-2: interned dependency keys are reused, not re-allocated per reindex
     try testing.expect(a.ptr != c.ptr);
 }
 
+test "issue-548: a string containing 'import ' is not captured as a dependency" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // A plain const whose string value merely contains "import " — it is NOT an
+    // import statement, so it must not produce a dependency edge.
+    try explorer.indexFile("src/msg.ts", "export const ERROR = 'failed to import the config module';");
+    var outline = (try explorer.getOutline("src/msg.ts", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    for (outline.imports.items) |imp| {
+        try testing.expect(!std.mem.eql(u8, imp, "failed to import the config module"));
+    }
+
+    // Regression guard: a real single-line import is still captured.
+    try explorer.indexFile("src/dep.ts", "import { real } from './real-dep.ts';");
+    var outline2 = (try explorer.getOutline("src/dep.ts", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline2.deinit();
+    try expectOutlineImport(&outline2, "./real-dep.ts");
+}
+
 test "issue-301: Dart / Flutter parser" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
Closes #548.

## Problem
`parseTsLine` (`src/explore.zig`) matched `"import "` **anywhere** on a line via `containsAny`, not just at statement position. With `extractStringLiteral` grabbing the first quoted run and `appendImportPath` doing no filtering, a plain string like `export const ERROR = 'failed to import the config module';` was recorded as a dependency edge — polluting the dep graph (`deps`/`imported_by`/call-graph inputs) with garbage. #542 guarded its new `} from` branch against exactly this; the original `import`/`require(` branch was never guarded.

## Fix
One line: match the import token at statement position — `startsWith(line, "import ")` (the line is already trimmed when `parseTsLine` runs) instead of `containsAny(line, "import ")`; `require(` detection is unchanged.

## Test
`test "issue-548: …"` in `src/test_parser.zig` (committed first, separately): a const whose string contains `"import "` must not become a dependency, plus a regression guard that a real single-line import still is.

- Before: `725/726` (issue-548 red).
- After: **`726/726`, 23/23 steps** — green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)