### PR TITLE
fix(cli): unexpanded ${workspaceFolder} root resolves to cwd, non-explicit (#639)

### DIFF
--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -10,6 +10,11 @@ const std = @import("std");
 /// commands; the dispatch chain calls cliIsQueryCmd directly.
 pub const cli_query_cmds = [_][]const u8{ "tree", "outline", "find", "search", "word", "read", "hot", "status", "symbol", "callers", "callpath", "deps", "glob", "ls", "file", "context", "changes" };
 
+/// Editors that don't expand the placeholder pass the literal token as the
+/// root. #639: normalized here (not in mainImpl) so it lands before the
+/// root == "." / !root_is_explicit gates.
+pub const workspace_placeholder = "${workspaceFolder}";
+
 /// True for the read-only query commands the daemon will serve / the client
 /// will proxy. Everything else (serve, mcp, snapshot, index, ...) is handled
 /// only by the cold path.
@@ -63,12 +68,20 @@ pub fn parsePositional(args: []const []const u8) ParsedPositional {
             // Only when args[2] doesn't look like a flag; otherwise it's a
             // legitimate command-arg that the mcp subcommand may consume.
             if (a2.len > 0 and a2[0] != '-') {
+                // #639: `codedb mcp ${workspaceFolder}` (unexpanded) → cwd, non-explicit.
+                if (std.mem.eql(u8, a2, workspace_placeholder))
+                    return .{ .root = ".", .cmd = "mcp", .cmd_args_start = 3, .root_is_explicit = false };
                 return .{ .root = a2, .cmd = "mcp", .cmd_args_start = 3, .root_is_explicit = true };
             }
         }
         return .{ .root = ".", .cmd = a1, .cmd_args_start = 2, .root_is_explicit = false };
     }
     if (args.len >= 3) {
+        // #639: unexpanded ${workspaceFolder} → cwd, non-explicit, so the
+        // CODEDB_ROOT fallback, #502 git-root walk-up, and mcp deferred-scan
+        // (all gated on root == "." / !root_is_explicit) apply.
+        if (std.mem.eql(u8, a1, workspace_placeholder))
+            return .{ .root = ".", .cmd = args[2], .cmd_args_start = 3, .root_is_explicit = false };
         return .{ .root = a1, .cmd = args[2], .cmd_args_start = 3, .root_is_explicit = true };
     }
     return .{ .root = "", .cmd = "", .cmd_args_start = 0, .root_is_explicit = false, .usage_exit = true };

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -87,6 +87,22 @@ pub fn parsePositional(args: []const []const u8) ParsedPositional {
     return .{ .root = "", .cmd = "", .cmd_args_start = 0, .root_is_explicit = false, .usage_exit = true };
 }
 
+/// True when an `mcp` root points at cwd and was left implicit — a bare
+/// `codedb mcp` or a normalized ${workspaceFolder}. Single source of truth for
+/// the #502 git-root walk-up AND the deferred-scan handshake; both used to be
+/// hand-written inline in mainImpl and drifted out of sync, which is how #639
+/// hid (a placeholder arrived with root_is_explicit set and silently disabled
+/// both paths).
+pub fn mcpRootIsImplicitCwd(cmd: []const u8, root: []const u8, root_is_explicit: bool) bool {
+    return std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".") and !root_is_explicit;
+}
+
+/// True when an `mcp` root points at cwd and is therefore eligible for the
+/// CODEDB_ROOT env fallback (which pins the root, explicit or not).
+pub fn mcpRootAcceptsEnv(cmd: []const u8, root: []const u8) bool {
+    return std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".");
+}
+
 /// A 1-based inclusive line range as accepted by `read -L FROM-TO`. `end` is
 /// `std.math.maxInt(u32)` when the spec used `$`/`end` (read to end-of-file).
 pub const LineRange = struct { start: u32, end: u32 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -35,6 +35,8 @@ pub const findGitRootFrom = cli_args.findGitRootFrom;
 pub const isValidMcpFlag = cli_args.isValidMcpFlag;
 pub const resolveRoot = cli_args.resolveRoot;
 const cliIsQueryCmd = cli_args.cliIsQueryCmd;
+const mcpRootIsImplicitCwd = cli_args.mcpRootIsImplicitCwd;
+const mcpRootAcceptsEnv = cli_args.mcpRootAcceptsEnv;
 
 /// The real entry point.  In Debug builds, Zig may merge all command-branch
 /// stack frames into one producing a frame that overflows the default OS stack,
@@ -203,7 +205,7 @@ fn mainImpl() !void {
     // so the MCP scan kicks off at startup instead of waiting for a roots
     // handshake — without this, every fresh `codedb mcp` call against a
     // client that doesn't send roots/list_changed sees an empty index.
-    if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".")) {
+    if (mcpRootAcceptsEnv(cmd, root)) {
         if (cio.posixGetenv("CODEDB_ROOT")) |env_root| {
             if (env_root.len > 0) {
                 root = env_root;
@@ -218,7 +220,7 @@ fn mainImpl() !void {
     // rather than the subdir they happen to be in. Skipped if the env var
     // or a positional arg already pinned the root, or if no .git is found.
     var git_root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".") and !root_is_explicit) {
+    if (mcpRootIsImplicitCwd(cmd, root, root_is_explicit)) {
         if (findGitRoot(io, &git_root_buf)) |git_root| {
             root = git_root;
             root_is_explicit = true;
@@ -296,7 +298,7 @@ fn mainImpl() !void {
     // path is fast (snapshot load happens in-process when the trigger fires),
     // and clients that don't advertise the roots capability fire the trigger
     // immediately on notifications/initialized — see handleSession.
-    const mcp_deferred_root = std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, ".") and !root_is_explicit;
+    const mcp_deferred_root = mcpRootIsImplicitCwd(cmd, root, root_is_explicit);
     if (!mcp_deferred_root and !root_policy.isIndexableRoot(abs_root)) {
         out.p("{s}\xe2\x9c\x97{s} refusing to index temporary root: {s}{s}{s}\n", .{
             s.red, s.reset, s.bold, abs_root, s.reset,

--- a/src/main.zig
+++ b/src/main.zig
@@ -282,10 +282,6 @@ fn mainImpl() !void {
         return;
     }
 
-    if (std.mem.eql(u8, cmd, "mcp") and std.mem.eql(u8, root, "${workspaceFolder}")) {
-        root = ".";
-    }
-
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
     const abs_root = resolveRoot(io, root, &root_buf) catch {
         out.p("{s}\xe2\x9c\x97{s} cannot resolve root: {s}{s}{s}\n", .{

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1784,6 +1784,37 @@ test "issue-639: placeholder is normalized in cli_args only, never re-rewritten 
     try testing.expect(std.mem.indexOf(u8, main_src, "${workspaceFolder}") == null);
 }
 
+test "issue-639: mcp root-resolution gate predicates" {
+    const ca = cli_args_mod;
+    // mcpRootIsImplicitCwd — single source for the #502 git-root walk-up AND
+    // the deferred-scan handshake. Fires only for an implicit cwd mcp root.
+    try testing.expect(ca.mcpRootIsImplicitCwd("mcp", ".", false)); // bare mcp → fire
+    try testing.expect(!ca.mcpRootIsImplicitCwd("mcp", ".", true)); // env/path-pinned → skip
+    try testing.expect(!ca.mcpRootIsImplicitCwd("mcp", "/proj", false)); // explicit path → skip
+    try testing.expect(!ca.mcpRootIsImplicitCwd("search", ".", false)); // non-mcp → skip
+    // mcpRootAcceptsEnv — gates the CODEDB_ROOT fallback (explicit or not).
+    try testing.expect(ca.mcpRootAcceptsEnv("mcp", "."));
+    try testing.expect(!ca.mcpRootAcceptsEnv("mcp", "/proj"));
+    try testing.expect(!ca.mcpRootAcceptsEnv("status", "."));
+}
+
+test "issue-639: parsed ${workspaceFolder} feeds the gates like a bare `codedb mcp`" {
+    // The two halves of the bug must agree: the parse half (parsePositional)
+    // and the consume half (the gate predicates). Before the fix the
+    // placeholder parsed to (root="${workspaceFolder}", explicit=true), so
+    // both gates returned false and the #502 walk-up / deferred scan /
+    // CODEDB_ROOT fallback were all silently skipped.
+    const forms = [_][]const []const u8{
+        &.{ "codedb", "${workspaceFolder}", "mcp" },
+        &.{ "codedb", "mcp", "${workspaceFolder}" },
+    };
+    for (forms) |argv| {
+        const p = main_mod.parsePositional(argv);
+        try testing.expect(cli_args_mod.mcpRootIsImplicitCwd(p.cmd, p.root, p.root_is_explicit));
+        try testing.expect(cli_args_mod.mcpRootAcceptsEnv(p.cmd, p.root));
+    }
+}
+
 test "issue-502: isValidMcpFlag whitelist rejects unknown flags" {
     // Before fix: `codedb mcp --snapshot` silently swallowed the flag and
     // started the server with surprising state. After fix, mainImpl rejects

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1738,6 +1738,52 @@ test "issue-639: unexpanded ${workspaceFolder} root normalizes to cwd, non-expli
     }
 }
 
+test "issue-639: parsePositional root/explicit matrix across arg forms" {
+    // The matrix that hid the bug: each arg form maps to a (root, cmd,
+    // explicit) triple. The deferred-scan / git-root-walkup / CODEDB_ROOT
+    // gates all key off (cmd=="mcp" and root=="." and !explicit), so the
+    // placeholder rows MUST land on root=".", explicit=false to behave like
+    // a bare `codedb mcp`. Anything else silently disables those paths (#639).
+    const Case = struct {
+        argv: []const []const u8,
+        root: []const u8,
+        cmd: []const u8,
+        explicit: bool,
+    };
+    const cases = [_]Case{
+        // bare mcp → cwd, deferred (non-explicit)
+        .{ .argv = &.{ "codedb", "mcp" }, .root = ".", .cmd = "mcp", .explicit = false },
+        // explicit path before cmd
+        .{ .argv = &.{ "codedb", "/proj", "mcp" }, .root = "/proj", .cmd = "mcp", .explicit = true },
+        // explicit path after mcp (#503)
+        .{ .argv = &.{ "codedb", "mcp", "/proj" }, .root = "/proj", .cmd = "mcp", .explicit = true },
+        // unexpanded placeholder before cmd → normalized to cwd, non-explicit (#639)
+        .{ .argv = &.{ "codedb", "${workspaceFolder}", "mcp" }, .root = ".", .cmd = "mcp", .explicit = false },
+        // unexpanded placeholder after mcp → normalized (#639)
+        .{ .argv = &.{ "codedb", "mcp", "${workspaceFolder}" }, .root = ".", .cmd = "mcp", .explicit = false },
+        // placeholder with a non-mcp command (generic root form) → cwd recovery (#639)
+        .{ .argv = &.{ "codedb", "${workspaceFolder}", "search" }, .root = ".", .cmd = "search", .explicit = false },
+        // explicit path + query cmd stays explicit
+        .{ .argv = &.{ "codedb", "/proj", "search" }, .root = "/proj", .cmd = "search", .explicit = true },
+    };
+    for (cases) |c| {
+        const p = main_mod.parsePositional(c.argv);
+        try testing.expect(!p.usage_exit);
+        try testing.expectEqualStrings(c.root, p.root);
+        try testing.expectEqualStrings(c.cmd, p.cmd);
+        try testing.expectEqual(c.explicit, p.root_is_explicit);
+    }
+}
+
+test "issue-639: placeholder is normalized in cli_args only, never re-rewritten in main" {
+    // Reintroduction guard. The bug hid because the placeholder was rewritten
+    // late in the dispatcher (mainImpl), after the gates had already branched
+    // on the un-normalized value. Keep the literal in exactly one place
+    // (cli_args.zig); its presence in main.zig means a late rewrite is back.
+    const main_src = @embedFile("main.zig");
+    try testing.expect(std.mem.indexOf(u8, main_src, "${workspaceFolder}") == null);
+}
+
 test "issue-502: isValidMcpFlag whitelist rejects unknown flags" {
     // Before fix: `codedb mcp --snapshot` silently swallowed the flag and
     // started the server with surprising state. After fix, mainImpl rejects

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1709,6 +1709,35 @@ test "parsePositional: existing commands still parse correctly (regression)" {
     }
 }
 
+test "issue-639: unexpanded ${workspaceFolder} root normalizes to cwd, non-explicit" {
+    // Editors that don't expand the ${workspaceFolder} placeholder pass the
+    // literal token as the root. It must behave like a bare `codedb mcp`
+    // (root ".", root_is_explicit=false) so the CODEDB_ROOT fallback, the #502
+    // git-root walk-up, and deferred-scan mode all apply. Before the fix
+    // parsePositional returned the literal placeholder with root_is_explicit
+    // = true, and mainImpl only rewrote root -> "." (too late, and without
+    // clearing the explicit flag), so all three paths were silently skipped.
+
+    // `codedb ${workspaceFolder} mcp`
+    {
+        const argv = [_][]const u8{ "codedb", "${workspaceFolder}", "mcp" };
+        const p = main_mod.parsePositional(&argv);
+        try testing.expect(!p.usage_exit);
+        try testing.expectEqualStrings(".", p.root);
+        try testing.expectEqualStrings("mcp", p.cmd);
+        try testing.expect(!p.root_is_explicit);
+    }
+    // `codedb mcp ${workspaceFolder}`
+    {
+        const argv = [_][]const u8{ "codedb", "mcp", "${workspaceFolder}" };
+        const p = main_mod.parsePositional(&argv);
+        try testing.expect(!p.usage_exit);
+        try testing.expectEqualStrings(".", p.root);
+        try testing.expectEqualStrings("mcp", p.cmd);
+        try testing.expect(!p.root_is_explicit);
+    }
+}
+
 test "issue-502: isValidMcpFlag whitelist rejects unknown flags" {
     // Before fix: `codedb mcp --snapshot` silently swallowed the flag and
     // started the server with surprising state. After fix, mainImpl rejects


### PR DESCRIPTION
## Problem

When an editor passes the **literal, unexpanded** `${workspaceFolder}` placeholder as the root (a known MCP-config misconfiguration), `parsePositional` returns it as the root with `root_is_explicit = true`. `mainImpl` only rewrote `root → "."` *after* the resolution steps that gate on `root == "."`, and never cleared the explicit flag:

- `CODEDB_ROOT` env fallback — gated on `cmd=="mcp" and root=="."`
- #502 git-root walk-up — gated on `cmd=="mcp" and root=="." and !root_is_explicit`
- mcp deferred-scan mode — gated on `cmd=="mcp" and root=="." and !root_is_explicit`

So a placeholder root silently skipped **all three**: no env-root fallback, no walk-up to the repo root (indexes the spawn subdir instead — the exact #502 failure), and eager non-deferred mcp startup.

## Failing Test

`src/test_mcp.zig` — `test "issue-639: unexpanded ${workspaceFolder} root normalizes to cwd, non-explicit"` asserts both `codedb ${workspaceFolder} mcp` and `codedb mcp ${workspaceFolder}` parse to `root="."`, `cmd="mcp"`, `root_is_explicit=false`. Fails on the release tip (returns the literal placeholder, `explicit=true`).

## Expected

A placeholder root behaves identically to a bare `codedb mcp` — `root="."`, `root_is_explicit=false`.

## Fix

Normalize `${workspaceFolder} → "."` (non-explicit) inside `parsePositional` for both arg orders, so it lands *before* the `root=="."` / `!root_is_explicit` gates. Remove the now-dead late rewrite in `mainImpl`.

Full suite green (`test_mcp` 134/134). zig fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)