### PR TITLE
test(snapshot): diagnostics tripwire for the parallel-freshness flake

### DIFF
--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -510,8 +510,17 @@ test "snapshot: parallel freshness load re-indexes changed files, restores the r
 
     // Changed files carry fresh content (changed branch); the rest keep snapshot
     // content (restored branch) — verified directly via the content cache.
+    // Flaked once under full-suite parallelism (2026-06-10, missing content with
+    // all outlines present; 0/25 repro in isolation) — on failure, dump which
+    // file and what state survived so the next occurrence localizes the branch.
     for (0..total) |i| {
-        const cached = exp2.contents.get(abs_paths[i]) orelse return error.MissingContent;
+        const cached = exp2.contents.get(abs_paths[i]) orelse {
+            std.debug.print(
+                "MissingContent: i={d} changed={} outline_present={} contents_cached={d}/{d}\n",
+                .{ i, is_changed[i], exp2.outlines.contains(abs_paths[i]), exp2.contents.len(), total },
+            );
+            return error.MissingContent;
+        };
         const want = if (is_changed[i])
             try std.fmt.allocPrint(aa, "pub fn newfn_{d}() void {{}}\n", .{i})
         else


### PR DESCRIPTION
The `parallel freshness load re-indexes changed files` test failed once during a full-suite run today (`error.MissingContent` at the content-cache assert, with all outlines present per the surrounding asserts) and shows 0 failures in 25 isolated runs — an under-parallel-load flake that can't be chased blind. Ruled out: ContentCache eviction (capacity 4096 vs 288 fixture files).

This makes the next natural occurrence informative: on failure the test reports the file index, changed-vs-restored branch, outline survival, and cache fill — enough to localize which Pass C branch dropped the content.

Test-only change; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)