### PR TITLE
fix(#546): CLI multi-word ranked search end-to-end (incl. first-cold-run) + audit bundle — callee comment stripping, codedb_query UAF, secret filters

### DIFF
--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -67,7 +67,29 @@ pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![][]const
 
     var i: usize = 0;
     while (i < body.len) : (i += 1) {
-        if (body[i] != '(') continue;
+        const c = body[i];
+        // Skip line comments, block comments, and string/char literals so an identifier
+        // mentioned only inside one is not mistaken for a call site (#548 family).
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            i += 1; // land on '/' of '*/'; the loop's i += 1 then moves past it
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < body.len and body[i] != c) {
+                if (body[i] == '\\') i += 1; // skip an escaped char
+                i += 1;
+            }
+            continue;
+        }
+        if (c != '(') continue;
         // Skip spaces/tabs between the identifier and the '('.
         var end = i;
         while (end > 0 and (body[end - 1] == ' ' or body[end - 1] == '\t')) end -= 1;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -863,6 +863,10 @@ pub const Explorer = struct {
         try self.contents.put(stable_path, content);
 
         if (full_index) {
+            // A disabled word index (cold CLI scan keeps it off to save memory)
+            // can't absorb this file, so it no longer reflects the indexed set —
+            // ranked/BM25 readers must lazy-rebuild instead of trusting it (#546).
+            if (!self.word_index.enabled) self.word_index_complete = false;
             if (!self.word_index_complete) {
                 self.word_index_can_load_from_disk = false;
             }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2253,9 +2253,7 @@ pub const Explorer = struct {
             "push",        "find",     "add",      "new",       "build",
             "run",         "deinit",   "toString", "valueOf",   "of",
         };
-        for (common) |c| {
-            if (std.mem.eql(u8, name, c)) return true;
-        }
+        for (common) |c| if (std.mem.eql(u8, name, c)) return true;
         return false;
     }
 
@@ -5642,17 +5640,13 @@ fn asciiContainsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 
 fn pathHasSegment(path: []const u8, segment: []const u8) bool {
     var iter = std.mem.tokenizeAny(u8, path, "/\\");
-    while (iter.next()) |seg| {
-        if (std.mem.eql(u8, seg, segment)) return true;
-    }
+    while (iter.next()) |seg| if (std.mem.eql(u8, seg, segment)) return true;
     return false;
 }
 
 fn pathHasSegmentIgnoreCase(path: []const u8, segment: []const u8) bool {
     var iter = std.mem.tokenizeAny(u8, path, "/\\");
-    while (iter.next()) |seg| {
-        if (asciiEqlIgnoreCase(seg, segment)) return true;
-    }
+    while (iter.next()) |seg| if (asciiEqlIgnoreCase(seg, segment)) return true;
     return false;
 }
 fn startsWith(haystack: []const u8, needle: []const u8) bool {
@@ -5833,9 +5827,7 @@ fn extractJvmMethodName(line: []const u8) ?[]const u8 {
 
 fn isControlKeyword(name: []const u8) bool {
     const keywords = [_][]const u8{ "if", "for", "while", "switch", "catch", "return", "throw", "new", "when" };
-    for (keywords) |kw| {
-        if (std.mem.eql(u8, name, kw)) return true;
-    }
+    for (keywords) |kw| if (std.mem.eql(u8, name, kw)) return true;
     return false;
 }
 
@@ -6230,9 +6222,7 @@ fn isCKeyword(s: []const u8) bool {
         "typedef",  "static",   "extern", "inline", "const",    "volatile",
         "register", "restrict", "auto",   "break",  "continue",
     };
-    for (keywords) |kw| {
-        if (std.mem.eql(u8, s, kw)) return true;
-    }
+    for (keywords) |kw| if (std.mem.eql(u8, s, kw)) return true;
     return false;
 }
 
@@ -6417,9 +6407,7 @@ fn resolveDartImport(raw: []const u8, file_path: []const u8, allocator: std.mem.
 }
 
 fn containsAny(s: []const u8, needles: []const []const u8) bool {
-    for (needles) |needle| {
-        if (std.mem.indexOf(u8, s, needle) != null) return true;
-    }
+    for (needles) |needle| if (std.mem.indexOf(u8, s, needle) != null) return true;
     return false;
 }
 
@@ -6484,9 +6472,7 @@ fn isSpecialEntryPoint(filename: []const u8) bool {
         "Makefile",     "build.zig",   "Cargo.toml",
         "package.json",
     };
-    for (specials) |s| {
-        if (std.mem.eql(u8, filename, s)) return true;
-    }
+    for (specials) |s| if (std.mem.eql(u8, filename, s)) return true;
     return false;
 }
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3210,6 +3210,20 @@ pub const Explorer = struct {
     }
 
     pub fn searchContentRanked(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
+        // #546: BM25 reads the word index's id_to_path + ranked-doc table, which a
+        // mmap/disk-loaded index lacks until rebuilt (word_index_complete = false).
+        // The recall readers (searchContent, searchWord, renderWord) already trigger
+        // this lazy rebuild; searchContentRanked did not — so ranked search returned
+        // nothing on a cold CLI / freshly-loaded snapshot (the index served `word`,
+        // but here N collapsed to 0). Rebuild before the shared lock, matching the
+        // siblings — rebuildWordIndex takes the exclusive lock.
+        if (max_results > 0) {
+            self.mu.lockShared();
+            const needs_rebuild = !self.word_index_complete and
+                (self.contents.len() > 0 or (self.io != null and self.root_dir != null));
+            self.mu.unlockShared();
+            if (needs_rebuild) try self.rebuildWordIndex();
+        }
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -3408,6 +3422,21 @@ pub const Explorer = struct {
         }
 
         return result_list.toOwnedSlice(allocator);
+    }
+
+    /// Query-shape-aware search shared by the CLI (`runQuery`, used by both the
+    /// cold path and the warm cli-daemon) and the MCP `search` handler so the two
+    /// rank identically. A multi-word query expresses conceptual/NL intent and
+    /// routes to BM25 + centrality (`searchContentRanked`); a single token keeps
+    /// literal substring matching (`searchContent`) so exact-identifier lookups
+    /// still work. #546: the CLI path previously always called the unranked
+    /// `searchContent`, so multi-word CLI/daemon searches never reached the ranker.
+    pub fn searchContentAuto(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
+        const multiword = std.mem.indexOfScalar(u8, query, ' ') != null;
+        return if (multiword)
+            self.searchContentRanked(query, allocator, max_results)
+        else
+            self.searchContent(query, allocator, max_results);
     }
 
     /// Search file contents using a regex pattern with trigram acceleration.

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3551,7 +3551,75 @@ pub const Explorer = struct {
 
         self.mu.lockShared();
         defer self.mu.unlockShared();
+        // #569: a multi-word query can never be a single index token — fall back
+        // to per-token matching so phrase-shaped queries don't silently dead-end.
+        if (std.mem.indexOfScalar(u8, word, ' ') != null) {
+            return self.searchWordTokensLocked(word, allocator);
+        }
         return self.word_index.searchDeduped(word, allocator);
+    }
+
+    /// Per-token fallback for a whitespace-separated query (#569): each distinct
+    /// token is looked up in the word index and files are ranked by how many
+    /// distinct tokens they hit, then total hits, then path. Returns one
+    /// representative hit (lowest matching line) per file, allocated for the
+    /// caller. Caller must hold the shared lock.
+    fn searchWordTokensLocked(self: *Explorer, query: []const u8, allocator: std.mem.Allocator) ![]const idx.WordHit {
+        var scratch = std.heap.ArenaAllocator.init(allocator);
+        defer scratch.deinit();
+        const sa = scratch.allocator();
+
+        const Agg = struct { distinct: u32, total: u32, line: u32, last_token: u32 };
+        var per_doc = U32HashMap(Agg).init(sa);
+
+        var seen_tokens = std.StringHashMap(void).init(sa);
+        var token_serial: u32 = 0;
+        var tok = idx.WordTokenizer{ .buf = query };
+        while (tok.next()) |raw| {
+            if (raw.len < 2) continue;
+            const lower = try sa.alloc(u8, raw.len);
+            for (raw, 0..) |c, i| lower[i] = idx.normalizeChar(c);
+            const tok_gop = try seen_tokens.getOrPut(lower);
+            if (tok_gop.found_existing) continue;
+            token_serial += 1;
+            for (self.word_index.search(lower)) |h| {
+                const gop = try per_doc.getOrPut(h.doc_id);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = .{ .distinct = 1, .total = 1, .line = h.line_num, .last_token = token_serial };
+                } else {
+                    gop.value_ptr.total += 1;
+                    if (gop.value_ptr.last_token != token_serial) {
+                        gop.value_ptr.distinct += 1;
+                        gop.value_ptr.last_token = token_serial;
+                    }
+                    if (h.line_num < gop.value_ptr.line) gop.value_ptr.line = h.line_num;
+                }
+            }
+        }
+        if (per_doc.count() == 0) return try allocator.alloc(idx.WordHit, 0);
+
+        const Ranked = struct { doc_id: u32, distinct: u32, total: u32, line: u32 };
+        const ranked = try sa.alloc(Ranked, per_doc.count());
+        var it = per_doc.iterator();
+        var n: usize = 0;
+        while (it.next()) |e| : (n += 1) {
+            ranked[n] = .{ .doc_id = e.key_ptr.*, .distinct = e.value_ptr.distinct, .total = e.value_ptr.total, .line = e.value_ptr.line };
+        }
+        const SortCtx = struct {
+            wi: *const idx.WordIndex,
+            fn lessThan(ctx: @This(), a: Ranked, b: Ranked) bool {
+                if (a.distinct != b.distinct) return a.distinct > b.distinct;
+                if (a.total != b.total) return a.total > b.total;
+                const pa = ctx.wi.hitPath(.{ .doc_id = a.doc_id, .line_num = 0 });
+                const pb = ctx.wi.hitPath(.{ .doc_id = b.doc_id, .line_num = 0 });
+                return std.mem.lessThan(u8, pa, pb);
+            }
+        };
+        std.mem.sort(Ranked, ranked, SortCtx{ .wi = &self.word_index }, SortCtx.lessThan);
+
+        const out_hits = try allocator.alloc(idx.WordHit, ranked.len);
+        for (ranked, 0..) |r, i| out_hits[i] = .{ .doc_id = r.doc_id, .line_num = r.line };
+        return out_hits;
     }
 
     /// Format a word-index lookup directly from the posting list. The indexer
@@ -3568,6 +3636,20 @@ pub const Explorer = struct {
 
         self.mu.lockShared();
         defer self.mu.unlockShared();
+
+        // #569: multi-word queries fall back to per-token matching — one line
+        // per file, files hitting more distinct tokens first.
+        if (std.mem.indexOfScalar(u8, word, ' ') != null) {
+            const hits = try self.searchWordTokensLocked(word, allocator);
+            defer allocator.free(hits);
+            try out.ensureUnusedCapacity(allocator, 64 + hits.len * 48);
+            const w = cio.listWriter(out, allocator);
+            try w.print("{d} hits for '{s}' (tokenized):\n", .{ hits.len, word });
+            for (hits) |h| {
+                try w.print("  {s}:{d}\n", .{ self.word_index.hitPath(h), h.line_num });
+            }
+            return;
+        }
 
         const hits = self.word_index.search(word);
         try out.ensureUnusedCapacity(allocator, 64 + hits.len * 48);

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -328,6 +328,10 @@ pub const DependencyGraph = struct {
     }
 
     pub fn getImportedBy(self: *const DependencyGraph, path: []const u8, allocator: std.mem.Allocator) ![]const []const u8 {
+        return self.getImportedByFiltered(path, allocator, true);
+    }
+
+    pub fn getImportedByFiltered(self: *const DependencyGraph, path: []const u8, allocator: std.mem.Allocator, allow_basename: bool) ![]const []const u8 {
         // Extract basename for matching (e.g., "src/store.zig" -> "store.zig")
         const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
 
@@ -346,8 +350,10 @@ pub const DependencyGraph = struct {
             }
         }
 
-        // Also check basename match (imports often use short names)
-        if (!std.mem.eql(u8, path, basename)) {
+        // Basename fallback (imports often use short names). Skipped when the basename is
+        // ambiguous across indexed files (allow_basename=false): a bare `import conf`
+        // can't be attributed to a specific same-basename file (a/conf.py vs b/conf.py).
+        if (allow_basename and !std.mem.eql(u8, path, basename)) {
             if (self.reverse.get(basename)) |rev_set| {
                 var rev_iter = rev_set.keyIterator();
                 while (rev_iter.next()) |key_ptr| {
@@ -1688,7 +1694,7 @@ pub const Explorer = struct {
         }
         const io = self.io orelse return null;
         const dir = self.root_dir orelse std.Io.Dir.cwd();
-        const data = dir.readFileAlloc(io, path, allocator, .limited(512 * 1024)) catch return null;
+        const data = dir.readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
         return .{ .data = data, .owned = true, .allocator = allocator };
     }
 
@@ -2452,9 +2458,6 @@ pub const Explorer = struct {
                 breakdown.tier0_ns = cio.nanoTimestamp() - t0_start;
                 breakdown.tier_reached = 0;
                 breakdown.result_count = @intCast(result_list.items.len);
-                if (use_line_hits) {
-                    return result_list.toOwnedSlice(allocator);
-                }
                 const t_rerank = cio.nanoTimestamp();
                 const res = self.rerankAndFinalize(&result_list, query, allocator);
                 breakdown.rerank_ns = cio.nanoTimestamp() - t_rerank;
@@ -2678,14 +2681,41 @@ pub const Explorer = struct {
         if (tier0_files_len == 0) return false;
         const tier0_files = tier0_files_buf[0..tier0_files_len];
         if (tier0_files.len > 1) {
-            std.sort.block(Tier0File, tier0_files, {}, struct {
-                pub fn lessThan(_: void, a: Tier0File, b: Tier0File) bool {
+            const RankCtx = struct {
+                query: []const u8,
+                // Path-prior portion of rerankSignalScore: the canonical-file signals
+                // (basename-stem match, path segment) and demotion penalties. Without it
+                // this fast-path rendered in raw hit-count order, so a high-frequency
+                // non-canonical file outranked the canonical basename match.
+                fn prior(path: []const u8, q: []const u8) f32 {
+                    const base = std.fs.path.basename(path);
+                    const stem_end = std.mem.indexOfScalar(u8, base, '.') orelse base.len;
+                    const stem = base[0..stem_end];
+                    var s: f32 = 0;
+                    if (asciiEqlIgnoreCase(stem, q)) {
+                        s += 15.0;
+                    } else if (asciiContainsIgnoreCase(stem, q) or asciiContainsIgnoreCase(q, stem)) {
+                        s += 8.0;
+                    } else if (pathHasSegmentIgnoreCase(path, q)) {
+                        s += 6.0;
+                    }
+                    if (pathHasSegment(path, "tests") or pathHasSegment(path, "test")) s *= 0.6;
+                    if (pathHasSegment(path, "examples") or pathHasSegment(path, "example")) s *= 0.6;
+                    if (pathHasSegment(path, "vendor") or pathHasSegment(path, "node_modules") or
+                        pathHasSegment(path, "third_party")) s *= 0.4;
+                    return s;
+                }
+                pub fn lessThan(ctx: @This(), a: Tier0File, b: Tier0File) bool {
+                    const pa = prior(a.path, ctx.query);
+                    const pb = prior(b.path, ctx.query);
+                    if (pa != pb) return pa > pb;
                     if (a.is_doc != b.is_doc) return !a.is_doc;
                     if (a.count != b.count) return a.count > b.count;
                     if (a.first_seen != b.first_seen) return a.first_seen < b.first_seen;
                     return std.mem.lessThan(u8, a.path, b.path);
                 }
-            }.lessThan);
+            };
+            std.sort.block(Tier0File, tier0_files, RankCtx{ .query = query }, RankCtx.lessThan);
         }
 
         const tier0_per_file_cap: usize = if (tier0_files.len <= 1) max_results else @max(1, max_results / 5);
@@ -3765,7 +3795,17 @@ pub const Explorer = struct {
     pub fn getImportedBy(self: *Explorer, path: []const u8, allocator: std.mem.Allocator) ![]const []const u8 {
         self.mu.lockShared();
         defer self.mu.unlockShared();
-        return self.dep_graph.getImportedBy(path, allocator);
+        // A bare import resolved only by basename is ambiguous when 2+ indexed files
+        // share that basename; disable the basename fallback in that case so it is not
+        // attributed to every same-basename file (e.g. a/conf.py and b/conf.py).
+        const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
+        var basename_count: usize = 0;
+        var it = self.outlines.keyIterator();
+        while (it.next()) |k| {
+            const kb = if (std.mem.lastIndexOfScalar(u8, k.*, '/')) |p| k.*[p + 1 ..] else k.*;
+            if (std.mem.eql(u8, kb, basename)) basename_count += 1;
+        }
+        return self.dep_graph.getImportedByFiltered(path, allocator, basename_count <= 1);
     }
 
     pub fn renderImportedBy(self: *Explorer, path: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8)) !struct { count: usize, known: bool } {
@@ -3967,24 +4007,22 @@ pub const Explorer = struct {
             }
         } else if (startsWith(line, "import ") or startsWith(line, "from ")) {
             try appendOutlineSymbol(a, outline, line, .import, line_num, null);
-            // Extract module path and convert dots to slashes for dep matching.
-            // "from mypackage.utils.helpers import X" → "mypackage/utils/helpers.py"
-            // "import os.path" → "os/path.py"
-            if (extractPythonModulePath(line)) |mod_path| {
-                var buf: [512]u8 = undefined;
-                var pos: usize = 0;
-                for (mod_path) |c| {
-                    if (pos >= buf.len - 3) break;
-                    buf[pos] = if (c == '.') '/' else c;
-                    pos += 1;
+            if (startsWith(line, "from ")) {
+                // "from mypackage.utils import X" -> mypackage/utils.py (single module dep)
+                if (extractPythonModulePath(line)) |mod_path| {
+                    try appendPythonModuleDep(a, outline, mod_path);
                 }
-                if (pos + 3 <= buf.len) {
-                    buf[pos] = '.';
-                    buf[pos + 1] = 'p';
-                    buf[pos + 2] = 'y';
-                    pos += 3;
+            } else {
+                // "import a, b.c, d as e" -- record one dep per comma-separated module.
+                const rest = std.mem.trimStart(u8, line[7..], " \t");
+                var it = std.mem.splitScalar(u8, rest, ',');
+                while (it.next()) |raw| {
+                    var mod = std.mem.trim(u8, raw, " \t");
+                    if (std.mem.indexOf(u8, mod, " as ")) |as_pos| mod = std.mem.trimEnd(u8, mod[0..as_pos], " \t");
+                    if (std.mem.indexOfScalar(u8, mod, ' ')) |sp| mod = mod[0..sp];
+                    if (mod.len == 0 or mod[0] == '.') continue;
+                    try appendPythonModuleDep(a, outline, mod);
                 }
-                try appendImportPath(a, outline, buf[0..pos]);
             }
         }
     }
@@ -5829,6 +5867,9 @@ fn parseDelimitedImport(line: []const u8, prefix: []const u8, delimiter: []const
     if (delimiter.len > 0) {
         if (std.mem.indexOf(u8, body, delimiter)) |end| body = body[0..end];
     }
+    // Strip a trailing `as <alias>` (Kotlin/Swift aliased import: `import X as Y`) so the
+    // dep key is the imported path X, not "X as Y".
+    if (std.mem.indexOf(u8, body, " as ")) |as_pos| body = body[0..as_pos];
     body = std.mem.trim(u8, body, " \t;");
     return if (body.len > 0) body else null;
 }
@@ -6460,7 +6501,7 @@ fn extractPythonModulePath(line: []const u8) ?[]const u8 {
         const rest = std.mem.trimStart(u8, line[5..], " \t");
         // Skip relative imports (start with dot)
         if (rest.len > 0 and rest[0] == '.') return null;
-        // "from module.path import ..." — extract up to " import"
+        // "from module.path import ..." -- extract up to " import"
         if (std.mem.indexOf(u8, rest, " import")) |imp_pos| {
             const mod = std.mem.trimEnd(u8, rest[0..imp_pos], " \t");
             if (mod.len > 0) return mod;
@@ -6468,13 +6509,33 @@ fn extractPythonModulePath(line: []const u8) ?[]const u8 {
         return null;
     } else if (startsWith(line, "import ")) {
         const rest = std.mem.trimStart(u8, line[7..], " \t");
-        // "import os.path" or "import foo" — take up to comma or space
+        // "import os.path" or "import foo" -- take up to comma or space
         var end: usize = 0;
         while (end < rest.len and rest[end] != ' ' and rest[end] != ',' and rest[end] != '\t') : (end += 1) {}
         if (end > 0) return rest[0..end];
         return null;
     }
     return null;
+}
+
+// Convert a Python module path (`os.path`, `mypackage.utils`) to a repo-style dep key
+// (`os/path.py`) and record it on the outline. Shared by the `from` branch and the
+// comma-split `import a, b` branch in parsePythonLine.
+fn appendPythonModuleDep(a: std.mem.Allocator, outline: *FileOutline, mod_path: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    var pos: usize = 0;
+    for (mod_path) |c| {
+        if (pos >= buf.len - 3) break;
+        buf[pos] = if (c == '.') '/' else c;
+        pos += 1;
+    }
+    if (pos + 3 <= buf.len) {
+        buf[pos] = '.';
+        buf[pos + 1] = 'p';
+        buf[pos + 2] = 'y';
+        pos += 3;
+    }
+    try appendImportPath(a, outline, buf[0..pos]);
 }
 
 // ── Fuzzy file matching ─────────────────────────────────────────

--- a/src/main.zig
+++ b/src/main.zig
@@ -678,9 +678,7 @@ fn cliWriteFull(fd: c_int, data: []const u8) bool {
 /// only by the cold path.
 fn cliIsQueryCmd(cmd: []const u8) bool {
     const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes" };
-    for (cmds) |c| {
-        if (std.mem.eql(u8, cmd, c)) return true;
-    }
+    for (cmds) |c| if (std.mem.eql(u8, cmd, c)) return true;
     return false;
 }
 
@@ -1948,9 +1946,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 
 fn isCommand(arg: []const u8) bool {
     const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
-    for (commands) |c| {
-        if (std.mem.eql(u8, arg, c)) return true;
-    }
+    for (commands) |c| if (std.mem.eql(u8, arg, c)) return true;
     return false;
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1264,8 +1264,19 @@ fn mainImpl() !void {
             // For search: single-pass scan + trigram build (no re-reading files).
             // For other commands: outline-only scan, trigrams from disk or rebuild.
             const is_search = std.mem.eql(u8, cmd, "search");
+            // #546: a multi-word query ranks via BM25, which rebuilds the word index
+            // from in-memory outlines/contents — the trigram-only fast scan commits
+            // neither, so the first-ever cold multi-word search ranked over an empty
+            // index and returned nothing. Route it through the full single-pass scan
+            // (outlines + contents + trigrams); single-token and --regex searches
+            // keep the trigram-only fast path.
+            const search_skips_outlines = blk: {
+                if (!is_search) break :blk true;
+                const sa = parseSearchArgs(args, cmd_args_start) catch break :blk true;
+                break :blk sa.use_regex or std.mem.indexOfScalar(u8, sa.query, ' ') == null;
+            };
             if (is_search and !heads_match) {
-                const tmp_tri = try watcher.initialScanWithTrigrams(io, &store, &explorer, root, allocator, std.heap.c_allocator, true);
+                const tmp_tri = try watcher.initialScanWithTrigrams(io, &store, &explorer, root, allocator, std.heap.c_allocator, search_skips_outlines);
                 if (tmp_tri) |tri| {
                     tri.writeToDisk(io, data_dir, git_head) catch {};
                     tri.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -290,7 +290,7 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
                 return 1;
             }
         else
-            explorer.searchContent(query, allocator, sa.max_results) catch return 1;
+            explorer.searchContentAuto(query, allocator, sa.max_results) catch return 1;
         defer {
             for (results) |r| {
                 allocator.free(r.path);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2654,6 +2654,7 @@ fn handleDeps(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
             };
             if (rendered.count == 0) {
                 w.writeAll("  (none)\n") catch {};
+                w.writeAll("(0 files)\n") catch {};
                 if (!rendered.known) appendFuzzyPathSuggestions(alloc, out, explorer, path);
             } else {
                 w.print("({d} files)\n", .{rendered.count}) catch {};
@@ -2682,6 +2683,9 @@ fn handleDeps(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *s
     }
     if (results.len == 0) {
         w.writeAll("  (none)\n") catch {};
+        // #568: empty lists must keep the '(N files)' summary so machine
+        // consumers never have to special-case the '(none)' sentinel.
+        w.writeAll("(0 files)\n") catch {};
         // Bug 4: if the path isn't indexed at all, agents read "(none)" as
         // "file exists but no callers" — which is wrong. Append fuzzy
         // suggestions so a typo is recoverable in one shot.
@@ -2706,6 +2710,7 @@ fn handleDepsPathOnly(alloc: std.mem.Allocator, path: []const u8, out: *std.Arra
     };
     if (rendered.count == 0) {
         w.writeAll("  (none)\n") catch {};
+        w.writeAll("(0 files)\n") catch {};
         if (!rendered.known) appendFuzzyPathSuggestions(alloc, out, explorer, path);
     } else {
         w.print("({d} files)\n", .{rendered.count}) catch {};

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -4401,6 +4401,11 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
 
     var file_set: std.ArrayList([]const u8) = .empty;
     defer file_set.deinit(alloc);
+    // Strings the deps op appends to file_set must outlive the per-file deps_result
+    // (freed each iteration); own them in a scoped arena freed at pipeline end.
+    var deps_arena = std.heap.ArenaAllocator.init(alloc);
+    defer deps_arena.deinit();
+    const deps_alloc = deps_arena.allocator();
     var have_set = false;
     const w = cio.listWriter(out, alloc);
 
@@ -4534,12 +4539,11 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
             // Accepts optional 'path' for standalone use without a prior seeding step.
             if (!have_set) {
                 if (getStr(step, "path")) |p| {
-                    const duped = alloc.dupe(u8, p) catch {
+                    const duped = deps_alloc.dupe(u8, p) catch {
                         w.print("error: out of memory\n", .{}) catch {};
                         return;
                     };
                     file_set.append(alloc, duped) catch {
-                        alloc.free(duped);
                         w.print("error: out of memory\n", .{}) catch {};
                         return;
                     };
@@ -4601,8 +4605,11 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
 
                 for (deps_result) |dep| {
                     if (!expanded.contains(dep)) {
-                        expanded.put(dep, {}) catch {};
-                        file_set.append(alloc, dep) catch {};
+                        // Own the string in the deps arena so it outlives deps_result
+                        // (freed by the defer above) once stored in file_set / expanded.
+                        const owned = deps_alloc.dupe(u8, dep) catch continue;
+                        expanded.put(owned, {}) catch {};
+                        file_set.append(alloc, owned) catch {};
                     }
                 }
             }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3397,9 +3397,7 @@ fn isRemoteRepoChar(c: u8) bool {
 fn isRemoteRepoPart(part: []const u8) bool {
     if (part.len == 0) return false;
     if (std.mem.eql(u8, part, ".") or std.mem.eql(u8, part, "..")) return false;
-    for (part) |c| {
-        if (!isRemoteRepoChar(c)) return false;
-    }
+    for (part) |c| if (!isRemoteRepoChar(c)) return false;
     return true;
 }
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1782,20 +1782,16 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             if (rendered) return;
         }
 
-        // Multi-word queries express natural-language / conceptual intent —
-        // rank them by BM25 (relevance) instead of raw substring order, which
-        // returns nothing for a phrase. Single-token queries keep literal
-        // substring matching so exact-identifier lookups still work.
-        const multiword = std.mem.indexOfScalar(u8, query, ' ') != null;
+        // Query-shape-aware routing lives in Explorer.searchContentAuto so the CLI
+        // (`runQuery`) and this MCP handler rank identically (#546): a multi-word
+        // query goes to BM25 + centrality, a single token keeps literal substring
+        // matching so exact-identifier lookups still work.
         // Over-fetch by `offset` (+1) so we can page into a stable window and
-        // detect whether more results exist beyond this page. BM25 ranking is
+        // detect whether more results exist beyond this page. Ranking is
         // deterministic per query, so the offset is a stable, stateless cursor.
         const want_count = @min(offset_n + max_results + 1, 100000);
         var fetch_count = want_count;
-        var fetched = (if (multiword)
-            explorer.searchContentRanked(query, alloc, fetch_count)
-        else
-            explorer.searchContent(query, alloc, fetch_count)) catch {
+        var fetched = explorer.searchContentAuto(query, alloc, fetch_count) catch {
             out.appendSlice(alloc, "error: search failed") catch {};
             return;
         };
@@ -1818,10 +1814,7 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
                     alloc.free(r.path);
                 }
                 alloc.free(fetched);
-                fetched = (if (multiword)
-                    explorer.searchContentRanked(query, alloc, fetch_count)
-                else
-                    explorer.searchContent(query, alloc, fetch_count)) catch {
+                fetched = explorer.searchContentAuto(query, alloc, fetch_count) catch {
                     out.appendSlice(alloc, "error: search failed") catch {};
                     return;
                 };

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -726,7 +726,7 @@ fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem
         const import_count = try readSectionInt(u32, bytes, &cursor);
         try outline.imports.ensureTotalCapacity(allocator, import_count);
         for (0..import_count) |_| {
-            const imp = try readSectionStringBorrowed(bytes, &cursor, 4096);
+            const imp = try readSectionStringBorrowed(bytes, &cursor, std.math.maxInt(u16));
             outline.imports.appendAssumeCapacity(imp);
         }
 
@@ -1302,50 +1302,46 @@ fn parseJsonU64(json: []const u8, key: []const u8) ?u64 {
 /// the two are parity-tested in test_snapshot.zig ("issue-528: isSensitivePath
 /// parity") so any future drift in this security filter fails CI.
 pub fn isSensitivePath(path: []const u8) bool {
-    const sensitive_names = [_][]const u8{
-        ".env",
-        ".env.local",
-        ".env.production",
-        ".env.development",
-        ".env.staging",
-        ".env.test",
-        ".dev.vars",
-        "credentials.json",
-        "service-account.json",
-        "secrets.json",
-        "secrets.yaml",
-        "secrets.yml",
-        ".npmrc",
-        ".pypirc",
-        ".netrc",
-        "id_rsa",
-        "id_ed25519",
-        ".pem",
-    };
-
-    // Check exact filename (basename)
     const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
-
+    // Fast path: most source files have extensions like .zig, .ts, .py — none start with '.'
+    // or match sensitive patterns. Skip the full check for common cases.
+    if (basename.len == 0) return false;
+    const first = basename[0];
+    // Only check sensitive names if basename starts with '.', 'c', 's', 'i' or has key/cert extension
+    if (first != '.' and first != 'c' and first != 's' and first != 'i') {
+        // Still need to check extensions and directory patterns
+        if (std.mem.endsWith(u8, basename, ".env") or
+            std.mem.endsWith(u8, basename, ".pem") or
+            std.mem.endsWith(u8, basename, ".key") or
+            std.mem.endsWith(u8, basename, ".p12") or
+            std.mem.endsWith(u8, basename, ".pfx") or
+            std.mem.endsWith(u8, basename, ".jks")) return true;
+        if (std.mem.indexOf(u8, path, ".ssh/") != null or
+            std.mem.indexOf(u8, path, ".gnupg/") != null or
+            std.mem.indexOf(u8, path, ".aws/") != null) return true;
+        return false;
+    }
+    // .env, .env.<token>; do NOT match .envoy, .envrc, .environment, etc.
+    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
+        (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
+    // Exact matches
+    const sensitive_names = [_][]const u8{
+        ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
+        "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
+        "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
+    };
     for (sensitive_names) |name| {
         if (std.mem.eql(u8, basename, name)) return true;
     }
-
-    // Catch .env, .env.anything; do NOT match .envoy, .envrc, .environment, etc.
-    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
-        (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
-
-    // Check extensions
-    if (endsWith(basename, ".pem")) return true;
-    if (endsWith(basename, ".key")) return true;
-    if (endsWith(basename, ".p12")) return true;
-    if (endsWith(basename, ".pfx")) return true;
-    if (endsWith(basename, ".jks")) return true;
-
-    // Check directory patterns
-    if (std.mem.indexOf(u8, path, ".ssh/") != null) return true;
-    if (std.mem.indexOf(u8, path, ".gnupg/") != null) return true;
-    if (std.mem.indexOf(u8, path, ".aws/") != null) return true;
-
+    if (std.mem.endsWith(u8, basename, ".env") or
+        std.mem.endsWith(u8, basename, ".pem") or
+        std.mem.endsWith(u8, basename, ".key") or
+        std.mem.endsWith(u8, basename, ".p12") or
+        std.mem.endsWith(u8, basename, ".pfx") or
+        std.mem.endsWith(u8, basename, ".jks")) return true;
+    if (std.mem.indexOf(u8, path, ".ssh/") != null or
+        std.mem.indexOf(u8, path, ".gnupg/") != null or
+        std.mem.indexOf(u8, path, ".aws/") != null) return true;
     return false;
 }
 fn endsWith(s: []const u8, suffix: []const u8) bool {

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2234,3 +2234,40 @@ test "issue-531: searchSymbols fuzzy match" {
     try testing.expect(results.len >= 1);
     try testing.expectEqualStrings("ensureCallGraph", results[0].symbol.name);
 }
+
+// ─── audit (2026-06-09): latent-issue sweep — call-graph phantom edges ───
+// src/codegraph.zig extractCallees paired every '(' with the preceding identifier with
+// no comment/string stripping, so a name mentioned only in a // comment surfaced as a
+// real resolved callee in codedb_context (#548 family, for the call graph).
+test "audit: comment-only mention is not a resolved callee" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var exp = Explorer.init(a, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try exp.indexFile("util.zig", "pub fn uniqueHelper() void {}\n");
+    try exp.indexFile("caller.zig",
+        \\pub fn caller() void {
+        \\    // see uniqueHelper() for details
+        \\}
+        \\
+    );
+    const callees = try exp.resolveCallees("caller.zig", 1, 3, a, 8);
+    for (callees) |c| try testing.expect(!std.mem.eql(u8, c.name, "uniqueHelper"));
+}
+
+test "audit: extractCallees ignores comment/string mentions" {
+    const body =
+        \\    realCall(x);
+        \\    // ghostFn() lives only in this comment
+        \\    log("please stringOnlyFn() here");
+    ;
+    const callees = try codegraph.extractCallees(testing.allocator, body);
+    defer testing.allocator.free(callees);
+    var saw_real = false;
+    for (callees) |c| {
+        if (std.mem.eql(u8, c, "realCall")) saw_real = true;
+        try testing.expect(!std.mem.eql(u8, c, "ghostFn"));
+        try testing.expect(!std.mem.eql(u8, c, "stringOnlyFn"));
+    }
+    try testing.expect(saw_real); // real call in code is still captured
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2076,3 +2076,47 @@ test "audit: isSensitivePath blocks *.env suffix files and .git-credentials" {
     try testing.expect(!watcher.isSensitivePath("main.zig"));
     try testing.expect(!watcher.isSensitivePath("environment.ts"));
 }
+
+// ─── #568: empty deps lists print '(none)' with no '(N files)' summary ───
+// Non-empty lists end with a '(N files)' summary; empty lists printed a body
+// line '  (none)' and no summary, so machine consumers that parse the list
+// body saw one entry (engram counted in-degree 1 for every zero-importer
+// file). The summary line must be present unconditionally.
+test "issue-568: deps empty list prints a (0 files) summary" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/lone.zig", "pub fn lonely() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    // imported_by (default): nothing imports src/lone.zig.
+    const rev_json =
+        \\{"path":"src/lone.zig"}
+    ;
+    const rev_parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, rev_json, .{});
+    defer rev_parsed.deinit();
+    var rev_out: std.ArrayList(u8) = .empty;
+    defer rev_out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_deps, &rev_parsed.value.object, &rev_out, &store, &explorer, &agents);
+    try testing.expect(std.mem.indexOf(u8, rev_out.items, "(none)") != null);
+    try testing.expect(std.mem.indexOf(u8, rev_out.items, "(0 files)") != null);
+
+    // depends_on: src/lone.zig imports nothing.
+    const fwd_json =
+        \\{"path":"src/lone.zig","direction":"depends_on"}
+    ;
+    const fwd_parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, fwd_json, .{});
+    defer fwd_parsed.deinit();
+    var fwd_out: std.ArrayList(u8) = .empty;
+    defer fwd_out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_deps, &fwd_parsed.value.object, &fwd_out, &store, &explorer, &agents);
+    try testing.expect(std.mem.indexOf(u8, fwd_out.items, "(none)") != null);
+    try testing.expect(std.mem.indexOf(u8, fwd_out.items, "(0 files)") != null);
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -25,7 +25,6 @@ comptime {
     _ = @import("config.zig");
 }
 
-
 fn buildCliForHelpTests() !void {
     const build = try cio.runCapture(.{
         .allocator = testing.allocator,
@@ -38,7 +37,6 @@ fn buildCliForHelpTests() !void {
     try testing.expect(build.term == .Exited);
     try testing.expect(build.term.Exited == 0);
 }
-
 
 test "issue-59: telemetry writes session, tool, and codebase stats ndjson" {
     var tmp = testing.tmpDir(.{});
@@ -79,7 +77,6 @@ test "issue-59: telemetry writes session, tool, and codebase stats ndjson" {
     try testing.expect(std.mem.indexOf(u8, contents, "\"languages\":[\"zig\",\"python\"]") != null);
 }
 
-
 test "issue-60: telemetry disabled path is a no-op" {
     var telem = telemetry_mod.Telemetry.init(io, "/tmp", testing.allocator, true);
     defer telem.deinit();
@@ -90,7 +87,6 @@ test "issue-60: telemetry disabled path is a no-op" {
     try testing.expect(telem.file == null);
     try testing.expect(telem.head.load(.monotonic) == 0);
 }
-
 
 test "issue-77: mcp index accepts temporary-directory roots that cause pathological cache growth" {
     var tmp_name_buf: [128]u8 = undefined;
@@ -123,7 +119,6 @@ test "issue-77: mcp index accepts temporary-directory roots that cause pathologi
     try testing.expect(result.term.Exited != 0);
 }
 
-
 test "issue-93: isSensitivePath blocks .env and credentials" {
     try testing.expect(watcher.isSensitivePath(".env"));
     try testing.expect(watcher.isSensitivePath(".env.local"));
@@ -145,7 +140,6 @@ test "issue-93: isSensitivePath blocks .env and credentials" {
     try testing.expect(!watcher.isSensitivePath("package.json"));
 }
 
-
 test "issue-93: isPathSafe blocks traversal" {
     const MCP = @import("mcp.zig");
     try testing.expect(!MCP.isPathSafe("../../../etc/passwd"));
@@ -154,7 +148,6 @@ test "issue-93: isPathSafe blocks traversal" {
     try testing.expect(MCP.isPathSafe("src/main.zig"));
     try testing.expect(MCP.isPathSafe("README.md"));
 }
-
 
 test "auto-update: shouldRunAutoUpdate gates correctly" {
     const day_ms: i64 = 24 * 60 * 60 * 1000;
@@ -177,7 +170,6 @@ test "auto-update: shouldRunAutoUpdate gates correctly" {
     try testing.expect(update_mod.shouldRunAutoUpdate(day_ms * 7, 0, false));
 }
 
-
 test "issue-394: shouldRunAutoUpdate permanently blocked by future-timestamp stamp file" {
     // Reproduces the case where the stamp file contains a timestamp in the
     // future relative to the wall clock — for example, after an NTP clock
@@ -197,7 +189,6 @@ test "issue-394: shouldRunAutoUpdate permanently blocked by future-timestamp sta
 
     try testing.expect(update_mod.shouldRunAutoUpdate(now_ms, future_last_ms, false));
 }
-
 
 test "issue-395: shouldRunAutoUpdate panics on i64 underflow when stamp is corrupt" {
     // Reproduces a panic when ~/.codedb/last_auto_update_check is corrupt
@@ -224,7 +215,6 @@ test "issue-395: shouldRunAutoUpdate panics on i64 underflow when stamp is corru
     try testing.expect(update_mod.shouldRunAutoUpdate(now_ms, last_ms, false));
 }
 
-
 test "issue-150: --help prints usage" {
     try buildCliForHelpTests();
 
@@ -246,7 +236,6 @@ test "issue-150: --help prints usage" {
         std.mem.indexOf(u8, result.stderr, "nuke") != null);
 }
 
-
 test "issue-150: -h prints usage" {
     try buildCliForHelpTests();
 
@@ -264,7 +253,6 @@ test "issue-150: -h prints usage" {
         std.mem.indexOf(u8, result.stderr, "usage:") != null);
 }
 
-
 test "update: compareVersions orders semantic versions" {
     try testing.expect(try update_mod.compareVersions("0.2.55", "0.2.56") == .lt);
     try testing.expect(try update_mod.compareVersions("0.2.56", "0.2.56") == .eq);
@@ -281,7 +269,6 @@ test "update: compareVersionsForUpdate allows superseded release train typo" {
     try testing.expect(!try update_mod.targetSupersedesCurrent("0.2.5823", "0.2.5824"));
 }
 
-
 test "update: checksumForBinary parses release manifest" {
     const manifest =
         \\7be38140d090b2e23723c8cde02be150171c818daa16b18c520b44cc1e078add  codedb-darwin-arm64
@@ -296,7 +283,6 @@ test "update: checksumForBinary parses release manifest" {
     try testing.expect(update_mod.checksumForBinary(manifest, "codedb-linux-x86_64") == null);
 }
 
-
 test "update: asset names match published release naming" {
     try testing.expectEqualStrings("codedb-darwin-arm64", update_mod.assetNameForTarget(.macos, .aarch64).?);
     try testing.expectEqualStrings("codedb-darwin-x86_64", update_mod.assetNameForTarget(.macos, .x86_64).?);
@@ -304,7 +290,6 @@ test "update: asset names match published release naming" {
     try testing.expectEqualStrings("codedb-linux-x86_64", update_mod.assetNameForTarget(.linux, .x86_64).?);
     try testing.expect(update_mod.assetNameForTarget(.windows, .x86_64) == null);
 }
-
 
 test "nuke: commandTargetsBinary only matches the current install path" {
     try testing.expect(nuke_mod.commandTargetsBinary(
@@ -320,7 +305,6 @@ test "nuke: commandTargetsBinary only matches the current install path" {
         "/tmp/codedb-test/bin/codedb",
     ));
 }
-
 
 test "nuke: removeJsonMcpServerEntry drops only codedb integration" {
     const input =
@@ -342,7 +326,6 @@ test "nuke: removeJsonMcpServerEntry drops only codedb integration" {
     try testing.expect(std.mem.indexOf(u8, output, "\"theme\"") != null);
 }
 
-
 test "nuke: removeJsonMcpServerEntry removes empty mcpServers object" {
     const input =
         \\{
@@ -361,7 +344,6 @@ test "nuke: removeJsonMcpServerEntry removes empty mcpServers object" {
     try testing.expect(std.mem.indexOf(u8, output, "\"mcpServers\"") == null);
     try testing.expect(std.mem.indexOf(u8, output, "\"theme\"") != null);
 }
-
 
 test "nuke: removeCodexMcpServerBlock removes codedb block only" {
     const input =
@@ -384,7 +366,6 @@ test "nuke: removeCodexMcpServerBlock removes codedb block only" {
     try testing.expect(std.mem.indexOf(u8, output, "command = \"other\"") != null);
 }
 
-
 test "nuke: removeCodexMcpServerBlock matches indented header with inline comment" {
     const input =
         \\  [mcp_servers.codedb] # local override
@@ -403,7 +384,6 @@ test "nuke: removeCodexMcpServerBlock matches indented header with inline commen
     try testing.expect(std.mem.indexOf(u8, output, "codedb") == null);
     try testing.expect(std.mem.indexOf(u8, output, "[mcp_servers.other]") != null);
 }
-
 
 test "nuke: deregisterJsonIntegrationFile handles configs larger than 64 KiB" {
     var tmp = testing.tmpDir(.{});
@@ -439,12 +419,10 @@ test "nuke: deregisterJsonIntegrationFile handles configs larger than 64 KiB" {
     try testing.expect(std.mem.indexOf(u8, rewritten, "\"padding\"") != null);
 }
 
-
 test "issue-148: dead MCP clients are polled every second" {
     const mcp = @import("mcp.zig");
     try testing.expectEqual(@as(u64, 1000), mcp.dead_client_poll_ms);
 }
-
 
 test "issue-148: POLLHUP detects closed pipe" {
     // Verify the polling infrastructure works for pipe-based transports
@@ -465,7 +443,6 @@ test "issue-148: POLLHUP detects closed pipe" {
     try testing.expect(n > 0);
     try testing.expect((fds[0].revents & std.posix.POLL.HUP) != 0);
 }
-
 
 test "issue-148: idle watchdog exits on shutdown signal" {
     // The watchdog should check shutdown every ~1s (not 30s)
@@ -500,7 +477,6 @@ test "issue-148: idle watchdog exits on shutdown signal" {
     }
 }
 
-
 test "issue-278: MCP tracks activity without using it as a transport timeout" {
     const mcp = @import("mcp.zig");
 
@@ -515,7 +491,6 @@ test "issue-278: MCP tracks activity without using it as a transport timeout" {
     const now = cio.milliTimestamp();
     try testing.expect(now - last < 1_000);
 }
-
 
 test "issue-278: MCP session may remain idle longer than old timeout" {
     const mcp = @import("mcp.zig");
@@ -535,7 +510,6 @@ test "issue-278: MCP session may remain idle longer than old timeout" {
     try testing.expect(now - last > old_idle_timeout_ms);
 }
 
-
 test "issue-148: open pipe does not trigger HUP" {
     const pipe = try cio.makePipe();
     defer _ = std.c.close(pipe[0]);
@@ -550,7 +524,6 @@ test "issue-148: open pipe does not trigger HUP" {
     const result = try std.posix.poll(&poll_fds, 0);
     try testing.expectEqual(@as(usize, 0), result);
 }
-
 
 test "issue-148: codedb mcp exits when stdin is closed" {
     // Integration test: spawn codedb mcp, close stdin, verify it exits
@@ -597,14 +570,12 @@ test "issue-148: codedb mcp exits when stdin is closed" {
     try testing.expect(elapsed < 5_000);
 }
 
-
 test "issue-249: nuke.removeJsonMcpServerEntry returns null when key absent" {
     // Verifies removeJsonMcpServerEntry does not signal a write when key is absent,
     // which ensures the non-atomic rewriteConfigFile path is never triggered unnecessarily.
     const result = try nuke_mod.removeJsonMcpServerEntry(testing.allocator, "{\"other\":1}", "codedb");
     try testing.expect(result == null);
 }
-
 
 test "issue-207: ScanState round-trips through atomic" {
     const initial = mcp_mod.getScanState();
@@ -623,14 +594,12 @@ test "issue-207: ScanState round-trips through atomic" {
     try testing.expectEqual(mcp_mod.ScanState.ready, mcp_mod.getScanState());
 }
 
-
 test "issue-207: ScanState.name covers all states" {
     try testing.expectEqualStrings("loading_snapshot", mcp_mod.ScanState.loading_snapshot.name());
     try testing.expectEqualStrings("walking", mcp_mod.ScanState.walking.name());
     try testing.expectEqualStrings("indexing", mcp_mod.ScanState.indexing.name());
     try testing.expectEqualStrings("ready", mcp_mod.ScanState.ready.name());
 }
-
 
 test "issue-346: root_policy rejects dangerous ambient cwd roots" {
     try testing.expect(!root_policy.isIndexableRoot("/"));
@@ -641,7 +610,6 @@ test "issue-346: root_policy rejects dangerous ambient cwd roots" {
     try testing.expect(!root_policy.isIndexableRoot("/opt"));
     try testing.expect(!root_policy.isIndexableRoot("/opt/homebrew"));
 }
-
 
 test "issue-357: bundle preserves nested 'arguments' for codedb_outline" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -677,7 +645,6 @@ test "issue-357: bundle preserves nested 'arguments' for codedb_outline" {
     try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "src/lib.zig") != null);
 }
-
 
 test "issue-357: bundle surfaces received keys when an op is missing required path" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -716,7 +683,6 @@ test "issue-357: bundle surfaces received keys when an op is missing required pa
     try testing.expect(std.mem.indexOf(u8, out.items, "file_path") != null);
 }
 
-
 test "issue-423: bundle emits 'received keys' exactly once per failing op" {
     // Regression: handler (handleSearch etc) appends the diagnostic, AND the
     // bundle dispatch loop also appends it — caller saw the line twice in a
@@ -753,7 +719,6 @@ test "issue-423: bundle emits 'received keys' exactly once per failing op" {
     }
     try testing.expectEqual(@as(usize, 1), count);
 }
-
 
 test "issue-367: openDataLog truncates orphan bytes from prior session" {
     var tmp_dir = testing.tmpDir(.{});
@@ -796,7 +761,6 @@ test "issue-367: openDataLog truncates orphan bytes from prior session" {
     try testing.expectEqualStrings(diff, buf[0..diff.len]);
 }
 
-
 test "issue-367-dx: tty summary surfaces received keys on missing-arg error" {
     const args_json =
         \\{"file_path":"src/main.zig","weird_key":"x"}
@@ -821,7 +785,6 @@ test "issue-367-dx: tty summary surfaces received keys on missing-arg error" {
     try testing.expect(std.mem.indexOf(u8, summary.items, "received") != null);
     try testing.expect(std.mem.indexOf(u8, summary.items, "file_path") != null);
 }
-
 
 test "issue-bug2: tool calls during scan-in-progress hint at scan state" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -852,7 +815,6 @@ test "issue-bug2: tool calls during scan-in-progress hint at scan state" {
     try testing.expect(std.mem.indexOf(u8, out.items, "0 results") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "scan still in progress") != null);
 }
-
 
 test "issue-378: search waits briefly for scan to reach ready instead of returning empty" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -894,7 +856,6 @@ test "issue-378: search waits briefly for scan to reach ready instead of returni
     try testing.expect(std.mem.indexOf(u8, out.items, "scan still in progress") == null);
 }
 
-
 test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
@@ -925,8 +886,7 @@ test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
     var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, dir_path, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
-    const args_json = try std.fmt.allocPrint(testing.allocator,
-        "{{\"path\":\"{s}\"}}", .{bin_rel});
+    const args_json = try std.fmt.allocPrint(testing.allocator, "{{\"path\":\"{s}\"}}", .{bin_rel});
     defer testing.allocator.free(args_json);
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
     defer parsed.deinit();
@@ -938,7 +898,6 @@ test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
     try testing.expect(std.mem.indexOf(u8, out.items, "binary file") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, &[_]u8{0}) == null);
 }
-
 
 test "issue-bug6: codedb_read errors when line_start > line_end" {
     var tmp_dir = testing.tmpDir(.{});
@@ -969,8 +928,7 @@ test "issue-bug6: codedb_read errors when line_start > line_end" {
     var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, dir_path, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
-    const args_json = try std.fmt.allocPrint(testing.allocator,
-        "{{\"path\":\"{s}\",\"line_start\":100,\"line_end\":10}}", .{rel});
+    const args_json = try std.fmt.allocPrint(testing.allocator, "{{\"path\":\"{s}\",\"line_start\":100,\"line_end\":10}}", .{rel});
     defer testing.allocator.free(args_json);
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
     defer parsed.deinit();
@@ -982,7 +940,6 @@ test "issue-bug6: codedb_read errors when line_start > line_end" {
     try testing.expect(std.mem.startsWith(u8, out.items, "error:"));
     try testing.expect(std.mem.indexOf(u8, out.items, "line_start") != null);
 }
-
 
 test "issue-bug7: codedb_search rejects empty query" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -1008,7 +965,6 @@ test "issue-bug7: codedb_search rejects empty query" {
     try testing.expect(std.mem.indexOf(u8, out.items, "empty") != null);
 }
 
-
 test "issue-bug7: codedb_search rejects negative max_results" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -1033,7 +989,6 @@ test "issue-bug7: codedb_search rejects negative max_results" {
     try testing.expect(std.mem.indexOf(u8, out.items, "max_results") != null);
 }
 
-
 test "issue-bug11: codedb_bundle marks isError when all ops fail" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -1056,7 +1011,6 @@ test "issue-bug11: codedb_bundle marks isError when all ops fail" {
 
     try testing.expect(std.mem.startsWith(u8, out.items, "error:"));
 }
-
 
 test "issue-386: telemetry recordToolCall preserves UTF-8 codepoint boundaries" {
     var tmp = testing.tmpDir(.{});
@@ -1093,7 +1047,6 @@ test "issue-386: telemetry recordToolCall preserves UTF-8 codepoint boundaries" 
     try testing.expect(std.unicode.utf8ValidateSlice(recorded));
 }
 
-
 test "issue-387: appendId preserves JSON-RPC numeric and number_string ids" {
     // JSON-RPC ids are typed as String|Number|Null. The MCP server must echo
     // the id verbatim so the client can correlate the reply with its request.
@@ -1126,7 +1079,6 @@ test "issue-387: appendId preserves JSON-RPC numeric and number_string ids" {
     }
 }
 
-
 test "issue-406: root_policy blocks /private/etc (macOS realpath of /etc)" {
     // /etc is in the system_prefixes deny list, but on macOS /etc is a symlink
     // to /private/etc. Callers feed isIndexableRoot a path resolved by
@@ -1137,7 +1089,6 @@ test "issue-406: root_policy blocks /private/etc (macOS realpath of /etc)" {
     try testing.expect(!root_policy.isIndexableRoot("/private/etc"));
     try testing.expect(!root_policy.isIndexableRoot("/private/etc/ssh"));
 }
-
 
 test "issue-407: root_policy blocks /var and its non-folders subtree" {
     // The system_prefixes list explicitly blocks /var/folders and /var/tmp,
@@ -1152,7 +1103,6 @@ test "issue-407: root_policy blocks /var and its non-folders subtree" {
     try testing.expect(!root_policy.isIndexableRoot("/private/var"));
     try testing.expect(!root_policy.isIndexableRoot("/private/var/log"));
 }
-
 
 test "issue-412: bundle reports 'missing tool' for tool field of wrong type" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -1176,7 +1126,6 @@ test "issue-412: bundle reports 'missing tool' for tool field of wrong type" {
 
     try testing.expect(std.mem.indexOf(u8, out.items, "missing 'tool' field") == null);
 }
-
 
 test "issue-413: bundle truncation drops subsequent ops without telling the caller" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -1222,7 +1171,6 @@ test "issue-413: bundle truncation drops subsequent ops without telling the call
     try testing.expect(std.mem.indexOf(u8, out.items, "[2]") != null);
 }
 
-
 test "issue-424-B: bundle falls through to inline args when arguments is empty object" {
     // Forge-style buggy clients sometimes send `arguments: {}` AND put the
     // real args inline at the op level. The dispatcher currently sees the
@@ -1257,7 +1205,6 @@ test "issue-424-B: bundle falls through to inline args when arguments is empty o
     try testing.expect(std.mem.indexOf(u8, out.items, "missing 'path'") == null);
     try testing.expect(std.mem.indexOf(u8, out.items, "received keys: []") == null);
 }
-
 
 test "issue-512: direct tools call accepts inline args when arguments is empty" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -1305,7 +1252,6 @@ test "issue-512: direct tools call accepts inline args when arguments is empty" 
     try testing.expect(std.mem.indexOf(u8, response, "missing 'path'") == null);
 }
 
-
 test "issue-424-D: received-keys diagnostic hints at inline-args workaround when empty" {
     // When a sub-op fails with truly-empty args, the diagnostic should
     // point users at the inline-args fallback so a broken client wrapper
@@ -1340,7 +1286,6 @@ test "issue-424-D: received-keys diagnostic hints at inline-args workaround when
     try testing.expect(std.mem.indexOf(u8, out.items, "received keys:") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "inline shape") != null);
 }
-
 
 test "issue-424-A: bundle envelope errors carry the 'error:' prefix consistently" {
     // Pre-fix the bundle dispatcher emits 'op must be an object' and
@@ -1381,7 +1326,6 @@ test "issue-424-A: bundle envelope errors carry the 'error:' prefix consistently
     try testing.expect(std.mem.indexOf(u8, out2.items, "error: missing 'tool'") != null);
 }
 
-
 test "issue-441: bundle rejects codedb_projects sub-op" {
     // codedb_projects lists every indexed project on the machine, which is a
     // global directory enumeration unrelated to whatever repo the agent is
@@ -1415,7 +1359,6 @@ test "issue-441: bundle rejects codedb_projects sub-op" {
     try testing.expect(std.mem.indexOf(u8, out.items, "error: codedb_projects not allowed in bundle") != null);
 }
 
-
 test "issue-441: codedb_projects branch is excluded from augmented oneOf" {
     // Mirror of the dispatcher rejection at the schema level — when the
     // discriminated oneOf is opted into via CODEDB_DISCRIMINATED_SCHEMA=1,
@@ -1444,7 +1387,6 @@ test "issue-441: codedb_projects branch is excluded from augmented oneOf" {
         try testing.expect(!std.mem.eql(u8, tool_const.string, "codedb_projects"));
     }
 }
-
 
 test "issue-443: codedb_bundle is omitted from default tools/list response" {
     // The codedb_bundle tool has been a footgun across multiple stages:
@@ -1489,7 +1431,6 @@ test "issue-443: codedb_bundle is omitted from default tools/list response" {
     try testing.expect(saw_outline);
 }
 
-
 test "issue-443: codedb_bundle is advertised when CODEDB_BUNDLE_ENABLED=1" {
     // Re-enable path. When bundle_enabled is true the runtime response
     // includes codedb_bundle, exactly as it did before this gate.
@@ -1509,7 +1450,6 @@ test "issue-443: codedb_bundle is advertised when CODEDB_BUNDLE_ENABLED=1" {
     }
     try testing.expect(saw_bundle);
 }
-
 
 test "issue-434: codedb_bundle ops items schema requires arguments field" {
     // The codedb_bundle inputSchema in tools_list advertises ops items as
@@ -1547,7 +1487,6 @@ test "issue-434: codedb_bundle ops items schema requires arguments field" {
     try testing.expect(has_tool);
     try testing.expect(has_arguments);
 }
-
 
 test "issue-437: codedb_bundle ops items schema has discriminated oneOf per sub-tool" {
     // Stage 2 of the bundle-schema fix. Stage 1 (#434) made `arguments`
@@ -1621,7 +1560,6 @@ test "issue-437: codedb_bundle ops items schema has discriminated oneOf per sub-
         try testing.expect(!std.mem.eql(u8, tool_const.string, "codedb_edit"));
     }
 }
-
 
 test "issue-503: parsePositional treats `codedb mcp <path>` as path-as-root" {
     // Before fix: parser took the isCommand("mcp") branch, set root=".",
@@ -1714,7 +1652,6 @@ test "parsePositional: existing commands still parse correctly (regression)" {
     }
 }
 
-
 test "issue-502: isValidMcpFlag whitelist rejects unknown flags" {
     // Before fix: `codedb mcp --snapshot` silently swallowed the flag and
     // started the server with surprising state. After fix, mainImpl rejects
@@ -1725,7 +1662,6 @@ test "issue-502: isValidMcpFlag whitelist rejects unknown flags" {
     try testing.expect(!main_mod.isValidMcpFlag("--help")); // rewritten by parsePositional before reaching here
     try testing.expect(!main_mod.isValidMcpFlag(""));
 }
-
 
 test "issue-502: findGitRootFrom walks up to a .git directory" {
     var tmp = testing.tmpDir(.{});
@@ -1983,7 +1919,6 @@ test "issue-538: temp roots are indexable only when CODEDB_ALLOW_TEMP opts in" {
     try testing.expect(!root_policy.isIndexableRoot("/"));
 }
 
-
 test "issue-570: codedb_context falls back to plain words for all-lowercase tasks" {
     // 'fix search ranking' has no identifier-shaped token (no snake_case, no
     // camelCase, no quotes), so extractContextCandidates finds nothing and the
@@ -2018,7 +1953,6 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     // …its longest meaningful word ('ranking') must drive the composer.
     try testing.expect(std.mem.indexOf(u8, out.items, "ranking") != null);
 }
-
 
 test "issue-573: cli bridge must not bind a leading flag as the positional name" {
     // Live repro: `codedb callers --max-results 3 indexFile` reported
@@ -2061,7 +1995,6 @@ test "issue-573: cli bridge must not bind a leading flag as the positional name"
     bench_ctx.runDispatch(io, testing.allocator, .codedb_symbol, &parsed.value.object, &sout, &store, &explorer, &agents);
     try testing.expect(std.mem.indexOf(u8, sout.items, "error: empty name") != null);
 }
-
 
 test "issue-576: codedb_ls distinguishes a non-indexed path from an empty listing" {
     // `codedb ls nonexistent/dir` printed 'no entries' with exit 0 —
@@ -2106,7 +2039,6 @@ test "issue-576: codedb_ls distinguishes a non-indexed path from an empty listin
     try testing.expect(std.mem.indexOf(u8, ok_out.items, "a.zig") != null);
 }
 
-
 test "issue-578: cli bridge serves codedb_changes" {
     // `codedb changes` parsed as a ROOT directory (unknown first token in the
     // [root] <command> grammar) and printed usage — codedb_changes existed
@@ -2127,4 +2059,20 @@ test "issue-578: cli bridge serves codedb_changes" {
     // Pre-#578 the bridge did not know 'changes' and returned null.
     try testing.expect(code != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "seq:") != null);
+}
+
+// ─── audit (2026-06-09): latent-issue sweep — secret-path detection ───
+// src/watcher.zig + src/snapshot.zig isSensitivePath missed *.env suffix files and
+// .git-credentials, so those secrets were indexed/read.
+test "audit: isSensitivePath blocks *.env suffix files and .git-credentials" {
+    try testing.expect(watcher.isSensitivePath("production.env"));
+    try testing.expect(watcher.isSensitivePath("staging.env"));
+    try testing.expect(watcher.isSensitivePath("secrets.env"));
+    try testing.expect(watcher.isSensitivePath("deploy/secrets.env"));
+    try testing.expect(watcher.isSensitivePath(".git-credentials"));
+    // existing positive (prefix .env.* form) must still hold
+    try testing.expect(watcher.isSensitivePath(".env.production"));
+    // negatives — guard against an over-broad change
+    try testing.expect(!watcher.isSensitivePath("main.zig"));
+    try testing.expect(!watcher.isSensitivePath("environment.ts"));
 }

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -1872,3 +1872,75 @@ test "issue-532: ReScript parser" {
     try expectOutlineImport(&outline, "Belt");
 }
 
+
+// ─── audit (2026-06-09): latent-issue sweep — parser/deps fixes ───
+
+// src/explore.zig parseDelimitedImport — Kotlin/Swift `import X as Y` stored "X as Y" as
+// the dep key because the alias-trim was skipped for the empty-delimiter callers.
+test "audit: Kotlin import alias stripped from dep path" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try explorer.indexFile("Main.kt", "import com.example.Foo as Bar\n");
+    var outline = (try explorer.getOutline("Main.kt", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+    var saw_clean = false;
+    var saw_aliased = false;
+    for (outline.imports.items) |imp| {
+        if (std.mem.eql(u8, imp, "com.example.Foo")) saw_clean = true;
+        if (std.mem.eql(u8, imp, "com.example.Foo as Bar")) saw_aliased = true;
+    }
+    try testing.expect(saw_clean);
+    try testing.expect(!saw_aliased);
+}
+
+// src/explore.zig getImportedBy — basename fallback over-attached an ambiguous bare
+// import to every same-basename file; now skipped when the basename is ambiguous.
+test "audit: ambiguous bare import must not cross same-basename dirs" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("a/conf.py", "x = 1\n");
+    try explorer.indexFile("b/conf.py", "y = 2\n");
+    try explorer.indexFile("importer.py", "import conf\n");
+
+    const a_imp = try explorer.getImportedBy("a/conf.py", testing.allocator);
+    defer {
+        for (a_imp) |i| testing.allocator.free(i);
+        testing.allocator.free(a_imp);
+    }
+    const b_imp = try explorer.getImportedBy("b/conf.py", testing.allocator);
+    defer {
+        for (b_imp) |i| testing.allocator.free(i);
+        testing.allocator.free(b_imp);
+    }
+
+    var a_attached = false;
+    for (a_imp) |i| {
+        if (std.mem.eql(u8, i, "importer.py")) a_attached = true;
+    }
+    var b_attached = false;
+    for (b_imp) |i| {
+        if (std.mem.eql(u8, i, "importer.py")) b_attached = true;
+    }
+
+    // the same ambiguous bare import must not be attributed to two same-basename files
+    try testing.expect(!(a_attached and b_attached));
+}
+
+// src/explore.zig extractPythonModulePath/parsePythonLine — `import a, b` recorded only
+// the first module; now one dep is recorded per comma-separated module.
+test "audit: Python comma import records all modules" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("m.py", "import alpha, beta\n");
+
+    var outline = (try explorer.getOutline("m.py", testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer outline.deinit();
+
+    try expectOutlineImport(&outline, "alpha.py");
+    try expectOutlineImport(&outline, "beta.py");
+}

--- a/src/test_query.zig
+++ b/src/test_query.zig
@@ -1321,3 +1321,34 @@ test "issue-558: codedb_query filter must filter (or error) — never silently p
 
     try testing.expect(std.mem.indexOf(u8, bad_out.items, "error: filter needs") != null);
 }
+
+// ─── audit (2026-06-09): latent-issue sweep — memory safety ───
+// src/mcp.zig deps op appended freed dependency strings into file_set (use-after-free)
+// and leaked the seed string. testing.allocator catches both (poisoned read + leak).
+test "audit: codedb_query deps op does not use freed dependency strings" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("auth.zig", "const std = @import(\"std\");\npub fn authenticate() bool { return true; }\n");
+    try explorer.indexFile("handler.zig", "const auth = @import(\"auth.zig\");\npub fn handleLogin() void { _ = auth.authenticate(); }\n");
+    try explorer.indexFile("auth_test.zig", "const auth = @import(\"auth.zig\");\ntest \"x\" { _ = auth.authenticate(); }\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const pipe_json =
+        \\{"pipeline":[{"op":"deps","path":"auth.zig","direction":"imported_by"}]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, pipe_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_query, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "handler.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "auth_test.zig") != null);
+}

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -556,6 +556,103 @@ test "issue-400: BM25 ranks both-terms file above single-term files" {
 }
 
 
+test "issue-546: searchContentAuto applies the ranker to multi-word queries (CLI parity with MCP)" {
+    // #546: `codedb search` runs through runQuery (shared by the cold CLI path and
+    // the warm cli-daemon), which always called the UNRANKED searchContent — so
+    // multi-word/conceptual CLI queries came back in recall order, never the
+    // BM25+centrality order the MCP `search` handler already used. searchContentAuto
+    // is the single query-shape-aware entry point both call, so they rank identically:
+    // a multi-word query routes to searchContentRanked. (Single tokens keep literal
+    // substring matching for exact-identifier lookups — covered elsewhere.)
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // both.zig covers BOTH query terms; the single-term files are denser lexical
+    // hits for one term but less relevant to the two-term query.
+    try explorer.indexFile("both.zig",
+        \\pub fn parseToken() void {
+        \\    parseToken();
+        \\    parseToken();
+        \\}
+    );
+    try explorer.indexFile("only_parse.zig",
+        \\pub fn parseFoo() void {
+        \\    parse();
+        \\    parse();
+        \\    parse();
+        \\}
+    );
+    try explorer.indexFile("only_token.zig",
+        \\pub fn tokenStream() void {
+        \\    token();
+        \\    token();
+        \\}
+    );
+
+    // Multi-word query: searchContentAuto must route to the ranker, so the
+    // both-terms file ranks first and carries a positive BM25 score (the unranked
+    // recall path neither guarantees this order nor populates a score).
+    const results = try explorer.searchContentAuto("parse Token", testing.allocator, 8);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len > 0);
+    try testing.expectEqualStrings("both.zig", results[0].path);
+    try testing.expect(results[0].score > 0.0);
+}
+
+test "issue-546: searchContentRanked rebuilds an incomplete (snapshot-loaded) word index" {
+    // #546 root cause: a mmap/disk-loaded word index is recall-ready but not
+    // BM25-ready (word_index_complete = false; empty id_to_path / ranked-doc table).
+    // searchContent and searchWord lazily rebuild in that state, but
+    // searchContentRanked did not — so multi-word ranked search returned NOTHING on
+    // a cold CLI / freshly-loaded snapshot even though `word` found hits. This pins
+    // the lazy rebuild: markWordIndexIncomplete simulates the post-load state (file
+    // contents remain), and ranked search must rebuild and return results instead of
+    // collapsing to an empty set.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("both.zig",
+        \\pub fn parseToken() void {
+        \\    parseToken();
+        \\    parseToken();
+        \\}
+    );
+    try explorer.indexFile("only_parse.zig",
+        \\pub fn parseFoo() void {
+        \\    parse();
+        \\}
+    );
+    try explorer.indexFile("only_token.zig",
+        \\pub fn tokenStream() void {
+        \\    token();
+        \\}
+    );
+
+    // Drop the in-memory word index to its post-snapshot-load state: not complete,
+    // contents still present. Without the lazy rebuild, searchContentRanked sees
+    // N == 0 and returns nothing.
+    explorer.markWordIndexIncomplete(false);
+
+    const results = try explorer.searchContentRanked("parse Token", testing.allocator, 8);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len > 0);
+    try testing.expectEqualStrings("both.zig", results[0].path);
+}
+
 test "issue-400-bug1: searchContentRanked returns ranked results when skip_file_words=true" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1916,3 +1916,43 @@ test "audit: searchContent loses a word-indexed file >512KB evicted from the con
     // big.zig must be reachable now that the read cap matches the indexer's 64MB
     try testing.expect(found);
 }
+
+// ─── #546 follow-up: cold CLI scan leaves an empty-but-"complete" word index ───
+// main.zig's cold non-index scan disables the word index to save memory, but
+// word_index_complete defaults to true. Files commit into outlines/contents while
+// WordIndex.indexFile silently no-ops, so searchContentRanked trusts the flag,
+// skips the lazy rebuild, sees N == 0, and every multi-word CLI search on a cold
+// start returns nothing.
+test "issue-546: cold CLI scan (word index disabled) still ranks multi-word queries" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // Mirror the cold CLI scan state (main.zig sets both for non-index commands).
+    explorer.word_index.skip_file_words = true;
+    explorer.word_index.enabled = false;
+
+    try explorer.indexFile("both.zig",
+        \\pub fn parseToken() void {
+        \\    parseToken();
+        \\    parseToken();
+        \\}
+    );
+    try explorer.indexFile("only_parse.zig",
+        \\pub fn parseFoo() void {
+        \\    parse();
+        \\}
+    );
+
+    const results = try explorer.searchContentAuto("parse Token", testing.allocator, 8);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.line_text);
+            testing.allocator.free(r.path);
+        }
+        testing.allocator.free(results);
+    }
+    // RED pre-fix: the empty index claims completeness, no rebuild runs, len == 0.
+    try testing.expect(results.len > 0);
+    try testing.expectEqualStrings("both.zig", results[0].path);
+}

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -16,7 +16,6 @@ const SymbolLocation = explore.SymbolLocation;
 const mcp_mod = @import("mcp.zig");
 const AgentRegistry = @import("agent.zig").AgentRegistry;
 
-
 test "issue-264: early exit at max_results misses valid matches in remaining candidates" {
     // searchContent stops as soon as result_list.items.len >= max_results.
     // The first-indexed file is iterated first (doc_id order).  If it has
@@ -56,7 +55,6 @@ test "issue-264: early exit at max_results misses valid matches in remaining can
     try testing.expect(found_quiet);
 }
 
-
 test "search: line numbers correct with incremental counting" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -80,7 +78,6 @@ test "search: line numbers correct with incremental counting" {
     try testing.expectEqual(@as(u32, 6), results[1].line_num);
 }
 
-
 test "issue-290: searchContent with hyphen query does not crash" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -95,7 +92,6 @@ test "issue-290: searchContent with hyphen query does not crash" {
         testing.allocator.free(results);
     }
 }
-
 
 test "issue-292: searchContent with pipe query does not crash" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -112,7 +108,6 @@ test "issue-292: searchContent with pipe query does not crash" {
     }
 }
 
-
 test "issue-292: codedb_search guidance hints regex=true on metachar query" {
     const args_json = "{\"query\":\"timestamp|activity|filter\"}";
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
@@ -122,7 +117,6 @@ test "issue-292: codedb_search guidance hints regex=true on metachar query" {
     mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, "", false, &buf);
     try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") != null);
 }
-
 
 test "issue-292: codedb_search guidance does not warn when regex=true is set" {
     const args_json = "{\"query\":\"timestamp|activity\",\"regex\":true}";
@@ -134,7 +128,6 @@ test "issue-292: codedb_search guidance does not warn when regex=true is set" {
     try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") == null);
 }
 
-
 test "issue-290: codedb_search guidance does not warn on plain hyphen" {
     const args_json = "{\"query\":\"test-case\"}";
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
@@ -144,7 +137,6 @@ test "issue-290: codedb_search guidance does not warn on plain hyphen" {
     mcp_mod.mcpGenerateGuidance(testing.allocator, "codedb_search", &parsed.value.object, "", false, &buf);
     try testing.expect(std.mem.indexOf(u8, buf.items, "regex=true") == null);
 }
-
 
 test "issue-363b: fuzzyFindFiles ranks exact basename match above unrelated lib.rs" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
@@ -170,7 +162,6 @@ test "issue-363b: fuzzyFindFiles ranks exact basename match above unrelated lib.
     try testing.expectEqualStrings("crates/forge_main/src/cli.rs", matches[0].path);
 }
 
-
 test "issue-363a: searchContent surfaces source-file matches even when doc files dominate the word index" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -184,7 +175,8 @@ test "issue-363a: searchContent surfaces source-file matches even when doc files
     var i: usize = 0;
     while (i < 4) : (i += 1) {
         const path = try std.fmt.bufPrint(&path_buf, "docs/notes_{d}.md", .{i});
-        const content = try std.fmt.bufPrint(&content_buf,
+        const content = try std.fmt.bufPrint(
+            &content_buf,
             "## Notes {d}\n\n" ++
                 "The searchContent function is documented here.\n" ++
                 "We discuss searchContent at length.\n" ++
@@ -229,7 +221,6 @@ test "issue-363a: searchContent surfaces source-file matches even when doc files
     try testing.expect(found_source);
 }
 
-
 test "issue-recall: codedb_search supports path_glob filter" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -258,7 +249,6 @@ test "issue-recall: codedb_search supports path_glob filter" {
     try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "CHANGELOG.md") == null);
 }
-
 
 test "issue-422: search header count must reflect post-filter visible results" {
     // From the issue: a query whose ONLY match would be displayed instead
@@ -321,7 +311,6 @@ test "issue-422: search header count must reflect post-filter visible results" {
     try testing.expect(std.mem.indexOf(u8, out.items, "1 results for 'struct ForgeAPI'") != null);
 }
 
-
 test "issue-390: codedb_search scope=true caps matches per file" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -374,7 +363,6 @@ test "issue-390: codedb_search scope=true caps matches per file" {
     try testing.expect(std.mem.indexOf(u8, out.items, "src/c.zig:") != null);
 }
 
-
 test "issue-391: codedb_callers tool exists" {
     // codedb_callers is the proposed reverse-callgraph tool: given a symbol
     // name, return the call sites across the index. It fuses the existing
@@ -386,7 +374,6 @@ test "issue-391: codedb_callers tool exists" {
     // workflow has to be assembled by hand on the client side.
     try testing.expect(@hasField(mcp_mod.Tool, "codedb_callers"));
 }
-
 
 test "issue-391: codedb_callers returns call sites with scope" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -421,7 +408,6 @@ test "issue-391: codedb_callers returns call sites with scope" {
     try testing.expect(std.mem.indexOf(u8, out.items, "def.zig:1") == null);
 }
 
-
 test "issue-391: codedb_callers rejects missing name" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -445,7 +431,6 @@ test "issue-391: codedb_callers rejects missing name" {
     try testing.expect(std.mem.startsWith(u8, out.items, "error:"));
     try testing.expect(std.mem.indexOf(u8, out.items, "name") != null);
 }
-
 
 test "issue-393: BM25 ranking surfaces high-density file before single-mention file" {
     // Multi-term content queries today return matches in scan order with only
@@ -519,7 +504,6 @@ test "issue-393: BM25 ranking surfaces high-density file before single-mention f
     }
 }
 
-
 test "issue-400: BM25 ranks both-terms file above single-term files" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -554,7 +538,6 @@ test "issue-400: BM25 ranks both-terms file above single-term files" {
     try testing.expectEqualStrings("both.zig", results[0].path);
     try testing.expect(results[0].score > 0.0);
 }
-
 
 test "issue-546: searchContentAuto applies the ranker to multi-word queries (CLI parity with MCP)" {
     // #546: `codedb search` runs through runQuery (shared by the cold CLI path and
@@ -670,7 +653,6 @@ test "issue-400-bug1: searchContentRanked returns ranked results when skip_file_
     try testing.expect(results.len > 0);
 }
 
-
 test "issue-400-bug2: total_tokens stays consistent across re-index when skip_file_words=true" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -680,7 +662,6 @@ test "issue-400-bug2: total_tokens stays consistent across re-index when skip_fi
     try explorer.indexFile("a.zig", "eight\n");
     try testing.expectEqual(@as(u64, 1), explorer.word_index.total_tokens);
 }
-
 
 test "bm25-recall-a: single-term tf ordering" {
     // 3 docs with identical length but "apple" on different numbers of lines.
@@ -714,7 +695,6 @@ test "bm25-recall-a: single-term tf ordering" {
     try testing.expect(results[0].score > results[1].score);
     try testing.expect(results[1].score > results[2].score);
 }
-
 
 test "bm25-recall-b: both-terms doc beats high-tf single-term doc" {
     // doc1 has apple+banana (both query terms, one occurrence each).
@@ -754,7 +734,6 @@ test "bm25-recall-b: both-terms doc beats high-tf single-term doc" {
     }
 }
 
-
 test "bm25-recall-c: df-saturation -- ubiquitous term has near-zero idf" {
     // "the" appears in all 11 docs -> idf near zero, barely contributes.
     // "unique_marker" appears only in special.txt -> high idf, special.txt ranks first.
@@ -790,7 +769,6 @@ test "bm25-recall-c: df-saturation -- ubiquitous term has near-zero idf" {
     }
 }
 
-
 test "bm25-recall-d: length normalization favors shorter doc" {
     // short.txt: 5 tokens, one "needle".
     // long.txt: ~50 tokens, one "needle".
@@ -800,10 +778,8 @@ test "bm25-recall-d: length normalization favors shorter doc" {
     var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
 
     try explorer.indexFile("short.txt", "needle alpha beta gamma delta");
-    try explorer.indexFile("long.txt",
-        "aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz " ++
-        "aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx needle yy zz"
-    );
+    try explorer.indexFile("long.txt", "aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx yy zz " ++
+        "aa bb cc dd ee ff gg hh ii jj kk ll mm nn oo pp qq rr ss tt uu vv ww xx needle yy zz");
 
     const results = try explorer.searchContentRanked("needle", testing.allocator, 10);
     defer {
@@ -818,7 +794,6 @@ test "bm25-recall-d: length normalization favors shorter doc" {
     try testing.expectEqualStrings("short.txt", results[0].path);
     try testing.expect(results[0].score > results[1].score);
 }
-
 
 test "bm25-recall-e: empty and pathological queries return empty without crash" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -844,7 +819,6 @@ test "bm25-recall-e: empty and pathological queries return empty without crash" 
     }
 }
 
-
 test "bm25-stress: 1000-doc index, common token, max_results cap honored" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -853,9 +827,7 @@ test "bm25-stress: 1000-doc index, common token, max_results cap honored" {
     var content_buf: [256]u8 = undefined;
     for (0..1000) |i| {
         const path = std.fmt.bufPrint(&path_buf, "stress/doc{d}.txt", .{i}) catch unreachable;
-        const content = std.fmt.bufPrint(&content_buf,
-            "common token alpha beta gamma doc{d} extra filler words here now", .{i}
-        ) catch unreachable;
+        const content = std.fmt.bufPrint(&content_buf, "common token alpha beta gamma doc{d} extra filler words here now", .{i}) catch unreachable;
         try explorer.indexFile(path, content);
     }
 
@@ -879,7 +851,6 @@ test "bm25-stress: 1000-doc index, common token, max_results cap honored" {
     }
 }
 
-
 test "bm25-state-sync: re-index and remove update total_tokens correctly" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
@@ -893,7 +864,6 @@ test "bm25-state-sync: re-index and remove update total_tokens correctly" {
     explorer.removeFile("sync.txt");
     try testing.expectEqual(@as(u64, 0), explorer.word_index.total_tokens);
 }
-
 
 test "issue-425: codedb_callers excludes substring matches in unrelated identifiers" {
     // handleCallers (mcp.zig:1339) currently calls searchContentWithScope(name)
@@ -938,7 +908,6 @@ test "issue-425: codedb_callers excludes substring matches in unrelated identifi
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'fooBar'") != null);
 }
 
-
 test "issue-426: codedb_callers excludes non-code files (markdown, docs)" {
     // handleCallers (mcp.zig:1339) feeds searchContentWithScope across every
     // indexed file regardless of language. Markdown and other documentation
@@ -982,7 +951,6 @@ test "issue-426: codedb_callers excludes non-code files (markdown, docs)" {
     // Header reflects the real count.
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'fooBar'") != null);
 }
-
 
 test "issue-427: searchContent Tier 1 sort starves the definition-dense file" {
     // searchContent's Tier 1 (explore.zig:1590-1598) sorts trigram candidates
@@ -1047,7 +1015,6 @@ test "issue-427: searchContent Tier 1 sort starves the definition-dense file" {
     try testing.expect(found_canonical);
 }
 
-
 test "issue-429-a: searchContent rerank boosts files whose basename matches the query" {
     // Two files, same hit count, same content length. The current rerank
     // (explore.zig:1700-1712) sorts ties by path-asc, so a file named
@@ -1073,7 +1040,6 @@ test "issue-429-a: searchContent rerank boosts files whose basename matches the 
     try testing.expectEqualStrings("src/widgetX.zig", results[0].path);
 }
 
-
 test "issue-429-b: searchContent rerank penalizes test/vendor/examples paths" {
     // Two files, same hit count, same content. Pre-fix the path-asc
     // tiebreaker promotes "examples/sample.zig" (e < s) above
@@ -1097,7 +1063,6 @@ test "issue-429-b: searchContent rerank penalizes test/vendor/examples paths" {
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("src/sample.zig", results[0].path);
 }
-
 
 test "issue-429-c: searchContent rerank boosts lines that are symbol definitions" {
     // Two files. "aaa.zig" has a passing comment mention of `fooSym`. The
@@ -1124,7 +1089,6 @@ test "issue-429-c: searchContent rerank boosts lines that are symbol definitions
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("zzz_def.zig", results[0].path);
 }
-
 
 test "issue-430: Tier 0 markdown dominance starves canonical source file" {
     // Tier 0 of searchContent (explore.zig:1525-1554) iterates the word
@@ -1158,11 +1122,10 @@ test "issue-430: Tier 0 markdown dominance starves canonical source file" {
 
     // Source file with the canonical definition + several real call sites,
     // indexed LAST so its posting-list entries come after the markdown noise.
-    try explorer.indexFile("src/foo.zig",
-        "pub fn fooBar() void {}\n" ++
-            "pub fn caller1() void { fooBar(); }\n" ++
-            "pub fn caller2() void { fooBar(); }\n" ++
-            "pub fn caller3() void { fooBar(); }\n");
+    try explorer.indexFile("src/foo.zig", "pub fn fooBar() void {}\n" ++
+        "pub fn caller1() void { fooBar(); }\n" ++
+        "pub fn caller2() void { fooBar(); }\n" ++
+        "pub fn caller3() void { fooBar(); }\n");
 
     const results = try explorer.searchContent("fooBar", testing.allocator, 50);
     defer {
@@ -1185,7 +1148,6 @@ test "issue-430: Tier 0 markdown dominance starves canonical source file" {
     // the source file is reached, then Tier 0 returns at max_results.
     try testing.expect(found_source);
 }
-
 
 test "issue-431: searchContent does not crash when query is longer than content" {
     // searchInContent (explore.zig:3881) computes
@@ -1216,7 +1178,6 @@ test "issue-431: searchContent does not crash when query is longer than content"
     try testing.expect(results.len == 0);
 }
 
-
 test "issue-429-d: searchContent rerank boosts path-segment match" {
     // Two files, same hit count, same content. The query "parser" appears
     // as a directory segment of one path. Pre-fix the alphabetic tiebreak
@@ -1240,7 +1201,6 @@ test "issue-429-d: searchContent rerank boosts path-segment match" {
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("src/parser/foo.zig", results[0].path);
 }
-
 
 test "issue-429-e: searchContent rerank penalises doc-language files so code beats markdown noise" {
     // CHANGELOG.md and benchmark docs often mention an identifier many times
@@ -1275,7 +1235,6 @@ test "issue-429-e: searchContent rerank penalises doc-language files so code bea
     try testing.expectEqualStrings("src/caller.zig", results[0].path);
 }
 
-
 test "issue-448-a: rerank boosts basename when query contains stem" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1296,7 +1255,6 @@ test "issue-448-a: rerank boosts basename when query contains stem" {
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("src/explore.zig", results[0].path);
 }
-
 
 test "issue-448-b: rerank symbol definition boost is case-insensitive" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1319,7 +1277,6 @@ test "issue-448-b: rerank symbol definition boost is case-insensitive" {
     try testing.expectEqualStrings("zzz.zig", results[0].path);
 }
 
-
 test "issue-449: popular markdown should not disable Tier 0 code-first behavior" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1339,11 +1296,10 @@ test "issue-449: popular markdown should not disable Tier 0 code-first behavior"
         try explorer.indexFile(path, md_block);
     }
 
-    try explorer.indexFile("src/foo.zig",
-        "pub fn fooBar() void {}\n" ++
-            "pub fn caller1() void { fooBar(); }\n" ++
-            "pub fn caller2() void { fooBar(); }\n" ++
-            "pub fn caller3() void { fooBar(); }\n");
+    try explorer.indexFile("src/foo.zig", "pub fn fooBar() void {}\n" ++
+        "pub fn caller1() void { fooBar(); }\n" ++
+        "pub fn caller2() void { fooBar(); }\n" ++
+        "pub fn caller3() void { fooBar(); }\n");
 
     const results = try explorer.searchContent("fooBar", testing.allocator, 10);
     defer {
@@ -1360,7 +1316,6 @@ test "issue-449: popular markdown should not disable Tier 0 code-first behavior"
     }
     try testing.expect(found_source);
 }
-
 
 test "issue-450: prefix tier respects max_results" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1382,7 +1337,6 @@ test "issue-450: prefix tier respects max_results" {
 
     try testing.expect(results.len <= 2);
 }
-
 
 test "rerank-trace: appends one JSON line per searchContent when enabled" {
     const tmp_io = testing.io;
@@ -1436,7 +1390,6 @@ test "rerank-trace: appends one JSON line per searchContent when enabled" {
     try testing.expect(std.mem.indexOf(u8, data, "\"results\":[") != null);
 }
 
-
 test "rerank-trace: disabled by default — no file is created" {
     const tmp_io = testing.io;
     var tmp = testing.tmpDir(.{});
@@ -1471,7 +1424,6 @@ test "rerank-trace: disabled by default — no file is created" {
     const open_err = std.Io.Dir.cwd().openFile(tmp_io, probe_path, .{});
     try testing.expectError(error.FileNotFound, open_err);
 }
-
 
 test "rerank-trace: clobbers when file exceeds size limit" {
     const tmp_io = testing.io;
@@ -1521,7 +1473,6 @@ test "rerank-trace: clobbers when file exceeds size limit" {
     try testing.expect(new_size > 0);
     try testing.expect(new_size < 16 * 1024);
 }
-
 
 test "rerank-trace: single-result query records non-zero rerank score" {
     // Pre-fix: rerankAndFinalize only scored when items.len > 1, so a
@@ -1573,7 +1524,6 @@ test "rerank-trace: single-result query records non-zero rerank score" {
     try testing.expect(std.mem.indexOf(u8, data, "src/loneSym.zig") != null);
 }
 
-
 test "issue-negq: negative-query search short-circuits Tier 5 full scan" {
     // When a query contains trigrams that no indexed file contains (a
     // definitively-negative query), searchContent should return [] without
@@ -1609,7 +1559,6 @@ test "issue-negq: negative-query search short-circuits Tier 5 full scan" {
     // ruled out a match. On main this expectation fails (count == 1).
     try testing.expectEqual(@as(u64, 0), explorer.search_tier5_count);
 }
-
 
 test "issue-471a: codedb_find accepts query/name/path/pattern/q aliases" {
     // Real-user telemetry (24h) showed 71% of codedb_find calls failing with
@@ -1656,7 +1605,6 @@ test "issue-471a: codedb_find accepts query/name/path/pattern/q aliases" {
         try testing.expect(std.mem.indexOf(u8, out.items, "main.zig") != null);
     }
 }
-
 
 test "issue-471b: codedb_find error message enumerates accepted aliases" {
     // If an agent calls codedb_find with no recognized key, the error message
@@ -1736,7 +1684,6 @@ test "issue-451: scope=true search surfaces skip-trigram files" {
     try testing.expect(found_canonical);
 }
 
-
 test "issue-546: searchContent rerank penalizes non-source tooling paths (bench/install/scripts/website)" {
     // Mirror of issue-429-b for first-party tooling directories. Five files,
     // identical content and hit count — only a path prior can separate them.
@@ -1763,7 +1710,6 @@ test "issue-546: searchContent rerank penalizes non-source tooling paths (bench/
     try testing.expect(results.len >= 5);
     try testing.expectEqualStrings("src/sample.zig", results[0].path);
 }
-
 
 test "issue-560: path_glob page must not be starved by higher-ranked out-of-glob files" {
     // 40 out-of-glob decoys tie the gold file on score; the path-asc
@@ -1808,7 +1754,6 @@ test "issue-560: path_glob page must not be starved by higher-ranked out-of-glob
     try testing.expect(std.mem.indexOf(u8, out.items, "0 results") == null);
 }
 
-
 test "issue-562: codedb_callers excludes full-line comment mentions" {
     // Live repro: callers of insertRestoredFile reported snapshot.zig:822
     // ('// is false: insertRestoredFile errors above…') and a test-file
@@ -1847,7 +1792,6 @@ test "issue-562: codedb_callers excludes full-line comment mentions" {
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'insertThing'") != null);
 }
 
-
 test "issue-580: basename test files rank below non-test source for concept queries" {
     // rerankSignalScore's test penalty only matches DIRECTORY segments named
     // test/tests, so files like src/tests.zig or src/widget_tests.zig dodge
@@ -1873,4 +1817,102 @@ test "issue-580: basename test files rank below non-test source for concept quer
     }
     try testing.expect(results.len >= 2);
     try testing.expectEqualStrings("src/owner.zig", results[0].path);
+}
+
+// ─── audit (2026-06-09): latent-issue sweep — failing test for a confirmed bug ───
+// src/explore.zig:2418 — searchContent Tier 0 `use_line_hits` fast-path returns before
+// rerankAndFinalize, so a high-count non-canonical file outranks the canonical basename
+// match (the #537/#448 structural-vs-lexical inversion, reintroduced for small max_results).
+test "audit: searchContent tier0 use_line_hits early-return skips rerank basename boost" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("src/other.zig", "widget\nwidget\nwidget\nwidget\nwidget\nwidget\n");
+    try explorer.indexFile("src/widget.zig", "const widget = 1;\n");
+
+    const results = try explorer.searchContent("widget", testing.allocator, 2);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    // RED on main: results[0] == src/other.zig (count 6); canonical basename must win.
+    try testing.expectEqualStrings("src/widget.zig", results[0].path);
+}
+
+// src/explore.zig renderPlainSearch — the MCP codedb_search fast-path rendered in raw
+// hit-count order with no basename prior, so a noise file outranked the canonical match.
+test "audit: renderPlainSearch fast-path ranks lexical count over canonical basename" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+
+    try explorer.indexFile("src/other.zig", "widget\nwidget\nwidget\nwidget\nwidget\nwidget\n");
+    try explorer.indexFile("src/widget.zig", "const widget = 1;\n");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    const rendered = try explorer.renderPlainSearch("widget", testing.allocator, &out, 2, false);
+    try testing.expect(rendered);
+
+    const wi = std.mem.indexOf(u8, out.items, "src/widget.zig");
+    const oi = std.mem.indexOf(u8, out.items, "src/other.zig");
+    try testing.expect(wi != null and oi != null);
+    // canonical src/widget.zig must render before the high-count src/other.zig
+    try testing.expect(wi.? < oi.?);
+}
+
+// src/explore.zig:1659 — readContentForSearch capped disk reads at 512KB while the indexer
+// reads up to 64MB, so a word-indexed file >512KB evicted from the content cache was
+// invisible to every search tier.
+test "audit: searchContent loses a word-indexed file >512KB evicted from the content cache" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var big: std.ArrayList(u8) = .empty;
+    defer big.deinit(testing.allocator);
+    try big.appendSlice(testing.allocator, "fn f() void { _ = widgetzzz; }\n");
+    // pad past the old 512KB cap with a few long comment lines — keeps the file
+    // >512KB while staying cheap to index (the token we search for is on line 1).
+    while (big.items.len < 600 * 1024) {
+        try big.appendSlice(testing.allocator, "// ");
+        try big.appendNTimes(testing.allocator, 'x', 560);
+        try big.appendSlice(testing.allocator, "\n");
+    }
+
+    var file = try tmp.dir.createFile(io, "big.zig", .{});
+    try file.writeStreamingAll(io, big.items);
+    file.close(io);
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+
+    var explorer = Explorer.init(testing.allocator, 1); // capacity 1 forces eviction
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+
+    try explorer.indexFile("big.zig", big.items);
+    try explorer.indexFile("filler.zig", "fn g() void {}\n");
+
+    try testing.expect(explorer.word_index.search("widgetzzz").len > 0);
+
+    const results = try explorer.searchContent("widgetzzz", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    var found = false;
+    for (results) |r| {
+        if (std.mem.eql(u8, r.path, "big.zig")) found = true;
+    }
+    // big.zig must be reachable now that the read cap matches the indexer's 64MB
+    try testing.expect(found);
 }

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1956,3 +1956,34 @@ test "issue-546: cold CLI scan (word index disabled) still ranks multi-word quer
     try testing.expect(results.len > 0);
     try testing.expectEqualStrings("both.zig", results[0].path);
 }
+
+// ─── #569: multi-word `word` queries dead-end — no per-token fallback ───
+// `word` looked up the literal phrase in the inverted index, so an agent-shaped
+// query like "gateway websocket reconnect" returned zero hits even when every
+// token had plentiful hits. Multi-word queries must fall back to per-token
+// lookup, ranking files that hit more distinct tokens first.
+test "issue-569: multi-word word query falls back to per-token matching" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("src/both.zig", "const gateway = 1;\nconst websocket = 2;\n");
+    try explorer.indexFile("src/one.zig", "const gateway = 9;\n");
+
+    // searchWord powers the CLI `word` cmd.
+    const hits = try explorer.searchWord("gateway websocket", testing.allocator);
+    defer testing.allocator.free(hits);
+    try testing.expect(hits.len > 0);
+    explorer.mu.lockShared();
+    const top = explorer.word_index.hitPath(hits[0]);
+    explorer.mu.unlockShared();
+    // the file hitting BOTH tokens must outrank the single-token file
+    try testing.expectEqualStrings("src/both.zig", top);
+
+    // renderWord powers MCP codedb_word — same files, with the mode noted.
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try explorer.renderWord("gateway websocket", testing.allocator, &out);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/both.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "(tokenized)") != null);
+}

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -1273,3 +1273,35 @@ test "issue-564: snapshot fast-load defers the symbol index until first symbol u
     try testing.expect(std.mem.eql(u8, results[0].path, "util_564.zig"));
     try testing.expect(exp2.symbol_index.count() > 0);
 }
+
+// ─── audit (2026-06-09): latent-issue sweep — snapshot fast-restore ───
+// src/snapshot.zig:729 — OUTLINE_STATE import read cap (4096) was narrower than the
+// write cap (65535); a >4096-byte import silently disabled fast-restore (borrow path).
+test "audit: long import specifier round-trips on fast-restore (borrow path preserved)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var exp = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    const long_imp = "a" ** 5000; // > 4096 (old read cap), <= 65535 (write cap)
+    const src = "package main\nimport \"" ++ long_imp ++ "\"\nfunc mainFn() {}\n";
+    try exp.indexFile("probe/main.go", src);
+    const pre = exp.outlines.get("probe/main.go") orelse return error.MissingOutline;
+    try testing.expect(pre.imports.items.len == 1);
+    try testing.expect(pre.imports.items[0].len == 5000);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/probe.codedb", .{dir_path});
+    defer testing.allocator.free(snap_path);
+    try snapshot_mod.writeSnapshot(io, &exp, dir_path, snap_path, testing.allocator);
+
+    var exp2 = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer exp2.deinit();
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &exp2, &store, testing.allocator));
+    const outline = exp2.outlines.get("probe/main.go") orelse return error.MissingOutline;
+    // borrows_strings is the only discriminator: false on main (re-parse fallback), true after fix
+    try testing.expect(outline.borrows_strings);
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -178,9 +178,7 @@ fn shouldSkip(path: []const u8) bool {
 }
 
 fn shouldSkipDir(name: []const u8) bool {
-    for (skip_dirs) |skip| {
-        if (std.mem.eql(u8, name, skip)) return true;
-    }
+    for (skip_dirs) |skip| if (std.mem.eql(u8, name, skip)) return true;
     return false;
 }
 

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1182,7 +1182,8 @@ pub fn isSensitivePath(path: []const u8) bool {
     // Only check sensitive names if basename starts with '.', 'c', 's', 'i' or has key/cert extension
     if (first != '.' and first != 'c' and first != 's' and first != 'i') {
         // Still need to check extensions and directory patterns
-        if (std.mem.endsWith(u8, basename, ".pem") or
+        if (std.mem.endsWith(u8, basename, ".env") or
+            std.mem.endsWith(u8, basename, ".pem") or
             std.mem.endsWith(u8, basename, ".key") or
             std.mem.endsWith(u8, basename, ".p12") or
             std.mem.endsWith(u8, basename, ".pfx") or
@@ -1199,12 +1200,13 @@ pub fn isSensitivePath(path: []const u8) bool {
     const sensitive_names = [_][]const u8{
         ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
         "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
-        "secrets.yml",      "id_rsa",               "id_ed25519",
+        "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
     };
     for (sensitive_names) |name| {
         if (std.mem.eql(u8, basename, name)) return true;
     }
-    if (std.mem.endsWith(u8, basename, ".pem") or
+    if (std.mem.endsWith(u8, basename, ".env") or
+        std.mem.endsWith(u8, basename, ".pem") or
         std.mem.endsWith(u8, basename, ".key") or
         std.mem.endsWith(u8, basename, ".p12") or
         std.mem.endsWith(u8, basename, ".pfx") or


### PR DESCRIPTION
## Problem

Two threads, rebased onto `release/0.2.5825` and overlap-resolved against #557/#559/#561/#563/#565 (and re-rebased over #567/#571):

**1. #546 — the CLI half.** `runQuery` (cold CLI + warm cli-daemon) always called the unranked `searchContent`, so multi-word queries came back in recall order (usually nothing, since the literal phrase rarely appears); only the MCP handler ranked. Complements #557, which fixed the single-word rerank priors.

While validating live, two further cold-start defects surfaced — multi-word `codedb search` returned **nothing** on any cold start even with the routing fixed:
- main.zig disables the word index for non-index commands, but `word_index_complete` defaults to `true` — the scan left an **empty index claiming completeness**, so `searchContentRanked` trusted the flag, skipped its lazy rebuild, and collapsed to `N == 0`.
- The first-ever cold `search` scan (no trigram on disk) used the trigram-extract-only fast path, committing **neither outlines nor contents** — BM25 had nothing to rank even after a rebuild.

**2. Audit (2026-06-09) latent-issue sweep** — failing tests committed first for each:
- `codegraph.extractCallees` paired every `(` with the preceding identifier with no comment/string stripping → names mentioned in `//`, `/* */`, or string literals surfaced as resolved callees in `codedb_context` (complements #563, same class in `handleCallers`)
- `codedb_query` deps op appended **freed** dependency strings into `file_set` (use-after-free) and leaked the seed string
- snapshot/watcher secret filter missed `*.env` suffixes (`prod.env`) and `.git-credentials`; fast-restore import read cap (4096) was narrower than the write cap (65535), silently disabling the borrow path
- searchContent Tier-0 `use_line_hits` early-return skipped `rerankAndFinalize` (the #537/#448 inversion, reintroduced for small max_results); `renderPlainSearch` basename prior; >512KB evicted-file read cap

**3. Appended: #568 + #569** (engram-bridge findings, red→green pairs):
- **#568** — empty `deps` lists printed a body line `  (none)` and **no `(N files)` summary**, so machine consumers parsing the list body saw one entry (engram counted in-degree 1 for every zero-importer file, degenerating its centrality features to all-1.0 ties).
- **#569** — multi-word `word` queries returned **zero hits** (literal-phrase lookup only; the multi-word analogue of #547, which `word` didn't catch either). `search` multi-word is fixed by thread 1; this closes the `word` half.

## Fix

- `Explorer.searchContentAuto` — query-shape routing (multi-word → BM25+centrality, single token → literal) shared by `runQuery` and the MCP handler
- `commitParsedFileOwnedOutline` clears `word_index_complete` when the disabled word index can't absorb a file, so ranked/BM25 readers lazy-rebuild instead of trusting a lying flag
- first-cold multi-word non-regex searches route through the full single-pass scan (outlines + contents + trigrams); single-token and `--regex` keep the trigram-only fast path
- comment/string spans stripped before call detection in `extractCallees`; `codedb_query` deps-op strings arena-owned; `isSensitivePath` extended + parity-kept; tier-0 results flow through rerank
- **#568:** `(0 files)` printed alongside `(none)` at all three deps render sites (imported-by fast path, general forward/transitive path, `handleDepsPathOnly`) — the summary line is now unconditional
- **#569:** `searchWordTokensLocked` — whitespace-bearing queries tokenize (normalized, deduped), look up each token, and rank files by distinct-token coverage → total hits → path, one representative hit per file; shared by CLI `searchWord` and MCP `renderWord` (which labels the mode `(tokenized)`)

## Rebase notes

Replayed onto the release tip twice (51c3c39, then 43228cc after #567/#571 merged). Conflicts resolved keeping **both** sides: `searchContentAuto` threaded through #561's path_glob escalation loop (both fetch sites), all EOF tests preserved pairwise, #557's tooling-path prior verified intact in the merged `rerankSignalScore` chain (tests 0.6 → bench/scripts/website/install 0.5 → vendor 0.4 → doc cap).

## Validation

- `zig build test`: **749/749 pass** (23/23 steps)
- Live matrix on this repo, in-process (`CODEDB_NO_CLI_DAEMON=1`):
  - first-ever cold multi-word `search`: **0 → 50 results** (`word index rebuild`, `snapshot load`); one-time scan cost 722ms → 1.7s, trigram persists so later runs stay fast
  - cold single-word (`rebuildWordIndex`): 9 results, fast path unchanged; cold `--regex`: 2 results, fast path unchanged
  - warm (snapshot-loaded) multi-word: 50 results
  - **#569:** `codedb word "word index rebuild"`: **0 → 176 hits**, files covering more tokens first
  - **#568:** `codedb deps src/tests.zig` (zero importers): now prints `  (none)` + `(0 files)`
- engram `codedb_insights` re-run post-fix: codedb MRR **0.398** vs engram re-rank 0.288 on the latest 25-commit window (the historical gap that spawned #546 was 0.30 vs 0.60 the other way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)