### PR TITLE
chore(cli): single shared query-command table (the #578 drift-class fix)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -673,12 +673,17 @@ fn cliWriteFull(fd: c_int, data: []const u8) bool {
     return true;
 }
 
+/// The read-only query commands — single source of truth (#578 grew from
+/// three hand-maintained copies drifting: cliIsQueryCmd, isCommand, and the
+/// runQuery dispatch chain in mainImpl). isCommand appends the non-query
+/// commands; the dispatch chain calls cliIsQueryCmd directly.
+const cli_query_cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes" };
+
 /// True for the read-only query commands the daemon will serve / the client
 /// will proxy. Everything else (serve, mcp, snapshot, index, ...) is handled
 /// only by the cold path.
 fn cliIsQueryCmd(cmd: []const u8) bool {
-    const cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes" };
-    for (cmds) |c| {
+    for (cli_query_cmds) |c| {
         if (std.mem.eql(u8, cmd, c)) return true;
     }
     return false;
@@ -1376,12 +1381,7 @@ fn mainImpl() !void {
             }
         } // end else (no snapshot)
     }
-    if (std.mem.eql(u8, cmd, "tree") or std.mem.eql(u8, cmd, "outline") or std.mem.eql(u8, cmd, "find") or
-        std.mem.eql(u8, cmd, "search") or std.mem.eql(u8, cmd, "word") or std.mem.eql(u8, cmd, "read") or
-        std.mem.eql(u8, cmd, "hot") or std.mem.eql(u8, cmd, "symbol") or std.mem.eql(u8, cmd, "callers") or
-        std.mem.eql(u8, cmd, "callpath") or std.mem.eql(u8, cmd, "deps") or std.mem.eql(u8, cmd, "glob") or
-        std.mem.eql(u8, cmd, "ls") or std.mem.eql(u8, cmd, "file") or std.mem.eql(u8, cmd, "context") or
-        std.mem.eql(u8, cmd, "changes") or std.mem.eql(u8, cmd, "status"))
+    if (cliIsQueryCmd(cmd))
     {
         const code = runQuery(io, allocator, &explorer, &store, abs_root, cmd, args, cmd_args_start, &out, s);
         out.flush();
@@ -1947,7 +1947,9 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 }
 
 fn isCommand(arg: []const u8) bool {
-    const commands = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes", "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
+    // cli_query_cmds is the shared query-command table (see its doc); only the
+    // non-query commands are listed here.
+    const commands = cli_query_cmds ++ [_][]const u8{ "snapshot", "serve", "mcp", "update", "nuke", "cli-daemon" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }


### PR DESCRIPTION
Three hand-maintained copies of the query-command list (`cliIsQueryCmd`, `isCommand`, the inline `eql` chain gating `runQuery`) drifted during #578 — a command registered in two of three lists silently exited 1 with no output. `cli_query_cmds` is now the single source of truth; `isCommand` appends the non-query commands via comptime concat and the dispatch chain calls `cliIsQueryCmd`.

Behavior-identical refactor: full suite green; live smoke of `ls`/`changes`/`status` and the unknown-command path (`✗ unknown command`, exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)