### PR TITLE
perf: search result caches, background warmup, symbol-scan gating

### DIFF
--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -91,7 +91,7 @@ fn benchSearch(explorer: *Explorer, query: []const u8, n: usize, alloc: std.mem.
     if (cio.posixGetenv("CODEDB_BENCH_BREAKDOWN") != null) {
         const b = explorer.last_search_breakdown;
         var buf: [512]u8 = undefined;
-        const msg = std.fmt.bufPrint(&buf, "  breakdown[{s}]: t0={d}ns t05={d}ns t1={d}ns t2={d}ns rerank={d}ns tier_reached={d} cands={d} results={d}\n", .{ query, b.tier0_ns, b.tier05_ns, b.tier1_ns, b.tier2_ns, b.rerank_ns, b.tier_reached, b.candidate_count, b.result_count }) catch "";
+        const msg = std.fmt.bufPrint(&buf, "  breakdown[{s}]: t0={d}ns t05={d}ns t1={d}ns t2={d}ns t3={d}ns t4={d}ns t5={d}ns rerank={d}ns tier_reached={d} cands={d} results={d}\n", .{ query, b.tier0_ns, b.tier05_ns, b.tier1_ns, b.tier2_ns, b.tier3_ns, b.tier4_ns, b.tier5_ns, b.rerank_ns, b.tier_reached, b.candidate_count, b.result_count }) catch "";
         cio.File.stderr().writeAll(msg) catch {};
     }
     return .{ .name = query, .kind = "search", .hits = hits, .avg_ns = total / n };

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -310,12 +310,21 @@ pub fn main(init: std.process.Init.Minimal) !void {
     };
     const index_ns = t0.read();
 
-    // Queries
+    // Queries — the per-query rows measure UNCACHED searches so they stay
+    // comparable across versions; one extra row shows the result-cache hit
+    // latency for a representative query.
+    cio.posixSetenv("CODEDB_NO_SEARCH_CACHE", "1");
     var qlist: std.ArrayList(QueryResult) = .empty;
     defer qlist.deinit(alloc);
 
     for ([_][]const u8{ "middleware", "authentication", "webhook", "database", "error" }) |q|
         (qlist.append(alloc, try benchSearch(&explorer, q, args.iterations, alloc)) catch {});
+    cio.posixUnsetenv("CODEDB_NO_SEARCH_CACHE");
+    if (benchSearch(&explorer, "error", args.iterations, alloc) catch null) |cached_qr| {
+        var qr = cached_qr;
+        qr.kind = "cached";
+        qlist.append(alloc, qr) catch {};
+    }
     for ([_][]const u8{ "request", "response", "config", "error" }) |q|
         (qlist.append(alloc, try benchWord(&explorer, q, args.iterations, alloc)) catch {});
     for ([_][]const u8{ "init", "main", "handleRequest", "render" }) |q|

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -924,6 +924,327 @@ const LineOffsetCache = struct {
         return n;
     }
 };
+
+/// Whole-query result cache for searchContent: agents re-issue identical
+/// searches constantly, and a hit copies the cached results into the
+/// caller's allocator instead of re-running the search tiers. An entry is
+/// served only when BOTH its generation (Explorer.search_gen, bumped by
+/// every mutation that can change results: indexing, removal, word-index
+/// rebuilds, and the lazy symbol-index / call-graph / co-change builds) and
+/// its env fingerprint (the ranking kill-switch variables) still match — so
+/// a hit can never observe state a fresh search would not have produced.
+/// CODEDB_NO_SEARCH_CACHE=1 disables it entirely (the repo benchmark sets
+/// this so its per-query numbers keep measuring uncached searches).
+const SearchResultCache = struct {
+    const CachedResult = struct {
+        path: []u8,
+        line_num: u32,
+        line_text: []u8,
+        score: f32,
+    };
+    const Entry = struct {
+        query: []u8,
+        max_results: usize,
+        gen: u64,
+        env_fp: u64,
+        results: []CachedResult,
+        bytes: usize,
+        last_used: u64,
+    };
+
+    allocator: std.mem.Allocator,
+    entries: std.ArrayList(Entry) = .empty,
+    mu: cio.Mutex = .{},
+    tick: u64 = 0,
+    total_bytes: usize = 0,
+    /// Test-visible counters; production code does not read them.
+    hits: u64 = 0,
+    misses: u64 = 0,
+
+    const MAX_ENTRIES: usize = 64;
+    const MAX_BYTES: usize = 4 * 1024 * 1024;
+    /// One entry may not claim more than a quarter of the byte budget.
+    const MAX_ENTRY_BYTES: usize = MAX_BYTES / 4;
+
+    fn init(allocator: std.mem.Allocator) SearchResultCache {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeEntry(self: *SearchResultCache, e: *Entry) void {
+        self.allocator.free(e.query);
+        for (e.results) |r| {
+            self.allocator.free(r.path);
+            self.allocator.free(r.line_text);
+        }
+        self.allocator.free(e.results);
+    }
+
+    fn deinit(self: *SearchResultCache) void {
+        for (self.entries.items) |*e| self.freeEntry(e);
+        self.entries.deinit(self.allocator);
+    }
+
+    /// On hit, returns results duped into `out_allocator` (caller owns each
+    /// path/line_text and the slice, same contract as a fresh search). A
+    /// stale same-key entry is dropped so the slot can refill.
+    fn get(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator) ?[]const SearchResult {
+        self.mu.lock();
+        defer self.mu.unlock();
+        var i: usize = 0;
+        while (i < self.entries.items.len) : (i += 1) {
+            const e = &self.entries.items[i];
+            if (e.max_results != max_results or !std.mem.eql(u8, e.query, query)) continue;
+            if (e.gen != gen or e.env_fp != env_fp) {
+                var dead = self.entries.swapRemove(i);
+                self.total_bytes -= dead.bytes;
+                self.freeEntry(&dead);
+                self.misses += 1;
+                return null;
+            }
+            const out = out_allocator.alloc(SearchResult, e.results.len) catch return null;
+            var n: usize = 0;
+            for (e.results) |r| {
+                const p = out_allocator.dupe(u8, r.path) catch break;
+                const t = out_allocator.dupe(u8, r.line_text) catch {
+                    out_allocator.free(p);
+                    break;
+                };
+                out[n] = .{ .path = p, .line_num = r.line_num, .line_text = t, .score = r.score };
+                n += 1;
+            }
+            if (n != e.results.len) {
+                // OOM mid-copy: release and fall through to a fresh search.
+                for (out[0..n]) |r| {
+                    out_allocator.free(r.path);
+                    out_allocator.free(r.line_text);
+                }
+                out_allocator.free(out);
+                return null;
+            }
+            self.tick += 1;
+            e.last_used = self.tick;
+            self.hits += 1;
+            return out;
+        }
+        self.misses += 1;
+        return null;
+    }
+
+    /// Copies `results` into cache-owned memory. Any OOM just skips caching.
+    fn put(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, results: []const SearchResult) void {
+        var bytes: usize = query.len + @sizeOf(Entry);
+        for (results) |r| bytes += r.path.len + r.line_text.len + @sizeOf(CachedResult);
+        if (bytes > MAX_ENTRY_BYTES) return;
+
+        const owned = self.allocator.alloc(CachedResult, results.len) catch return;
+        var n: usize = 0;
+        for (results) |r| {
+            const p = self.allocator.dupe(u8, r.path) catch break;
+            const t = self.allocator.dupe(u8, r.line_text) catch {
+                self.allocator.free(p);
+                break;
+            };
+            owned[n] = .{ .path = p, .line_num = r.line_num, .line_text = t, .score = r.score };
+            n += 1;
+        }
+        const query_copy = if (n == results.len) self.allocator.dupe(u8, query) catch null else null;
+        if (query_copy == null) {
+            for (owned[0..n]) |r| {
+                self.allocator.free(r.path);
+                self.allocator.free(r.line_text);
+            }
+            self.allocator.free(owned);
+            return;
+        }
+
+        self.mu.lock();
+        defer self.mu.unlock();
+        // Replace any existing same-key entry (it was a miss or stale).
+        var i: usize = 0;
+        while (i < self.entries.items.len) {
+            const e = &self.entries.items[i];
+            if (e.max_results == max_results and std.mem.eql(u8, e.query, query)) {
+                var dead = self.entries.swapRemove(i);
+                self.total_bytes -= dead.bytes;
+                self.freeEntry(&dead);
+                continue;
+            }
+            i += 1;
+        }
+        // Evict least-recently-used entries until the new one fits.
+        while (self.entries.items.len >= MAX_ENTRIES or
+            (self.entries.items.len > 0 and self.total_bytes + bytes > MAX_BYTES))
+        {
+            var lru: usize = 0;
+            for (self.entries.items, 0..) |e, j| {
+                if (e.last_used < self.entries.items[lru].last_used) lru = j;
+            }
+            var dead = self.entries.swapRemove(lru);
+            self.total_bytes -= dead.bytes;
+            self.freeEntry(&dead);
+        }
+        self.tick += 1;
+        self.entries.append(self.allocator, .{
+            .query = query_copy.?,
+            .max_results = max_results,
+            .gen = gen,
+            .env_fp = env_fp,
+            .results = owned,
+            .bytes = bytes,
+            .last_used = self.tick,
+        }) catch {
+            self.allocator.free(query_copy.?);
+            for (owned) |r| {
+                self.allocator.free(r.path);
+                self.allocator.free(r.line_text);
+            }
+            self.allocator.free(owned);
+            return;
+        };
+        self.total_bytes += bytes;
+    }
+};
+
+/// Rendered-output sibling of SearchResultCache for renderPlainSearch — the
+/// MCP fast path renders straight to text and never reaches searchContent,
+/// so it gets its own (query, max_results, paths_only) → bytes cache with
+/// identical generation + env-fingerprint validation and LRU discipline.
+const PlainRenderCache = struct {
+    const Entry = struct {
+        query: []u8,
+        max_results: usize,
+        paths_only: bool,
+        gen: u64,
+        env_fp: u64,
+        bytes: []u8,
+        last_used: u64,
+    };
+
+    allocator: std.mem.Allocator,
+    entries: std.ArrayList(Entry) = .empty,
+    mu: cio.Mutex = .{},
+    tick: u64 = 0,
+    total_bytes: usize = 0,
+    /// Test-visible counters; production code does not read them.
+    hits: u64 = 0,
+    misses: u64 = 0,
+
+    const MAX_ENTRIES: usize = 64;
+    const MAX_BYTES: usize = 4 * 1024 * 1024;
+    const MAX_ENTRY_BYTES: usize = MAX_BYTES / 4;
+
+    fn init(allocator: std.mem.Allocator) PlainRenderCache {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeEntry(self: *PlainRenderCache, e: *Entry) void {
+        self.allocator.free(e.query);
+        self.allocator.free(e.bytes);
+    }
+
+    fn deinit(self: *PlainRenderCache) void {
+        for (self.entries.items) |*e| self.freeEntry(e);
+        self.entries.deinit(self.allocator);
+    }
+
+    /// On hit, appends the cached rendering to `out` and returns true.
+    fn render(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator, out: *std.ArrayList(u8)) bool {
+        self.mu.lock();
+        defer self.mu.unlock();
+        var i: usize = 0;
+        while (i < self.entries.items.len) : (i += 1) {
+            const e = &self.entries.items[i];
+            if (e.max_results != max_results or e.paths_only != paths_only or !std.mem.eql(u8, e.query, query)) continue;
+            if (e.gen != gen or e.env_fp != env_fp) {
+                var dead = self.entries.swapRemove(i);
+                self.total_bytes -= dead.bytes.len;
+                self.freeEntry(&dead);
+                self.misses += 1;
+                return false;
+            }
+            out.appendSlice(out_allocator, e.bytes) catch return false;
+            self.tick += 1;
+            e.last_used = self.tick;
+            self.hits += 1;
+            return true;
+        }
+        self.misses += 1;
+        return false;
+    }
+
+    /// Copies `bytes` into cache-owned memory. Any OOM just skips caching.
+    fn put(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, bytes: []const u8) void {
+        if (bytes.len > MAX_ENTRY_BYTES) return;
+        const bytes_copy = self.allocator.dupe(u8, bytes) catch return;
+        const query_copy = self.allocator.dupe(u8, query) catch {
+            self.allocator.free(bytes_copy);
+            return;
+        };
+
+        self.mu.lock();
+        defer self.mu.unlock();
+        var i: usize = 0;
+        while (i < self.entries.items.len) {
+            const e = &self.entries.items[i];
+            if (e.max_results == max_results and e.paths_only == paths_only and std.mem.eql(u8, e.query, query)) {
+                var dead = self.entries.swapRemove(i);
+                self.total_bytes -= dead.bytes.len;
+                self.freeEntry(&dead);
+                continue;
+            }
+            i += 1;
+        }
+        while (self.entries.items.len >= MAX_ENTRIES or
+            (self.entries.items.len > 0 and self.total_bytes + bytes_copy.len > MAX_BYTES))
+        {
+            var lru: usize = 0;
+            for (self.entries.items, 0..) |e, j| {
+                if (e.last_used < self.entries.items[lru].last_used) lru = j;
+            }
+            var dead = self.entries.swapRemove(lru);
+            self.total_bytes -= dead.bytes.len;
+            self.freeEntry(&dead);
+        }
+        self.tick += 1;
+        self.entries.append(self.allocator, .{
+            .query = query_copy,
+            .max_results = max_results,
+            .paths_only = paths_only,
+            .gen = gen,
+            .env_fp = env_fp,
+            .bytes = bytes_copy,
+            .last_used = self.tick,
+        }) catch {
+            self.allocator.free(query_copy);
+            self.allocator.free(bytes_copy);
+            return;
+        };
+        self.total_bytes += bytes_copy.len;
+    }
+};
+
+/// Fingerprint of the env kill-switches that change ranking/search output —
+/// part of the SearchResultCache key so toggling one (tests do this
+/// mid-process) can never serve results computed under the other setting.
+fn rankingEnvFingerprint() u64 {
+    var h = std.hash.Wyhash.init(0x5eed);
+    inline for ([_][]const u8{
+        "CODEDB_NO_CENTRALITY",
+        "CODEDB_NO_GRAPH_DISTANCE",
+        "CODEDB_NO_COCHANGE",
+        "CODEDB_LEX_FREQ_PENALTY",
+        "CODEDB_LEX_FREQ_AMP",
+        "CODEDB_RVSM_SIZE_PRIOR",
+        "CODEDB_RVSM_AMP",
+        "CODEDB_RVSM_K",
+        "CODEDB_IN_DEGREE_CENTRALITY",
+    }) |name| {
+        h.update(name);
+        if (cio.posixGetenv(name)) |v| h.update(v) else h.update(&[_]u8{0});
+    }
+    return h.final();
+}
+
 pub const Explorer = struct {
     outlines: std.StringHashMap(FileOutline),
     dep_graph: DependencyGraph,
@@ -979,6 +1300,14 @@ pub const Explorer = struct {
     /// Production code does not read this field.
     search_tier5_count: u64 = 0,
     last_search_breakdown: SearchBreakdown = .{},
+    /// Whole-query result cache for searchContent, validated against
+    /// search_gen + the ranking-env fingerprint (see SearchResultCache).
+    search_cache: SearchResultCache,
+    /// Rendered-output cache for renderPlainSearch (same validation).
+    plain_render_cache: PlainRenderCache,
+    /// Bumped (atomically — searches run under the SHARED lock) by every
+    /// mutation that can change search results; see bumpSearchGen callers.
+    search_gen: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     /// Buffers adopted from snapshot loads (the raw outline_state section).
     /// Restored FileOutlines borrow their import/symbol strings as slices into
     /// these (see FileOutline.borrows_strings), so they must outlive every
@@ -1015,6 +1344,8 @@ pub const Explorer = struct {
             .dep_graph = DependencyGraph.init(allocator),
             .contents = try ContentCache.initAlloc(allocator, content_cache_capacity),
             .line_offsets = LineOffsetCache.init(allocator),
+            .search_cache = SearchResultCache.init(allocator),
+            .plain_render_cache = PlainRenderCache.init(allocator),
             .symbol_index = std.StringHashMap(std.ArrayList(SymbolLocation)).init(allocator),
             .symbol_index_complete = true,
             .word_index = WordIndex.init(allocator),
@@ -1043,6 +1374,8 @@ pub const Explorer = struct {
 
         self.contents.deinit();
         self.line_offsets.deinit();
+        self.search_cache.deinit();
+        self.plain_render_cache.deinit();
         if (self.call_centrality) |*c| c.deinit();
         if (self.call_graph) |*cg| cg.deinit(self.allocator);
         if (self.co_change) |*cc| git.freeCoChange(cc, self.allocator);
@@ -1118,6 +1451,7 @@ pub const Explorer = struct {
     }
 
     pub fn commitParsedFileOwnedOutline(self: *Explorer, path: []const u8, content: []const u8, outline: FileOutline, full_index: bool, skip_trigram: bool) !void {
+        self.bumpSearchGen();
         var owned_outline = outline;
         // One deinit only: an errdefer here would stack with the defer below
         // and double-free the parsed outline on any post-clone error.
@@ -1624,6 +1958,15 @@ pub const Explorer = struct {
         const parsed = try parseContentForIndexing(self.allocator, path, content);
         return self.commitParsedFileOwnedOutline(path, parsed.content, parsed.outline, full_index, skip_trigram);
     }
+
+    /// Invalidate the searchContent result cache. Called by every mutation
+    /// that can change what a search returns — file commits/removals, index
+    /// rebuilds, and the one-shot lazy ranking-signal builds (symbol index,
+    /// call graph, co-change). Atomic because the lazy builds run under the
+    /// SHARED lock.
+    fn bumpSearchGen(self: *Explorer) void {
+        _ = self.search_gen.fetchAdd(1, .release);
+    }
     /// Rebuild trigram index from the stored file contents.
     /// Used after a cache hit to populate trigrams when they were skipped during the fast scan.
     pub fn rebuildTrigrams(self: *Explorer) !void {
@@ -1646,6 +1989,7 @@ pub const Explorer = struct {
     /// by streaming source files from the project root when the content cache
     /// was capped during fast snapshot restore.
     pub fn rebuildWordIndex(self: *Explorer) !void {
+        self.bumpSearchGen();
         const source_paths = blk: {
             self.mu.lockShared();
             defer self.mu.unlockShared();
@@ -1741,6 +2085,7 @@ pub const Explorer = struct {
         self.mu.lock();
         defer self.mu.unlock();
         if (self.symbol_index_complete) return;
+        self.bumpSearchGen();
         self.symbol_index_complete = true;
         var it = self.outlines.iterator();
         while (it.next()) |entry| {
@@ -1802,6 +2147,7 @@ pub const Explorer = struct {
     }
 
     pub fn removeFile(self: *Explorer, path: []const u8) void {
+        self.bumpSearchGen();
         self.mu.lock();
         defer self.mu.unlock();
         if (!self.word_index_complete) {
@@ -2654,6 +3000,25 @@ pub const Explorer = struct {
     }
 
     pub fn searchContent(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
+        // Result-cache front door: a hit copies the cached results into the
+        // caller's allocator (same ownership contract as a fresh search).
+        // The generation is read BEFORE the search runs, so any concurrent
+        // mutation makes the stored entry stale immediately — conservative
+        // in the safe direction. Lazy builds during a query's FIRST run bump
+        // the generation mid-search; that entry just never hits and the next
+        // run stores a valid one.
+        const cacheable = max_results > 0 and query.len > 0 and query.len <= 1024 and
+            cio.posixGetenv("CODEDB_NO_SEARCH_CACHE") == null;
+        if (!cacheable) return self.searchContentUncached(query, allocator, max_results);
+        const gen = self.search_gen.load(.acquire);
+        const env_fp = rankingEnvFingerprint();
+        if (self.search_cache.get(query, max_results, gen, env_fp, allocator)) |hit| return hit;
+        const res = try self.searchContentUncached(query, allocator, max_results);
+        self.search_cache.put(query, max_results, gen, env_fp, res);
+        return res;
+    }
+
+    fn searchContentUncached(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
         // #539: ensure the word index — Tier 0's recall source — is populated.
         // After a snapshot fast-load it is built lazily (see issue-220); without
         // this, searchContent's recall collapses to the trigram/skip_trigram tiers
@@ -3072,6 +3437,26 @@ pub const Explorer = struct {
     }
 
     pub fn renderPlainSearch(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8), max_results: usize, paths_only: bool) !bool {
+        // Rendered-output cache front door — same generation discipline as
+        // searchContent's cache (see that wrapper for the staleness
+        // reasoning). Only successful renders (rendered == true) are stored;
+        // a false return falls through to searchContentAuto, which caches
+        // through searchContent itself.
+        const cacheable = max_results > 0 and query.len > 0 and query.len <= 1024 and
+            cio.posixGetenv("CODEDB_NO_SEARCH_CACHE") == null;
+        const cache_gen = self.search_gen.load(.acquire);
+        const cache_fp = if (cacheable) rankingEnvFingerprint() else 0;
+        if (cacheable and self.plain_render_cache.render(query, max_results, paths_only, cache_gen, cache_fp, allocator, out)) return true;
+        const out_start = out.items.len;
+
+        const rendered = try self.renderPlainSearchUncached(query, allocator, out, max_results, paths_only);
+        if (rendered and cacheable) {
+            self.plain_render_cache.put(query, max_results, paths_only, cache_gen, cache_fp, out.items[out_start..]);
+        }
+        return rendered;
+    }
+
+    fn renderPlainSearchUncached(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8), max_results: usize, paths_only: bool) !bool {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -3849,6 +4234,9 @@ pub const Explorer = struct {
         self.co_change_attempted = true;
         const root = self.root_path orelse return;
         self.co_change = git.buildCoChange(self.allocator, root, 500, 32, 8);
+        // The co-change boost just became available: results cached before
+        // the build could differ from a fresh search.
+        if (self.co_change != null) self.bumpSearchGen();
     }
 
     /// Boost for files that historically change together with the files
@@ -4012,6 +4400,9 @@ pub const Explorer = struct {
             .node_name = nn,
             .node_line = nl,
         };
+        // The graph-distance boost gate (`call_graph != null`) just flipped:
+        // results cached before the build could differ from a fresh search.
+        self.bumpSearchGen();
     }
 
     /// Build `call_centrality` once (idempotent, mutex-guarded). Must be called

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1333,6 +1333,10 @@ pub const Explorer = struct {
     /// Whole-query result cache for searchContent, validated against
     /// search_gen + the ranking-env fingerprint (see SearchResultCache).
     search_cache: SearchResultCache,
+    /// Separate instance for searchContentRanked (BM25 path): the two
+    /// functions return DIFFERENT results for the same (query, max_results)
+    /// key, so they must never share entries.
+    ranked_cache: SearchResultCache,
     /// Rendered-output cache for renderPlainSearch (same validation).
     plain_render_cache: PlainRenderCache,
     /// Bumped (atomically — searches run under the SHARED lock) by every
@@ -1375,6 +1379,7 @@ pub const Explorer = struct {
             .contents = try ContentCache.initAlloc(allocator, content_cache_capacity),
             .line_offsets = LineOffsetCache.init(allocator),
             .search_cache = SearchResultCache.init(allocator),
+            .ranked_cache = SearchResultCache.init(allocator),
             .plain_render_cache = PlainRenderCache.init(allocator),
             .symbol_index = std.StringHashMap(std.ArrayList(SymbolLocation)).init(allocator),
             .symbol_index_complete = true,
@@ -1405,6 +1410,7 @@ pub const Explorer = struct {
         self.contents.deinit();
         self.line_offsets.deinit();
         self.search_cache.deinit();
+        self.ranked_cache.deinit();
         self.plain_render_cache.deinit();
         if (self.call_centrality) |*c| c.deinit();
         if (self.call_graph) |*cg| cg.deinit(self.allocator);
@@ -4500,6 +4506,22 @@ pub const Explorer = struct {
     }
 
     pub fn searchContentRanked(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
+        // Result-cache front door — same discipline as searchContent's
+        // wrapper (gen read BEFORE the search; see that comment), but a
+        // SEPARATE cache instance: the BM25 ranking returns different
+        // results than searchContent for the same (query, max_results) key.
+        const cacheable = max_results > 0 and query.len > 0 and query.len <= 1024 and
+            cio.posixGetenv("CODEDB_NO_SEARCH_CACHE") == null;
+        if (!cacheable) return self.searchContentRankedUncached(query, allocator, max_results);
+        const gen = self.search_gen.load(.acquire);
+        const env_fp = rankingEnvFingerprint();
+        if (self.ranked_cache.get(query, max_results, gen, env_fp, allocator, &self.last_search_breakdown)) |hit| return hit;
+        const res = try self.searchContentRankedUncached(query, allocator, max_results);
+        self.ranked_cache.put(query, max_results, gen, env_fp, res, .{ .result_count = @intCast(@min(res.len, std.math.maxInt(u32))) });
+        return res;
+    }
+
+    fn searchContentRankedUncached(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, max_results: usize) ![]const SearchResult {
         // #546: BM25 reads the word index's id_to_path + ranked-doc table, which a
         // mmap/disk-loaded index lacks until rebuilt (word_index_complete = false).
         // The recall readers (searchContent, searchWord, renderWord) already trigger

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -270,6 +270,11 @@ pub const SearchBreakdown = struct {
     tier_reached: u8 = 0,
     candidate_count: u32 = 0,
     result_count: u32 = 0,
+    /// True when the results were served from the whole-query result cache.
+    /// The tier/candidate/result fields then describe the search that
+    /// PRODUCED the cached entry; the *_ns timings are zeroed because the
+    /// hit did not pay them.
+    cache_hit: bool = false,
 };
 
 pub const DependencyGraph = struct {
@@ -948,6 +953,11 @@ const SearchResultCache = struct {
         gen: u64,
         env_fp: u64,
         results: []CachedResult,
+        /// Breakdown of the search that produced the entry (timings zeroed,
+        /// cache_hit set), restored into last_search_breakdown on a hit so
+        /// telemetry and the MCP provenance meta describe the results
+        /// actually served instead of whatever search ran last.
+        breakdown: SearchBreakdown,
         bytes: usize,
         last_used: u64,
     };
@@ -985,9 +995,10 @@ const SearchResultCache = struct {
     }
 
     /// On hit, returns results duped into `out_allocator` (caller owns each
-    /// path/line_text and the slice, same contract as a fresh search). A
-    /// stale same-key entry is dropped so the slot can refill.
-    fn get(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator) ?[]const SearchResult {
+    /// path/line_text and the slice, same contract as a fresh search) and
+    /// writes the producing search's breakdown to `out_breakdown`. A stale
+    /// same-key entry is dropped so the slot can refill.
+    fn get(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator, out_breakdown: *SearchBreakdown) ?[]const SearchResult {
         self.mu.lock();
         defer self.mu.unlock();
         var i: usize = 0;
@@ -1024,6 +1035,7 @@ const SearchResultCache = struct {
             self.tick += 1;
             e.last_used = self.tick;
             self.hits += 1;
+            out_breakdown.* = e.breakdown;
             return out;
         }
         self.misses += 1;
@@ -1031,7 +1043,7 @@ const SearchResultCache = struct {
     }
 
     /// Copies `results` into cache-owned memory. Any OOM just skips caching.
-    fn put(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, results: []const SearchResult) void {
+    fn put(self: *SearchResultCache, query: []const u8, max_results: usize, gen: u64, env_fp: u64, results: []const SearchResult, breakdown: SearchBreakdown) void {
         var bytes: usize = query.len + @sizeOf(Entry);
         for (results) |r| bytes += r.path.len + r.line_text.len + @sizeOf(CachedResult);
         if (bytes > MAX_ENTRY_BYTES) return;
@@ -1090,6 +1102,7 @@ const SearchResultCache = struct {
             .gen = gen,
             .env_fp = env_fp,
             .results = owned,
+            .breakdown = sanitizeCachedBreakdown(breakdown),
             .bytes = bytes,
             .last_used = self.tick,
         }) catch {
@@ -1105,6 +1118,18 @@ const SearchResultCache = struct {
     }
 };
 
+/// Keep the producing search's provenance (tier/candidate/result counts) but
+/// zero the timings a hit never pays, and mark it as a hit. Stored at put
+/// time so a cache hit can restore an honest last_search_breakdown.
+fn sanitizeCachedBreakdown(bd: SearchBreakdown) SearchBreakdown {
+    return .{
+        .tier_reached = bd.tier_reached,
+        .candidate_count = bd.candidate_count,
+        .result_count = bd.result_count,
+        .cache_hit = true,
+    };
+}
+
 /// Rendered-output sibling of SearchResultCache for renderPlainSearch — the
 /// MCP fast path renders straight to text and never reaches searchContent,
 /// so it gets its own (query, max_results, paths_only) → bytes cache with
@@ -1117,6 +1142,8 @@ const PlainRenderCache = struct {
         gen: u64,
         env_fp: u64,
         bytes: []u8,
+        /// See SearchResultCache.Entry.breakdown.
+        breakdown: SearchBreakdown,
         last_used: u64,
     };
 
@@ -1147,8 +1174,9 @@ const PlainRenderCache = struct {
         self.entries.deinit(self.allocator);
     }
 
-    /// On hit, appends the cached rendering to `out` and returns true.
-    fn render(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator, out: *std.ArrayList(u8)) bool {
+    /// On hit, appends the cached rendering to `out`, writes the producing
+    /// search's breakdown to `out_breakdown`, and returns true.
+    fn render(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, out_allocator: std.mem.Allocator, out: *std.ArrayList(u8), out_breakdown: *SearchBreakdown) bool {
         self.mu.lock();
         defer self.mu.unlock();
         var i: usize = 0;
@@ -1166,6 +1194,7 @@ const PlainRenderCache = struct {
             self.tick += 1;
             e.last_used = self.tick;
             self.hits += 1;
+            out_breakdown.* = e.breakdown;
             return true;
         }
         self.misses += 1;
@@ -1173,7 +1202,7 @@ const PlainRenderCache = struct {
     }
 
     /// Copies `bytes` into cache-owned memory. Any OOM just skips caching.
-    fn put(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, bytes: []const u8) void {
+    fn put(self: *PlainRenderCache, query: []const u8, max_results: usize, paths_only: bool, gen: u64, env_fp: u64, bytes: []const u8, breakdown: SearchBreakdown) void {
         if (bytes.len > MAX_ENTRY_BYTES) return;
         const bytes_copy = self.allocator.dupe(u8, bytes) catch return;
         const query_copy = self.allocator.dupe(u8, query) catch {
@@ -1213,6 +1242,7 @@ const PlainRenderCache = struct {
             .gen = gen,
             .env_fp = env_fp,
             .bytes = bytes_copy,
+            .breakdown = sanitizeCachedBreakdown(breakdown),
             .last_used = self.tick,
         }) catch {
             self.allocator.free(query_copy);
@@ -1451,7 +1481,6 @@ pub const Explorer = struct {
     }
 
     pub fn commitParsedFileOwnedOutline(self: *Explorer, path: []const u8, content: []const u8, outline: FileOutline, full_index: bool, skip_trigram: bool) !void {
-        self.bumpSearchGen();
         var owned_outline = outline;
         // One deinit only: an errdefer here would stack with the defer below
         // and double-free the parsed outline on any post-clone error.
@@ -1468,6 +1497,7 @@ pub const Explorer = struct {
 
         self.mu.lock();
         defer self.mu.unlock();
+        self.bumpSearchGen();
 
         const outline_gop = try self.outlines.getOrPut(path);
         const is_new = !outline_gop.found_existing;
@@ -1964,6 +1994,12 @@ pub const Explorer = struct {
     /// rebuilds, and the one-shot lazy ranking-signal builds (symbol index,
     /// call graph, co-change). Atomic because the lazy builds run under the
     /// SHARED lock.
+    ///
+    /// Ordering invariant: never bump BEFORE a mutation outside the
+    /// exclusive lock — a search could load the new generation, win the
+    /// shared lock, and cache pre-mutation results under the post-mutation
+    /// generation. Bump while holding the exclusive lock, or (for the lazy
+    /// shared-lock builds) only after the mutation is visible.
     fn bumpSearchGen(self: *Explorer) void {
         _ = self.search_gen.fetchAdd(1, .release);
     }
@@ -1989,7 +2025,6 @@ pub const Explorer = struct {
     /// by streaming source files from the project root when the content cache
     /// was capped during fast snapshot restore.
     pub fn rebuildWordIndex(self: *Explorer) !void {
-        self.bumpSearchGen();
         const source_paths = blk: {
             self.mu.lockShared();
             defer self.mu.unlockShared();
@@ -2037,6 +2072,7 @@ pub const Explorer = struct {
 
         self.mu.lock();
         defer self.mu.unlock();
+        self.bumpSearchGen();
         self.word_index.deinit();
         self.word_index = rebuilt;
         self.word_index_generation +%= 1;
@@ -2147,9 +2183,9 @@ pub const Explorer = struct {
     }
 
     pub fn removeFile(self: *Explorer, path: []const u8) void {
-        self.bumpSearchGen();
         self.mu.lock();
         defer self.mu.unlock();
+        self.bumpSearchGen();
         if (!self.word_index_complete) {
             self.word_index_can_load_from_disk = false;
         } else {
@@ -3012,9 +3048,9 @@ pub const Explorer = struct {
         if (!cacheable) return self.searchContentUncached(query, allocator, max_results);
         const gen = self.search_gen.load(.acquire);
         const env_fp = rankingEnvFingerprint();
-        if (self.search_cache.get(query, max_results, gen, env_fp, allocator)) |hit| return hit;
+        if (self.search_cache.get(query, max_results, gen, env_fp, allocator, &self.last_search_breakdown)) |hit| return hit;
         const res = try self.searchContentUncached(query, allocator, max_results);
-        self.search_cache.put(query, max_results, gen, env_fp, res);
+        self.search_cache.put(query, max_results, gen, env_fp, res, self.last_search_breakdown);
         return res;
     }
 
@@ -3446,12 +3482,12 @@ pub const Explorer = struct {
             cio.posixGetenv("CODEDB_NO_SEARCH_CACHE") == null;
         const cache_gen = self.search_gen.load(.acquire);
         const cache_fp = if (cacheable) rankingEnvFingerprint() else 0;
-        if (cacheable and self.plain_render_cache.render(query, max_results, paths_only, cache_gen, cache_fp, allocator, out)) return true;
+        if (cacheable and self.plain_render_cache.render(query, max_results, paths_only, cache_gen, cache_fp, allocator, out, &self.last_search_breakdown)) return true;
         const out_start = out.items.len;
 
         const rendered = try self.renderPlainSearchUncached(query, allocator, out, max_results, paths_only);
         if (rendered and cacheable) {
-            self.plain_render_cache.put(query, max_results, paths_only, cache_gen, cache_fp, out.items[out_start..]);
+            self.plain_render_cache.put(query, max_results, paths_only, cache_gen, cache_fp, out.items[out_start..], self.last_search_breakdown);
         }
         return rendered;
     }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2128,6 +2128,17 @@ pub const Explorer = struct {
         defer self.mu.unlock();
         if (self.symbol_index_complete) return;
         self.bumpSearchGen();
+        // Rebuild from scratch: entries indexed BEFORE the index was marked
+        // incomplete would otherwise be duplicated by the loop below (it
+        // passes had_prior=false, which skips per-file eviction). The index
+        // is authoritative once complete — lookups no longer outline-scan —
+        // so it must hold exactly one entry per live symbol.
+        var sym_iter = self.symbol_index.iterator();
+        while (sym_iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.symbol_index.clearRetainingCapacity();
         self.symbol_index_complete = true;
         var it = self.outlines.iterator();
         while (it.next()) |entry| {
@@ -2580,21 +2591,26 @@ pub const Explorer = struct {
             }
         }
 
-        // Fallback: scan outlines (handles edge cases during index build)
-        var iter = self.outlines.iterator();
-        while (iter.next()) |entry| {
-            for (entry.value_ptr.symbols.items) |sym| {
-                if (std.mem.eql(u8, sym.name, name)) {
-                    return .{
-                        .path = try allocator.dupe(u8, entry.key_ptr.*),
-                        .symbol = .{
-                            .name = try allocator.dupe(u8, sym.name),
-                            .kind = sym.kind,
-                            .line_start = sym.line_start,
-                            .line_end = sym.line_end,
-                            .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
-                        },
-                    };
+        // Fallback: scan outlines, only while the symbol index is incomplete
+        // (see findAllSymbols for the invariant). When complete, a miss in
+        // the index IS the answer — the scan was an O(files × symbols) "no"
+        // on every missing-symbol lookup.
+        if (!self.symbol_index_complete) {
+            var iter = self.outlines.iterator();
+            while (iter.next()) |entry| {
+                for (entry.value_ptr.symbols.items) |sym| {
+                    if (std.mem.eql(u8, sym.name, name)) {
+                        return .{
+                            .path = try allocator.dupe(u8, entry.key_ptr.*),
+                            .symbol = .{
+                                .name = try allocator.dupe(u8, sym.name),
+                                .kind = sym.kind,
+                                .line_start = sym.line_start,
+                                .line_end = sym.line_end,
+                                .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
+                            },
+                        };
+                    }
                 }
             }
         }
@@ -2633,30 +2649,37 @@ pub const Explorer = struct {
             });
         }
 
-        // Safety scan: append any outline symbols the index missed.
-        const LocLookup = struct {
-            fn contains(locs: []const SymbolLocation, path: []const u8, line_start: u32) bool {
-                for (locs) |loc| {
-                    if (loc.line_start == line_start and std.mem.eql(u8, loc.path, path)) return true;
+        // Safety scan: append any outline symbols the index missed. Only
+        // needed while the index is incomplete (fast-snapshot restore marks
+        // it so; ensureSymbolIndex above normally rebuilds it first) — when
+        // complete, commits (rebuildSymbolIndexFor) and removals
+        // (removeSymbolIndexFor) keep it authoritative, and this scan is
+        // O(files × symbols) of pure overhead (~6ms on a 20k-file corpus).
+        if (!self.symbol_index_complete) {
+            const LocLookup = struct {
+                fn contains(locs: []const SymbolLocation, path: []const u8, line_start: u32) bool {
+                    for (locs) |loc| {
+                        if (loc.line_start == line_start and std.mem.eql(u8, loc.path, path)) return true;
+                    }
+                    return false;
                 }
-                return false;
-            }
-        };
-        var iter = self.outlines.iterator();
-        while (iter.next()) |entry| {
-            for (entry.value_ptr.symbols.items) |sym| {
-                if (!std.mem.eql(u8, sym.name, name)) continue;
-                if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
-                try result_list.append(allocator, .{
-                    .path = try allocator.dupe(u8, entry.key_ptr.*),
-                    .symbol = .{
-                        .name = try allocator.dupe(u8, sym.name),
-                        .kind = sym.kind,
-                        .line_start = sym.line_start,
-                        .line_end = sym.line_end,
-                        .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
-                    },
-                });
+            };
+            var iter = self.outlines.iterator();
+            while (iter.next()) |entry| {
+                for (entry.value_ptr.symbols.items) |sym| {
+                    if (!std.mem.eql(u8, sym.name, name)) continue;
+                    if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
+                    try result_list.append(allocator, .{
+                        .path = try allocator.dupe(u8, entry.key_ptr.*),
+                        .symbol = .{
+                            .name = try allocator.dupe(u8, sym.name),
+                            .kind = sym.kind,
+                            .line_start = sym.line_start,
+                            .line_end = sym.line_end,
+                            .detail = if (sym.detail) |d| try allocator.dupe(u8, d) else null,
+                        },
+                    });
+                }
             }
         }
         return result_list.toOwnedSlice(allocator);
@@ -2999,14 +3022,20 @@ pub const Explorer = struct {
                 return false;
             }
         };
+        // Safety scans (count + render below) are only needed while the
+        // symbol index is incomplete — see findAllSymbols for the invariant.
+        // When complete they were two O(files × symbols) passes per call.
+        const scan_outlines = !self.symbol_index_complete;
 
         var total: usize = indexed_locs.len;
-        var count_iter = self.outlines.iterator();
-        while (count_iter.next()) |entry| {
-            for (entry.value_ptr.symbols.items) |sym| {
-                if (!std.mem.eql(u8, sym.name, name)) continue;
-                if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
-                total += 1;
+        if (scan_outlines) {
+            var count_iter = self.outlines.iterator();
+            while (count_iter.next()) |entry| {
+                for (entry.value_ptr.symbols.items) |sym| {
+                    if (!std.mem.eql(u8, sym.name, name)) continue;
+                    if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
+                    total += 1;
+                }
             }
         }
         if (total == 0) return false;
@@ -3028,14 +3057,16 @@ pub const Explorer = struct {
             try w.writeAll("\n");
         }
 
-        var render_iter = self.outlines.iterator();
-        while (render_iter.next()) |entry| {
-            for (entry.value_ptr.symbols.items) |sym| {
-                if (!std.mem.eql(u8, sym.name, name)) continue;
-                if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
-                try w.print("  {s}:{d} ({s})", .{ entry.key_ptr.*, sym.line_start, @tagName(sym.kind) });
-                if (sym.detail) |d| try w.print("  // {s}", .{d});
-                try w.writeAll("\n");
+        if (scan_outlines) {
+            var render_iter = self.outlines.iterator();
+            while (render_iter.next()) |entry| {
+                for (entry.value_ptr.symbols.items) |sym| {
+                    if (!std.mem.eql(u8, sym.name, name)) continue;
+                    if (LocLookup.contains(indexed_locs, entry.key_ptr.*, sym.line_start)) continue;
+                    try w.print("  {s}:{d} ({s})", .{ entry.key_ptr.*, sym.line_start, @tagName(sym.kind) });
+                    if (sym.detail) |d| try w.print("  // {s}", .{d});
+                    try w.writeAll("\n");
+                }
             }
         }
         return true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,6 +19,7 @@ const snapshot_mod = @import("snapshot.zig");
 const telemetry = @import("telemetry.zig");
 const root_policy = @import("root_policy.zig");
 const nuke_mod = @import("nuke.zig");
+const warmup_mod = @import("warmup.zig");
 const update_mod = @import("update.zig");
 const release_info = @import("release_info.zig");
 const Config = @import("config.zig").Config;
@@ -1659,6 +1660,11 @@ fn mainImpl() !void {
             return;
         }
 
+        // Warm the word index + result caches in the background so the first
+        // proxied CLI queries hit a fully warm explorer (the daemon used to
+        // stay lean and charge the first `word`/`context` query the rebuild).
+        spawnWarmup(io, allocator, &explorer, data_dir, abs_root, &shutdown);
+
         // Block here until idle (or a bind-race shutdown). On return the process
         // exits immediately — std.process.exit reclaims everything and avoids
         // racing the detached listener thread against freed explorer/store.
@@ -1718,6 +1724,7 @@ fn mainImpl() !void {
         } else |err| {
             std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
         }
+        spawnWarmup(io, allocator, &explorer, data_dir, abs_root, &shutdown);
         try server.serve(io, allocator, &store, &agents, &explorer, queue, port);
     } else if (std.mem.eql(u8, cmd, "mcp")) {
         // Background auto-update check (no-op when CODEDB_NO_AUTO_UPDATE is set
@@ -1813,6 +1820,7 @@ fn mainImpl() !void {
         } else |err| {
             std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
         }
+        spawnWarmup(io, allocator, &explorer, data_dir, abs_root, &shutdown);
         mcp_server.run(io, allocator, &store, &explorer, &agents, abs_root, cfg.max_cached, &telem, maybe_deferred, &shutdown);
 
         shutdown.store(true, .release);
@@ -2160,6 +2168,98 @@ fn loadWordIndexFromDiskIfPresent(
     } else {
         std.log.debug("word.index disk load skipped: mmap and heap read both failed", .{});
         explorer.disableWordIndexDiskLoad();
+    }
+}
+
+/// Background warmup for the long-lived server modes (#tail-latency): real
+/// query logs show the latency tail is lazy work charged to the first query
+/// (word-index rebuild after a snapshot fast-load: 50ms–2s), and 62% of
+/// calls are exact repeats that the result caches can serve at µs — but only
+/// if something fills them. The thread waits for the scan to be ready, then
+/// (1) loads-or-rebuilds + persists the word index, and (2) replays the most
+/// repeated recent queries from queries.log through the same entry points
+/// real codedb_search calls use. CODEDB_NO_WARMUP=1 disables it.
+const WarmupCtx = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    data_dir: []u8,
+    abs_root: []u8,
+    shutdown: *std.atomic.Value(bool),
+};
+
+fn warmupThreadMain(ctx: *WarmupCtx) void {
+    const allocator = ctx.allocator;
+    defer {
+        allocator.free(ctx.data_dir);
+        allocator.free(ctx.abs_root);
+        allocator.destroy(ctx);
+    }
+
+    // Deferred MCP scans flip the state back to .ready when indexing is done;
+    // serve/cli-daemon never leave .ready. Cap the wait so a wedged scan
+    // can't pin this thread forever.
+    var waited_ms: u64 = 0;
+    while (mcp_server.getScanState() != .ready and waited_ms < 120_000) {
+        if (ctx.shutdown.load(.acquire)) return;
+        cio.sleepMs(50);
+        waited_ms += 50;
+    }
+    if (ctx.shutdown.load(.acquire) or mcp_server.getScanState() != .ready) return;
+
+    // (1) Index prewarm: pay the word-index load/rebuild here instead of on
+    // the first codedb_word/search call, and persist a rebuild so the NEXT
+    // process start mmap-loads it.
+    const git_head = git_mod.getGitHead(ctx.abs_root, allocator) catch null;
+    loadWordIndexFromDiskIfPresent(ctx.io, ctx.explorer, ctx.data_dir, git_head, allocator);
+    if (!ctx.explorer.wordIndexIsComplete()) {
+        ctx.explorer.rebuildWordIndex() catch {};
+        if (ctx.explorer.wordIndexIsComplete()) {
+            persistWordIndexToDisk(ctx.io, ctx.explorer, ctx.data_dir, git_head);
+        }
+    }
+    if (ctx.shutdown.load(.acquire)) return;
+
+    // (2) Result-cache warmup: replay the most repeated recent queries. The
+    // searches also trigger the lazy ranking builds (symbol index, call
+    // graph, co-change) so no real query pays for those either.
+    if (cio.posixGetenv("CODEDB_NO_SEARCH_CACHE") != null) return;
+    var path_buf: [1024]u8 = undefined;
+    const log_path = std.fmt.bufPrint(&path_buf, "{s}/queries.log", .{ctx.data_dir}) catch return;
+    const log_bytes = std.Io.Dir.cwd().readFileAlloc(ctx.io, log_path, allocator, .limited(warmup_mod.max_log_tail_bytes)) catch return;
+    defer allocator.free(log_bytes);
+    const queries = warmup_mod.topQueries(allocator, log_bytes, warmup_mod.max_replay_queries) catch return;
+    defer warmup_mod.freeQueries(allocator, queries);
+    warmup_mod.replay(ctx.explorer, allocator, queries, ctx.shutdown);
+}
+
+fn spawnWarmup(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, data_dir: []const u8, abs_root: []const u8, shutdown: *std.atomic.Value(bool)) void {
+    if (cio.posixGetenv("CODEDB_NO_WARMUP") != null) return;
+    const ctx = allocator.create(WarmupCtx) catch return;
+    const data_dir_copy = allocator.dupe(u8, data_dir) catch {
+        allocator.destroy(ctx);
+        return;
+    };
+    const abs_root_copy = allocator.dupe(u8, abs_root) catch {
+        allocator.free(data_dir_copy);
+        allocator.destroy(ctx);
+        return;
+    };
+    ctx.* = .{
+        .io = io,
+        .allocator = allocator,
+        .explorer = explorer,
+        .data_dir = data_dir_copy,
+        .abs_root = abs_root_copy,
+        .shutdown = shutdown,
+    };
+    if (std.Thread.spawn(.{}, warmupThreadMain, .{ctx})) |t| {
+        t.detach();
+    } else |err| {
+        std.log.debug("warmup: could not start thread: {s}", .{@errorName(err)});
+        allocator.free(ctx.data_dir);
+        allocator.free(ctx.abs_root);
+        allocator.destroy(ctx);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2235,6 +2235,9 @@ fn warmupThreadMain(ctx: *WarmupCtx) void {
 
 fn spawnWarmup(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, data_dir: []const u8, abs_root: []const u8, shutdown: *std.atomic.Value(bool)) void {
     if (cio.posixGetenv("CODEDB_NO_WARMUP") != null) return;
+    // Low-memory mode trades latency for RSS everywhere else (see
+    // compactMcpReadyMemory); don't pre-pay index builds + caches there.
+    if (cio.posixGetenv("CODEDB_LOW_MEMORY") != null) return;
     const ctx = allocator.create(WarmupCtx) catch return;
     const data_dir_copy = allocator.dupe(u8, data_dir) catch {
         allocator.destroy(ctx);

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2383,3 +2383,39 @@ test "issue-594: failed re-index restores the word index from valid prior conten
         }
     }
 }
+
+test "symbol lookups stay correct across the deferred-index restore path" {
+    // The outline safety scans in findSymbol/findAllSymbols/renderSymbols are
+    // now gated on !symbol_index_complete. This covers the scenario they
+    // existed for (#310): outlines populated while the symbol index is
+    // deferred (snapshot fast-load marks it incomplete, #564). Lookups must
+    // still find every symbol — ensureSymbolIndex rebuilds first.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+
+    try explorer.indexFile("a.zig", "pub fn gatedSym() void {}");
+    explorer.markSymbolIndexIncomplete();
+    // While incomplete, per-file index updates no-op — this outline lands
+    // with NO symbol_index entry, exactly the #310 gap shape.
+    try explorer.indexFile("b.zig", "pub fn gatedSym() void {}");
+
+    const all = try explorer.findAllSymbols("gatedSym", arena.allocator());
+    try testing.expectEqual(@as(usize, 2), all.len);
+
+    const one = try explorer.findSymbol("gatedSym", arena.allocator());
+    try testing.expect(one != null);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(arena.allocator());
+    try testing.expect(try explorer.renderSymbols("gatedSym", arena.allocator(), &out));
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "b.zig") != null);
+
+    // And with a COMPLETE index, a removed file's symbols must vanish from
+    // results (the index, not the scan, is authoritative now).
+    explorer.removeFile("b.zig");
+    const after = try explorer.findAllSymbols("gatedSym", arena.allocator());
+    try testing.expectEqual(@as(usize, 1), after.len);
+    try testing.expectEqualStrings("a.zig", after[0].path);
+}

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2298,3 +2298,167 @@ test "issue-550: co-change partner of the defining file outranks an unrelated eq
     try testing.expect(stranger_score > 0);
     try testing.expect(partner_score > stranger_score);
 }
+
+// ── searchContent result cache ────────────────────────────────────────────────
+
+fn freeSearchResults(results: []const SearchResult) void {
+    for (results) |r| {
+        testing.allocator.free(r.path);
+        testing.allocator.free(r.line_text);
+    }
+    testing.allocator.free(results);
+}
+
+test "search-cache: repeated query is served from cache with identical caller-owned results" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    // Plain content mention (no symbol named like the query) so no lazy
+    // ranking build bumps the generation during the first search.
+    try explorer.indexFile("src/alpha.zig", "const a = 1; // zebraword here\nconst b = 2; // zebraword again\n");
+
+    const r1 = try explorer.searchContent("zebraword", testing.allocator, 10);
+    defer freeSearchResults(r1);
+    try testing.expect(r1.len >= 2);
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+
+    const r2 = try explorer.searchContent("zebraword", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 1), explorer.search_cache.hits);
+    try testing.expectEqual(r1.len, r2.len);
+    for (r1, r2) |a, b| {
+        try testing.expectEqualStrings(a.path, b.path);
+        try testing.expectEqual(a.line_num, b.line_num);
+        try testing.expectEqualStrings(a.line_text, b.line_text);
+    }
+}
+
+test "search-cache: indexFile invalidates cached results" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/one.zig", "const a = 1; // quaggatok\n");
+
+    const r1 = try explorer.searchContent("quaggatok", testing.allocator, 10);
+    freeSearchResults(r1);
+    try explorer.indexFile("src/two.zig", "const b = 2; // quaggatok\n");
+
+    const r2 = try explorer.searchContent("quaggatok", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    // The new file must appear — a stale hit would still show one result.
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+    var saw_two = false;
+    for (r2) |r| {
+        if (std.mem.eql(u8, r.path, "src/two.zig")) saw_two = true;
+    }
+    try testing.expect(saw_two);
+}
+
+test "search-cache: removeFile invalidates cached results" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/keep.zig", "const a = 1; // okapitok\n");
+    try explorer.indexFile("src/gone.zig", "const b = 2; // okapitok\n");
+
+    const r1 = try explorer.searchContent("okapitok", testing.allocator, 10);
+    try testing.expect(r1.len == 2);
+    freeSearchResults(r1);
+    explorer.removeFile("src/gone.zig");
+
+    const r2 = try explorer.searchContent("okapitok", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+    for (r2) |r| {
+        try testing.expect(!std.mem.eql(u8, r.path, "src/gone.zig"));
+    }
+}
+
+test "search-cache: ranking env toggle prevents stale hits" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/env.zig", "const a = 1; // gnutok\n");
+
+    const r1 = try explorer.searchContent("gnutok", testing.allocator, 10);
+    freeSearchResults(r1);
+
+    // Different fingerprint -> the cached entry must NOT be served.
+    _ = setenv("CODEDB_RVSM_SIZE_PRIOR", "1", 1);
+    defer _ = unsetenv("CODEDB_RVSM_SIZE_PRIOR");
+    const r2 = try explorer.searchContent("gnutok", testing.allocator, 10);
+    freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+
+    // Same fingerprint as the stored entry -> now it hits.
+    const r3 = try explorer.searchContent("gnutok", testing.allocator, 10);
+    freeSearchResults(r3);
+    try testing.expectEqual(@as(u64, 1), explorer.search_cache.hits);
+}
+
+test "search-cache: CODEDB_NO_SEARCH_CACHE disables caching entirely" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/off.zig", "const a = 1; // dingotok\n");
+
+    _ = setenv("CODEDB_NO_SEARCH_CACHE", "1", 1);
+    defer _ = unsetenv("CODEDB_NO_SEARCH_CACHE");
+    const r1 = try explorer.searchContent("dingotok", testing.allocator, 10);
+    freeSearchResults(r1);
+    const r2 = try explorer.searchContent("dingotok", testing.allocator, 10);
+    freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.misses);
+    try testing.expectEqual(@as(usize, 0), explorer.search_cache.entries.items.len);
+}
+
+test "search-cache: entry count stays bounded under distinct queries" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/bound.zig", "const a = 1; // boundtok\n");
+
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        var qbuf: [32]u8 = undefined;
+        const q = try std.fmt.bufPrint(&qbuf, "boundquery{d}", .{i});
+        const r = try explorer.searchContent(q, testing.allocator, 10);
+        freeSearchResults(r);
+    }
+    try testing.expect(explorer.search_cache.entries.items.len <= 64);
+}
+
+test "search-cache: renderPlainSearch repeated query is served from the render cache" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/render.zig", "const a = 1; // ibextok\nconst b = 2; // ibextok\n");
+
+    var out1: std.ArrayList(u8) = .empty;
+    defer out1.deinit(testing.allocator);
+    // renderPlainSearch only renders when Tier 0 alone can satisfy
+    // max_results, so ask for exactly the two hits the file contains.
+    const rendered1 = try explorer.renderPlainSearch("ibextok", testing.allocator, &out1, 2, false);
+    try testing.expect(rendered1);
+    try testing.expectEqual(@as(u64, 0), explorer.plain_render_cache.hits);
+
+    var out2: std.ArrayList(u8) = .empty;
+    defer out2.deinit(testing.allocator);
+    const rendered2 = try explorer.renderPlainSearch("ibextok", testing.allocator, &out2, 2, false);
+    try testing.expect(rendered2);
+    try testing.expectEqual(@as(u64, 1), explorer.plain_render_cache.hits);
+    try testing.expectEqualStrings(out1.items, out2.items);
+}
+
+test "search-cache: renderPlainSearch cache is invalidated by indexFile" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/r1.zig", "const a = 1; // lemurtok\n");
+
+    var out1: std.ArrayList(u8) = .empty;
+    defer out1.deinit(testing.allocator);
+    const rendered1 = try explorer.renderPlainSearch("lemurtok", testing.allocator, &out1, 1, false);
+    try testing.expect(rendered1);
+
+    try explorer.indexFile("src/r2.zig", "const b = 2; // lemurtok\n");
+
+    // The generation moved, so the cached rendering must NOT be served.
+    var out2: std.ArrayList(u8) = .empty;
+    defer out2.deinit(testing.allocator);
+    _ = try explorer.renderPlainSearch("lemurtok", testing.allocator, &out2, 1, false);
+    try testing.expectEqual(@as(u64, 0), explorer.plain_render_cache.hits);
+}

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2492,6 +2492,66 @@ test "search-cache: hit restores the producing search's breakdown provenance" {
     try testing.expectEqual(@as(i128, 0), restored.rerank_ns);
 }
 
+test "search-cache: ranked repeated query is served from the ranked cache" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/rank.zig", "const a = 1; // bisontok grazes\nconst b = 2; // bisontok grazes more\n");
+
+    const r1 = try explorer.searchContentRanked("bisontok grazes", testing.allocator, 10);
+    defer freeSearchResults(r1);
+    try testing.expect(r1.len >= 1);
+    try testing.expectEqual(@as(u64, 0), explorer.ranked_cache.hits);
+
+    const r2 = try explorer.searchContentRanked("bisontok grazes", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 1), explorer.ranked_cache.hits);
+    try testing.expectEqual(r1.len, r2.len);
+    for (r1, r2) |a, b| {
+        try testing.expectEqualStrings(a.path, b.path);
+        try testing.expectEqual(a.line_num, b.line_num);
+        try testing.expectEqualStrings(a.line_text, b.line_text);
+        try testing.expectEqual(a.score, b.score);
+    }
+    // The plain searchContent cache must be untouched.
+    try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
+    try testing.expectEqual(@as(usize, 0), explorer.search_cache.entries.items.len);
+}
+
+test "search-cache: ranked and plain caches never share entries for the same key" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/iso.zig", "const a = 1; // elktok\n");
+
+    // Prime the PLAIN cache with this (query, max_results) key.
+    const p = try explorer.searchContent("elktok", testing.allocator, 10);
+    freeSearchResults(p);
+    // The first RANKED call with the identical key must MISS (a shared
+    // cache would serve the plain results here).
+    const r = try explorer.searchContentRanked("elktok", testing.allocator, 10);
+    freeSearchResults(r);
+    try testing.expectEqual(@as(u64, 0), explorer.ranked_cache.hits);
+    try testing.expectEqual(@as(u64, 1), explorer.ranked_cache.misses);
+}
+
+test "search-cache: ranked cache is invalidated by indexFile" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/ra.zig", "const a = 1; // moosetok wanders\n");
+
+    const r1 = try explorer.searchContentRanked("moosetok wanders", testing.allocator, 10);
+    freeSearchResults(r1);
+    try explorer.indexFile("src/rb.zig", "const b = 2; // moosetok wanders too\n");
+
+    const r2 = try explorer.searchContentRanked("moosetok wanders", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    try testing.expectEqual(@as(u64, 0), explorer.ranked_cache.hits);
+    var saw_new = false;
+    for (r2) |res| {
+        if (std.mem.eql(u8, res.path, "src/rb.zig")) saw_new = true;
+    }
+    try testing.expect(saw_new);
+}
+
 // ── warmup: queries.log replay ───────────────────────────────────────────────
 
 const warmup = @import("warmup.zig");
@@ -2544,7 +2604,9 @@ test "warmup: replay pre-fills the result caches so real calls hit" {
     try explorer.indexFile("src/rare.zig", "const r = 1; // raretok\n");
 
     var shutdown = std.atomic.Value(bool).init(false);
-    const queries = [_][]const u8{ "warmtok", "raretok" };
+    // A multi-word query routes through searchContentAuto to the ranked
+    // (BM25) path, exercising the ranked cache.
+    const queries = [_][]const u8{ "warmtok", "raretok", "raretok warmtok" };
     warmup.replay(&explorer, testing.allocator, &queries, &shutdown);
 
     // Real MCP-handler-shaped calls must now be cache hits.
@@ -2556,6 +2618,10 @@ test "warmup: replay pre-fills the result caches so real calls hit" {
     const r = try explorer.searchContent("raretok", testing.allocator, 21);
     defer freeSearchResults(r);
     try testing.expectEqual(@as(u64, 1), explorer.search_cache.hits);
+
+    const rr = try explorer.searchContentRanked("raretok warmtok", testing.allocator, 21);
+    defer freeSearchResults(rr);
+    try testing.expectEqual(@as(u64, 1), explorer.ranked_cache.hits);
 }
 
 test "warmup: replay honors shutdown" {
@@ -2566,6 +2632,7 @@ test "warmup: replay honors shutdown" {
     const queries = [_][]const u8{"stoptok"};
     warmup.replay(&explorer, testing.allocator, &queries, &shutdown);
     try testing.expectEqual(@as(usize, 0), explorer.search_cache.entries.items.len);
+    try testing.expectEqual(@as(usize, 0), explorer.ranked_cache.entries.items.len);
     try testing.expectEqual(@as(usize, 0), explorer.plain_render_cache.entries.items.len);
 }
 

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2462,3 +2462,56 @@ test "search-cache: renderPlainSearch cache is invalidated by indexFile" {
     _ = try explorer.renderPlainSearch("lemurtok", testing.allocator, &out2, 1, false);
     try testing.expectEqual(@as(u64, 0), explorer.plain_render_cache.hits);
 }
+
+test "search-cache: hit restores the producing search's breakdown provenance" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/bd.zig", "const a = 1; // pandatok\nconst b = 2; // pandatok\n");
+
+    const r1 = try explorer.searchContent("pandatok", testing.allocator, 10);
+    freeSearchResults(r1);
+    const fresh = explorer.last_search_breakdown;
+    try testing.expect(!fresh.cache_hit);
+
+    // Clobber the breakdown with a different query so the hit must restore
+    // it, not inherit whatever search ran last (mcp.zig's telemetry and the
+    // provenance meta both read last_search_breakdown after the call).
+    const other = try explorer.searchContent("nosuchtok", testing.allocator, 10);
+    freeSearchResults(other);
+
+    const r2 = try explorer.searchContent("pandatok", testing.allocator, 10);
+    defer freeSearchResults(r2);
+    const restored = explorer.last_search_breakdown;
+    try testing.expectEqual(@as(u64, 1), explorer.search_cache.hits);
+    try testing.expect(restored.cache_hit);
+    try testing.expectEqual(fresh.tier_reached, restored.tier_reached);
+    try testing.expectEqual(fresh.candidate_count, restored.candidate_count);
+    try testing.expectEqual(fresh.result_count, restored.result_count);
+    // A hit pays none of the tier timings.
+    try testing.expectEqual(@as(i128, 0), restored.tier0_ns);
+    try testing.expectEqual(@as(i128, 0), restored.rerank_ns);
+}
+
+test "search-cache: renderPlainSearch hit restores the producing search's breakdown" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/rbd.zig", "const a = 1; // foxtok\nconst b = 2; // foxtok\n");
+
+    var out1: std.ArrayList(u8) = .empty;
+    defer out1.deinit(testing.allocator);
+    try testing.expect(try explorer.renderPlainSearch("foxtok", testing.allocator, &out1, 2, false));
+    const fresh = explorer.last_search_breakdown;
+    try testing.expect(!fresh.cache_hit);
+
+    explorer.last_search_breakdown = .{ .tier_reached = 7 };
+
+    var out2: std.ArrayList(u8) = .empty;
+    defer out2.deinit(testing.allocator);
+    try testing.expect(try explorer.renderPlainSearch("foxtok", testing.allocator, &out2, 2, false));
+    const restored = explorer.last_search_breakdown;
+    try testing.expectEqual(@as(u64, 1), explorer.plain_render_cache.hits);
+    try testing.expect(restored.cache_hit);
+    try testing.expectEqual(fresh.tier_reached, restored.tier_reached);
+    try testing.expectEqual(fresh.result_count, restored.result_count);
+    try testing.expectEqual(@as(i128, 0), restored.tier0_ns);
+}

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2492,6 +2492,83 @@ test "search-cache: hit restores the producing search's breakdown provenance" {
     try testing.expectEqual(@as(i128, 0), restored.rerank_ns);
 }
 
+// ── warmup: queries.log replay ───────────────────────────────────────────────
+
+const warmup = @import("warmup.zig");
+
+test "warmup: topQueries ranks by repeat count, skips malformed and non-search lines" {
+    const log =
+        \\{"ts":1,"ev":"query","tool":"codedb_search","query":"alpha","result_bytes":10,"latency_us":5}
+        \\{"ts":2,"ev":"query","tool":"codedb_search","query":"beta","result_bytes":10,"latency_us":5}
+        \\{"ts":3,"ev":"query","tool":"codedb_search","query":"beta","result_bytes":10,"latency_us":5}
+        \\not json at all
+        \\{"ts":4,"ev":"query","tool":"codedb_word","query":"gamma","result_bytes":10,"latency_us":5}
+        \\{"ts":5,"ev":"file_access","tool":"codedb_read","query":"delta"}
+        \\{"ts":6,"ev":"query","tool":"codedb_search","query":"beta","result_bytes":10,"latency_us":5}
+        \\{"ts":7,"ev":"query","tool":"codedb_search","query":"alpha","result_bytes":10,"latency_us":5}
+        \\{"ts":8,"ev":"query","tool":"codedb_search","query":""}
+    ;
+    const qs = try warmup.topQueries(testing.allocator, log, 16);
+    defer warmup.freeQueries(testing.allocator, qs);
+    try testing.expectEqual(@as(usize, 2), qs.len);
+    try testing.expectEqualStrings("beta", qs[0]);
+    try testing.expectEqualStrings("alpha", qs[1]);
+}
+
+test "warmup: topQueries respects the max cap" {
+    var log: std.ArrayList(u8) = .empty;
+    defer log.deinit(testing.allocator);
+    const w = cio.listWriter(&log, testing.allocator);
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        try w.print("{{\"ts\":{d},\"ev\":\"query\",\"tool\":\"codedb_search\",\"query\":\"warmq{d}\",\"result_bytes\":1,\"latency_us\":1}}\n", .{ i, i });
+    }
+    const qs = try warmup.topQueries(testing.allocator, log.items, 3);
+    defer warmup.freeQueries(testing.allocator, qs);
+    try testing.expectEqual(@as(usize, 3), qs.len);
+}
+
+test "warmup: replay pre-fills the result caches so real calls hit" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    // 20+ matching lines so the MCP fast path (renderPlainSearch with the
+    // default max_results=20) renders from Tier 0 and fills the render cache.
+    var content: std.ArrayList(u8) = .empty;
+    defer content.deinit(testing.allocator);
+    const cw = cio.listWriter(&content, testing.allocator);
+    var i: usize = 0;
+    while (i < 24) : (i += 1) try cw.print("const v{d} = 1; // warmtok\n", .{i});
+    try explorer.indexFile("src/warm.zig", content.items);
+    // A sparse query that renderPlainSearch can NOT satisfy, so replay falls
+    // back to searchContentAuto and fills the searchContent cache instead.
+    try explorer.indexFile("src/rare.zig", "const r = 1; // raretok\n");
+
+    var shutdown = std.atomic.Value(bool).init(false);
+    const queries = [_][]const u8{ "warmtok", "raretok" };
+    warmup.replay(&explorer, testing.allocator, &queries, &shutdown);
+
+    // Real MCP-handler-shaped calls must now be cache hits.
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try testing.expect(try explorer.renderPlainSearch("warmtok", testing.allocator, &out, 20, false));
+    try testing.expectEqual(@as(u64, 1), explorer.plain_render_cache.hits);
+
+    const r = try explorer.searchContent("raretok", testing.allocator, 21);
+    defer freeSearchResults(r);
+    try testing.expectEqual(@as(u64, 1), explorer.search_cache.hits);
+}
+
+test "warmup: replay honors shutdown" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/stop.zig", "const s = 1; // stoptok\n");
+    var shutdown = std.atomic.Value(bool).init(true);
+    const queries = [_][]const u8{"stoptok"};
+    warmup.replay(&explorer, testing.allocator, &queries, &shutdown);
+    try testing.expectEqual(@as(usize, 0), explorer.search_cache.entries.items.len);
+    try testing.expectEqual(@as(usize, 0), explorer.plain_render_cache.entries.items.len);
+}
+
 test "search-cache: renderPlainSearch hit restores the producing search's breakdown" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();

--- a/src/warmup.zig
+++ b/src/warmup.zig
@@ -1,0 +1,122 @@
+//! Background warmup for the long-lived server modes (mcp / serve /
+//! cli-daemon). Production query logs show the latency tail is lazy work
+//! charged to an innocent first query — the word-index rebuild after a
+//! snapshot fast-load (50ms–2s) — while 62% of real calls are exact repeats
+//! of an earlier (tool, query) pair. This module supplies the two warmers:
+//! the index prewarm runs from main.zig (which owns the disk-load helpers),
+//! and the query replay here pre-fills the whole-query result caches from
+//! the project's queries.log WAL so cross-restart repeats hit at ~µs.
+//!
+//! Replay deliberately mirrors the MCP codedb_search handler's default path
+//! (renderPlainSearch with max_results=20, falling back to searchContentAuto
+//! with 21) so the cache keys match what real calls will look up.
+
+const std = @import("std");
+const explore = @import("explore.zig");
+
+/// Replay at most this many distinct queries.
+pub const max_replay_queries: usize = 16;
+/// Read at most this much of the WAL tail (recent activity matters most).
+pub const max_log_tail_bytes: usize = 256 * 1024;
+
+/// The MCP search handler's defaults (mcp.zig handleSearch): cache keys
+/// include max_results, so replay must use the same numbers.
+const default_max_results: usize = 20;
+const fallback_fetch_count: usize = 21; // offset 0 + max_results + 1
+
+/// Extract the most frequently repeated codedb_search queries from a
+/// queries.log tail (JSONL, one event per line). Malformed lines are
+/// skipped. Returns up to `max` queries ordered by descending repeat count,
+/// each duped into `allocator`; caller frees each slice and the outer slice.
+pub fn topQueries(allocator: std.mem.Allocator, log_bytes: []const u8, max: usize) ![][]u8 {
+    var keys: std.ArrayList([]u8) = .empty;
+    var counts = std.StringHashMap(u32).init(allocator);
+    defer {
+        for (keys.items) |k| allocator.free(k);
+        keys.deinit(allocator);
+        counts.deinit();
+    }
+
+    var lines = std.mem.splitScalar(u8, log_bytes, '\n');
+    while (lines.next()) |line| {
+        // A tail read may begin mid-line; the fragment simply fails to parse
+        // and is skipped like any other malformed line.
+        if (line.len == 0) continue;
+        const parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
+        defer parsed.deinit();
+        const obj = switch (parsed.value) {
+            .object => |o| o,
+            else => continue,
+        };
+        const ev = obj.get("ev") orelse continue;
+        if (ev != .string or !std.mem.eql(u8, ev.string, "query")) continue;
+        const tool = obj.get("tool") orelse continue;
+        if (tool != .string or !std.mem.eql(u8, tool.string, "codedb_search")) continue;
+        const query = obj.get("query") orelse continue;
+        if (query != .string) continue;
+        const q = query.string;
+        if (q.len == 0 or q.len > 1024) continue;
+        const gop = try counts.getOrPut(q);
+        if (gop.found_existing) {
+            gop.value_ptr.* += 1;
+        } else {
+            const owned = try allocator.dupe(u8, q);
+            errdefer allocator.free(owned);
+            try keys.append(allocator, owned);
+            gop.key_ptr.* = owned;
+            gop.value_ptr.* = 1;
+        }
+    }
+
+    const n = @min(keys.items.len, max);
+    const out = try allocator.alloc([]u8, n);
+    errdefer allocator.free(out);
+    // Insertion order (keys) breaks count ties; selection by max count keeps
+    // it simple — the candidate set is tiny.
+    var remaining = std.ArrayList(u32).empty;
+    defer remaining.deinit(allocator);
+    try remaining.ensureTotalCapacity(allocator, keys.items.len);
+    for (keys.items) |k| remaining.appendAssumeCapacity(counts.get(k).?);
+    var filled: usize = 0;
+    while (filled < n) : (filled += 1) {
+        var best: usize = 0;
+        var best_count: u32 = 0;
+        for (remaining.items, 0..) |c, i| {
+            if (c > best_count) {
+                best_count = c;
+                best = i;
+            }
+        }
+        remaining.items[best] = 0;
+        out[filled] = try allocator.dupe(u8, keys.items[best]);
+    }
+    return out;
+}
+
+pub fn freeQueries(allocator: std.mem.Allocator, queries: [][]u8) void {
+    for (queries) |q| allocator.free(q);
+    allocator.free(queries);
+}
+
+/// Replay queries through the same entry points the MCP codedb_search
+/// handler uses, populating the plain-render and searchContent result
+/// caches (and, via the lazy builds those searches trigger, the word/symbol
+/// indexes, call graph, and co-change map). Errors are swallowed — warmup
+/// must never take the server down — and `shutdown` is honored between
+/// queries.
+pub fn replay(explorer: *explore.Explorer, allocator: std.mem.Allocator, queries: []const []const u8, shutdown: *std.atomic.Value(bool)) void {
+    for (queries) |q| {
+        if (shutdown.load(.acquire)) return;
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(allocator);
+        const rendered = explorer.renderPlainSearch(q, allocator, &buf, default_max_results, false) catch false;
+        if (!rendered) {
+            const res = explorer.searchContentAuto(q, allocator, fallback_fetch_count) catch continue;
+            for (res) |r| {
+                allocator.free(r.path);
+                allocator.free(r.line_text);
+            }
+            allocator.free(res);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Five commits attacking the production latency tail (search p90 30ms, codedb_find p90 17.7ms) from the 2,467-call production query log:

- **Whole-query result LRUs** for `searchContent`/`renderPlainSearch` (7c60f7d) and the BM25 `searchContentRanked` path (2e1c148). 64 entries / 4MB each; entries validated against both `Explorer.search_gen` and a fingerprint of the nine ranking kill-switch env vars. `CODEDB_NO_SEARCH_CACHE=1` disables. Measured: error query 20.7us -> 2.0us on hit.
- **Race fix** (2a40e62): generation bumps moved inside the exclusive lock — bumping before the lock let a concurrent search cache pre-mutation results under the post-mutation generation (permanent stale hit). Cache hits also restore the producing search's breakdown for telemetry/provenance.
- **Background warmup** (9fdbc15): serve/mcp/cli-daemon spawn a thread that builds+persists the word index off the query path and replays the most-repeated queries from `queries.log` through the real search entry points. 62% of production calls are exact repeats of an earlier (tool, query) pair. First-call MCP search: 21.8ms -> 6.3ms. `CODEDB_NO_WARMUP=1` disables; skipped under `CODEDB_LOW_MEMORY` (956c8d9).
- **Symbol-scan gating** (c7fec7e): `findSymbol`/`findAllSymbols`/`renderSymbols` ran full O(files x symbols) outline safety scans on every call — a #310-era net that predates `symbol_index_complete` (#564). Gated on the flag: ~6ms/call -> 50-100ns for index misses on a 20k-file corpus. `ensureSymbolIndex` now rebuilds from scratch to avoid duplicate entries.

Stacked follow-up: the skip_trigram_files reconciliation fix (separate PR, based on this branch).

#### Test plan
- [x] `zig build test` — 835/835
- [x] `python3 scripts/e2e_mcp_test.py` — 20/20
- [x] Live MCP measurement on this repo (first-call latency, cache-hit timings)
- [x] Repo benchmark runs with `CODEDB_NO_SEARCH_CACHE=1` for comparable per-query rows + explicit cached row

Generated with [Devin](https://cli.devin.ai/docs)
