### PR TITLE
fix(#603): store appendVersion error path — no poisoned files entry on failed path dupe

### DIFF
--- a/src/store.zig
+++ b/src/store.zig
@@ -85,6 +85,7 @@ pub const Store = struct {
 
         const entry = try self.files.getOrPut(path);
         if (!entry.found_existing) {
+            errdefer self.files.removeByPtr(entry.key_ptr);
             const duped = try self.allocator.dupe(u8, path);
             entry.key_ptr.* = duped;
             entry.value_ptr.* = FileVersions.init(self.allocator, duped);

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -1172,3 +1172,13 @@ test "issue-597: data log compacts orphaned diff ranges and fixes offsets" {
     _ = try log_file.readPositionalAll(io, &buf, 5);
     try testing.expectEqualStrings("DDDDD", &buf);
 }
+
+
+test "issue-603: appendVersion failed key dupe leaves a poisoned files entry" {
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    var store = Store.init(failing.allocator());
+
+    try testing.expectError(error.OutOfMemory, store.recordSnapshot("src/a.zig", 10, 0x1));
+    try testing.expectEqual(@as(usize, 0), store.files.count());
+    store.deinit();
+}


### PR DESCRIPTION
## What

Fixes #603 (note: merging into the release branch will not auto-close it — add it to the ship closes-list).

`appendVersion`'s first-touch block inserted the map slot via `getOrPut` and only then duped the path. A failed dupe (OOM) left a poisoned entry behind: key = the caller's transient slice, value = undefined `FileVersions`. A retry appended into undefined memory (UB), `deinit` invalid-freed the borrowed key, and once the caller freed its buffer the map held a dangling key. Same error-path class as #594, in the store.

The fix scopes an `errdefer self.files.removeByPtr(entry.key_ptr)` to the first-touch block, so the dupe failing rolls the insert back. `FileVersions.init` is infallible, so the errdefer guards exactly the dupe; a later `versions.append` failure still leaves a valid initialized entry, which is fine.

## Test plan

- [x] `test(#603)` commit: failing test (`expected 0, found 1` + leak) on the release tip
- [x] With fix: `zig build test` — 23/23 steps, **808/808 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)