### PR TITLE
chore(test): align issue-573 test name with the filed issue number

### DIFF
--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2020,7 +2020,7 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
 }
 
 
-test "issue-572: cli bridge must not bind a leading flag as the positional name" {
+test "issue-573: cli bridge must not bind a leading flag as the positional name" {
     // Live repro: `codedb callers --max-results 3 indexFile` reported
     // "1 call sites for '--max-results'" — the bridge takes args[cmd_args_start]
     // blindly, so a leading flag silently becomes the name. It must fall


### PR DESCRIPTION
The failing test for #573 was committed under the predicted name issue-572 before the issue number landed as #573; the rename edit missed the commit. Name-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)