### PR TITLE
fix: memory/RSS + daemon-lifecycle bug hunt — 8 issues (#583 #584 #586 #587 #589 #592 #593 #594)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -749,6 +749,7 @@ pub const Explorer = struct {
 
         var sym_iter = self.symbol_index.iterator();
         while (sym_iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
             entry.value_ptr.deinit(self.allocator);
         }
         self.symbol_index.deinit();
@@ -1504,6 +1505,7 @@ pub const Explorer = struct {
         }
         self.dep_graph.remove(path);
         self.removeSymbolIndexFor(path);
+        _ = self.skip_trigram_files.remove(path);
         self.contents.remove(path);
         self.word_index.removeFile(path);
         self.trigram_index.removeFile(path);
@@ -2252,16 +2254,16 @@ pub const Explorer = struct {
     /// name-only resolution. Conservative: only the highest-collision names.
     fn isUbiquitousName(name: []const u8) bool {
         const common = [_][]const u8{
-            "init",        "deinit",   "append",   "get",       "set",
-            "put",         "getOrPut", "remove",   "contains",  "has",
-            "count",       "len",      "items",    "alloc",     "free",
-            "create",      "destroy",  "lock",     "unlock",    "tryLock",
-            "next",        "iterator", "clone",    "dupe",      "slice",
-            "reset",       "clear",    "format",   "hash",      "eql",
-            "write",       "writeAll", "print",    "read",      "close",
-            "open",        "value",    "key",      "toOwnedSlice", "pop",
-            "push",        "find",     "add",      "new",       "build",
-            "run",         "deinit",   "toString", "valueOf",   "of",
+            "init",   "deinit",   "append",   "get",          "set",
+            "put",    "getOrPut", "remove",   "contains",     "has",
+            "count",  "len",      "items",    "alloc",        "free",
+            "create", "destroy",  "lock",     "unlock",       "tryLock",
+            "next",   "iterator", "clone",    "dupe",         "slice",
+            "reset",  "clear",    "format",   "hash",         "eql",
+            "write",  "writeAll", "print",    "read",         "close",
+            "open",   "value",    "key",      "toOwnedSlice", "pop",
+            "push",   "find",     "add",      "new",          "build",
+            "run",    "deinit",   "toString", "valueOf",      "of",
         };
         for (common) |c| if (std.mem.eql(u8, name, c)) return true;
         return false;
@@ -4132,7 +4134,7 @@ pub const Explorer = struct {
                 try appendOutlineSymbol(a, outline, name, kind, line_num, line);
             }
         }
-        if (startsWith(line, "import ") or containsAny(line, &.{ "require(" })) {
+        if (startsWith(line, "import ") or containsAny(line, &.{"require("})) {
             try appendOutlineSymbol(a, outline, line, .import, line_num, null);
             if (extractStringLiteral(line)) |path| {
                 try appendImportPath(a, outline, path);
@@ -5080,6 +5082,13 @@ pub const Explorer = struct {
         for (outline.symbols.items) |sym| {
             const gop = self.symbol_index.getOrPut(sym.name) catch continue;
             if (!gop.found_existing) {
+                // The map owns its keys: sym.name belongs to the outline and
+                // dies with it on re-index, while shared-name entries survive.
+                const owned = self.allocator.dupe(u8, sym.name) catch {
+                    _ = self.symbol_index.remove(sym.name);
+                    continue;
+                };
+                gop.key_ptr.* = owned;
                 gop.value_ptr.* = std.ArrayList(SymbolLocation).empty;
             }
             gop.value_ptr.append(self.allocator, .{
@@ -5112,7 +5121,9 @@ pub const Explorer = struct {
             }
         }
         for (to_remove.items) |key| {
-            _ = self.symbol_index.remove(key);
+            if (self.symbol_index.fetchRemove(key)) |kv| {
+                self.allocator.free(kv.key);
+            }
         }
     }
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -724,10 +724,15 @@ pub const Explorer = struct {
     }
 
     pub fn init(allocator: std.mem.Allocator, content_cache_capacity: u32) Explorer {
+        return initFallible(allocator, content_cache_capacity) catch
+            std.debug.panic("Explorer.init: OOM allocating {d} content cache slots", .{content_cache_capacity});
+    }
+
+    fn initFallible(allocator: std.mem.Allocator, content_cache_capacity: u32) !Explorer {
         return .{
             .outlines = std.StringHashMap(FileOutline).init(allocator),
             .dep_graph = DependencyGraph.init(allocator),
-            .contents = ContentCache.init(allocator, content_cache_capacity),
+            .contents = try ContentCache.initAlloc(allocator, content_cache_capacity),
             .symbol_index = std.StringHashMap(std.ArrayList(SymbolLocation)).init(allocator),
             .symbol_index_complete = true,
             .word_index = WordIndex.init(allocator),
@@ -828,8 +833,12 @@ pub const Explorer = struct {
 
     pub fn commitParsedFileOwnedOutline(self: *Explorer, path: []const u8, content: []const u8, outline: FileOutline, full_index: bool, skip_trigram: bool) !void {
         var owned_outline = outline;
-        errdefer owned_outline.deinit();
-        var persistent_outline = try cloneOutline(&owned_outline, self.allocator);
+        // One deinit only: an errdefer here would stack with the defer below
+        // and double-free the parsed outline on any post-clone error.
+        var persistent_outline = cloneOutline(&owned_outline, self.allocator) catch |err| {
+            owned_outline.deinit();
+            return err;
+        };
         defer owned_outline.deinit();
         errdefer persistent_outline.deinit();
         if (persistent_outline.owns_path) {
@@ -861,7 +870,17 @@ pub const Explorer = struct {
         persistent_outline.path = stable_path;
 
         const prior_content = self.contents.get(stable_path);
-        try self.contents.put(stable_path, content);
+        // Any failure below must put the word index back the way it was —
+        // indexFile wipes the old postings before adding new ones, and search
+        // serves whatever the postings say. prior_content stays valid through
+        // every fallible step because contents.put runs last.
+        errdefer if (full_index and !self.defer_word_index) {
+            if (prior_content) |old| {
+                self.word_index.indexFile(stable_path, old) catch {};
+            } else {
+                self.word_index.removeFile(stable_path);
+            }
+        };
 
         if (full_index) {
             // A disabled word index (cold CLI scan keeps it off to save memory)
@@ -872,13 +891,6 @@ pub const Explorer = struct {
                 self.word_index_can_load_from_disk = false;
             }
             if (!self.defer_word_index) try self.word_index.indexFile(stable_path, content);
-            // If trigram indexing fails below, restore word_index to its previous state
-            // to prevent word_index and trigram_index from diverging.
-            errdefer if (prior_content) |old| {
-                self.word_index.indexFile(stable_path, old) catch {};
-            } else {
-                self.word_index.removeFile(stable_path);
-            };
             if (self.word_index_complete) {
                 self.word_index_generation +%= 1;
             }
@@ -911,6 +923,10 @@ pub const Explorer = struct {
 
         try self.rebuildDepsFor(stable_path, &persistent_outline);
         self.rebuildSymbolIndexFor(stable_path, &persistent_outline, !is_new);
+
+        // Last fallible step: put frees the prior cache value in place, so it
+        // must run only once nothing after it can still need prior_content.
+        try self.contents.put(stable_path, content);
 
         outline_gop.value_ptr.* = persistent_outline;
         if (prior_outline) |*old_outline| old_outline.deinit();
@@ -1304,7 +1320,10 @@ pub const Explorer = struct {
     }
 
     pub fn parseContentForIndexing(allocator: std.mem.Allocator, path: []const u8, content: []const u8) !ParsedFile {
-        var parser = Explorer.init(allocator, DEFAULT_CONTENT_CACHE_CAPACITY);
+        // A parser shell only carries the allocator into the parse methods: a
+        // 1-slot cache keeps the per-file cost flat, and OOM here must surface
+        // as an error, not ContentCache.init's daemon-killing panic.
+        var parser = try Explorer.initFallible(allocator, 1);
         defer parser.deinit();
         var parsed_outline = try parseOutlineWithParser(&parser, path, content);
         defer parsed_outline.deinit();
@@ -5116,12 +5135,16 @@ pub const Explorer = struct {
                 }
             }
             if (list.items.len == 0) {
-                list.deinit(self.allocator);
+                // Deinit only at actual removal below: ArrayList.deinit poisons
+                // the in-map value, so a failed append here must leave a VALID
+                // (empty) list behind, not a landmine for the next iteration.
                 to_remove.append(self.allocator, entry.key_ptr.*) catch {};
             }
         }
         for (to_remove.items) |key| {
             if (self.symbol_index.fetchRemove(key)) |kv| {
+                var hits = kv.value;
+                hits.deinit(self.allocator);
                 self.allocator.free(kv.key);
             }
         }

--- a/src/hot_cache.zig
+++ b/src/hot_cache.zig
@@ -11,14 +11,15 @@ const std = @import("std");
 pub const ContentCache = struct {
     slots: []Slot,
     capacity: u32,
-    hand: u32,
     count_: u32,
     allocator: std.mem.Allocator,
     hits_: std.atomic.Value(u64),
     misses_: std.atomic.Value(u64),
     evictions_: std.atomic.Value(u64),
 
-    const PROBE_LIMIT: u32 = 4;
+    // 8-way set-associative: at typical occupancy a full window (the only
+    // eviction trigger) is vanishingly rare; probes stay short and contiguous.
+    const PROBE_LIMIT: u32 = 8;
 
     pub const Slot = struct {
         key_hash: u64,
@@ -57,7 +58,6 @@ pub const ContentCache = struct {
         return .{
             .slots = slots,
             .capacity = capacity,
-            .hand = 0,
             .count_ = 0,
             .allocator = allocator,
             .hits_ = std.atomic.Value(u64).init(0),
@@ -73,7 +73,6 @@ pub const ContentCache = struct {
         return .{
             .slots = slots,
             .capacity = capacity,
-            .hand = 0,
             .count_ = 0,
             .allocator = allocator,
             .hits_ = std.atomic.Value(u64).init(0),
@@ -104,7 +103,6 @@ pub const ContentCache = struct {
                 _ = self.hits_.fetchAdd(1, .monotonic);
                 return slot.value;
             }
-            if (!slot.present and slot.key_hash == 0) break;
         }
         _ = self.misses_.fetchAdd(1, .monotonic);
         return null;
@@ -129,43 +127,58 @@ pub const ContentCache = struct {
         const h = hashKey(key);
         const base = @as(u32, @truncate(h)) % self.capacity;
 
+        // Scan the whole window: update an existing entry in place (a hole must
+        // not shadow it into a duplicate), otherwise remember the first empty slot.
+        var empty_idx: ?u32 = null;
         var i: u32 = 0;
         while (i < PROBE_LIMIT) : (i += 1) {
             const slot_idx = (base +% i) % self.capacity;
             const slot = &self.slots[slot_idx];
-            if (slot.present and slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
-                // Compute the new value first so a failed dupe leaves the slot intact.
-                const new_value = if (own) try self.allocator.dupe(u8, value) else value;
-                if (slot.value_owned) self.allocator.free(slot.value);
-                slot.value = new_value;
-                slot.value_owned = own;
-                slot.ref_bit = true;
-                return;
-            }
-            if (!slot.present) {
-                const duped_key = try self.allocator.dupe(u8, key);
-                errdefer self.allocator.free(duped_key);
-                const new_value = if (own) try self.allocator.dupe(u8, value) else value;
-                slot.key_hash = h;
-                slot.key = duped_key;
-                slot.value = new_value;
-                slot.value_owned = own;
-                slot.ref_bit = true;
-                slot.present = true;
-                self.count_ += 1;
-                return;
+            if (slot.present) {
+                if (slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
+                    // Compute the new value first so a failed dupe leaves the slot intact.
+                    const new_value = if (own) try self.allocator.dupe(u8, value) else value;
+                    if (slot.value_owned) self.allocator.free(slot.value);
+                    slot.value = new_value;
+                    slot.value_owned = own;
+                    slot.ref_bit = true;
+                    return;
+                }
+            } else if (empty_idx == null) {
+                empty_idx = slot_idx;
             }
         }
 
-        // All probe slots occupied — evict via CLOCK sweep.
-        const evict_idx = self.clockEvict();
-        const slot = &self.slots[evict_idx];
-        if (slot.present) {
+        // Window full of other keys — evict in-window (second chance over the
+        // probe slots) so the new entry stays reachable by get(). A victim from
+        // a global sweep would strand the entry outside its own window.
+        const target_idx = empty_idx orelse blk: {
+            var victim: ?u32 = null;
+            i = 0;
+            while (i < PROBE_LIMIT) : (i += 1) {
+                const slot_idx = (base +% i) % self.capacity;
+                if (!self.slots[slot_idx].ref_bit) {
+                    victim = slot_idx;
+                    break;
+                }
+            }
+            if (victim == null) {
+                i = 0;
+                while (i < PROBE_LIMIT) : (i += 1) {
+                    self.slots[(base +% i) % self.capacity].ref_bit = false;
+                }
+                victim = base;
+            }
+            const slot = &self.slots[victim.?];
             self.allocator.free(slot.key);
             if (slot.value_owned) self.allocator.free(slot.value);
+            slot.* = empty_slot;
             self.count_ -= 1;
             _ = self.evictions_.fetchAdd(1, .monotonic);
-        }
+            break :blk victim.?;
+        };
+
+        const slot = &self.slots[target_idx];
         const duped_key = try self.allocator.dupe(u8, key);
         errdefer self.allocator.free(duped_key);
         const new_value = if (own) try self.allocator.dupe(u8, value) else value;
@@ -192,7 +205,6 @@ pub const ContentCache = struct {
                 self.count_ -= 1;
                 return;
             }
-            if (!slot.present and slot.key_hash == 0) return;
         }
     }
 
@@ -205,7 +217,6 @@ pub const ContentCache = struct {
             }
         }
         self.count_ = 0;
-        self.hand = 0;
     }
 
     pub fn len(self: *const ContentCache) u32 {
@@ -256,23 +267,6 @@ pub const ContentCache = struct {
 
     pub fn iterator(self: *const ContentCache) Iterator {
         return .{ .cache = self, .index = 0 };
-    }
-
-    fn clockEvict(self: *ContentCache) u32 {
-        var sweeps: u32 = 0;
-        while (sweeps < self.capacity * 2) : (sweeps += 1) {
-            const slot_idx = self.hand % self.capacity;
-            self.hand = (self.hand +% 1) % self.capacity;
-            const slot = &self.slots[slot_idx];
-            if (!slot.present) return slot_idx;
-            if (!slot.ref_bit) {
-                return slot_idx;
-            }
-            slot.ref_bit = false;
-        }
-        const slot_idx = self.hand % self.capacity;
-        self.hand = (self.hand +% 1) % self.capacity;
-        return slot_idx;
     }
 
     fn hashKey(key: []const u8) u64 {
@@ -374,8 +368,8 @@ test "ContentCache: mixed owned/borrowed — transitions and eviction free corre
     defer cache.deinit();
 
     const lit: []const u8 = "literal-borrowed-value";
-    try cache.put("a", "heap-duped");       // owned
-    try cache.putBorrowed("b", lit);        // borrowed
+    try cache.put("a", "heap-duped"); // owned
+    try cache.putBorrowed("b", lit); // borrowed
     try std.testing.expectEqualStrings("heap-duped", cache.get("a").?);
     try std.testing.expectEqual(lit.ptr, cache.get("b").?.ptr);
 

--- a/src/index.zig
+++ b/src/index.zig
@@ -219,7 +219,14 @@ pub const WordIndex = struct {
     ) !void {
         const gop = try self.index.getOrPut(token);
         if (!gop.found_existing) {
-            const duped = try self.allocator.dupe(u8, token);
+            // A failed dupe must take the fresh entry with it — the key still
+            // points at the tokenizer's stack buffer and the value is
+            // undefined; left in place, the next insert that lands on it
+            // dereferences garbage.
+            const duped = self.allocator.dupe(u8, token) catch |err| {
+                _ = self.index.remove(token);
+                return err;
+            };
             gop.key_ptr.* = duped;
             gop.value_ptr.* = .empty;
         }
@@ -376,7 +383,12 @@ pub const WordIndex = struct {
             const shard_hits = entry.value_ptr.items;
             const gop = try self.index.getOrPut(term);
             if (!gop.found_existing) {
-                const dterm = try self.allocator.dupe(u8, term);
+                // A failed dupe must take the fresh entry with it — the key
+                // still points at the shard's arena, freed after the merge.
+                const dterm = self.allocator.dupe(u8, term) catch |err| {
+                    _ = self.index.remove(term);
+                    return err;
+                };
                 gop.key_ptr.* = dterm;
                 gop.value_ptr.* = .empty;
             }
@@ -2399,8 +2411,26 @@ pub const AnyTrigramIndex = union(enum) {
     pub const MmapOverlay = struct {
         base: MmapTrigramIndex,
         overlay: TrigramIndex,
+        /// Paths whose base entries are superseded (re-indexed into the
+        /// overlay) or removed. Owns its keys; base answers for these paths
+        /// are filtered out everywhere.
+        masked: std.StringHashMap(void),
+        masked_in_base: u32 = 0,
+
+        fn mask(self: *MmapOverlay, path: []const u8) void {
+            if (self.masked.contains(path)) return;
+            const key = self.overlay.allocator.dupe(u8, path) catch return;
+            self.masked.put(key, {}) catch {
+                self.overlay.allocator.free(key);
+                return;
+            };
+            if (self.base.containsFile(path)) self.masked_in_base += 1;
+        }
 
         pub fn deinit(self: *MmapOverlay) void {
+            var it = self.masked.keyIterator();
+            while (it.next()) |k| self.overlay.allocator.free(k.*);
+            self.masked.deinit();
             self.base.deinit();
             self.overlay.deinit();
         }
@@ -2421,33 +2451,50 @@ pub const AnyTrigramIndex = union(enum) {
             .mmap_overlay => |*mo| blk: {
                 const base = mo.base.candidates(query, allocator);
                 const over = mo.overlay.candidates(query, allocator);
-                if (base == null and over == null) break :blk null;
-                if (base == null) break :blk over;
-                if (over == null) break :blk base;
-                // Merge and dedup — return null on alloc failure (triggers full scan fallback)
-                var merged = std.StringHashMap(void).init(allocator);
-                defer merged.deinit();
-                for (base.?) |p| merged.put(p, {}) catch {
-                    allocator.free(base.?);
-                    allocator.free(over.?);
-                    break :blk null;
-                };
-                for (over.?) |p| merged.put(p, {}) catch {
-                    allocator.free(base.?);
-                    allocator.free(over.?);
-                    break :blk null;
-                };
-                allocator.free(base.?);
-                allocator.free(over.?);
-                var result: std.ArrayList([]const u8) = .empty;
-                result.ensureTotalCapacity(allocator, merged.count()) catch break :blk null;
-                var it = merged.keyIterator();
-                while (it.next()) |k| result.appendAssumeCapacity(k.*);
-                break :blk result.toOwnedSlice(allocator) catch {
-                    result.deinit(allocator);
-                    break :blk null;
-                };
+                break :blk mergeOverlayCandidates(mo, base, over, allocator);
             },
+        };
+    }
+
+    /// Merge base + overlay candidate lists, dropping base hits for masked
+    /// (superseded or removed) paths. Returns null on alloc failure so callers
+    /// fall back to the full scan.
+    fn mergeOverlayCandidates(
+        mo: *const MmapOverlay,
+        base: ?[]const []const u8,
+        over: ?[]const []const u8,
+        allocator: std.mem.Allocator,
+    ) ?[]const []const u8 {
+        if (base == null and over == null) return null;
+        if (base == null) return over;
+        var merged = std.StringHashMap(void).init(allocator);
+        defer merged.deinit();
+        var failed = false;
+        for (base.?) |p| {
+            if (mo.masked.contains(p)) continue;
+            merged.put(p, {}) catch {
+                failed = true;
+                break;
+            };
+        }
+        if (!failed) if (over) |ov| {
+            for (ov) |p| {
+                merged.put(p, {}) catch {
+                    failed = true;
+                    break;
+                };
+            }
+        };
+        allocator.free(base.?);
+        if (over) |ov| allocator.free(ov);
+        if (failed) return null;
+        var result: std.ArrayList([]const u8) = .empty;
+        result.ensureTotalCapacity(allocator, merged.count()) catch return null;
+        var it = merged.keyIterator();
+        while (it.next()) |k| result.appendAssumeCapacity(k.*);
+        return result.toOwnedSlice(allocator) catch {
+            result.deinit(allocator);
+            return null;
         };
     }
 
@@ -2458,31 +2505,7 @@ pub const AnyTrigramIndex = union(enum) {
             .mmap_overlay => |*mo| blk: {
                 const base = mo.base.candidatesRegex(query, allocator);
                 const over = mo.overlay.candidatesRegex(query, allocator);
-                if (base == null and over == null) break :blk null;
-                if (base == null) break :blk over;
-                if (over == null) break :blk base;
-                var merged = std.StringHashMap(void).init(allocator);
-                defer merged.deinit();
-                for (base.?) |p| merged.put(p, {}) catch {
-                    allocator.free(base.?);
-                    allocator.free(over.?);
-                    break :blk null;
-                };
-                for (over.?) |p| merged.put(p, {}) catch {
-                    allocator.free(base.?);
-                    allocator.free(over.?);
-                    break :blk null;
-                };
-                allocator.free(base.?);
-                allocator.free(over.?);
-                var result: std.ArrayList([]const u8) = .empty;
-                result.ensureTotalCapacity(allocator, merged.count()) catch break :blk null;
-                var it = merged.keyIterator();
-                while (it.next()) |k| result.appendAssumeCapacity(k.*);
-                break :blk result.toOwnedSlice(allocator) catch {
-                    result.deinit(allocator);
-                    break :blk null;
-                };
+                break :blk mergeOverlayCandidates(mo, base, over, allocator);
             },
         };
     }
@@ -2491,7 +2514,8 @@ pub const AnyTrigramIndex = union(enum) {
         return switch (self.*) {
             .heap => |*h| h.file_trigrams.contains(path),
             .mmap => |*m| m.containsFile(path),
-            .mmap_overlay => |*mo| mo.base.containsFile(path) or mo.overlay.file_trigrams.contains(path),
+            .mmap_overlay => |*mo| (mo.base.containsFile(path) and !mo.masked.contains(path)) or
+                mo.overlay.file_trigrams.contains(path),
         };
     }
 
@@ -2505,18 +2529,37 @@ pub const AnyTrigramIndex = union(enum) {
                 self.* = .{ .mmap_overlay = .{
                     .base = base,
                     .overlay = TrigramIndex.init(alloc),
+                    .masked = std.StringHashMap(void).init(alloc),
                 } };
                 try self.mmap_overlay.overlay.indexFile(path, content);
+                self.mmap_overlay.mask(path);
             },
-            .mmap_overlay => |*mo| try mo.overlay.indexFile(path, content),
+            .mmap_overlay => |*mo| {
+                try mo.overlay.indexFile(path, content);
+                mo.mask(path);
+            },
         }
     }
 
     pub fn removeFile(self: *AnyTrigramIndex, path: []const u8) void {
         switch (self.*) {
             .heap => |*h| h.removeFile(path),
-            .mmap => {},
-            .mmap_overlay => |*mo| mo.overlay.removeFile(path),
+            .mmap => |*m| {
+                // A remove is a write: promote so the base entry can be masked.
+                if (!m.containsFile(path)) return;
+                const alloc = m.allocator;
+                const base = self.mmap;
+                self.* = .{ .mmap_overlay = .{
+                    .base = base,
+                    .overlay = TrigramIndex.init(alloc),
+                    .masked = std.StringHashMap(void).init(alloc),
+                } };
+                self.mmap_overlay.mask(path);
+            },
+            .mmap_overlay => |*mo| {
+                mo.overlay.removeFile(path);
+                mo.mask(path);
+            },
         }
     }
 
@@ -2532,7 +2575,7 @@ pub const AnyTrigramIndex = union(enum) {
         return switch (self.*) {
             .heap => |*h| h.fileCount(),
             .mmap => |*m| m.fileCount(),
-            .mmap_overlay => |*mo| mo.base.fileCount() + mo.overlay.fileCount(),
+            .mmap_overlay => |*mo| mo.base.fileCount() + mo.overlay.fileCount() - mo.masked_in_base,
         };
     }
 

--- a/src/index.zig
+++ b/src/index.zig
@@ -105,47 +105,108 @@ pub const WordIndex = struct {
 
     /// Remove all index entries for a file (call before re-indexing).
     pub fn removeFile(self: *WordIndex, path: []const u8) void {
-        const removed = self.file_words.fetchRemove(path) orelse return;
-        const stable_path = removed.key;
-        const words_slice = removed.value;
-
-        const doc_id = self.path_to_id.get(stable_path) orelse {
-            self.allocator.free(words_slice);
-            self.allocator.free(stable_path);
-            return;
-        };
-        _ = self.path_to_id.remove(stable_path);
-        if (doc_id < self.id_to_path.items.len) {
-            self.id_to_path.items[doc_id] = "";
+        if (self.mmap_data != null) {
+            // Zero-copy mode: postings live in the mmap and a remove is a
+            // write, so promote first — but only when the file is actually
+            // tracked (id_to_path is the only populated map in this mode).
+            var tracked = false;
+            for (self.id_to_path.items) |p| {
+                if (std.mem.eql(u8, p, path)) {
+                    tracked = true;
+                    break;
+                }
+            }
+            if (!tracked) return;
+            self.promoteIfBorrowed() catch return;
         }
+
+        if (self.file_words.fetchRemove(path)) |removed| {
+            const stable_path = removed.key;
+            const words_slice = removed.value;
+
+            const doc_id = self.path_to_id.get(stable_path) orelse {
+                self.allocator.free(words_slice);
+                self.allocator.free(stable_path);
+                return;
+            };
+            _ = self.path_to_id.remove(stable_path);
+            if (doc_id < self.id_to_path.items.len) {
+                const old_path = self.id_to_path.items[doc_id];
+                // Bulk modes (skip_file_words) give id_to_path its own strings;
+                // otherwise the slot aliases stable_path, freed below.
+                if (self.skip_file_words and old_path.len > 0) self.allocator.free(old_path);
+                self.id_to_path.items[doc_id] = "";
+            }
+            if (self.doc_lengths.fetchRemove(doc_id)) |kv| {
+                self.total_tokens -= kv.value;
+            }
+            defer {
+                self.allocator.free(words_slice);
+                self.allocator.free(stable_path);
+            }
+
+            // For each word this file contributed, remove hits with this doc_id.
+            // Prune empty buckets so churn does not leak key/list entries.
+            for (words_slice) |word| {
+                const word_ptr = &word;
+                if (self.index.getEntry(word_ptr.*)) |entry| {
+                    const hits = entry.value_ptr;
+                    var i: usize = 0;
+                    while (i < hits.items.len) {
+                        if (hits.items[i].doc_id == doc_id) {
+                            _ = hits.swapRemove(i);
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    if (hits.items.len == 0) {
+                        const owned_word = entry.key_ptr.*;
+                        hits.deinit(self.allocator);
+                        _ = self.index.remove(word_ptr.*);
+                        self.allocator.free(owned_word);
+                    }
+                }
+            }
+            return;
+        }
+
+        // No per-file word list: the file came from a bulk path (disk
+        // fast-load, sharded cold scan), where removeFile used to be a silent
+        // no-op that left every stale posting behind. Sweep all posting lists
+        // for the doc_id instead; the next indexFile gives the file a word
+        // list, so this runs at most once per file.
+        const doc_id = self.path_to_id.get(path) orelse return;
+        _ = self.path_to_id.remove(path);
         if (self.doc_lengths.fetchRemove(doc_id)) |kv| {
             self.total_tokens -= kv.value;
         }
-        defer {
-            self.allocator.free(words_slice);
-            self.allocator.free(stable_path);
+        if (doc_id < self.id_to_path.items.len) {
+            const old_path = self.id_to_path.items[doc_id];
+            if (self.skip_file_words and old_path.len > 0) self.allocator.free(old_path);
+            self.id_to_path.items[doc_id] = "";
         }
-
-        // For each word this file contributed, remove hits with this doc_id.
-        // Prune empty buckets so churn does not leak key/list entries.
-        for (words_slice) |word| {
-            const word_ptr = &word;
-            if (self.index.getEntry(word_ptr.*)) |entry| {
-                const hits = entry.value_ptr;
-                var i: usize = 0;
-                while (i < hits.items.len) {
-                    if (hits.items[i].doc_id == doc_id) {
-                        _ = hits.swapRemove(i);
-                    } else {
-                        i += 1;
-                    }
+        var empty_words: std.ArrayList([]const u8) = .empty;
+        defer empty_words.deinit(self.allocator);
+        var it = self.index.iterator();
+        while (it.next()) |entry| {
+            const hits = entry.value_ptr;
+            var i: usize = 0;
+            while (i < hits.items.len) {
+                if (hits.items[i].doc_id == doc_id) {
+                    _ = hits.swapRemove(i);
+                } else {
+                    i += 1;
                 }
-                if (hits.items.len == 0) {
-                    const owned_word = entry.key_ptr.*;
-                    hits.deinit(self.allocator);
-                    _ = self.index.remove(word_ptr.*);
-                    self.allocator.free(owned_word);
-                }
+            }
+            if (hits.items.len == 0) {
+                empty_words.append(self.allocator, entry.key_ptr.*) catch continue;
+            }
+        }
+        for (empty_words.items) |word| {
+            if (self.index.fetchRemove(word)) |kv| {
+                var hits = kv.value;
+                hits.deinit(self.allocator);
+                self.allocator.free(kv.key);
             }
         }
     }
@@ -182,17 +243,12 @@ pub const WordIndex = struct {
         if (!self.enabled) return;
         // A write to a zero-copy (mmap) index must first materialize a heap index.
         try self.promoteIfBorrowed();
-        // Clean up old entries first
+        // Clean up old entries first; removeFile guarantees the path is no
+        // longer tracked, so the stable copy is always a fresh dupe.
         self.removeFile(path);
 
-        // If the path is already tracked (e.g. skip_file_words=true and removeFile
-        // early-exited), reuse the existing stable copy rather than leaking a new dup.
-        const stable_path = if (self.path_to_id.contains(path))
-            path
-        else
-            try self.allocator.dupe(u8, path);
-        const owned_path = stable_path.ptr != path.ptr;
-        errdefer if (owned_path) self.allocator.free(stable_path);
+        const stable_path = try self.allocator.dupe(u8, path);
+        errdefer self.allocator.free(stable_path);
 
         const doc_id = try self.getOrCreateDocId(stable_path);
 
@@ -260,15 +316,25 @@ pub const WordIndex = struct {
             }
         }
 
-        if (!self.skip_file_words) {
-            // Compact the HashMap to a simple slice — saves ~70KB per file
+        // Per-file word list — what makes the next removeFile O(file) instead
+        // of an index-wide sweep. Bulk paths (readFromDisk/mergeShard) leave it
+        // empty for their files; anything indexed through here gets a list. In
+        // skip_file_words mode id_to_path owns stable_path, so the file_words
+        // key must be its own allocation.
+        {
+            const fw_key = if (self.skip_file_words)
+                try self.allocator.dupe(u8, stable_path)
+            else
+                stable_path;
+            errdefer if (self.skip_file_words) self.allocator.free(fw_key);
             const compact = try self.allocator.alloc([]const u8, words_set.count());
+            errdefer self.allocator.free(compact);
             var ki: usize = 0;
             var wk_iter = words_set.keyIterator();
             while (wk_iter.next()) |k| : (ki += 1) {
                 compact[ki] = k.*;
             }
-            try self.file_words.put(stable_path, compact);
+            try self.file_words.put(fw_key, compact);
         }
         words_set.deinit();
 
@@ -552,23 +618,14 @@ pub const WordIndex = struct {
         var disk_path_to_id = std.StringHashMap(u32).init(self.allocator);
         defer disk_path_to_id.deinit();
 
-        if (self.file_words.count() > 0) {
-            var file_iter = self.file_words.iterator();
-            while (file_iter.next()) |entry| {
-                const path = entry.key_ptr.*;
-                if (path.len > std.math.maxInt(u16)) return error.NameTooLong;
-                const id: u32 = @intCast(file_table.items.len);
-                try file_table.append(self.allocator, path);
-                try disk_path_to_id.put(path, id);
-            }
-        } else {
-            for (self.id_to_path.items) |path| {
-                if (path.len == 0) continue;
-                if (path.len > std.math.maxInt(u16)) return error.NameTooLong;
-                const id: u32 = @intCast(file_table.items.len);
-                try file_table.append(self.allocator, path);
-                try disk_path_to_id.put(path, id);
-            }
+        // id_to_path is the doc table and always complete; file_words only
+        // covers incrementally indexed files once bulk-loaded docs exist.
+        for (self.id_to_path.items) |path| {
+            if (path.len == 0) continue;
+            if (path.len > std.math.maxInt(u16)) return error.NameTooLong;
+            const id: u32 = @intCast(file_table.items.len);
+            try file_table.append(self.allocator, path);
+            try disk_path_to_id.put(path, id);
         }
 
         var words_sorted: std.ArrayList([]const u8) = .empty;

--- a/src/main.zig
+++ b/src/main.zig
@@ -322,7 +322,7 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
             for (results) |r| {
                 if (paths_only) {
                     out.p("  {s}{s}{s}:{s}{d}{s}\n", .{
-                        s.cyan, r.path, s.reset,
+                        s.cyan, r.path,     s.reset,
                         s.dim,  r.line_num, s.reset,
                     });
                 } else {
@@ -482,11 +482,11 @@ fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store
             const unbounded = end == std.math.maxInt(u32);
             if (unbounded) {
                 out.p("{s}\xe2\x9c\x93{s} {s}{s}{s}  {s}{s}{s}  L{d}-EOF  {s}{s}{s}\n", .{
-                    s.green,                       s.reset,
-                    s.bold,                        path,
-                    s.reset,                       s.langColor(@tagName(lang)),
-                    @tagName(lang),                s.reset,
-                    start,                         sty.durationColor(s, elapsed),
+                    s.green,                               s.reset,
+                    s.bold,                                path,
+                    s.reset,                               s.langColor(@tagName(lang)),
+                    @tagName(lang),                        s.reset,
+                    start,                                 sty.durationColor(s, elapsed),
                     sty.formatDuration(&dur_buf, elapsed), s.reset,
                 });
             } else {
@@ -690,6 +690,32 @@ fn cliIsQueryCmd(cmd: []const u8) bool {
 /// keeps working and clients simply fall back to the cold path.
 /// Daemon side. Bind a per-project Unix socket and serve framed query requests
 /// against the warm `explorer`/`store`. Runs on its own detached thread so it
+/// #592: per-project cli-daemon spawn lock. Open-or-create
+/// `<data_dir>/cli-daemon.lock` and take an exclusive non-blocking flock.
+/// Returns the fd on success — callers keep it open for the process lifetime
+/// (the kernel releases flocks on exit, so crashes never leave a stale lock).
+/// Returns null when another process holds the lock or the file can't be
+/// opened.
+pub fn daemonLockTryAcquire(data_dir: []const u8) ?c_int {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const p = std.fmt.bufPrintZ(&buf, "{s}/cli-daemon.lock", .{data_dir}) catch return null;
+    const fd = std.c.open(p.ptr, .{ .ACCMODE = .RDWR, .CREAT = true }, @as(c_uint, 0o600));
+    if (fd < 0) return null;
+    if (std.c.flock(fd, std.c.LOCK.EX | std.c.LOCK.NB) != 0) {
+        _ = std.c.close(fd);
+        return null;
+    }
+    return fd;
+}
+
+/// Probe whether the spawn lock is free without keeping it: used by the CLI
+/// auto-spawn path so racing cold calls don't fork duplicate daemons.
+pub fn daemonLockAvailable(data_dir: []const u8) bool {
+    const fd = daemonLockTryAcquire(data_dir) orelse return false;
+    _ = std.c.flock(fd, std.c.LOCK.UN);
+    _ = std.c.close(fd);
+    return true;
+}
 /// never blocks the daemon's primary loop. Connections are handled sequentially
 /// (CLI calls are infrequent and runQuery already tolerates concurrent reads
 /// from the watcher).
@@ -1017,12 +1043,13 @@ fn mainImpl() !void {
             }
             if (!isValidMcpFlag(a)) {
                 out.p("{s}\xe2\x9c\x97{s} unknown flag for {s}mcp{s}: {s}{s}{s}\n  valid: {s}--no-telemetry{s}, {s}--help{s}, {s}--config-file=<path>{s}\n", .{
-                    s.red,  s.reset,
-                    s.bold, s.reset,
-                    s.bold, a,      s.reset,
-                    s.bold, s.reset,
-                    s.bold, s.reset,
-                    s.bold, s.reset,
+                    s.red,   s.reset,
+                    s.bold,  s.reset,
+                    s.bold,  a,
+                    s.reset, s.bold,
+                    s.reset, s.bold,
+                    s.reset, s.bold,
+                    s.reset,
                 });
                 out.exitWithFlush(1);
             }
@@ -1138,17 +1165,35 @@ fn mainImpl() !void {
         // `codedb <abs_root> cli-daemon`, with stdio redirected to /dev/null and
         // no waitpid (fire-and-forget). Skipped for an empty root. cli-daemon is
         // not a query command, so the spawned process won't recurse into this path.
+        // #592: also skipped while another daemon holds the per-project spawn
+        // lock — concurrent cold calls otherwise fork a daemon EACH, every
+        // duplicate rescans the index, and the stampede leaves orphans churning
+        // CPU. Losers of this probe simply cold-serve their one call.
         if (abs_root.len > 0) {
-            if (std.process.executablePathAlloc(io, allocator)) |self_exe| {
-                defer allocator.free(self_exe);
-                const daemon_argv = [_][]const u8{ self_exe, abs_root, "cli-daemon" };
-                cio.spawnDetached(allocator, &daemon_argv);
-            } else |_| {}
+            const probe_dir = getDataDir(io, allocator, abs_root) catch null;
+            defer if (probe_dir) |d| allocator.free(d);
+            const lock_free = if (probe_dir) |d| daemonLockAvailable(d) else true;
+            if (lock_free) {
+                if (std.process.executablePathAlloc(io, allocator)) |self_exe| {
+                    defer allocator.free(self_exe);
+                    const daemon_argv = [_][]const u8{ self_exe, abs_root, "cli-daemon" };
+                    cio.spawnDetached(allocator, &daemon_argv);
+                } else |_| {}
+            }
         }
     }
 
     const data_dir = try getDataDir(io, allocator, abs_root);
     defer allocator.free(data_dir);
+
+    // #592: exactly one cli-daemon per project. Take the per-project flock
+    // BEFORE the expensive load below so a duplicate exits without paying a
+    // full rescan (or stealing the winner's socket via the stale-path unlink
+    // in cliDaemonListen). The fd is held for the process lifetime; the
+    // kernel drops the lock on any exit, so a crash never leaves it stale.
+    if (std.mem.eql(u8, cmd, "cli-daemon")) {
+        if (daemonLockTryAcquire(data_dir) == null) return;
+    }
 
     // Load user config (.codedbrc). Resolution: --config-file=<path>, then
     // $CWD/.codedbrc, then <binary_dir>/.codedbrc. Silently falls back to
@@ -1424,7 +1469,10 @@ fn mainImpl() !void {
         } else if (std.mem.eql(u8, op, "search") or std.mem.eql(u8, op, "search-fmt")) {
             const warm = explorer.searchContent(query, allocator, 50) catch &[_]explore_mod.SearchResult{};
             defer {
-                for (warm) |r| { allocator.free(r.path); allocator.free(r.line_text); }
+                for (warm) |r| {
+                    allocator.free(r.path);
+                    allocator.free(r.line_text);
+                }
                 allocator.free(warm);
             }
         }
@@ -1464,13 +1512,19 @@ fn mainImpl() !void {
             } else if (std.mem.eql(u8, op, "search")) {
                 const r = explorer.searchContent(query, allocator, 50) catch &[_]explore_mod.SearchResult{};
                 hits_seen = r.len;
-                for (r) |item| { allocator.free(item.path); allocator.free(item.line_text); }
+                for (r) |item| {
+                    allocator.free(item.path);
+                    allocator.free(item.line_text);
+                }
                 allocator.free(r);
             } else if (std.mem.eql(u8, op, "search-fmt")) {
                 const r = explorer.searchContent(query, allocator, 50) catch &[_]explore_mod.SearchResult{};
                 hits_seen = r.len;
                 defer {
-                    for (r) |item| { allocator.free(item.path); allocator.free(item.line_text); }
+                    for (r) |item| {
+                        allocator.free(item.path);
+                        allocator.free(item.line_text);
+                    }
                     allocator.free(r);
                 }
                 var scratch: std.ArrayList(u8) = .empty;
@@ -1488,7 +1542,10 @@ fn mainImpl() !void {
                 const r = explorer.searchContent(query, allocator, 50) catch &[_]explore_mod.SearchResult{};
                 hits_seen = r.len;
                 defer {
-                    for (r) |item| { allocator.free(item.path); allocator.free(item.line_text); }
+                    for (r) |item| {
+                        allocator.free(item.path);
+                        allocator.free(item.line_text);
+                    }
                     allocator.free(r);
                 }
                 var seen = std.StringHashMap(void).init(allocator);

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1329,6 +1329,7 @@ pub fn isSensitivePath(path: []const u8) bool {
         ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
         "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
         "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
+        "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
     };
     for (sensitive_names) |name| {
         if (std.mem.eql(u8, basename, name)) return true;

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -11,6 +11,7 @@ const explore = @import("explore.zig");
 const Explorer = explore.Explorer;
 const linter = @import("linter.zig");
 const linter_pref = @import("linter_pref.zig");
+const ContentCache = @import("hot_cache.zig").ContentCache;
 
 
 test "store: record and retrieve snapshots" {
@@ -1049,3 +1050,87 @@ test "issue-101+102: .codedbrc max_cached threads through to ContentCache capaci
     try testing.expectEqual(@as(u32, 32), explorer.contents.capacity);
 }
 
+
+test "issue-584: ContentCache probe-window — overflow inserts, holes, and duplicate keys" {
+    // putImpl's overflow path evicts via a global CLOCK hand, so the new entry
+    // lands OUTSIDE the key's 4-slot probe window: get() can never find it.
+    // The entry's bytes (file contents, up to 64MB each) sit stranded in the
+    // cache while every lookup for that key re-reads from disk. Holes left by
+    // remove() also break lookups for in-window entries (`key_hash == 0`
+    // early-break) and let put() insert a duplicate copy of a key it already
+    // holds. All three violate the probe-window invariant.
+    const fnvBase = struct {
+        fn base(key: []const u8, cap: u32) u32 {
+            var h: u64 = 14695981039346656037;
+            for (key) |b| {
+                h ^= b;
+                h *%= 1099511628211;
+            }
+            if (h == 0) h = 1;
+            return @as(u32, @truncate(h)) % cap;
+        }
+    }.base;
+
+    // Collect 5 keys sharing one probe-window base in [1, 60] (slot 0 stays
+    // outside the window, no wraparound).
+    var bufs: [5][16]u8 = undefined;
+    var lens: [5]usize = undefined;
+    var nkeys: usize = 0;
+    var counts = [_]u8{0} ** 64;
+    var pick: u32 = 0;
+    var i: usize = 0;
+    while (i < 4096) : (i += 1) {
+        var tmp: [16]u8 = undefined;
+        const k = std.fmt.bufPrint(&tmp, "k{d}", .{i}) catch unreachable;
+        const b = fnvBase(k, 64);
+        if (b < 1 or b > 60) continue;
+        counts[b] += 1;
+        if (counts[b] >= 5) {
+            pick = b;
+            break;
+        }
+    }
+    try testing.expect(pick != 0);
+    i = 0;
+    while (i < 4096 and nkeys < 5) : (i += 1) {
+        var tmp: [16]u8 = undefined;
+        const k = std.fmt.bufPrint(&tmp, "k{d}", .{i}) catch unreachable;
+        if (fnvBase(k, 64) == pick) {
+            @memcpy(bufs[nkeys][0..k.len], k);
+            lens[nkeys] = k.len;
+            nkeys += 1;
+        }
+    }
+    try testing.expectEqual(@as(usize, 5), nkeys);
+    const k0 = bufs[0][0..lens[0]];
+    const k1 = bufs[1][0..lens[1]];
+    const k2 = bufs[2][0..lens[2]];
+    const k3 = bufs[3][0..lens[3]];
+    const k4 = bufs[4][0..lens[4]];
+
+    // 1) Overflow insert must stay retrievable from its own probe window.
+    {
+        var cache = try ContentCache.initAlloc(testing.allocator, 64);
+        defer cache.deinit();
+        try cache.put(k0, "v0");
+        try cache.put(k1, "v1");
+        try cache.put(k2, "v2");
+        try cache.put(k3, "v3");
+        try cache.put(k4, "v4"); // window full -> eviction path
+        try testing.expect(cache.get(k4) != null);
+    }
+
+    // 2) A hole left by remove() must not hide in-window entries behind it.
+    // 3) Re-putting such an entry must not create a duplicate copy.
+    {
+        var cache = try ContentCache.initAlloc(testing.allocator, 64);
+        defer cache.deinit();
+        try cache.put(k0, "v0");
+        try cache.put(k1, "v1");
+        try cache.put(k2, "v2");
+        cache.remove(k1); // hole between k0 and k2
+        try testing.expect(cache.get(k2) != null);
+        try cache.put(k2, "v2b");
+        try testing.expectEqual(@as(u32, 2), cache.len());
+    }
+}

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2311,3 +2311,75 @@ test "issue-587: removeFile drops the path from skip_trigram_files" {
     explorer.removeFile("src/gone.zig");
     try testing.expectEqual(@as(usize, 0), explorer.skip_trigram_files.count());
 }
+
+test "issue-594: failed re-index restores the word index from valid prior content" {
+    // commitParsedFileOwnedOutline reads `prior_content` out of the content
+    // cache and THEN calls contents.put, which frees that value in place. The
+    // trigram-failure errdefer later "restores" the word index by re-indexing
+    // prior_content — freed memory. Under the DebugAllocator poison the
+    // tokenizer finds no words in it, so a failed re-index silently wipes the
+    // file's postings instead of restoring them (release builds read garbage).
+    const FailOnce = struct {
+        backing: std.mem.Allocator,
+        next_index: usize = 0,
+        fail_index: usize,
+
+        fn allocator(self: *@This()) std.mem.Allocator {
+            return .{ .ptr = self, .vtable = &.{
+                .alloc = allocImpl,
+                .resize = resizeImpl,
+                .remap = remapImpl,
+                .free = freeImpl,
+            } };
+        }
+        fn allocImpl(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            const idx = self.next_index;
+            self.next_index += 1;
+            if (idx == self.fail_index) return null;
+            return self.backing.rawAlloc(len, alignment, ra);
+        }
+        fn resizeImpl(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.backing.rawResize(memory, alignment, new_len, ra);
+        }
+        fn remapImpl(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.backing.rawRemap(memory, alignment, new_len, ra);
+        }
+        fn freeImpl(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.backing.rawFree(memory, alignment, ra);
+        }
+    };
+
+    // Pass 1: count the allocation window of the re-index on a successful run.
+    var window_start: usize = 0;
+    var window_end: usize = 0;
+    {
+        var counter = FailOnce{ .backing = testing.allocator, .fail_index = std.math.maxInt(usize) };
+        var explorer = Explorer.init(counter.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+        defer explorer.deinit();
+        try explorer.indexFile("src/a.zig", "pub fn alphaTok() void {}\n");
+        window_start = counter.next_index;
+        try explorer.indexFile("src/a.zig", "pub fn betaTok() void {}\n");
+        window_end = counter.next_index;
+    }
+    try testing.expect(window_end > window_start);
+
+    // Pass 2: fail each allocation in that window exactly once. Whenever the
+    // re-index errors out, the old content must still be word-searchable.
+    var fi = window_start;
+    while (fi < window_end) : (fi += 1) {
+        var failer = FailOnce{ .backing = testing.allocator, .fail_index = fi };
+        var explorer = Explorer.init(failer.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+        defer explorer.deinit();
+        explorer.indexFile("src/a.zig", "pub fn alphaTok() void {}\n") catch unreachable;
+        if (explorer.indexFile("src/a.zig", "pub fn betaTok() void {}\n")) |_| {
+            // Tolerated failure — the new content must be live.
+            try testing.expect(explorer.word_index.search("betatok").len > 0);
+        } else |_| {
+            if (explorer.word_index.search("alphatok").len == 0) return error.PriorContentLostOnFailedReindex;
+        }
+    }
+}

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2271,3 +2271,43 @@ test "audit: extractCallees ignores comment/string mentions" {
     }
     try testing.expect(saw_real); // real call in code is still captured
 }
+
+test "issue-586: symbol_index keys must survive re-index of the file that first inserted them" {
+    // rebuildSymbolIndexFor keys the global symbol index with sym.name slices
+    // OWNED BY THE FILE'S OUTLINE. Re-indexing that file deinits the old
+    // outline — freeing the bytes the map hashes and compares — but the entry
+    // survives whenever another file shares the name (init/deinit/main are
+    // shared by nearly every Zig file). Every later probe eql()s freed memory:
+    // UB in release, and under the DebugAllocator poison the O(1) index
+    // silently loses the name, degrading every lookup to the outline scans.
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+
+    // a.zig inserts sharedFn first -> the map key aliases a.zig's outline string.
+    try explorer.indexFile("src/a.zig", "pub fn sharedFn() void {}\n");
+    try explorer.indexFile("src/b.zig", "pub fn sharedFn() void {}\n");
+
+    // Re-index the key owner: its old outline is freed; the entry stays alive
+    // because b.zig still holds a location.
+    try explorer.indexFile("src/a.zig", "pub fn sharedFn() void {}\npub fn other() void {}\n");
+
+    const locs = explorer.symbol_index.get("sharedFn") orelse return error.SymbolLostFromIndex;
+    try testing.expect(locs.items.len >= 2);
+}
+
+test "issue-587: removeFile drops the path from skip_trigram_files" {
+    // Explorer.removeFile cleans dep_graph, symbol_index, contents, word and
+    // trigram indexes, then frees the outlines key — but never removes the
+    // skip_trigram_files entry, whose key ALIASES that freed outlines key.
+    // The tier-3 search scan then iterates a dangling path and hands it to
+    // readContentForSearch (UB read; with reused memory, an arbitrary path).
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+
+    // Outline-only indexing registers the file in skip_trigram_files (#507).
+    try explorer.indexFileOutlineOnly("src/gone.zig", "pub fn ghostFn() void {}\n");
+    try testing.expectEqual(@as(usize, 1), explorer.skip_trigram_files.count());
+
+    explorer.removeFile("src/gone.zig");
+    try testing.expectEqual(@as(usize, 0), explorer.skip_trigram_files.count());
+}

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3077,3 +3077,54 @@ test "issue-583: disk-loaded word index — re-index and removeFile must drop st
     defer alloc.free(mghost);
     try testing.expectEqual(@as(usize, 0), mghost.len);
 }
+
+test "issue-593: mmap trigram index — removeFile takes effect and re-index masks stale base entries" {
+    // AnyTrigramIndex.removeFile is a silent no-op in pure-mmap mode, and the
+    // mmap_overlay promotion never masks the base: a deleted file stays
+    // "contained" forever and an edited file feeds candidates from BOTH its
+    // old (mmap base) and new (overlay) content — ghost candidates that every
+    // search tier then has to read and discard.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/auth.zig", "pub fn handleAuth(req: *Request) !void { validate(req); }");
+    try explorer.indexFile("src/gate.zig", "pub fn checkGate(ctx: *Context) !bool { return ctx.authenticated; }");
+    try explorer.indexFile("src/util.zig", "pub fn formatStr(buf: []u8, args: anytype) !void {}");
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path_len = try tmp_dir.dir.realPathFile(io, ".", &path_buf);
+    const tmp_path = path_buf[0..tmp_path_len];
+    try explorer.trigram_index.writeToDisk(io, tmp_path, null);
+
+    const mmap_idx = MmapTrigramIndex.initFromDisk(io, tmp_path, testing.allocator) orelse
+        return error.MmapInitFailed;
+    var any_idx = AnyTrigramIndex{ .mmap = mmap_idx };
+    defer any_idx.deinit();
+
+    // A delete while zero-copy must take effect, not silently no-op.
+    any_idx.removeFile("src/gate.zig");
+    try testing.expect(!any_idx.containsFile("src/gate.zig"));
+    if (any_idx.candidates("checkGate", allocator)) |cands| {
+        for (cands) |p| try testing.expect(!std.mem.eql(u8, p, "src/gate.zig"));
+    }
+
+    // Re-indexing must mask the base's stale trigrams for that path.
+    try any_idx.indexFile("src/auth.zig", "pub fn renamedAuth() void {}");
+    if (any_idx.candidates("handleAuth", allocator)) |cands| {
+        for (cands) |p| try testing.expect(!std.mem.eql(u8, p, "src/auth.zig"));
+    }
+    const fresh = any_idx.candidates("renamedAuth", allocator) orelse return error.NoCandidates;
+    var found = false;
+    for (fresh) |p| {
+        if (std.mem.eql(u8, p, "src/auth.zig")) found = true;
+    }
+    try testing.expect(found);
+
+    // File accounting follows: 3 on disk, one removed.
+    try testing.expectEqual(@as(u32, 2), any_idx.fileCount());
+}

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3032,3 +3032,48 @@ test "issue-447: searchContent surfaces large (>64KB) skip-trigram files for com
     try testing.expect(found_canonical);
 }
 
+
+test "issue-583: disk-loaded word index — re-index and removeFile must drop stale postings" {
+    // readFromDisk/mmapFromDisk set skip_file_words=true, which made removeFile
+    // a silent no-op (file_words is empty). In a daemon that fast-loads the
+    // index, every file edit then APPENDS postings while the stale ones stay:
+    // deleted terms keep hitting (wrong lines), deleted files ghost-hit, and
+    // postings grow without bound across re-saves (RSS).
+    const alloc = testing.allocator;
+    var wi = WordIndex.init(alloc);
+    defer wi.deinit();
+    try wi.indexFile("src/a.zig", "pub fn alphaToken() void {}\n");
+    try wi.indexFile("src/b.zig", "pub fn betaToken() void {}\n");
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+    try wi.writeToDisk(io, dir_path, null);
+
+    // Heap fast-load: re-indexing a file must drop its old postings.
+    var loaded = WordIndex.readFromDisk(io, dir_path, alloc).?;
+    defer loaded.deinit();
+    try loaded.indexFile("src/a.zig", "pub fn gammaToken() void {}\n");
+    const stale = try loaded.searchDeduped("alphaToken", alloc);
+    defer alloc.free(stale);
+    try testing.expectEqual(@as(usize, 0), stale.len);
+    const fresh = try loaded.searchDeduped("gammaToken", alloc);
+    defer alloc.free(fresh);
+    try testing.expectEqual(@as(usize, 1), fresh.len);
+
+    // Deleting a file must drop its postings outright.
+    loaded.removeFile("src/b.zig");
+    const ghost = try loaded.searchDeduped("betaToken", alloc);
+    defer alloc.free(ghost);
+    try testing.expectEqual(@as(usize, 0), ghost.len);
+
+    // Zero-copy mmap load: removeFile is a write — it must promote, not no-op.
+    var mloaded = WordIndex.mmapFromDisk(io, dir_path, alloc).?;
+    defer mloaded.deinit();
+    mloaded.removeFile("src/a.zig");
+    const mghost = try mloaded.searchDeduped("alphaToken", alloc);
+    defer alloc.free(mghost);
+    try testing.expectEqual(@as(usize, 0), mghost.len);
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2137,3 +2137,28 @@ test "issue-589: isSensitivePath blocks all OpenSSH default private key names" {
     try testing.expect(!watcher.isSensitivePath("id_map.zig"));
     try testing.expect(!watcher.isSensitivePath("identity.ts"));
 }
+
+test "issue-592: cli-daemon spawn lock is exclusive per project" {
+    // Concurrent cold CLI calls used to fork a cli-daemon EACH (no mutual
+    // exclusion), every duplicate re-scanned the index, and the stale-socket
+    // unlink let late arrivals steal the winner's socket — orphan daemons
+    // churned CPU long after the calls exited. The per-project flock makes
+    // spawn mutually exclusive: holders win, probes report unavailable, and
+    // the kernel releases the lock on any exit.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_len];
+
+    const held = main_mod.daemonLockTryAcquire(dir_path);
+    try testing.expect(held != null);
+    // A second acquire (the would-be duplicate daemon) must lose...
+    try testing.expect(main_mod.daemonLockTryAcquire(dir_path) == null);
+    // ...and the CLI spawn probe must report the lock as taken.
+    try testing.expect(!main_mod.daemonLockAvailable(dir_path));
+
+    _ = std.c.flock(held.?, std.c.LOCK.UN);
+    _ = std.c.close(held.?);
+    try testing.expect(main_mod.daemonLockAvailable(dir_path));
+}

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2120,3 +2120,20 @@ test "issue-568: deps empty list prints a (0 files) summary" {
     try testing.expect(std.mem.indexOf(u8, fwd_out.items, "(none)") != null);
     try testing.expect(std.mem.indexOf(u8, fwd_out.items, "(0 files)") != null);
 }
+
+test "issue-589: isSensitivePath blocks all OpenSSH default private key names" {
+    // The exact-name list covers id_rsa and id_ed25519 but misses the other
+    // ssh-keygen defaults: id_ecdsa, id_dsa, and the FIDO variants
+    // id_ecdsa_sk / id_ed25519_sk. Outside ~/.ssh (which the directory rule
+    // catches), a key copied into a repo — deploy/id_ecdsa — was indexed and
+    // readable while deploy/id_rsa was blocked.
+    const keys = [_][]const u8{ "id_ecdsa", "id_dsa", "id_ecdsa_sk", "id_ed25519_sk" };
+    for (keys) |k| {
+        try testing.expect(watcher.isSensitivePath(k));
+        try testing.expect(snapshot_mod.isSensitivePath(k));
+    }
+    try testing.expect(watcher.isSensitivePath("deploy/id_ecdsa"));
+    // negatives — names that merely start like a key must stay indexable
+    try testing.expect(!watcher.isSensitivePath("id_map.zig"));
+    try testing.expect(!watcher.isSensitivePath("identity.ts"));
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1201,6 +1201,7 @@ pub fn isSensitivePath(path: []const u8) bool {
         ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
         "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
         "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
+        "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
     };
     for (sensitive_names) |name| {
         if (std.mem.eql(u8, basename, name)) return true;


### PR DESCRIPTION
Memory/RSS-focused bug hunt grown across three rounds, all red→green where a red state exists. Suite **761/761**.

## Round 1 — index growth & cache integrity
- **#583** — disk-loaded word index never removes stale postings: bulk paths (`readFromDisk`/`mmapFromDisk`/`mergeShard` — the warm-daemon config) left `removeFile` a no-op → ghost/stale postings, doubled BM25 tf, unbounded growth per save. Fix: doc_id sweep slow path, hybrid per-file word lists, `writeToDisk` file table from `id_to_path`, mmap promote-on-remove.
- **#584** — ContentCache probe-window violations: global-CLOCK overflow eviction stranded entries outside the lookup window (bytes hoarded, permanent misses, disk re-reads); holes broke lookups; duplicate keys possible. Fix: full-window scan, in-window second-chance eviction, PROBE_LIMIT 4→8, dead CLOCK machinery removed. Also explains + kills the longstanding ~1-in-6 snapshot-freshness flake (see PR comment).

## Round 2 — dangling references & secrets
- **#586** — `symbol_index` keyed by outline-owned `sym.name`: re-index/delete of the first inserter freed the key while shared-name entries survived (`init`/`deinit`/`main` are shared by nearly every Zig file) → UAF on every probe, names silently dropping to slow scans. Fix: map owns its keys.
- **#587** — `Explorer.removeFile` left a dangling path in `skip_trigram_files` (key aliases the freed outlines key) → tier-3 scan iterated freed memory. Fix: remove alongside the other structures.
- **#589** — `isSensitivePath` missed `id_ecdsa`/`id_dsa`/`*_sk` SSH keys: `deploy/id_ecdsa` indexed while `deploy/id_rsa` blocked. Both copies fixed.

## Round 3 — mmap trigram ghosts + the indexFile OOM family + daemon stampede
- **#593** — `AnyTrigramIndex.removeFile` no-op'd in pure-mmap mode and the overlay never masked base entries: deleted files stayed "contained" with live candidates; edited files answered from both old and new content. Fix: `MmapOverlay.masked` path set (owned keys), filtered through `containsFile`/`candidates`/`candidatesRegex` (shared merge helper), `fileCount` correction, promote-on-remove.
- **#594** — a fail-once-allocator sweep over one re-index surfaced **six** failure-path defects, all fixed: per-parse throwaway full Explorer whose `ContentCache.init` *panics* on OOM (now a fallible 1-slot parser shell); `errdefer`+`defer` double-deinit of the parsed outline; the `prior_content` UAF (cache `put` now last fallible step + one function-scoped word-index restore); restore gap for failures inside `word_index.indexFile`; orphaned `getOrPut` entries on key-dupe failure in `indexOneToken`/`mergeShard` (stack-buffer keys, undefined values → segfault); `removeSymbolIndexFor` poisoning the in-map value before a fallible append.
- **#592** — cli-daemon spawn stampede (filed from the engram side with measurements): concurrent cold calls forked a daemon each, duplicates paid full rescans, and the stale-socket unlink let late arrivals steal the winner's live socket → orphans churning CPU. Fix: per-project exclusive flock taken before the load (kernel-released on exit, crash-safe) + CLI-side spawn probe. Verified live: 8 concurrent cold calls → exactly 1 daemon. The related #591 (cold path answers from the wrong repo, 0.2.5824) no longer reproduces on this branch — closed with repro evidence.

## Also filed (enhancements, per #550/#564 precedent)
- #596 — byte-budgeted ContentCache eviction (entry-bounded today, byte-blind)
- #597 — Store hardening: advisory-lock failure proceeds unlocked; data_log never compacts

## Notes
- Found by dogfooding `codedb` (outline/deps/context/status) against its own tree plus targeted reads and a fail-once allocator sweep.
- Known + parked: `commitParsedFileOwnedOutline` metadata flags drift on failure paths (cosmetic); serve-vs-cli-daemon socket handover quirk (pre-existing, proxy-disabled fallback).
- The `test_mcp` issue-148 EOF test and the three `test_index` perf-threshold tests flake when their binaries re-run under concurrent load; all pass consistently on green suites.

Closes #583. Closes #584. Closes #586. Closes #587. Closes #589. Closes #592. Closes #593. Closes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)