### PR TITLE
fix(#598): pre-boost occurrence cap stops mention-dense tooling files saturating the path prior

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2861,6 +2861,17 @@ pub const Explorer = struct {
     fn rerankSignalScore(self: *const Explorer, r: SearchResult, query: []const u8) f32 {
         var score: f32 = countOccurrences(r.line_text, query);
 
+        // #598: mention-dense tooling files (a bench script repeating the term
+        // six times per line) saturate the per-line count and shrug off the
+        // ×0.5 path prior below. Cap the occurrence BASE for tooling paths
+        // before the stem/symbol boosts so density cannot dominate, while an
+        // eponymous lookup (query 'install' → install/install.sh) still wins
+        // through its +15 stem boost.
+        const is_tooling_path = pathHasSegment(r.path, "bench") or pathHasSegment(r.path, "benchmarks") or
+            pathHasSegment(r.path, "scripts") or pathHasSegment(r.path, "website") or
+            pathHasSegment(r.path, "install");
+        if (is_tooling_path) score = @min(score, 2.0);
+
         if (self.outlines.get(r.path)) |outline| {
             for (outline.symbols.items) |sym| {
                 if (sym.line_start == r.line_num and asciiEqlIgnoreCase(sym.name, query)) {
@@ -2897,9 +2908,7 @@ pub const Explorer = struct {
             std.mem.startsWith(u8, basename, "test") or std.mem.indexOf(u8, basename, "_test") != null;
         if (is_test_file) score *= 0.6;
         if (pathHasSegment(r.path, "examples") or pathHasSegment(r.path, "example")) score *= 0.6;
-        if (pathHasSegment(r.path, "bench") or pathHasSegment(r.path, "benchmarks") or
-            pathHasSegment(r.path, "scripts") or pathHasSegment(r.path, "website") or
-            pathHasSegment(r.path, "install")) score *= 0.5;
+        if (is_tooling_path) score *= 0.5;
         if (pathHasSegment(r.path, "vendor") or pathHasSegment(r.path, "node_modules") or
             pathHasSegment(r.path, "third_party")) score *= 0.4;
         // Doc-language penalty: markdown / data files (CHANGELOG.md, design

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1987,3 +1987,48 @@ test "issue-569: multi-word word query falls back to per-token matching" {
     try testing.expect(std.mem.indexOf(u8, out.items, "src/both.zig") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "(tokenized)") != null);
 }
+
+
+test "issue-598: mention-dense tooling files cannot saturate past the path prior" {
+    // A bench script repeating the term six times per line scores 6.0×0.5=3.0
+    // and shrugs off the tooling-path prior, beating the implementation's 2.0
+    // (live: 'capture' put benchmarks/search-shootout/shootout.py in every
+    // top-8 slot). Cap the occurrence base for tooling paths BEFORE the
+    // stem/symbol boosts so density cannot dominate.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("bench/shootout.py", "captureTerm captureTerm captureTerm captureTerm captureTerm captureTerm\n");
+    try explorer.indexFile("src/owner.zig", "pub fn x() void { _ = captureTerm; _ = captureTerm; }\n");
+
+    const results = try explorer.searchContent("captureTerm", testing.allocator, 10);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len >= 2);
+    try testing.expectEqualStrings("src/owner.zig", results[0].path);
+
+    // Eponymy must survive the cap: a query that IS the tooling file's stem
+    // still ranks that file first (the stem boost applies after the cap).
+    var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena2.deinit();
+    var explorer2 = Explorer.init(arena2.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    try explorer2.indexFile("install/install.sh", "echo install install install\n");
+    try explorer2.indexFile("src/setup.zig", "pub fn x() void { _ = install; }\n");
+
+    const results2 = try explorer2.searchContent("install", testing.allocator, 10);
+    defer {
+        for (results2) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.line_text);
+        }
+        testing.allocator.free(results2);
+    }
+    try testing.expect(results2.len >= 2);
+    try testing.expectEqualStrings("install/install.sh", results2[0].path);
+}


### PR DESCRIPTION
Fixes #598 — the last evidenced ranking failure mode from the audit rounds.

The ×0.5 tooling prior (#557) is multiplicative against the raw per-line occurrence count, so density shrugs it off: live, `codedb search capture` returned `benchmarks/search-shootout/shootout.py` in every top-8 slot. A naive total-score cap (the doc-penalty approach) would destroy eponymy — `codedb search install` must keep ranking `install/install.sh` first.

Fix: cap the occurrence BASE at 2.0 for tooling paths **before** the stem/symbol boosts. Density can't dominate (6 mentions → 2.0×0.5=1.0, below any 2-mention source line), while the +15 stem boost applies after the cap so eponymous lookups still win (cap 2 + 15 = 17 → ×0.5 = 8.5).

Failing test committed red (dense bench file ranked first; eponymy case pinned in the same test). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)