### PR TITLE
fix(#546): down-rank first-party tooling paths in searchContent rerank

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2823,6 +2823,9 @@ pub const Explorer = struct {
 
         if (pathHasSegment(r.path, "tests") or pathHasSegment(r.path, "test")) score *= 0.6;
         if (pathHasSegment(r.path, "examples") or pathHasSegment(r.path, "example")) score *= 0.6;
+        if (pathHasSegment(r.path, "bench") or pathHasSegment(r.path, "benchmarks") or
+            pathHasSegment(r.path, "scripts") or pathHasSegment(r.path, "website") or
+            pathHasSegment(r.path, "install")) score *= 0.5;
         if (pathHasSegment(r.path, "vendor") or pathHasSegment(r.path, "node_modules") or
             pathHasSegment(r.path, "third_party")) score *= 0.4;
         // Doc-language penalty: markdown / data files (CHANGELOG.md, design

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1638,3 +1638,31 @@ test "issue-451: scope=true search surfaces skip-trigram files" {
     }
     try testing.expect(found_canonical);
 }
+
+
+test "issue-546: searchContent rerank penalizes non-source tooling paths (bench/install/scripts/website)" {
+    // Mirror of issue-429-b for first-party tooling directories. Five files,
+    // identical content and hit count — only a path prior can separate them.
+    // Pre-fix the path-asc tiebreaker puts bench/ first; the implementation
+    // under src/ must win.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("bench/sample.zig", "pub fn x() void { _ = coreTerm; }\n");
+    try explorer.indexFile("install/sample.zig", "pub fn x() void { _ = coreTerm; }\n");
+    try explorer.indexFile("scripts/sample.zig", "pub fn x() void { _ = coreTerm; }\n");
+    try explorer.indexFile("website/sample.zig", "pub fn x() void { _ = coreTerm; }\n");
+    try explorer.indexFile("src/sample.zig", "pub fn x() void { _ = coreTerm; }\n");
+
+    const results = try explorer.searchContent("coreTerm", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 5);
+    try testing.expectEqualStrings("src/sample.zig", results[0].path);
+}


### PR DESCRIPTION
## Problem

Part of #546 (structurally-relevant files rank below lexical hits). Single-word `codedb_search`/CLI `search` queries rank via `rerankSignalScore`, which penalizes `tests/examples/vendor`/doc files but has **no prior for first-party tooling directories**. Mention-heavy files under `bench/`, `scripts/`, `website/`, `install/` tie the implementing source file and win the path-asc tiebreaker.

Observed on this repo (audit run, 2026-06-10):
- `snapshot` → `install/install.sh` outranked `src/snapshot.zig` (gold at rank 6)
- `cli status` → `scripts/codedb-cli` at #2, `src/main.zig` at #3
- `word index` / `trigram index` → `bench/run-benchmarks.*` mixed into top-5
- engram `codedb_insights` over 25 commits: codedb MRR **0.30** vs engram re-rank 0.60, diagnosis "lexical anti-correlates"

## Fix

One multiplier in `rerankSignalScore` (`src/explore.zig`): path segments `bench`/`benchmarks`/`scripts`/`website`/`install` → score ×0.5 (between vendor 0.4 and tests 0.6). BM25/`searchContentRanked` path was checked and does **not** exhibit the bug in a minimal repro, so it is left untouched.

## Failing Test

`test "issue-546: searchContent rerank penalizes non-source tooling paths (bench/install/scripts/website)"` in `src/test_search.zig` — 5 identical-content files; pre-fix `bench/sample.zig` ranks first by path-asc, post-fix `src/sample.zig` wins. Committed red in 87e5386, fix in follow-up commit.

## Validation

- `zig build test`: 728/728 pass
- Live check on this repo: `codedb search snapshot` now ranks `src/snapshot.zig` **#1**; `install/install.sh` no longer in the top page

🤖 Generated with [Claude Code](https://claude.com/claude-code)