### PR TITLE
fix(#553): cheap metadata-only CLI status — stop materializing the full index

### DIFF
--- a/src/index.zig
+++ b/src/index.zig
@@ -1913,6 +1913,26 @@ pub const TrigramIndex = struct {
     }
 };
 
+/// On-disk `status` metadata, readable WITHOUT loading the full index into
+/// memory. #553: CLI `status` used to materialize the whole index (snapshot
+/// mmap, or a full re-index + multi-GB snapshot rewrite when none existed)
+/// before reading a few counts, so a backgrounded `codedb . status &` from a
+/// SessionStart hook leaked a multi-GB resident orphan that stacked to OOM.
+pub const StatusMeta = struct {
+    indexed: bool,
+    file_count: u32,
+    git_head: ?[40]u8,
+};
+
+/// Read `status` metadata from the persisted trigram header alone — no Explorer,
+/// no snapshot load, no re-index. Returns indexed=false when the project has no
+/// persisted index so the caller reports "not indexed" instead of re-indexing.
+pub fn readStatusMeta(io: std.Io, data_dir: []const u8, allocator: std.mem.Allocator) StatusMeta {
+    const hdr = (TrigramIndex.readDiskHeader(io, data_dir, allocator) catch null) orelse
+        return .{ .indexed = false, .file_count = 0, .git_head = null };
+    return .{ .indexed = true, .file_count = hdr.file_count, .git_head = hdr.git_head };
+}
+
 // ── mmap-backed trigram index ───────────────────────────────
 // Zero-copy: binary search on mmap'd lookup table, read postings directly.
 // Replaces heap-based TrigramIndex after writeToDisk for O(log n) lookups

--- a/src/main.zig
+++ b/src/main.zig
@@ -1081,6 +1081,44 @@ fn mainImpl() !void {
         out.exitWithFlush(1);
     }
 
+    // #553: `status` must be a cheap, fast-exiting metadata query. It previously
+    // fell through to the full index bootstrap below (snapshot mmap, or — with no
+    // snapshot — a complete re-index + multi-GB snapshot rewrite) and, being in
+    // cliIsQueryCmd, also auto-spawned a warm cli-daemon. Backgrounded as a
+    // SessionStart warmup (`codedb . status &`), each call left a multi-GB
+    // resident orphan that stacked until the machine OOM'd. Report from on-disk
+    // metadata only — no Explorer load, no daemon spawn — and exit immediately.
+    if (std.mem.eql(u8, cmd, "status")) {
+        const t0 = cio.nanoTimestamp();
+        const data_dir = getDataDir(io, allocator, abs_root) catch {
+            out.p("{s}\xe2\x9c\x97{s} cannot resolve data dir for {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, abs_root, s.reset,
+            });
+            out.exitWithFlush(1);
+        };
+        defer allocator.free(data_dir);
+        const meta = index_mod.readStatusMeta(io, data_dir, allocator);
+        const elapsed = cio.nanoTimestamp() - t0;
+        var dur_buf: [64]u8 = undefined;
+        out.p("{s}\xe2\x9c\x93{s} {s}codedb {s}{s}  {s}{s}{s}\n", .{
+            s.green,                               s.reset,
+            s.bold,                                release_info.semver,
+            s.reset,                               sty.durationColor(s, elapsed),
+            sty.formatDuration(&dur_buf, elapsed), s.reset,
+        });
+        out.p("  {s}root{s}      {s}{s}{s}\n", .{ s.dim, s.reset, s.cyan, root, s.reset });
+        if (meta.indexed) {
+            out.p("  {s}files{s}     {s}{d}{s} indexed\n", .{ s.dim, s.reset, s.bold, meta.file_count, s.reset });
+            if (meta.git_head) |h| {
+                out.p("  {s}head{s}      {s}{s}{s}\n", .{ s.dim, s.reset, s.cyan, h[0..12], s.reset });
+            }
+        } else {
+            out.p("  {s}files{s}     {s}not indexed{s}  \xe2\x80\x94 run `codedb {s} index`\n", .{ s.dim, s.reset, s.bold, s.reset, root });
+        }
+        out.p("  {s}data{s}      {s}{s}{s}\n", .{ s.dim, s.reset, s.dim, data_dir, s.reset });
+        out.exitWithFlush(0);
+    }
+
     // Thin-client fast path: if a warm daemon (codedb <root> serve / mcp) is
     // already listening for this project, proxy read-only query commands to it
     // and skip the per-invocation snapshot reload entirely. Falls through to

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -2261,6 +2261,44 @@ test "disk index: readDiskHeader returns file_count and git_head" {
     try testing.expectEqualSlices(u8, &fake_head, &hdr.?.git_head.?);
 }
 
+test "issue-553: status reads file_count from disk header without loading the index" {
+    // #553: `codedb status` must report from on-disk metadata and exit — never
+    // materialize the full index, or a backgrounded `status &` leaks a multi-GB
+    // resident orphan. readStatusMeta is that cheap path: it reads ONLY the
+    // trigram header (no Explorer, no snapshot load, no re-index).
+    const readStatusMeta = @import("index.zig").readStatusMeta;
+    const alloc = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+
+    // No persisted index -> "not indexed", no load, no crash (so `status` on an
+    // unindexed repo reports state instead of triggering a full re-index).
+    {
+        const meta = readStatusMeta(io, dir_path, alloc);
+        try testing.expect(!meta.indexed);
+        try testing.expectEqual(@as(u32, 0), meta.file_count);
+        try testing.expect(meta.git_head == null);
+    }
+
+    // Persist a 2-file index; status reports the count straight from the header.
+    var ti = TrigramIndex.init(alloc);
+    defer ti.deinit();
+    try ti.indexFile("a.zig", "pub const A = 1;");
+    try ti.indexFile("b.zig", "pub const B = 2;");
+    const fake_head = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".*;
+    try ti.writeToDisk(io, dir_path, fake_head);
+
+    const meta = readStatusMeta(io, dir_path, alloc);
+    try testing.expect(meta.indexed);
+    try testing.expectEqual(@as(u32, 2), meta.file_count);
+    try testing.expect(meta.git_head != null);
+    try testing.expectEqualSlices(u8, &fake_head, &meta.git_head.?);
+}
+
 
 test "disk index: v1 format (no git_head) still loads and readGitHead returns null" {
     const alloc = testing.allocator;


### PR DESCRIPTION
## Problem (#553, reported by @lekt9)

`codedb [root] status` is grouped with the heavy query commands, so it **materializes the full index before reading three cheap counts**:
- with a snapshot → mmaps the whole index (~18GB on the reporter's repo) + builds ~2.8GB in-memory;
- with no/stale snapshot → full `initialScan` + `buildCallCentrality` + a multi-GB snapshot rewrite (the multi-hour path);
- and because `status` is in `cliIsQueryCmd`, it **also auto-spawns a warm cli-daemon** — a second resident copy.

Run backgrounded from a Claude Code `SessionStart` hook (`codedb . status >/dev/null 2>&1 &`), each call reparents to launchd (ppid=1) and lingers. They stack across sessions until RAM is exhausted → jetsam kills + WindowServer `userspace_watchdog_timeout` freeze (hard restart). The reporter saw 3× ~20GB `codedb . status` orphans on a 64GB machine.

## Fix

An early `status` branch **before** the load/daemon path that reports from on-disk metadata only and exits immediately:
- `readStatusMeta` → `TrigramIndex.readDiskHeader` (header-only read of `trigram.postings`: `file_count` + `git_head`). No Explorer, no snapshot mmap, no re-index, **no daemon spawn**.
- No persisted index → prints **"not indexed — run `codedb <root> index`"** instead of triggering a full scan.

The `codedb_status` **MCP** tool is unaffected — it runs inside the already-loaded server, where the counts are free.

### Before → after
Old `status` loaded the full index (seconds-to-hours + GBs resident). New `status`, measured on this repo (670 files):
```
✓ codedb 0.2.5825  ⚡ 72.0µs
  root      .
  files     670 indexed
  head      1047ab9a0b2c
  data      ~/.codedb/projects/<hash>
```
72µs, exits immediately, no index load.

## Test

`test "issue-553: status reads file_count from disk header without loading the index"` (test_index.zig): asserts the cheap path reports `file_count`/`git_head` from the header for an indexed dir and `indexed=false` for an empty one. It references the new `readStatusMeta`, so it **cannot compile/pass without this fix**.

`zig build test` → **23/23 steps, 727/727 tests passed**.

## Notes
- Minimal/surgical: the rich status (outline count, trigram type, RSS) still renders inside the MCP server via `codedb_status`; only the cold CLI path changed.
- Reported on 0.2.5824; confirmed still present on 0.2.5825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
