### PR TITLE
fix(#606): word index reuses freed doc_id slots

### DIFF
--- a/src/index.zig
+++ b/src/index.zig
@@ -21,6 +21,8 @@ pub const WordIndex = struct {
     enabled: bool = true,
     path_to_id: std.StringHashMap(u32),
     id_to_path: std.ArrayList([]const u8),
+    /// freed doc_id slots available for reuse by getOrCreateDocId
+    free_ids: std.ArrayList(u32) = .empty,
     /// doc_id → number of tokens indexed for that doc (BM25 length normalization).
     doc_lengths: std.AutoHashMap(u32, u32),
     /// Sum of all values in doc_lengths.
@@ -41,9 +43,20 @@ pub const WordIndex = struct {
 
     fn getOrCreateDocId(self: *WordIndex, path: []const u8) !u32 {
         if (self.path_to_id.get(path)) |id| return id;
+        if (self.free_ids.items.len > 0) {
+            const freed = self.free_ids.items[self.free_ids.items.len - 1];
+            // put first: a failed put must leave the free list and slot untouched
+            try self.path_to_id.put(path, freed);
+            _ = self.free_ids.pop();
+            self.id_to_path.items[@as(usize, freed)] = path;
+            return freed;
+        }
         const id: u32 = @intCast(self.id_to_path.items.len);
         try self.id_to_path.append(self.allocator, path);
-        try self.path_to_id.put(path, id);
+        self.path_to_id.put(path, id) catch |err| {
+            _ = self.id_to_path.pop();
+            return err;
+        };
         return id;
     }
 
@@ -71,6 +84,7 @@ pub const WordIndex = struct {
                 if (path.len > 0) self.allocator.free(path);
             }
             self.id_to_path.deinit(self.allocator);
+            self.free_ids.deinit(self.allocator);
             self.doc_lengths.deinit();
             self.allocator.free(self.word_dir);
             std.posix.munmap(m);
@@ -100,6 +114,7 @@ pub const WordIndex = struct {
 
         self.path_to_id.deinit();
         self.id_to_path.deinit(self.allocator);
+        self.free_ids.deinit(self.allocator);
         self.doc_lengths.deinit();
     }
 
@@ -136,6 +151,7 @@ pub const WordIndex = struct {
                 // otherwise the slot aliases stable_path, freed below.
                 if (self.skip_file_words and old_path.len > 0) self.allocator.free(old_path);
                 self.id_to_path.items[doc_id] = "";
+                self.free_ids.append(self.allocator, doc_id) catch {};
             }
             if (self.doc_lengths.fetchRemove(doc_id)) |kv| {
                 self.total_tokens -= kv.value;
@@ -184,6 +200,7 @@ pub const WordIndex = struct {
             const old_path = self.id_to_path.items[doc_id];
             if (self.skip_file_words and old_path.len > 0) self.allocator.free(old_path);
             self.id_to_path.items[doc_id] = "";
+            self.free_ids.append(self.allocator, doc_id) catch {};
         }
         var empty_words: std.ArrayList([]const u8) = .empty;
         defer empty_words.deinit(self.allocator);

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3254,3 +3254,15 @@ test "issue-600: mmap_overlay writeToDisk persists overlay edits" {
         try testing.expectEqual(@as(usize, 0), g.len);
     }
 }
+
+
+test "issue-606: word index reuses doc_id slots freed by removeFile" {
+    var wi = WordIndex.init(testing.allocator);
+    defer wi.deinit();
+
+    try wi.indexFile("a.zig", "const alpha = 1;\n");
+    wi.removeFile("a.zig");
+    try wi.indexFile("b.zig", "const beta = 2;\n");
+
+    try testing.expectEqual(@as(usize, 1), wi.id_to_path.items.len);
+}

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3255,7 +3255,6 @@ test "issue-600: mmap_overlay writeToDisk persists overlay edits" {
     }
 }
 
-
 test "issue-606: word index reuses doc_id slots freed by removeFile" {
     var wi = WordIndex.init(testing.allocator);
     defer wi.deinit();
@@ -3265,4 +3264,58 @@ test "issue-606: word index reuses doc_id slots freed by removeFile" {
     try wi.indexFile("b.zig", "const beta = 2;\n");
 
     try testing.expectEqual(@as(usize, 1), wi.id_to_path.items.len);
+
+    const beta_hits = try wi.searchDeduped("beta", testing.allocator);
+    defer testing.allocator.free(beta_hits);
+    try testing.expectEqual(@as(usize, 1), beta_hits.len);
+    try testing.expectEqualStrings("b.zig", wi.hitPath(beta_hits[0]));
+
+    const alpha_hits = try wi.searchDeduped("alpha", testing.allocator);
+    defer testing.allocator.free(alpha_hits);
+    try testing.expectEqual(@as(usize, 0), alpha_hits.len);
+}
+
+test "issue-606: doc_id reuse survives a persist/reload round-trip" {
+    const alloc = testing.allocator;
+    var wi = WordIndex.init(alloc);
+    defer wi.deinit();
+
+    try wi.indexFile("a.zig", "const alpha = 1;\n");
+    try wi.indexFile("keep.zig", "const kappa = 3;\n");
+    wi.removeFile("a.zig");
+    // Reuses a.zig's freed slot; a stale posting resolving to the recycled id
+    // would attribute alpha hits to c.zig after reload.
+    try wi.indexFile("c.zig", "const gamma = 4;\n");
+
+    try testing.expectEqual(@as(usize, 2), wi.id_to_path.items.len);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_path = path_buf[0..dir_path_len];
+
+    try wi.writeToDisk(io, dir_path, null);
+
+    const maybe_loaded = WordIndex.readFromDisk(io, dir_path, alloc);
+    try testing.expect(maybe_loaded != null);
+    var loaded = maybe_loaded.?;
+    defer loaded.deinit();
+
+    try testing.expectEqual(@as(usize, 2), loaded.id_to_path.items.len);
+    try testing.expect(loaded.path_to_id.get("a.zig") == null);
+
+    const gamma_hits = try loaded.searchDeduped("gamma", alloc);
+    defer alloc.free(gamma_hits);
+    try testing.expectEqual(@as(usize, 1), gamma_hits.len);
+    try testing.expectEqualStrings("c.zig", loaded.hitPath(gamma_hits[0]));
+
+    const kappa_hits = try loaded.searchDeduped("kappa", alloc);
+    defer alloc.free(kappa_hits);
+    try testing.expectEqual(@as(usize, 1), kappa_hits.len);
+    try testing.expectEqualStrings("keep.zig", loaded.hitPath(kappa_hits[0]));
+
+    const alpha_hits = try loaded.searchDeduped("alpha", alloc);
+    defer alloc.free(alpha_hits);
+    try testing.expectEqual(@as(usize, 0), alpha_hits.len);
 }


### PR DESCRIPTION
Fixes #606 (manual close — base is not the default branch).

## What

`WordIndex.removeFile` tombstoned freed slots but `getOrCreateDocId` always appended, so `id_to_path` ratcheted up forever in a long-lived daemon. This adds the `free_ids` reuse pool the issue prescribes, mirroring `TrigramIndex`.

## ABA safety (the caution flagged in #606)

Reuse is safe across persistence because `writeToDisk` **compacts on write**: tombstones are skipped and postings are remapped to dense disk ids via path lookup, so no on-disk posting can reference a recycled id. In memory, both `removeFile` paths (incremental and bulk, post-#583) sweep every posting for the freed id before it can be recycled. The new round-trip test pins exactly the failure the issue warned about: a recycled id misattributing the removed file's hits after persist/reload.

## Error-path hardening

Deliberately did **not** copy TrigramIndex's reuse branch verbatim — it mutates the slot before the fallible `path_to_id.put`, the same poisoned-entry class as #594/#603. Both branches here mutate state only after the fallible call (reuse: put-then-pop; append: put failure pops the appended slot).

## Tests

- `issue-606: word index reuses doc_id slots freed by removeFile` — red on the previous tip (expected 1, found 2), green here; extended with hit-attribution checks.
- `issue-606: doc_id reuse survives a persist/reload round-trip` — new; dense table after reload, recycled-id hits attribute to the new file, removed file gone.

Suite: **810/810** (was 808; +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)