### PR TITLE
fix(#562): codedb_callers excludes full-line comment mentions from call sites

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1949,7 +1949,10 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
 
     var shown: usize = 0;
     for (results) |r| {
-        if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
+        const lang = explore_mod.detectLanguage(r.path);
+        if (!langHasCallSites(lang)) continue;
+        // #562: a full-line comment mention is documentation, not a call site.
+        if (explore_mod.isCommentOrBlank(r.line_text, lang)) continue;
         var is_def = false;
         for (defs) |d| {
             if (r.line_num == d.symbol.line_start and std.mem.eql(u8, r.path, d.path)) {
@@ -1965,7 +1968,10 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     const w = cio.listWriter(out, alloc);
     w.print("{d} call sites for '{s}':\n", .{ shown, name }) catch {};
     for (results) |r| {
-        if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
+        const lang = explore_mod.detectLanguage(r.path);
+        if (!langHasCallSites(lang)) continue;
+        // #562: a full-line comment mention is documentation, not a call site.
+        if (explore_mod.isCommentOrBlank(r.line_text, lang)) continue;
         var is_def = false;
         for (defs) |d| {
             if (r.line_num == d.symbol.line_start and std.mem.eql(u8, r.path, d.path)) {

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1638,3 +1638,42 @@ test "issue-451: scope=true search surfaces skip-trigram files" {
     }
     try testing.expect(found_canonical);
 }
+
+
+test "issue-562: codedb_callers excludes full-line comment mentions" {
+    // Live repro: callers of insertRestoredFile reported snapshot.zig:822
+    // ('// is false: insertRestoredFile errors above…') and a test-file
+    // comment as call sites. A full-line comment is documentation, not a
+    // call — it must not be counted or rendered.
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/zlib.zig", "pub fn insertThing() void {}\n");
+    try explorer.indexFile("src/caller.zig", "pub fn doIt() void {\n    insertThing();\n}\n");
+    try explorer.indexFile("src/noisy.zig", "// insertThing errors above if the path already exists\npub fn unrelated() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"name":"insertThing"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_callers, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    // The real call site stays.
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/caller.zig:2") != null);
+    // The comment mention must not appear as a call site…
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/noisy.zig") == null);
+    // …and must not inflate the header count.
+    try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'insertThing'") != null);
+}


### PR DESCRIPTION
Fixes #562.

## Problem
`handleCallers` filtered by language, definition-line, and whole-word match — but never by comment-ness. Full-line `//` mentions were counted and rendered as call sites (live: `insertRestoredFile` reported snapshot.zig:822, a comment, as a call site; 2 of its 3 'call sites' were comments).

## Fix
Both loops skip `explore_mod.isCommentOrBlank(r.line_text, lang)` lines (the helper compact-mode search already uses), with `detectLanguage` hoisted. Trailing comments on code lines are untouched — position-aware parsing is out of scope per the issue.

## Failing Test
`test "issue-562: codedb_callers excludes full-line comment mentions"` (src/test_search.zig), committed red: real call kept, comment mention excluded, header says `1 call sites`. Pre-fix 67/68.

## Validation
`zig build test`: all green (730 tests), including issue-391/425/426 callers tests.

Note: trivial EOF conflict with #557/#561 in src/test_search.zig (each appends a test at file end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)