### PR TITLE
feat(#578): codedb changes CLI command (bridge to codedb_changes) + flush-before-exit fix

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -587,7 +587,7 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
         // reach the same warm tools the MCP surface exposes.
         var nav: std.ArrayList(u8) = .empty;
         defer nav.deinit(allocator);
-        if (mcp_server.runCliTool(io, allocator, explorer, root, cmd, args, cmd_args_start, &nav)) |code| {
+        if (mcp_server.runCliTool(io, allocator, explorer, store, root, cmd, args, cmd_args_start, &nav)) |code| {
             out.p("{s}", .{nav.items});
             return code;
         }
@@ -677,7 +677,7 @@ fn cliWriteFull(fd: c_int, data: []const u8) bool {
 /// will proxy. Everything else (serve, mcp, snapshot, index, ...) is handled
 /// only by the cold path.
 fn cliIsQueryCmd(cmd: []const u8) bool {
-    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context" };
+    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes" };
     for (cmds) |c| {
         if (std.mem.eql(u8, cmd, c)) return true;
     }
@@ -1381,7 +1381,7 @@ fn mainImpl() !void {
         std.mem.eql(u8, cmd, "hot") or std.mem.eql(u8, cmd, "symbol") or std.mem.eql(u8, cmd, "callers") or
         std.mem.eql(u8, cmd, "callpath") or std.mem.eql(u8, cmd, "deps") or std.mem.eql(u8, cmd, "glob") or
         std.mem.eql(u8, cmd, "ls") or std.mem.eql(u8, cmd, "file") or std.mem.eql(u8, cmd, "context") or
-        std.mem.eql(u8, cmd, "status"))
+        std.mem.eql(u8, cmd, "changes") or std.mem.eql(u8, cmd, "status"))
     {
         const code = runQuery(io, allocator, &explorer, &store, abs_root, cmd, args, cmd_args_start, &out, s);
         out.flush();
@@ -1758,6 +1758,10 @@ fn mainImpl() !void {
         out.p("{s}\xe2\x9c\x97{s} unknown command: {s}{s}{s}\n", .{
             s.red, s.reset, s.bold, cmd, s.reset,
         });
+        // #578: flush before exit — std.process.exit skips buffered output, so
+        // the 'unknown command' line was silently lost (observed as exit 1
+        // with no output at all).
+        out.flush();
         std.process.exit(1);
     }
 }
@@ -1943,7 +1947,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 }
 
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
+    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -4138,6 +4138,7 @@ pub fn runCliTool(
     io: std.Io,
     alloc: std.mem.Allocator,
     explorer: *Explorer,
+    store: *Store,
     root: []const u8,
     cmd: []const u8,
     args: []const []const u8,
@@ -4173,6 +4174,15 @@ pub fn runCliTool(
         // the heap word index. Keeps the footprint at the MCP level.
         loadProjectTrigramFromDiskIfPresent(io, explorer, root, alloc);
         handleCallers(alloc, &m, out, explorer);
+        return finishCli(out, out_start);
+    } else if (std.mem.eql(u8, cmd, "changes")) {
+        // #578: changes reads the Store ledger (not the Explorer), which is why
+        // the bridge takes `store`. Optional positional = since_seq.
+        if (pos) |p| {
+            const since = std.fmt.parseInt(i64, p, 10) catch return cliUsage(alloc, out, "changes [since_seq]");
+            m.put(alloc, "since", .{ .integer = since }) catch return 1;
+        }
+        handleChanges(alloc, &m, out, store);
         return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "callpath")) {
         if (args.len < cmd_args_start + 2) return cliUsage(alloc, out, "callpath <from> <to>");

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2104,3 +2104,26 @@ test "issue-576: codedb_ls distinguishes a non-indexed path from an empty listin
     bench_ctx.runDispatch(io, testing.allocator, .codedb_ls, &ok_parsed.value.object, &ok_out, &store, &explorer, &agents);
     try testing.expect(std.mem.indexOf(u8, ok_out.items, "a.zig") != null);
 }
+
+
+test "issue-578: cli bridge serves codedb_changes" {
+    // `codedb changes` parsed as a ROOT directory (unknown first token in the
+    // [root] <command> grammar) and printed usage — codedb_changes existed
+    // only as an MCP tool because the bridge had no store to hand to
+    // handleChanges. The bridge must serve it like the other read-only tools.
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/a.zig", "pub fn a() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = store.recordSnapshot("src/a.zig", 10, 123) catch {};
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    const argv = [_][]const u8{};
+    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, ".", "changes", &argv, 0, &out);
+    // Pre-#578 the bridge did not know 'changes' and returned null.
+    try testing.expect(code != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "seq:") != null);
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2029,10 +2029,13 @@ test "issue-573: cli bridge must not bind a leading flag as the positional name"
     defer explorer.deinit();
     try explorer.indexFile("src/a.zig", "pub fn indexFile() void {}\npub fn caller() void {\n    indexFile();\n}\n");
 
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
     const argv = [_][]const u8{ "--max-results", "3", "indexFile" };
-    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, ".", "callers", &argv, 0, &out);
+    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, &store, ".", "callers", &argv, 0, &out);
     try testing.expect(code != null);
     // The flag must not be reported as the function name…
     try testing.expect(std.mem.indexOf(u8, out.items, "call sites for '--max-results'") == null);
@@ -2041,8 +2044,6 @@ test "issue-573: cli bridge must not bind a leading flag as the positional name"
 
     // Companion UX defect, same audit: an explicitly empty symbol name must be
     // a usage error (mirrors codedb_callers), not "no results for: ".
-    var store = Store.init(testing.allocator);
-    defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
     defer agents.deinit();
     _ = try agents.register("__filesystem__");
@@ -2122,7 +2123,7 @@ test "issue-578: cli bridge serves codedb_changes" {
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
     const argv = [_][]const u8{};
-    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, ".", "changes", &argv, 0, &out);
+    const code = mcp_mod.runCliTool(io, testing.allocator, &explorer, &store, ".", "changes", &argv, 0, &out);
     // Pre-#578 the bridge did not know 'changes' and returned null.
     try testing.expect(code != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "seq:") != null);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11694,11 +11694,13 @@ test "cli-mcp-parity: runCliTool bridges navigation commands to MCP handlers" {
     try exp.indexFile("src/store.zig", "pub const Store = struct {};\n");
     try exp.indexFile("src/main.zig", "const Store = @import(\"store.zig\").Store;\npub fn main() void {}\n");
 
+    var store = Store.init(aa);
+
     // glob: pattern -> matching indexed paths (reuses handleGlob)
     {
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(aa);
-        const code = mcp_mod.runCliTool(io, aa, &exp, ".", "glob", &.{ "codedb", ".", "glob", "src/*.zig" }, 3, &out);
+        const code = mcp_mod.runCliTool(io, aa, &exp, &store, ".", "glob", &.{ "codedb", ".", "glob", "src/*.zig" }, 3, &out);
         try testing.expectEqual(@as(?u8, 0), code);
         try testing.expect(std.mem.indexOf(u8, out.items, "src/store.zig") != null);
         try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
@@ -11708,7 +11710,7 @@ test "cli-mcp-parity: runCliTool bridges navigation commands to MCP handlers" {
     {
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(aa);
-        const code = mcp_mod.runCliTool(io, aa, &exp, ".", "symbol", &.{ "codedb", ".", "symbol", "Store" }, 3, &out);
+        const code = mcp_mod.runCliTool(io, aa, &exp, &store, ".", "symbol", &.{ "codedb", ".", "symbol", "Store" }, 3, &out);
         try testing.expectEqual(@as(?u8, 0), code);
         try testing.expect(std.mem.indexOf(u8, out.items, "src/store.zig") != null);
     }
@@ -11717,14 +11719,14 @@ test "cli-mcp-parity: runCliTool bridges navigation commands to MCP handlers" {
     {
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(aa);
-        try testing.expectEqual(@as(?u8, null), mcp_mod.runCliTool(io, aa, &exp, ".", "bogus", &.{ "codedb", ".", "bogus" }, 3, &out));
+        try testing.expectEqual(@as(?u8, null), mcp_mod.runCliTool(io, aa, &exp, &store, ".", "bogus", &.{ "codedb", ".", "bogus" }, 3, &out));
     }
 
     // missing required arg -> usage line, exit 1
     {
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(aa);
-        try testing.expectEqual(@as(?u8, 1), mcp_mod.runCliTool(io, aa, &exp, ".", "glob", &.{ "codedb", ".", "glob" }, 3, &out));
+        try testing.expectEqual(@as(?u8, 1), mcp_mod.runCliTool(io, aa, &exp, &store, ".", "glob", &.{ "codedb", ".", "glob" }, 3, &out));
         try testing.expect(std.mem.indexOf(u8, out.items, "usage") != null);
     }
 }


### PR DESCRIPTION
Fixes #578.

## Problem
`codedb changes` printed the usage screen: an unknown first token parses as the ROOT in the `[root] <command>` grammar. codedb_changes existed only as an MCP tool — the CLI bridge couldn't serve it without `store`.

## Fix
- `runCliTool` gains `store: *Store` + a `changes [since_seq]` branch calling `handleChanges`
- `changes` registered in `cliIsQueryCmd`, `isCommand`, and the `runQuery` dispatch chain (three separate command lists — found the third one the hard way: live check exited 1 with no output)
- That silent exit exposed a second defect: the unknown-command branch wrote to the buffered writer and then `std.process.exit(1)`, losing the message — now flushes first

## Failing Test
`test "issue-578: cli bridge serves codedb_changes"` (src/test_mcp.zig), committed red (bridge returned null).

## Validation
- Full suite green
- Live: `codedb changes` → `seq: 622, 622 files changed since 0:` + per-file list; `codedb changes 600` filters by seq

🤖 Generated with [Claude Code](https://claude.com/claude-code)