### PR TITLE
perf(#564): defer the symbol index on snapshot fast-load (−33% load time, −43MB footprint on openclaw)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -655,6 +655,8 @@ pub const Explorer = struct {
     dep_graph: DependencyGraph,
     contents: ContentCache,
     symbol_index: std.StringHashMap(std.ArrayList(SymbolLocation)),
+    /// False after a snapshot fast-load until ensureSymbolIndex runs (#564).
+    symbol_index_complete: bool,
     word_index: WordIndex,
     trigram_index: AnyTrigramIndex,
     /// Paths indexed with skip_trigram=true (past 15k cap or excluded).
@@ -721,6 +723,7 @@ pub const Explorer = struct {
             .dep_graph = DependencyGraph.init(allocator),
             .contents = ContentCache.init(allocator, content_cache_capacity),
             .symbol_index = std.StringHashMap(std.ArrayList(SymbolLocation)).init(allocator),
+            .symbol_index_complete = true,
             .word_index = WordIndex.init(allocator),
             .trigram_index = .{ .heap = TrigramIndex.init(allocator) },
             .skip_trigram_files = std.StringHashMap(void).init(allocator),
@@ -1399,6 +1402,35 @@ pub const Explorer = struct {
         self.word_index_persisted_generation = self.word_index_generation;
     }
 
+    /// Snapshot fast-load defers the global symbol index — plain content
+    /// search never reads it, so one-shot CLI queries skip ~symbols-per-file
+    /// map inserts and their heap (#564). rebuildSymbolIndexFor no-ops while
+    /// incomplete; ensureSymbolIndex builds it on first symbol/caller use.
+    pub fn markSymbolIndexIncomplete(self: *Explorer) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.symbol_index_complete = false;
+    }
+
+    /// Build the global symbol index from outlines if a snapshot fast-load
+    /// deferred it (#564). Cheap when complete (one flag check). Mirrors the
+    /// lazy word-index rebuild: call BEFORE taking the shared lock — this
+    /// takes the exclusive lock itself.
+    pub fn ensureSymbolIndex(self: *Explorer) void {
+        self.mu.lockShared();
+        const incomplete = !self.symbol_index_complete;
+        self.mu.unlockShared();
+        if (!incomplete) return;
+        self.mu.lock();
+        defer self.mu.unlock();
+        if (self.symbol_index_complete) return;
+        self.symbol_index_complete = true;
+        var it = self.outlines.iterator();
+        while (it.next()) |entry| {
+            self.rebuildSymbolIndexFor(entry.key_ptr.*, entry.value_ptr, false);
+        }
+    }
+
     pub fn disableWordIndexDiskLoad(self: *Explorer) void {
         self.mu.lock();
         defer self.mu.unlock();
@@ -1809,6 +1841,7 @@ pub const Explorer = struct {
     }
 
     pub fn findSymbol(self: *Explorer, name: []const u8, allocator: std.mem.Allocator) !?struct { path: []const u8, symbol: Symbol } {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -1861,6 +1894,7 @@ pub const Explorer = struct {
     }
 
     pub fn findAllSymbols(self: *Explorer, name: []const u8, allocator: std.mem.Allocator) ![]const SymbolResult {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -1971,6 +2005,7 @@ pub const Explorer = struct {
     }
 
     pub fn searchSymbols(self: *Explorer, spec: SymbolSearchSpec, allocator: std.mem.Allocator) ![]ScoredSymbolResult {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -2133,6 +2168,7 @@ pub const Explorer = struct {
         max: usize,
     ) ![]CalleeRef {
         if (max == 0 or line_end < line_start) return &.{};
+        self.ensureSymbolIndex();
         const content = (self.getContent(path, allocator) catch return &.{}) orelse return &.{};
         const body = sliceLineRange(content, line_start, line_end);
         if (body.len == 0) return &.{};
@@ -2244,6 +2280,7 @@ pub const Explorer = struct {
         return content[start..i];
     }
     pub fn renderSymbols(self: *Explorer, name: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8)) !bool {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -2973,6 +3010,7 @@ pub const Explorer = struct {
     /// ensureCallCentrality assumes the caller already holds a shared lock (it is
     /// normally reached from searchContentRanked); this wrapper takes that lock.
     pub fn buildCallCentrality(self: *Explorer, allocator: std.mem.Allocator) void {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
         self.ensureCallCentrality(allocator);
@@ -2983,6 +3021,11 @@ pub const Explorer = struct {
     /// codedb_callpath and computes per-file centrality (PageRank by default).
     fn ensureCallGraph(self: *Explorer, allocator: std.mem.Allocator) void {
         if (self.call_graph != null) return;
+        // #564: never build (and cache) a graph from a deferred symbol index —
+        // resolveCallees would see no definitions and the empty graph would be
+        // cached forever. Callers that need the graph ensureSymbolIndex first;
+        // ranking paths just skip the boost until then.
+        if (!self.symbol_index_complete) return;
         self.centrality_build_mu.lock();
         defer self.centrality_build_mu.unlock();
         if (self.call_graph != null) return;
@@ -3118,6 +3161,7 @@ pub const Explorer = struct {
         allocator: std.mem.Allocator,
         max_hops: usize,
     ) !?[]CallPathStep {
+        self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -4864,6 +4908,11 @@ pub const Explorer = struct {
     }
 
     pub fn rebuildSymbolIndexFor(self: *Explorer, path: []const u8, outline: *FileOutline, had_prior: bool) void {
+        // #564: while the index is deferred (snapshot fast-load), per-file
+        // rebuilds are wasted work — ensureSymbolIndex rebuilds everything from
+        // outlines on first use. ensureSymbolIndex flips the flag back BEFORE
+        // calling this, so its own rebuild passes the guard.
+        if (!self.symbol_index_complete) return;
         // removeSymbolIndexFor scans the entire global symbol index, so calling
         // it per file makes a cold scan O(files * total_symbols). A brand-new
         // path has no prior entries to evict, so skip the scan entirely — only

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -789,6 +789,21 @@ fn rebuildDepsFromOutline(explorer: *Explorer, path: []const u8, outline: *const
     try explorer.dep_graph.setDeps(path, deps);
 }
 
+// Process max-RSS in bytes (macOS getrusage reports bytes; Linux reports KiB).
+// Profiler-only: attribution of load-phase memory growth, not a public API.
+fn loadMaxRssBytes() u64 {
+    var ru: std.c.rusage = undefined;
+    if (std.c.getrusage(0, &ru) != 0) return 0;
+    const raw: u64 = @intCast(@max(0, ru.maxrss));
+    return if (@import("builtin").os.tag == .linux) raw * 1024 else raw;
+}
+// Written only when `load_prof` is set by loadSnapshotFast; the loader is
+// single-threaded so plain vars are safe.
+var load_prof: bool = false;
+var prof_content_ns: i128 = 0;
+var prof_deps_ns: i128 = 0;
+var prof_symidx_ns: i128 = 0;
+
 fn insertRestoredFile(
     explorer: *Explorer,
     path: []const u8,
@@ -807,20 +822,26 @@ fn insertRestoredFile(
 
     // When the content was read from an mmap the Explorer has adopted, store a
     // borrowed (zero-copy) cache value; otherwise dupe it as usual.
+    const t_content: i128 = if (load_prof) cio.nanoTimestamp() else 0;
     if (borrow_content) {
         try explorer.contents.putBorrowed(path, content);
     } else {
         try explorer.contents.put(path, content);
     }
+    if (load_prof) prof_content_ns += cio.nanoTimestamp() - t_content;
 
+    const t_deps: i128 = if (load_prof) cio.nanoTimestamp() else 0;
     try rebuildDepsFromOutline(explorer, path, &restored_outline, allocator);
+    if (load_prof) prof_deps_ns += cio.nanoTimestamp() - t_deps;
 
     // Mirror commitParsedFileOwnedOutline (explore.zig:872): symbol_index is built
     // eagerly on every ingest and has NO lazy rebuild trigger. resolveCallees reads
     // it without a fallback (#524 perf note), so restored files must populate it
     // here or call-graph edges into them are lost after a snapshot load. had_prior
     // is false: insertRestoredFile errors above if the path already exists.
+    const t_symidx: i128 = if (load_prof) cio.nanoTimestamp() else 0;
     explorer.rebuildSymbolIndexFor(path, &restored_outline, false);
+    if (load_prof) prof_symidx_ns += cio.nanoTimestamp() - t_symidx;
 
     // Restored files are absent from word_index and trigram_index at load time
     // (both are rebuilt lazily/incrementally). Register the path in
@@ -886,6 +907,11 @@ fn loadSnapshotFast(
     // Optional phase profiler (CODEDB_LOAD_PROFILE): prints a load breakdown to
     // stderr. Near-zero cost when off (one getenv + a few timestamps).
     const prof = cio.posixGetenv("CODEDB_LOAD_PROFILE") != null;
+    load_prof = prof;
+    prof_content_ns = 0;
+    prof_deps_ns = 0;
+    prof_symidx_ns = 0;
+    const rss0: u64 = if (prof) loadMaxRssBytes() else 0;
     const t_load0: i128 = if (prof) cio.nanoTimestamp() else 0;
     var fresh_ns: i128 = 0;
 
@@ -916,6 +942,7 @@ fn loadSnapshotFast(
         explorer.dep_graph.reverse.ensureTotalCapacity(fc) catch {};
     }
 
+    const rss_outline: u64 = if (prof) loadMaxRssBytes() else 0;
     const t_outline: i128 = if (prof) cio.nanoTimestamp() else 0;
     var sections = (try readSections(io, snapshot_path, allocator)) orelse return false;
     defer sections.deinit();
@@ -1011,6 +1038,7 @@ fn loadSnapshotFast(
         }
     }
 
+    const rss_recs: u64 = if (prof) loadMaxRssBytes() else 0;
     // ── Pass B: freshness check (parallelized for large trees). ──
     // statFile every record to detect edits made since the snapshot. These are
     // independent, allocation-free per-file syscalls — the dominant load cost once
@@ -1067,8 +1095,15 @@ fn loadSnapshotFast(
         }
     }
     if (prof) fresh_ns += cio.nanoTimestamp() - t_fresh0;
-
+    const rss_fresh: u64 = if (prof) loadMaxRssBytes() else 0;
     // ── Pass C: insert restored / changed / outline-only files (sequential). ──
+    // #564: defer the global symbol index — Pass C's per-file rebuilds become
+    // no-ops and ensureSymbolIndex builds it from outlines on first
+    // symbol/caller/callpath use. Plain search never needs it, so one-shot
+    // CLI queries skip the inserts and their heap entirely.
+    explorer.markSymbolIndexIncomplete();
+    var insert_ns: i128 = 0;
+    var store_ns: i128 = 0;
     for (records.items, fresh_results) |record, fr| {
         const path = record.path;
         const content = record.content;
@@ -1092,14 +1127,18 @@ fn loadSnapshotFast(
             const hash = std.hash.Wyhash.hash(0, dc);
             _ = store.recordSnapshot(path, dc.len, hash) catch {};
         } else if (outline_states.fetchRemove(path)) |removed| {
+            const t_ins: i128 = if (prof) cio.nanoTimestamp() else 0;
             insertRestoredFile(explorer, removed.key, content, removed.value, allocator, content_borrowed) catch {
                 allocator.free(removed.key);
                 var bad_outline = removed.value;
                 bad_outline.deinit();
                 continue;
             };
+            if (prof) insert_ns += cio.nanoTimestamp() - t_ins;
             const hash = record.stored_hash orelse std.hash.Wyhash.hash(0, content);
+            const t_st: i128 = if (prof) cio.nanoTimestamp() else 0;
             _ = store.recordSnapshot(removed.key, content.len, hash) catch {};
+            if (prof) store_ns += cio.nanoTimestamp() - t_st;
         } else {
             word_index_can_load_from_disk = false;
             explorer.indexFileOutlineOnly(path, content) catch continue;
@@ -1110,6 +1149,7 @@ fn loadSnapshotFast(
         file_count += 1;
     }
 
+    const rss_insert: u64 = if (prof) loadMaxRssBytes() else 0;
     if (file_count == 0) return false;
     if (expected_file_count) |expected| {
         if (file_count != expected) return false;
@@ -1163,6 +1203,20 @@ fn loadSnapshotFast(
         std.debug.print(
             "[load-profile] {d} files  total={d:.1}ms  outline={d:.1}ms  loop={d:.1}ms (freshness={d:.1}ms, rest={d:.1}ms)\n",
             .{ file_count, ms(now - t_load0), ms(outline_ns), ms(loop_ns), ms(fresh_ns), ms(loop_ns - fresh_ns) },
+        );
+        std.debug.print(
+            "[load-profile]   insert={d:.1}ms (content={d:.1}ms, deps={d:.1}ms, symidx={d:.1}ms, other={d:.1}ms)  store={d:.1}ms\n",
+            .{ ms(insert_ns), ms(prof_content_ns), ms(prof_deps_ns), ms(prof_symidx_ns), ms(insert_ns - prof_content_ns - prof_deps_ns - prof_symidx_ns), ms(store_ns) },
+        );
+        const mb = struct {
+            fn f(b: u64) f64 {
+                return @as(f64, @floatFromInt(b)) / (1024.0 * 1024.0);
+            }
+        }.f;
+        const rss_end = loadMaxRssBytes();
+        std.debug.print(
+            "[load-profile]   maxrss: start={d:.1}MB +outline={d:.1}MB +records={d:.1}MB +freshness={d:.1}MB +insert={d:.1}MB +tail={d:.1}MB end={d:.1}MB\n",
+            .{ mb(rss0), mb(rss_outline -| rss0), mb(rss_recs -| rss_outline), mb(rss_fresh -| rss_recs), mb(rss_insert -| rss_fresh), mb(rss_end -| rss_insert), mb(rss_end) },
         );
     }
 

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -1231,3 +1231,45 @@ test "issue-539b: search recall ranks a relevant restored file above quota (inde
     };
     try testing.expect(found_canonical);
 }
+
+
+test "issue-564: snapshot fast-load defers the symbol index until first symbol use" {
+    // Pre-#564 the fast-load eagerly rebuilt the global symbol index for every
+    // restored file (~symbols-per-file map inserts and their heap) even though
+    // plain content search never reads it. The load now defers it; the first
+    // symbol/caller/callpath use builds it from outlines and answers the same.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    var exp = Explorer.init(aa, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try exp.indexFile("util_564.zig", "pub fn uniqueSym564() void {}\n");
+    try exp.indexFile("main_564.zig", "pub fn caller564() void {\n    uniqueSym564();\n}\n");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/lazy564.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    const aa2 = arena2.allocator();
+    var exp2 = Explorer.init(aa2, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, aa2));
+
+    // The fast-load must NOT have materialized the symbol index — the deferral
+    // is the point: one-shot search pays neither the inserts nor their heap.
+    try testing.expectEqual(@as(usize, 0), exp2.symbol_index.count());
+
+    // First symbol use builds it on demand and answers correctly.
+    const results = try exp2.findAllSymbols("uniqueSym564", aa2);
+    try testing.expect(results.len >= 1);
+    try testing.expect(std.mem.eql(u8, results[0].path, "util_564.zig"));
+    try testing.expect(exp2.symbol_index.count() > 0);
+}


### PR DESCRIPTION
Fixes #564.

## What

Snapshot fast-load (Pass C) eagerly built the global symbol index for every restored file. Plain content search never reads it, so every one-shot CLI query paid the inserts and their heap for nothing. This PR defers it using the codebase's existing lazy pattern (word index, #539):

- `markSymbolIndexIncomplete()` before Pass C; `rebuildSymbolIndexFor` no-ops while deferred
- `ensureSymbolIndex()` builds from outlines on first use, hooked at every reader entry: `findSymbol`, `findAllSymbols`, `searchSymbols`, `renderSymbols`, `resolveCallees`, `findCallPath`, `buildCallCentrality`
- `ensureCallGraph` refuses to build from a deferred index — an empty call graph can never be cached (ranking paths simply skip the centrality boost until the index exists; the snapshot-restored centrality section is unaffected)

Also extends the gated `CODEDB_LOAD_PROFILE` profiler with insert sub-phases (content/deps/symidx/store) and per-phase maxrss attribution — the instrumentation that found this.

## Measured (openclaw, 13,654 files, ReleaseFast, warm cache, 3 runs)

| metric | before | after |
|---|---|---|
| snapshot load | ~60ms | **~40ms** |
| symidx during load | 18–20ms | 0.2ms |
| Pass C heap growth | +62.5MB | **+20.5MB** |
| one-shot search max RSS | 244MB | **200MB** |
| one-shot search phys footprint | 132.7MB | **89.2MB (−33%)** |

First symbol/caller use pays a one-time ~18ms ensure; verified live: `codedb symbol GatewayClient` correct on the lazy path.

## Tests

- New `issue-564` test: `symbol_index.count() == 0` after fast-load, then first `findAllSymbols` builds on demand and answers correctly (fails red on release/0.2.5825)
- `issue-537b` (call edges after restore) now exercises the `resolveCallees` ensure-hook — caught a missing hook during development
- Full suite green (731 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)