### PR TITLE
fix(#573): CLI/MCP argument UX — flag-as-name, empty symbol name, callers single-pass

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1459,6 +1459,17 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         return;
     }
 
+    // #573: an explicitly empty name is a usage error, not a lookup for ""
+    // (which rendered as 'no results for: '). Mirrors codedb_callers.
+    if (name != null and name.?.len == 0) {
+        if (json_fmt) {
+            writeJsonToolError(out, alloc, "codedb_symbol", "empty_name", "empty name — pass a non-empty symbol name");
+        } else {
+            out.appendSlice(alloc, "error: empty name — pass a non-empty symbol name") catch {};
+        }
+        return;
+    }
+
     const kind = if (kind_str) |k| Explorer.parseSymbolKind(k) else null;
     if (kind_str != null and kind == null) {
         if (json_fmt) {
@@ -1986,8 +1997,12 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
         alloc.free(results);
     }
 
-    var shown: usize = 0;
-    for (results) |r| {
+    // #573: single filter pass — the header count and the printed entries come
+    // from the same accumulation, so a predicate edit cannot desync them (the
+    // previous count loop + print loop duplicated four predicates verbatim).
+    var kept: std.ArrayList(usize) = .empty;
+    defer kept.deinit(alloc);
+    for (results, 0..) |r, r_idx| {
         const lang = explore_mod.detectLanguage(r.path);
         if (!langHasCallSites(lang)) continue;
         // #562: a full-line comment mention is documentation, not a call site.
@@ -2001,25 +2016,13 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
         }
         if (is_def) continue;
         if (!hasWholeWordMatch(r.line_text, name)) continue;
-        shown += 1;
+        kept.append(alloc, r_idx) catch {};
     }
 
     const w = cio.listWriter(out, alloc);
-    w.print("{d} call sites for '{s}':\n", .{ shown, name }) catch {};
-    for (results) |r| {
-        const lang = explore_mod.detectLanguage(r.path);
-        if (!langHasCallSites(lang)) continue;
-        // #562: a full-line comment mention is documentation, not a call site.
-        if (explore_mod.isCommentOrBlank(r.line_text, lang)) continue;
-        var is_def = false;
-        for (defs) |d| {
-            if (r.line_num == d.symbol.line_start and std.mem.eql(u8, r.path, d.path)) {
-                is_def = true;
-                break;
-            }
-        }
-        if (is_def) continue;
-        if (!hasWholeWordMatch(r.line_text, name)) continue;
+    w.print("{d} call sites for '{s}':\n", .{ kept.items.len, name }) catch {};
+    for (kept.items) |kept_idx| {
+        const r = results[kept_idx];
         if (r.scope_name) |sn| {
             w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
                 r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
@@ -4132,7 +4135,14 @@ pub fn runCliTool(
     cmd_args_start: usize,
     out: *std.ArrayList(u8),
 ) ?u8 {
-    const pos: ?[]const u8 = if (args.len > cmd_args_start) args[cmd_args_start] else null;
+    // First positional. A leading '-'-prefixed arg is NOT silently bound as
+    // the positional — `callers --max-results 3 foo` previously reported call
+    // sites for '--max-results' (#573). Commands here take <name>/<path>
+    // first, so a leading flag falls through to the command's usage error.
+    const pos: ?[]const u8 = if (args.len > cmd_args_start and !std.mem.startsWith(u8, args[cmd_args_start], "-"))
+        args[cmd_args_start]
+    else
+        null;
     const out_start = out.items.len;
 
     var m: std.json.ObjectMap = .empty;

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2018,3 +2018,45 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     // …its longest meaningful word ('ranking') must drive the composer.
     try testing.expect(std.mem.indexOf(u8, out.items, "ranking") != null);
 }
+
+
+test "issue-572: cli bridge must not bind a leading flag as the positional name" {
+    // Live repro: `codedb callers --max-results 3 indexFile` reported
+    // "1 call sites for '--max-results'" — the bridge takes args[cmd_args_start]
+    // blindly, so a leading flag silently becomes the name. It must fall
+    // through to the command's usage error instead.
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/a.zig", "pub fn indexFile() void {}\npub fn caller() void {\n    indexFile();\n}\n");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    const argv = [_][]const u8{ "--max-results", "3", "indexFile" };
+    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, ".", "callers", &argv, 0, &out);
+    try testing.expect(code != null);
+    // The flag must not be reported as the function name…
+    try testing.expect(std.mem.indexOf(u8, out.items, "call sites for '--max-results'") == null);
+    // …the command fails to its usage line instead.
+    try testing.expect(std.mem.indexOf(u8, out.items, "callers <name>") != null);
+
+    // Companion UX defect, same audit: an explicitly empty symbol name must be
+    // a usage error (mirrors codedb_callers), not "no results for: ".
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const sargs_json =
+        \\{"name":""}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, sargs_json, .{});
+    defer parsed.deinit();
+
+    var sout: std.ArrayList(u8) = .empty;
+    defer sout.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_symbol, &parsed.value.object, &sout, &store, &explorer, &agents);
+    try testing.expect(std.mem.indexOf(u8, sout.items, "error: empty name") != null);
+}


### PR DESCRIPTION
Fixes #573.

## Problems (2026-06-10 re-audit)
1. `runCliTool` bound `args[cmd_args_start]` blindly: `codedb callers --max-results 3 indexFile` → **"1 call sites for '--max-results'"** — silently wrong instead of a usage error. Affected every bridge command taking a leading <name>/<path>.
2. `codedb_symbol name:""` → `no results for: ` instead of a usage error (callers already rejects empty names).
3. `handleCallers` duplicated four predicates across a count loop and a print loop — a future edit to one silently desyncs the header count (flagged as a maintenance trap).

## Fixes
- Bridge: a leading `-`-prefixed arg is not bound as the positional; the command's existing usage error fires
- `handleSymbol`: empty-name guard (text + json paths), mirroring callers
- `handleCallers`: single filter pass accumulates kept indices; header count and printed entries come from the same list (behavior unchanged — guarded by issue-391/425/426/562 tests)

## Failing Test
`test "issue-573: cli bridge must not bind a leading flag as the positional name"` (src/test_mcp.zig), committed red: 107/108 pre-fix (reported call sites for '--max-results').

## Validation
Full `zig build test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)