### PR TITLE
fix(#580): basename test files no longer dodge the rerank test penalty

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2858,7 +2858,12 @@ pub const Explorer = struct {
             score += 6.0;
         }
 
-        if (pathHasSegment(r.path, "tests") or pathHasSegment(r.path, "test")) score *= 0.6;
+        // #580: match BM25's pathRelevanceMultiplier — test files identified by
+        // BASENAME (tests.zig, test_*.zig, *_tests.zig) are tests even without
+        // a test/ directory segment.
+        const is_test_file = pathHasSegment(r.path, "tests") or pathHasSegment(r.path, "test") or
+            std.mem.startsWith(u8, basename, "test") or std.mem.indexOf(u8, basename, "_test") != null;
+        if (is_test_file) score *= 0.6;
         if (pathHasSegment(r.path, "examples") or pathHasSegment(r.path, "example")) score *= 0.6;
         if (pathHasSegment(r.path, "bench") or pathHasSegment(r.path, "benchmarks") or
             pathHasSegment(r.path, "scripts") or pathHasSegment(r.path, "website") or

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1749,3 +1749,31 @@ test "issue-562: codedb_callers excludes full-line comment mentions" {
     // …and must not inflate the header count.
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'insertThing'") != null);
 }
+
+
+test "issue-580: basename test files rank below non-test source for concept queries" {
+    // rerankSignalScore's test penalty only matches DIRECTORY segments named
+    // test/tests, so files like src/tests.zig or src/widget_tests.zig dodge
+    // the ×0.6 entirely (live: 'codedb search snapshot' put src/tests.zig at
+    // file-rank 3, above non-test source). BM25's pathRelevanceMultiplier
+    // already checks the basename — the scan-rerank path must match it.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    // The test-named file mentions the term more densely (as test files do);
+    // without a basename penalty it outranks the implementation line.
+    try explorer.indexFile("src/zz_tests.zig", "pub fn x() void { _ = conceptTerm; _ = conceptTerm; _ = conceptTerm; }\n");
+    try explorer.indexFile("src/owner.zig", "pub fn x() void { _ = conceptTerm; _ = conceptTerm; }\n");
+
+    const results = try explorer.searchContent("conceptTerm", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("src/owner.zig", results[0].path);
+}


### PR DESCRIPTION
Fixes #580.

`rerankSignalScore`'s test penalty matched only directory segments (`test/`, `tests/`); files identified as tests by BASENAME — `src/tests.zig`, `src/test_*.zig`, `*_tests.zig` — escaped the ×0.6 in the scan-rerank path, while BM25's `pathRelevanceMultiplier` already caught them. The scorers now share the basename rule.

Failing test committed red (denser-mentioning `src/zz_tests.zig` outranked `src/owner.zig`); 737/737 green after, no fixture collateral.

Honest live note: on this repo's 'snapshot' query the visible file ranking barely moves (`src/tests.zig` stays at file-rank 3 — its best line ×0.6 still scores above the next class of lines). The fix changes relative ordering only where a test file and non-test source are within 1.67× of each other, which is exactly the tie-adjacent class the unit test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)