### PR TITLE
fix(#588): renderImportedBy honors the basename-ambiguity guard from #572

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3899,6 +3899,15 @@ pub const Explorer = struct {
         defer self.mu.unlockShared();
 
         const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[pos + 1 ..] else path;
+        // #588: mirror getImportedBy — a bare import resolved only by basename
+        // is ambiguous when 2+ indexed files share the basename; skip the
+        // fallback rather than attribute it to every candidate.
+        var basename_count: usize = 0;
+        var bit = self.outlines.keyIterator();
+        while (bit.next()) |k| {
+            const kb = if (std.mem.lastIndexOfScalar(u8, k.*, '/')) |p| k.*[p + 1 ..] else k.*;
+            if (std.mem.eql(u8, kb, basename)) basename_count += 1;
+        }
         const exact = self.dep_graph.reverse.get(path);
         const w = cio.listWriter(out, allocator);
         var count: usize = 0;
@@ -3911,7 +3920,7 @@ pub const Explorer = struct {
             }
         }
 
-        if (!std.mem.eql(u8, path, basename)) {
+        if (basename_count <= 1 and !std.mem.eql(u8, path, basename)) {
             if (self.dep_graph.reverse.get(basename)) |rev_set| {
                 var rev_iter = rev_set.keyIterator();
                 while (rev_iter.next()) |key_ptr| {

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -1944,3 +1944,43 @@ test "audit: Python comma import records all modules" {
     try expectOutlineImport(&outline, "alpha.py");
     try expectOutlineImport(&outline, "beta.py");
 }
+
+
+// renderImportedBy (the MCP codedb_deps reverse path) kept the unconditional
+// basename fallback when getImportedBy gained the ambiguity guard — the same
+// bare import is still attributed to every same-basename file through the
+// main deps tool.
+test "issue-588: renderImportedBy suppresses the ambiguous basename fallback" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("a/conf.py", "x = 1\n");
+    try explorer.indexFile("b/conf.py", "y = 2\n");
+    try explorer.indexFile("importer.py", "import conf\n");
+
+    var a_out: std.ArrayList(u8) = .empty;
+    defer a_out.deinit(testing.allocator);
+    _ = try explorer.renderImportedBy("a/conf.py", testing.allocator, &a_out);
+    var b_out: std.ArrayList(u8) = .empty;
+    defer b_out.deinit(testing.allocator);
+    _ = try explorer.renderImportedBy("b/conf.py", testing.allocator, &b_out);
+
+    const a_attached = std.mem.indexOf(u8, a_out.items, "importer.py") != null;
+    const b_attached = std.mem.indexOf(u8, b_out.items, "importer.py") != null;
+    // The ambiguous bare import must not be attributed to both files.
+    try testing.expect(!(a_attached and b_attached));
+
+    // Single-basename case keeps the fallback: with exactly one conf.py the
+    // importer is still listed.
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    var explorer2 = Explorer.init(arena2.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try explorer2.indexFile("a/conf.py", "x = 1\n");
+    try explorer2.indexFile("importer.py", "import conf\n");
+
+    var solo_out: std.ArrayList(u8) = .empty;
+    defer solo_out.deinit(testing.allocator);
+    _ = try explorer2.renderImportedBy("a/conf.py", testing.allocator, &solo_out);
+    try testing.expect(std.mem.indexOf(u8, solo_out.items, "importer.py") != null);
+}


### PR DESCRIPTION
Fixes #588.

The #572 bundle added the same-basename ambiguity guard to `getImportedBy`/`getImportedByFiltered` (query-pipeline deps op), but `renderImportedBy` — backing the main MCP `codedb_deps` reverse listing — kept the unconditional basename fallback (explore.zig:3914). A bare `import conf` was still attributed to every indexed `conf.py` through the primary tool while the pipeline op correctly suppressed it.

Found by a focused defect review of the freshly-merged #572 bundle (9 other candidates investigated and cleared — incl. the codegraph literal-scanner boundary cases, the deps-arena UAF fix, the secret-filter fast path, and the import-cap widening).

Failing test committed red on merged HEAD (64/65 — importer attributed to both `a/conf.py` and `b/conf.py`); fix mirrors `getImportedBy`'s guard; single-basename fallback behavior pinned by the same test. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)