### PR TITLE
fix(#547): load the word index for `search` so identifier terms surface

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1168,6 +1168,14 @@ fn mainImpl() !void {
                 // all content per query. Matches the serve/mcp daemon.
                 loadTrigramFromDiskIfPresent(io, &explorer, data_dir, allocator);
             }
+            if (std.mem.eql(u8, cmd, "search")) {
+                // #547: searchContent's Tier 0 recall is the word inverted index,
+                // not the trigram. Without it, `search` is blind to identifier
+                // terms that `word` surfaces (long / low-frequency names). Cheap
+                // mmap load, mirroring the trigram load above; `word`/`mcp`
+                // already load it, `search` did not.
+                loadWordIndexFromDiskIfPresent(io, &explorer, data_dir, git_head, allocator);
+            }
             if (std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "bench-engine") or std.mem.eql(u8, cmd, "cli-daemon")) {
                 loadWordIndexFromDiskIfPresent(io, &explorer, data_dir, git_head, allocator);
                 // word/bench-engine want a guaranteed-ready index — rebuild + persist


### PR DESCRIPTION
Addresses #547 (and lifts #546's "not a lexical hit" misses).

## Root cause
`searchContent`'s Tier 0 recall — the part that surfaces identifier terms — is the **word inverted index**. But the CLI `search` path never loaded it: after a snapshot load it loaded only the **trigram** index (`src/main.zig`), whereas `word`/`mcp` load the word index. With Tier 0 dead, `search` fell back to trigram-only, which at scale (per-trigram candidate caps on common grams) drops low-frequency identifiers — so `codedb search openrouter` returned nothing while `codedb word openrouter` found 1227 hits. This is also the root cause behind #546's "10/30 changed files weren't lexical hits at all."

## Fix
Load the word index for the `search` command too — a cheap mmap load mirroring the existing trigram load (`word`/`mcp` already do this; `search` didn't). `searchContent` Tier 0 then queries the same complete inverted index `word` uses. **8 lines, `search`-only**, no change to ranking or the Explorer.

## Verification — please read
- ✅ Builds on Zig 0.16; **full suite green (726/726, 23/23 steps)** — no regressions.
- ⚠️ **No red-to-green unit test.** The symptom is scale-dependent (~13.6k files + trigram caps) and does **not** reproduce at unit-test scale — any word-index token is also a contiguous substring the trigram tier finds, so there's no small input that goes red. The reproduction is the CLI sequence in #547.
- 🔎 **Recommended before merge:** confirm against the real index — `codedb <openclaw> search openrouter` should now return hits (matching `codedb word openrouter`).

Opening for review rather than auto-merging, precisely because of that verification gap.

## Out of scope
Fresh-scan `search` (no prior snapshot) still builds trigram-only — a rarer path; this fixes the snapshot case (the #547 repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)