### PR TITLE
feat(#596,#597): ContentCache byte budget; store lock hardening + data-log compaction

### DIFF
--- a/src/hot_cache.zig
+++ b/src/hot_cache.zig
@@ -16,10 +16,22 @@ pub const ContentCache = struct {
     hits_: std.atomic.Value(u64),
     misses_: std.atomic.Value(u64),
     evictions_: std.atomic.Value(u64),
+    /// Total bytes of cache-owned values (borrowed values are exempt).
+    owned_bytes: usize,
+    /// CLOCK hand for the global budget sweep (window eviction has its own).
+    sweep_hand: u32,
+    /// Owned-value byte budget (#596); puts evict cold owned entries to stay under it.
+    byte_budget: usize,
+    /// Owned values larger than this are not cached at all — search re-reads
+    /// from disk on a miss, so refusing oversized values is safe.
+    max_entry_bytes: usize,
 
     // 8-way set-associative: at typical occupancy a full window (the only
     // eviction trigger) is vanishingly rare; probes stay short and contiguous.
     const PROBE_LIMIT: u32 = 8;
+
+    pub const DEFAULT_BYTE_BUDGET: usize = 256 * 1024 * 1024;
+    pub const DEFAULT_MAX_ENTRY_BYTES: usize = 8 * 1024 * 1024;
 
     pub const Slot = struct {
         key_hash: u64,
@@ -47,8 +59,10 @@ pub const ContentCache = struct {
         evictions: u64,
         count: u32,
         capacity: u32,
+        owned_bytes: usize,
     };
 
+    /// capacity must be >= 1. Panics if the allocator cannot provide the slot array.
     /// capacity must be >= 1. Panics if the allocator cannot provide the slot array.
     pub fn init(allocator: std.mem.Allocator, capacity: u32) ContentCache {
         std.debug.assert(capacity >= 1);
@@ -63,6 +77,10 @@ pub const ContentCache = struct {
             .hits_ = std.atomic.Value(u64).init(0),
             .misses_ = std.atomic.Value(u64).init(0),
             .evictions_ = std.atomic.Value(u64).init(0),
+            .owned_bytes = 0,
+            .sweep_hand = 0,
+            .byte_budget = DEFAULT_BYTE_BUDGET,
+            .max_entry_bytes = DEFAULT_MAX_ENTRY_BYTES,
         };
     }
 
@@ -78,6 +96,10 @@ pub const ContentCache = struct {
             .hits_ = std.atomic.Value(u64).init(0),
             .misses_ = std.atomic.Value(u64).init(0),
             .evictions_ = std.atomic.Value(u64).init(0),
+            .owned_bytes = 0,
+            .sweep_hand = 0,
+            .byte_budget = DEFAULT_BYTE_BUDGET,
+            .max_entry_bytes = DEFAULT_MAX_ENTRY_BYTES,
         };
     }
 
@@ -110,6 +132,8 @@ pub const ContentCache = struct {
 
     /// Insert key/value, duping both into the cache allocator. On collision past
     /// the probe limit, evicts a cold slot via CLOCK sweep and frees its memory.
+    /// Insert key/value, duping both into the cache allocator. On collision past
+    /// the probe limit, evicts a cold slot via CLOCK sweep and frees its memory.
     pub fn put(self: *ContentCache, key: []const u8, value: []const u8) !void {
         return self.putImpl(key, value, true);
     }
@@ -119,11 +143,20 @@ pub const ContentCache = struct {
     /// stored as-is (no dupe) and is never freed by the cache; the key is still
     /// duped/owned as usual. The caller guarantees `value`'s backing stays valid
     /// for as long as the entry can live (until Explorer.deinit munmaps it).
+    /// Borrowed values are exempt from the byte budget.
     pub fn putBorrowed(self: *ContentCache, key: []const u8, value: []const u8) !void {
         return self.putImpl(key, value, false);
     }
 
     fn putImpl(self: *ContentCache, key: []const u8, value: []const u8, own: bool) !void {
+        if (own and (value.len > self.max_entry_bytes or value.len > self.byte_budget)) {
+            // Too large to cache; drop any stale entry for the key so get()
+            // cannot serve outdated content. Search re-reads from disk on miss.
+            self.remove(key);
+            return;
+        }
+        if (own) self.evictForBudget(value.len);
+
         const h = hashKey(key);
         const base = @as(u32, @truncate(h)) % self.capacity;
 
@@ -138,9 +171,13 @@ pub const ContentCache = struct {
                 if (slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
                     // Compute the new value first so a failed dupe leaves the slot intact.
                     const new_value = if (own) try self.allocator.dupe(u8, value) else value;
-                    if (slot.value_owned) self.allocator.free(slot.value);
+                    if (slot.value_owned) {
+                        self.owned_bytes -= slot.value.len;
+                        self.allocator.free(slot.value);
+                    }
                     slot.value = new_value;
                     slot.value_owned = own;
+                    if (own) self.owned_bytes += value.len;
                     slot.ref_bit = true;
                     return;
                 }
@@ -170,6 +207,7 @@ pub const ContentCache = struct {
                 victim = base;
             }
             const slot = &self.slots[victim.?];
+            if (slot.value_owned) self.owned_bytes -= slot.value.len;
             self.allocator.free(slot.key);
             if (slot.value_owned) self.allocator.free(slot.value);
             slot.* = empty_slot;
@@ -188,7 +226,39 @@ pub const ContentCache = struct {
         slot.value_owned = own;
         slot.ref_bit = true;
         slot.present = true;
+        if (own) self.owned_bytes += value.len;
         self.count_ += 1;
+    }
+
+    /// Evict cold owned entries (global second-chance sweep) until `incoming`
+    /// more owned bytes fit the byte budget. Borrowed entries are skipped —
+    /// evicting them frees no budget. Holes are safe: get() and putImpl()
+    /// always scan the full probe window. Stops when no owned victim remains.
+    fn evictForBudget(self: *ContentCache, incoming: usize) void {
+        while (self.owned_bytes + incoming > self.byte_budget) {
+            var victim: ?u32 = null;
+            var scanned: u32 = 0;
+            while (scanned < self.capacity * 2) : (scanned += 1) {
+                const idx = self.sweep_hand;
+                self.sweep_hand = (self.sweep_hand + 1) % self.capacity;
+                const slot = &self.slots[idx];
+                if (!slot.present or !slot.value_owned) continue;
+                if (slot.ref_bit) {
+                    slot.ref_bit = false;
+                    continue;
+                }
+                victim = idx;
+                break;
+            }
+            const idx = victim orelse return;
+            const slot = &self.slots[idx];
+            self.owned_bytes -= slot.value.len;
+            self.allocator.free(slot.key);
+            self.allocator.free(slot.value);
+            slot.* = empty_slot;
+            self.count_ -= 1;
+            _ = self.evictions_.fetchAdd(1, .monotonic);
+        }
     }
 
     pub fn remove(self: *ContentCache, key: []const u8) void {
@@ -200,7 +270,10 @@ pub const ContentCache = struct {
             const slot = &self.slots[slot_idx];
             if (slot.present and slot.key_hash == h and std.mem.eql(u8, slot.key, key)) {
                 self.allocator.free(slot.key);
-                if (slot.value_owned) self.allocator.free(slot.value);
+                if (slot.value_owned) {
+                    self.owned_bytes -= slot.value.len;
+                    self.allocator.free(slot.value);
+                }
                 slot.* = empty_slot;
                 self.count_ -= 1;
                 return;
@@ -217,6 +290,7 @@ pub const ContentCache = struct {
             }
         }
         self.count_ = 0;
+        self.owned_bytes = 0;
     }
 
     pub fn len(self: *const ContentCache) u32 {
@@ -238,6 +312,7 @@ pub const ContentCache = struct {
             .evictions = self.evictions_.load(.monotonic),
             .count = self.count_,
             .capacity = self.capacity,
+            .owned_bytes = self.owned_bytes,
         };
     }
 
@@ -390,4 +465,69 @@ test "ContentCache: mixed owned/borrowed — transitions and eviction free corre
     }
     try std.testing.expect(cache.len() <= 8);
     // No leak (DebugAllocator) and no bad free => the owned/borrowed split holds.
+}
+
+test "ContentCache: byte budget evicts owned values until the new value fits" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 64);
+    defer cache.deinit();
+    cache.byte_budget = 1000;
+    cache.max_entry_bytes = 1000;
+
+    const v300 = "x" ** 300;
+    try cache.put("a", v300);
+    try cache.put("b", v300);
+    try cache.put("c", v300);
+    try std.testing.expectEqual(@as(usize, 900), cache.stats().owned_bytes);
+
+    try cache.put("d", v300);
+    const s = cache.stats();
+    try std.testing.expect(s.owned_bytes <= 1000);
+    try std.testing.expect(s.evictions >= 1);
+    try std.testing.expect(cache.get("d") != null);
+}
+
+test "ContentCache: per-entry ceiling refuses oversized values and drops the stale entry" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 8);
+    defer cache.deinit();
+    cache.max_entry_bytes = 100;
+
+    try cache.put("k", "small");
+    try std.testing.expect(cache.get("k") != null);
+
+    const big = "y" ** 200;
+    try cache.put("k", big);
+    try std.testing.expect(cache.get("k") == null);
+    try std.testing.expectEqual(@as(usize, 0), cache.stats().owned_bytes);
+}
+
+test "ContentCache: borrowed values are exempt from the byte budget" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 8);
+    defer cache.deinit();
+    cache.byte_budget = 10;
+
+    const big = "z" ** 1000;
+    try cache.putBorrowed("snap", big);
+    try std.testing.expect(cache.get("snap") != null);
+    try std.testing.expectEqual(@as(usize, 0), cache.stats().owned_bytes);
+    try std.testing.expectEqual(@as(u64, 0), cache.stats().evictions);
+
+    try cache.put("o", "abcdefgh");
+    try std.testing.expect(cache.get("o") != null);
+    try std.testing.expect(cache.get("snap") != null);
+}
+
+test "ContentCache: owned_bytes accounting tracks update, remove, and clear" {
+    var cache = try ContentCache.initAlloc(std.testing.allocator, 8);
+    defer cache.deinit();
+
+    try cache.put("k", "0123456789");
+    try std.testing.expectEqual(@as(usize, 10), cache.stats().owned_bytes);
+    try cache.put("k", "01234");
+    try std.testing.expectEqual(@as(usize, 5), cache.stats().owned_bytes);
+    try cache.put("j", "012");
+    try std.testing.expectEqual(@as(usize, 8), cache.stats().owned_bytes);
+    cache.remove("k");
+    try std.testing.expectEqual(@as(usize, 3), cache.stats().owned_bytes);
+    cache.clear();
+    try std.testing.expectEqual(@as(usize, 0), cache.stats().owned_bytes);
 }

--- a/src/store.zig
+++ b/src/store.zig
@@ -24,6 +24,11 @@ pub const Store = struct {
     io: ?std.Io = null,
     /// Cap per-file version history. Configurable via .codedbrc (#101).
     max_versions: usize = 100,
+    /// Compact the diff data log once it exceeds this and at least half of it
+    /// is orphaned bytes (#597).
+    compact_min: u64 = 16 * 1024 * 1024,
+    /// High-water mark for the next compaction check (exponential back-off).
+    next_compact_check: u64 = 0,
 
     pub fn init(allocator: std.mem.Allocator) Store {
         return .{
@@ -90,21 +95,25 @@ pub const Store = struct {
         if (diff) |d| {
             if (self.data_log) |log| {
                 const io = self.io orelse return error.Unexpected;
-                // Advisory lock for cross-process safety
+                // Advisory lock for cross-process safety. If it cannot be
+                // acquired, skip the diff persist rather than write unlocked
+                // (#597) — the version still records with data_offset = null.
                 const locked = blk: {
                     log.lock(io, .exclusive) catch break :blk false;
                     break :blk true;
                 };
-                defer if (locked) log.unlock(io);
+                if (locked) {
+                    defer log.unlock(io);
 
-                // Re-stat to get current end position (another process may have appended)
-                const end_pos = log.length(io) catch return error.Unexpected;
-                self.data_log_pos = end_pos;
+                    // Re-stat to get current end position (another process may have appended)
+                    const end_pos = log.length(io) catch return error.Unexpected;
+                    self.data_log_pos = end_pos;
 
-                data_offset = self.data_log_pos;
-                data_len = @intCast(d.len);
-                try log.writePositionalAll(io, d, self.data_log_pos);
-                self.data_log_pos += d.len;
+                    data_offset = self.data_log_pos;
+                    data_len = @intCast(d.len);
+                    try log.writePositionalAll(io, d, self.data_log_pos);
+                    self.data_log_pos += d.len;
+                }
             }
         }
 
@@ -129,7 +138,79 @@ pub const Store = struct {
             entry.value_ptr.versions.items.len = max_versions;
         }
 
+        self.maybeCompactDataLog();
+
         return next_seq;
+    }
+
+    /// Compact when the data log is past compact_min and at least half of it
+    /// is orphaned diff bytes (versions trimmed by max_versions). Checks back
+    /// off exponentially so the live-bytes scan stays amortized. Caller must
+    /// hold self.mu.
+    fn maybeCompactDataLog(self: *Store) void {
+        if (self.data_log == null) return;
+        if (self.data_log_pos < @max(self.compact_min, self.next_compact_check)) return;
+        if (self.liveDataBytes() * 2 <= self.data_log_pos) {
+            self.compactDataLog() catch {};
+        }
+        self.next_compact_check = self.data_log_pos * 2;
+    }
+
+    fn liveDataBytes(self: *Store) u64 {
+        var total: u64 = 0;
+        var iter = self.files.iterator();
+        while (iter.next()) |entry| {
+            for (entry.value_ptr.versions.items) |v| {
+                if (v.data_offset != null) total += v.data_len;
+            }
+        }
+        return total;
+    }
+
+    /// Rewrite live diff ranges to the front of the data log, update the
+    /// version offsets in place, and truncate the orphaned tail. Ranges are
+    /// processed in ascending offset order so data only ever moves down, and
+    /// each range is buffered whole before its write, so overlap is safe.
+    /// Bailing midway leaves a consistent log (moved versions point at their
+    /// new offsets, unmoved at their old ones; nothing truncated yet).
+    /// Caller must hold self.mu.
+    fn compactDataLog(self: *Store) !void {
+        const log = self.data_log orelse return;
+        const io = self.io orelse return;
+
+        log.lock(io, .exclusive) catch return;
+        defer log.unlock(io);
+
+        var live: std.ArrayList(*Version) = .empty;
+        defer live.deinit(self.allocator);
+        var iter = self.files.iterator();
+        while (iter.next()) |entry| {
+            for (entry.value_ptr.versions.items) |*v| {
+                if (v.data_offset != null) try live.append(self.allocator, v);
+            }
+        }
+        std.mem.sort(*Version, live.items, {}, struct {
+            fn lt(_: void, a: *Version, b: *Version) bool {
+                return a.data_offset.? < b.data_offset.?;
+            }
+        }.lt);
+
+        var write_pos: u64 = 0;
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        for (live.items) |v| {
+            const off = v.data_offset.?;
+            const len: usize = v.data_len;
+            if (off != write_pos) {
+                try buf.resize(self.allocator, len);
+                if (try log.readPositionalAll(io, buf.items, off) != len) return error.Unexpected;
+                try log.writePositionalAll(io, buf.items, write_pos);
+                v.data_offset = write_pos;
+            }
+            write_pos += len;
+        }
+        try log.setLength(io, write_pos);
+        self.data_log_pos = write_pos;
     }
 
     pub fn getLatest(self: *Store, path: []const u8) ?Version {

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -1134,3 +1134,41 @@ test "issue-584: ContentCache probe-window — overflow inserts, holes, and dupl
         try testing.expectEqual(@as(u32, 2), cache.len());
     }
 }
+
+test "issue-597: data log compacts orphaned diff ranges and fixes offsets" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp_dir.dir.realPathFile(io, ".", &dir_buf);
+    const dir_path = dir_buf[0..dir_path_len];
+    const log_path = try std.fmt.allocPrint(testing.allocator, "{s}/data.log", .{dir_path});
+    defer testing.allocator.free(log_path);
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try store.openDataLog(io, log_path);
+    store.max_versions = 2;
+    store.compact_min = 1;
+
+    _ = try store.recordEdit("f.zig", 1, .replace, 0x1, 5, "AAAAA");
+    _ = try store.recordEdit("f.zig", 1, .replace, 0x2, 5, "BBBBB");
+    _ = try store.recordEdit("f.zig", 1, .replace, 0x3, 5, "CCCCC");
+    _ = try store.recordEdit("f.zig", 1, .replace, 0x4, 5, "DDDDD");
+    // max_versions=2 keeps C and D; A and B are orphaned (10 of 20 bytes),
+    // so the post-append check compacts: C -> 0, D -> 5, file truncated to 10.
+
+    const latest = store.getLatest("f.zig").?;
+    try testing.expectEqual(@as(?u64, 5), latest.data_offset);
+    const prev = store.getAtCursor("f.zig", 3).?;
+    try testing.expectEqual(@as(?u64, 0), prev.data_offset);
+
+    const log_file = try std.Io.Dir.cwd().openFile(io, log_path, .{});
+    defer log_file.close(io);
+    try testing.expectEqual(@as(u64, 10), try log_file.length(io));
+    var buf: [5]u8 = undefined;
+    _ = try log_file.readPositionalAll(io, &buf, 0);
+    try testing.expectEqualStrings("CCCCC", &buf);
+    _ = try log_file.readPositionalAll(io, &buf, 5);
+    try testing.expectEqualStrings("DDDDD", &buf);
+}


### PR DESCRIPTION
Implements both parked enhancements. Closes #596, closes #597. Independent of #601 (no shared files); branched off the release tip.

## #596 — ContentCache byte budget (src/hot_cache.zig)

The cache bounded entries (4096 slots), not bytes — values are file contents, so worst-case retained bytes were unbounded. Now:

- **`owned_bytes` accounting** through put/update/evict/remove/clear, surfaced in `Stats`.
- **Byte budget** (default 256MB, field-configurable): a put that would exceed it runs a global second-chance sweep over *owned* entries until the incoming value fits. Holes are safe — post-#584, `get()`/`putImpl()` scan the full probe window, so a globally-evicted slot can't strand anything. The in-window collision eviction is untouched.
- **Per-entry ceiling** (default 8MB): oversized owned values are not cached at all, and any stale entry for that key is dropped so `get()` can't serve outdated content (search re-reads from disk on miss).
- **Borrowed values exempt** (snapshot adoption): they cost no budget and budget sweeps skip them — evicting them would free nothing.

Four new tests: budget eviction, ceiling + stale-drop, borrowed exemption, accounting through update/remove/clear.

## #597 — store hardening (src/store.zig)

1. **No unlocked diff writes.** `appendVersion` proceeded without the advisory lock when acquisition failed — two processes could compute the same `end_pos` and interleave writes. Now a failed lock skips the diff persist; the version still records with `data_offset = null`.
2. **Data-log compaction.** Cross-lifetime growth was already solved by truncate-on-open (#367); within one daemon lifetime, versions trimmed by `max_versions` orphaned their diff bytes forever. `appendVersion` now checks past a 16MB floor with exponential back-off; when ≥ half the file is orphaned, live ranges are rewritten to the front in ascending offset order (each buffered whole — overlap-safe), version offsets fixed in place, tail truncated. Bailing midway leaves a consistent log. Test drives `max_versions` trimming and asserts the file shrinks, offsets are rewritten, and both surviving diffs read back intact.

## Verification

`zig build test --summary all`: **799/799**, exit 0 (the four cache tests are inline in hot_cache.zig and run in every binary that transitively imports it, same as the existing inline cache tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)