### PR TITLE
Add Windows warm daemon IPC

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -66,9 +66,17 @@ jobs:
           script: |
             const fs = require('fs');
             const body = fs.readFileSync('bench-report.md', 'utf8');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            } catch (err) {
+              if (err.status === 403) {
+                core.warning('Skipping benchmark PR comment because this run token cannot write comments.');
+              } else {
+                throw err;
+              }
+            }

--- a/src/cio.zig
+++ b/src/cio.zig
@@ -320,6 +320,11 @@ pub fn randU64() u64 {
     return x;
 }
 
+pub fn currentProcessId() u32 {
+    if (is_windows) return @intCast(winsync.GetCurrentProcessId());
+    return @intCast(std.c.getpid());
+}
+
 pub fn userId() usize {
     if (is_windows) return 0;
     return @intCast(std.c.getuid());
@@ -584,11 +589,30 @@ pub fn runCapture(opts: RunOptions) !CaptureResult {
 
 fn runCaptureWindows(opts: RunOptions) !CaptureResult {
     const alloc = opts.allocator;
+    if (opts.argv.len == 0) return error.EmptyArgv;
+
+    var resolved_argv0: ?[]u8 = null;
+    defer if (resolved_argv0) |path| alloc.free(path);
+    var argv_buf: ?[][]const u8 = null;
+    defer if (argv_buf) |buf| alloc.free(buf);
+
+    const argv = blk: {
+        if (try windowsResolvedRunCaptureArgv0(alloc, opts.argv[0], opts.cwd)) |resolved| {
+            resolved_argv0 = resolved;
+            const copied = try alloc.alloc([]const u8, opts.argv.len);
+            @memcpy(copied, opts.argv);
+            copied[0] = resolved;
+            argv_buf = copied;
+            break :blk copied;
+        }
+        break :blk opts.argv;
+    };
+
     var threaded: std.Io.Threaded = .init(alloc, .{});
     defer threaded.deinit();
     const io = threaded.io();
     const result = try std.process.run(alloc, io, .{
-        .argv = opts.argv,
+        .argv = argv,
         .cwd = if (opts.cwd) |cwd| .{ .path = cwd } else .inherit,
         .stdout_limit = .limited(opts.max_output_bytes),
         .stderr_limit = .limited(opts.max_output_bytes),
@@ -604,6 +628,78 @@ fn runCaptureWindows(opts: RunOptions) !CaptureResult {
         .stderr = result.stderr,
         .term = term,
     };
+}
+
+const INVALID_FILE_ATTRIBUTES: u32 = 0xffff_ffff;
+const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x0000_0010;
+
+extern "kernel32" fn GetFileAttributesW(lpFileName: [*:0]const u16) callconv(.winapi) u32;
+
+fn windowsResolvedRunCaptureArgv0(allocator: std.mem.Allocator, argv0: []const u8, cwd: ?[]const u8) !?[]u8 {
+    if (!is_windows) return null;
+    if (argv0.len == 0) return error.EmptyArgv;
+
+    if (windowsArgv0HasPathComponent(argv0)) {
+        if (std.fs.path.isAbsoluteWindows(argv0)) return null;
+        if (cwd != null) return error.UnsafeRelativeExecutable;
+        return null;
+    }
+
+    return try resolveExecutableFromPathWindows(allocator, argv0) orelse error.ExecutableNotFound;
+}
+
+fn windowsArgv0HasPathComponent(argv0: []const u8) bool {
+    return std.mem.indexOfAny(u8, argv0, "\\/:") != null;
+}
+
+pub fn resolveExecutableFromPathWindows(allocator: std.mem.Allocator, name: []const u8) !?[]u8 {
+    if (!is_windows) return null;
+    if (name.len == 0 or windowsArgv0HasPathComponent(name)) return null;
+
+    const explicit_ext = std.fs.path.extension(name);
+    if (explicit_ext.len > 0 and !isSafeWindowsExecutableExtension(explicit_ext)) return null;
+
+    const path = posixGetenv("PATH") orelse return null;
+    var dirs = std.mem.splitScalar(u8, path, ';');
+    while (dirs.next()) |raw_dir| {
+        const dir = std.mem.trim(u8, raw_dir, " \t\"");
+        if (dir.len == 0 or !std.fs.path.isAbsoluteWindows(dir)) continue;
+
+        if (explicit_ext.len > 0) {
+            if (try windowsExecutableCandidate(allocator, dir, name)) |candidate| return candidate;
+            continue;
+        }
+
+        const safe_exts = [_][]const u8{ ".exe", ".com" };
+        for (safe_exts) |ext| {
+            const candidate_name = try std.fmt.allocPrint(allocator, "{s}{s}", .{ name, ext });
+            defer allocator.free(candidate_name);
+            if (try windowsExecutableCandidate(allocator, dir, candidate_name)) |candidate| return candidate;
+        }
+    }
+    return null;
+}
+
+fn isSafeWindowsExecutableExtension(ext: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(ext, ".exe") or std.ascii.eqlIgnoreCase(ext, ".com");
+}
+
+fn windowsExecutableCandidate(allocator: std.mem.Allocator, dir: []const u8, file_name: []const u8) !?[]u8 {
+    const sep: []const u8 = if (std.mem.endsWith(u8, dir, "\\") or std.mem.endsWith(u8, dir, "/")) "" else "\\";
+    const candidate = try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ dir, sep, file_name });
+    errdefer allocator.free(candidate);
+    if (!windowsFileExists(candidate, allocator)) {
+        allocator.free(candidate);
+        return null;
+    }
+    return candidate;
+}
+
+fn windowsFileExists(path: []const u8, allocator: std.mem.Allocator) bool {
+    const w = std.unicode.utf8ToUtf16LeAllocZ(allocator, path) catch return false;
+    defer allocator.free(w);
+    const attrs = GetFileAttributesW(w.ptr);
+    return attrs != INVALID_FILE_ATTRIBUTES and (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
 }
 
 fn runCapturePosix(opts: RunOptions) !CaptureResult {

--- a/src/cio.zig
+++ b/src/cio.zig
@@ -320,6 +320,11 @@ pub fn randU64() u64 {
     return x;
 }
 
+pub fn userId() usize {
+    if (is_windows) return 0;
+    return @intCast(std.c.getuid());
+}
+
 pub fn sleepMs(ms: u64) void {
     if (is_windows) {
         winsync.Sleep(@intCast(@min(ms, @as(u64, std.math.maxInt(u32)))));
@@ -346,6 +351,10 @@ pub fn makePipe() PipeError![2]c_int {
 
 pub fn closeFd(fd: c_int) void {
     _ = close(fd);
+}
+
+pub fn readFd(fd: c_int, buf: []u8) isize {
+    return read(fd, buf.ptr, buf.len);
 }
 
 pub fn posixGetenv(name: []const u8) ?[]const u8 {
@@ -567,14 +576,34 @@ const PosixSpawnFAStorage = [256]u8;
 /// a background thread to avoid pipe-buffer deadlock when the child writes
 /// substantially to either stream).
 /// Run `argv` and capture stdout/stderr. POSIX uses a posix_spawnp fast path;
-/// Windows has no equivalent here yet, so it reports SpawnUnsupported and every
-/// caller (git metadata, telemetry, nuke, self-update) degrades gracefully.
+/// Windows falls back to std.process.run with matching output bounds.
 pub fn runCapture(opts: RunOptions) !CaptureResult {
-    if (is_windows) {
-        return error.SpawnUnsupported;
-    } else {
-        return runCapturePosix(opts);
-    }
+    if (is_windows) return runCaptureWindows(opts);
+    return runCapturePosix(opts);
+}
+
+fn runCaptureWindows(opts: RunOptions) !CaptureResult {
+    const alloc = opts.allocator;
+    var threaded: std.Io.Threaded = .init(alloc, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const result = try std.process.run(alloc, io, .{
+        .argv = opts.argv,
+        .cwd = if (opts.cwd) |cwd| .{ .path = cwd } else .inherit,
+        .stdout_limit = .limited(opts.max_output_bytes),
+        .stderr_limit = .limited(opts.max_output_bytes),
+    });
+    const term: CaptureResult.Term = switch (result.term) {
+        .exited => |code| .{ .Exited = code },
+        .signal => |sig| .{ .Signal = @intFromEnum(sig) },
+        .stopped => |sig| .{ .Stopped = @intFromEnum(sig) },
+        .unknown => |code| .{ .Unknown = code },
+    };
+    return .{
+        .stdout = result.stdout,
+        .stderr = result.stderr,
+        .term = term,
+    };
 }
 
 fn runCapturePosix(opts: RunOptions) !CaptureResult {
@@ -713,14 +742,62 @@ fn runCapturePosix(opts: RunOptions) !CaptureResult {
 }
 
 /// Fire-and-forget spawn of a detached child (used to launch the warm
-/// cli-daemon). POSIX uses posix_spawnp + /dev/null redirection; on Windows the
-/// warm-daemon accelerator is disabled, so this is a no-op.
+/// cli-daemon). POSIX uses posix_spawnp + /dev/null redirection; Windows uses
+/// CreateProcessW with detached/no-window flags.
 pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) void {
     if (is_windows) {
+        spawnDetachedWindows(allocator, argv);
         return;
     } else {
         spawnDetachedPosix(allocator, argv);
     }
+}
+
+pub fn windowsCommandLine(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8 {
+    var cmd: std.ArrayList(u8) = .empty;
+    defer cmd.deinit(allocator);
+    for (argv, 0..) |arg, i| {
+        if (i != 0) cmd.append(allocator, ' ') catch return null;
+        cmd.append(allocator, '"') catch return null;
+        var backslashes: usize = 0;
+        for (arg) |ch| {
+            switch (ch) {
+                '\\' => backslashes += 1,
+                '"' => {
+                    cmd.appendNTimes(allocator, '\\', backslashes * 2 + 1) catch return null;
+                    cmd.append(allocator, '"') catch return null;
+                    backslashes = 0;
+                },
+                else => {
+                    if (backslashes > 0) {
+                        cmd.appendNTimes(allocator, '\\', backslashes) catch return null;
+                        backslashes = 0;
+                    }
+                    cmd.append(allocator, ch) catch return null;
+                },
+            }
+        }
+        cmd.appendNTimes(allocator, '\\', backslashes * 2) catch return null;
+        cmd.append(allocator, '"') catch return null;
+    }
+    return cmd.toOwnedSlice(allocator) catch null;
+}
+
+fn spawnDetachedWindows(allocator: std.mem.Allocator, argv: []const []const u8) void {
+    if (argv.len == 0) return;
+
+    const cmd = windowsCommandLine(allocator, argv) orelse return;
+    defer allocator.free(cmd);
+    const cmd_w = std.unicode.utf8ToUtf16LeAllocZ(allocator, cmd) catch return;
+    defer allocator.free(cmd_w);
+
+    var si: std.os.windows.STARTUPINFOW = std.mem.zeroes(std.os.windows.STARTUPINFOW);
+    si.cb = @sizeOf(std.os.windows.STARTUPINFOW);
+    var pi: std.os.windows.PROCESS.INFORMATION = undefined;
+    const flags: std.os.windows.CreateProcessFlags = .{ .detached_process = true, .create_no_window = true };
+    if (std.os.windows.kernel32.CreateProcessW(null, cmd_w.ptr, null, null, .FALSE, flags, null, null, &si, &pi) == .FALSE) return;
+    std.os.windows.CloseHandle(pi.hThread);
+    std.os.windows.CloseHandle(pi.hProcess);
 }
 
 /// Fire-and-forget spawn: posix_spawnp `argv` with stdin/stdout/stderr
@@ -807,7 +884,7 @@ pub fn mmapReadonly(handle: anytype, len: usize) MmapError![]align(std.heap.page
         defer _ = winmap.CloseHandle(mapping);
         const base = winmap.MapViewOfFile(mapping, winmap.FILE_MAP_READ, 0, 0, len) orelse
             return error.MapFailed;
-        const ptr: [*]align(std.heap.page_size_min) const u8 = @alignCast(@ptrCast(base));
+        const ptr: [*]align(std.heap.page_size_min) const u8 = @ptrCast(@alignCast(base));
         return ptr[0..len];
     } else {
         return std.posix.mmap(null, len, .{ .READ = true }, .{ .TYPE = .SHARED }, handle, 0) catch

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -32,16 +32,21 @@ const cliIsQueryCmd = cli_args.cliIsQueryCmd;
 //   response (daemon→client): [u8 exit_code][u32 out_len][out_bytes]
 const cli_blob_max: u32 = 64 * 1024;
 const cli_response_max: u32 = 16 * 1024 * 1024;
-const cli_response_too_large = "error: daemon response too large\n";
 
 fn cliResponseLenAllowed(out_len: u32) bool {
     return out_len <= cli_response_max;
+}
+
+fn cliResponseSendAllowed(out_len: usize) bool {
+    return out_len <= @as(usize, cli_response_max);
 }
 
 test "cli response length cap rejects oversized frames" {
     try std.testing.expect(cliResponseLenAllowed(0));
     try std.testing.expect(cliResponseLenAllowed(cli_response_max));
     try std.testing.expect(!cliResponseLenAllowed(cli_response_max + 1));
+    try std.testing.expect(cliResponseSendAllowed(cli_response_max));
+    try std.testing.expect(!cliResponseSendAllowed(@as(usize, cli_response_max) + 1));
 }
 
 const win = std.os.windows;
@@ -203,6 +208,55 @@ fn readCliPipeMetadata(io: std.Io, allocator: std.mem.Allocator, data_dir: []con
     const path = cliPipeMetadataPath(allocator, data_dir) catch return null;
     defer allocator.free(path);
     return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1024)) catch null;
+}
+
+fn cliPipeMetadataNeedsPublish(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8, pid: u32, pipe_name: []const u8) bool {
+    const content = readCliPipeMetadata(io, allocator, data_dir) orelse return true;
+    defer allocator.free(content);
+    if (cliPipeMetadataMatchesOwner(content, pid, pipe_name)) return false;
+    const metadata = parseCliPipeMetadata(content) orelse return true;
+    if (metadata.pid == pid) return true;
+    return !processUserMatchesCurrent(allocator, metadata.pid);
+}
+
+fn cliPipeMetadataMonitor(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8, pid: u32, pipe_name: []const u8, shutdown: *std.atomic.Value(bool)) void {
+    while (!shutdown.load(.acquire)) {
+        if (cliPipeMetadataNeedsPublish(io, allocator, data_dir, pid, pipe_name)) {
+            if (!writeCliPipeMetadata(io, allocator, data_dir, pid, pipe_name)) {
+                std.log.warn("cli-proxy: could not refresh pipe metadata", .{});
+            }
+        }
+        cio.sleepMs(cli_bind_retry_ms);
+    }
+}
+
+test "cli pipe metadata publish decision handles stale owner records" {
+    const allocator = std.testing.allocator;
+    var io = std.Io.Threaded.init(allocator, .{});
+    defer io.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var data_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const data_dir_len = try tmp.dir.realPath(io.io(), &data_dir_buf);
+    const data_dir = data_dir_buf[0..data_dir_len];
+
+    const pid: u32 = 4242;
+    const pipe_name = "\\\\.\\pipe\\codedb-test-owner";
+    const other_pipe_name = "\\\\.\\pipe\\codedb-test-other";
+
+    try std.testing.expect(cliPipeMetadataNeedsPublish(io.io(), allocator, data_dir, pid, pipe_name));
+    try std.testing.expect(writeCliPipeMetadata(io.io(), allocator, data_dir, pid, pipe_name));
+    try std.testing.expect(!cliPipeMetadataNeedsPublish(io.io(), allocator, data_dir, pid, pipe_name));
+    try std.testing.expect(writeCliPipeMetadata(io.io(), allocator, data_dir, pid, other_pipe_name));
+    try std.testing.expect(cliPipeMetadataNeedsPublish(io.io(), allocator, data_dir, pid, pipe_name));
+
+    const metadata_path = try cliPipeMetadataPath(allocator, data_dir);
+    defer allocator.free(metadata_path);
+    const malformed = try std.Io.Dir.cwd().createFile(io.io(), metadata_path, .{ .truncate = true });
+    defer malformed.close(io.io());
+    try malformed.writePositionalAll(io.io(), "pid=nope\npipe=bad\n", 0);
+    try std.testing.expect(cliPipeMetadataNeedsPublish(io.io(), allocator, data_dir, pid, pipe_name));
 }
 
 fn windowsPathZ(allocator: std.mem.Allocator, path: []const u8) ?[:0]u16 {
@@ -519,8 +573,10 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
         var retry_failures: u32 = 0;
         var first_pipe_instance = true;
         const listener_pid = cio.currentProcessId();
+        var metadata_monitor_thread: ?std.Thread = null;
         defer if (listening_pipe) |pipe| win.CloseHandle(pipe);
         defer if (metadata_written and pipe_name != null) deleteCliPipeMetadataIfOwner(io, allocator, data_dir, listener_pid, pipe_name.?);
+        defer if (metadata_monitor_thread) |thread| thread.join();
 
         while (!shutdown.load(.acquire)) {
             if (pipe_name == null) {
@@ -558,6 +614,13 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
                 }
                 metadata_written = true;
                 retry_failures = 0;
+                if (retry and metadata_monitor_thread == null) {
+                    if (std.Thread.spawn(.{}, cliPipeMetadataMonitor, .{ io, allocator, data_dir, listener_pid, pipe_name.?, shutdown })) |thread| {
+                        metadata_monitor_thread = thread;
+                    } else |err| {
+                        std.log.warn("cli-proxy: could not start pipe metadata monitor: {s}", .{@errorName(err)});
+                    }
+                }
             } else {
                 retry_failures = 0;
             }
@@ -687,14 +750,12 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
 
 /// Write the framed response [u8 code][u32 out_len][out_bytes] to `conn`.
 fn cliRespond(conn: CliConn, code: u8, out_bytes: []const u8) void {
-    const response_too_large = out_bytes.len > @as(usize, cli_response_max);
-    const bounded_code: u8 = if (response_too_large) 1 else code;
-    const bounded_bytes: []const u8 = if (response_too_large) cli_response_too_large else out_bytes;
+    if (!cliResponseSendAllowed(out_bytes.len)) return;
     var hdr: [5]u8 = undefined;
-    hdr[0] = bounded_code;
-    std.mem.writeInt(u32, hdr[1..5], @intCast(bounded_bytes.len), .little);
+    hdr[0] = code;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(out_bytes.len), .little);
     if (!cliWriteFull(conn, &hdr)) return;
-    if (bounded_bytes.len > 0) _ = cliWriteFull(conn, bounded_bytes);
+    if (out_bytes.len > 0) _ = cliWriteFull(conn, out_bytes);
 }
 
 /// Client side. If a daemon is listening for this project, proxy the command to

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -1,7 +1,6 @@
 //! Thin CLI client → warm daemon proxy + the per-project spawn lock.
 const std = @import("std");
 const builtin = @import("builtin");
-const is_windows = builtin.os.tag == .windows;
 const cio = @import("cio.zig");
 const sty = @import("style.zig");
 const Store = @import("store.zig").Store;
@@ -32,6 +31,65 @@ const cliIsQueryCmd = cli_args.cliIsQueryCmd;
 //       blob = argv[1..] NUL-joined, e.g. "/proj\0find\0foo"
 //   response (daemon→client): [u8 exit_code][u32 out_len][out_bytes]
 const cli_blob_max: u32 = 64 * 1024;
+const cli_response_max: u32 = 16 * 1024 * 1024;
+const cli_response_too_large = "error: daemon response too large\n";
+
+fn cliResponseLenAllowed(out_len: u32) bool {
+    return out_len <= cli_response_max;
+}
+
+test "cli response length cap rejects oversized frames" {
+    try std.testing.expect(cliResponseLenAllowed(0));
+    try std.testing.expect(cliResponseLenAllowed(cli_response_max));
+    try std.testing.expect(!cliResponseLenAllowed(cli_response_max + 1));
+}
+
+const win = std.os.windows;
+const INVALID_HANDLE_VALUE = win.INVALID_HANDLE_VALUE;
+const GENERIC_READ: u32 = 0x80000000;
+const GENERIC_WRITE: u32 = 0x40000000;
+const OPEN_EXISTING: u32 = 3;
+const OPEN_ALWAYS: u32 = 4;
+const PIPE_ACCESS_DUPLEX: u32 = 0x00000003;
+const PIPE_TYPE_BYTE: u32 = 0x00000000;
+const PIPE_READMODE_BYTE: u32 = 0x00000000;
+const PIPE_WAIT: u32 = 0x00000000;
+const PIPE_UNLIMITED_INSTANCES: u32 = 255;
+const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
+const SECURITY_SQOS_PRESENT: u32 = 0x00100000;
+const SECURITY_IDENTIFICATION: u32 = 0x00010000;
+const SDDL_REVISION_1: u32 = 1;
+
+extern "kernel32" fn CreateNamedPipeA(
+    lpName: [*:0]const u8,
+    dwOpenMode: u32,
+    dwPipeMode: u32,
+    nMaxInstances: u32,
+    nOutBufferSize: u32,
+    nInBufferSize: u32,
+    nDefaultTimeOut: u32,
+    lpSecurityAttributes: ?*anyopaque,
+) callconv(.winapi) win.HANDLE;
+extern "kernel32" fn ConnectNamedPipe(hNamedPipe: win.HANDLE, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
+extern "kernel32" fn DisconnectNamedPipe(hNamedPipe: win.HANDLE) callconv(.winapi) win.BOOL;
+extern "kernel32" fn CreateFileA(
+    lpFileName: [*:0]const u8,
+    dwDesiredAccess: u32,
+    dwShareMode: u32,
+    lpSecurityAttributes: ?*anyopaque,
+    dwCreationDisposition: u32,
+    dwFlagsAndAttributes: u32,
+    hTemplateFile: ?win.HANDLE,
+) callconv(.winapi) win.HANDLE;
+extern "kernel32" fn ReadFile(hFile: win.HANDLE, lpBuffer: [*]u8, nNumberOfBytesToRead: u32, lpNumberOfBytesRead: *u32, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
+extern "kernel32" fn WriteFile(hFile: win.HANDLE, lpBuffer: [*]const u8, nNumberOfBytesToWrite: u32, lpNumberOfBytesWritten: *u32, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
+extern "kernel32" fn LocalFree(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorA(
+    sddl: [*:0]const u8,
+    revision: u32,
+    sd: *?*anyopaque,
+    sd_size: ?*u32,
+) callconv(.winapi) win.BOOL;
 
 /// How often a long-lived serve/mcp daemon that lost the CLI socket bind
 /// re-attempts it (see cliAcquireListener) — one second, matching the daemons'
@@ -42,15 +100,15 @@ const cli_bind_retry_ms: u64 = 1000;
 /// (104 bytes on macOS / 108 on Linux): "/tmp/codedb-<uid>-<hash16>.sock" is
 /// at most ~40 bytes. Returns null only if formatting somehow overflows `buf`.
 pub fn cliSocketPath(buf: []u8, abs_root: []const u8) ?[]const u8 {
+    const uid = cio.userId();
     const hash = std.hash.Wyhash.hash(0xc0de, abs_root);
-    if (is_windows) {
-        // The warm-daemon proxy is disabled on Windows; this only needs to
-        // produce a stable, compilable path (no getuid()).
-        return std.fmt.bufPrint(buf, "codedb-{x:0>16}.sock", .{hash}) catch null;
-    } else {
-        const uid = std.c.getuid();
-        return std.fmt.bufPrint(buf, "/tmp/codedb-{d}-{x:0>16}.sock", .{ uid, hash }) catch null;
-    }
+    return std.fmt.bufPrint(buf, "/tmp/codedb-{d}-{x:0>16}.sock", .{ uid, hash }) catch null;
+}
+
+fn cliPipeName(buf: []u8, abs_root: []const u8) ?[:0]const u8 {
+    const hash = std.hash.Wyhash.hash(0xc0de, abs_root);
+    const user_hash = std.hash.Wyhash.hash(0xc0de, cio.posixGetenv("USERNAME") orelse "");
+    return std.fmt.bufPrintZ(buf, "\\\\.\\pipe\\codedb-{x:0>16}-{x:0>16}", .{ hash, user_hash }) catch null;
 }
 
 /// Fill a sockaddr.un for `path` (which must be NUL-terminatable into sun_path).
@@ -69,33 +127,54 @@ fn cliFillSockaddr(path: []const u8) ?SockAddr {
 
 /// Read exactly `buf.len` bytes from a blocking fd, looping over short reads.
 /// Returns false on EOF-before-full or a hard error (EINTR is retried).
-fn cliReadFull(fd: c_int, buf: []u8) bool {
+const CliConn = if (builtin.os.tag == .windows) win.HANDLE else c_int;
+
+fn connRead(conn: CliConn, buf: []u8) ?usize {
+    if (builtin.os.tag == .windows) {
+        var got: u32 = 0;
+        const want: u32 = @intCast(@min(buf.len, std.math.maxInt(u32)));
+        if (ReadFile(conn, buf.ptr, want, &got, null) == .FALSE) return null;
+        return got;
+    }
+    while (true) {
+        const n = std.c.read(conn, buf.ptr, buf.len);
+        if (n >= 0) return @intCast(n);
+        if (std.c.errno(n) != .INTR) return null;
+    }
+}
+
+fn connWrite(conn: CliConn, data: []const u8) ?usize {
+    if (builtin.os.tag == .windows) {
+        var wrote: u32 = 0;
+        const want: u32 = @intCast(@min(data.len, std.math.maxInt(u32)));
+        if (WriteFile(conn, data.ptr, want, &wrote, null) == .FALSE) return null;
+        return wrote;
+    }
+    while (true) {
+        const n = std.c.write(conn, data.ptr, data.len);
+        if (n >= 0) return @intCast(n);
+        if (std.c.errno(n) != .INTR) return null;
+    }
+}
+
+fn cliReadFull(conn: CliConn, buf: []u8) bool {
     var off: usize = 0;
     while (off < buf.len) {
-        const n = std.c.read(fd, buf.ptr + off, buf.len - off);
-        if (n > 0) {
-            off += @intCast(n);
-            continue;
-        }
-        if (n == 0) return false; // peer closed early
-        if (std.c.errno(n) == .INTR) continue;
-        return false;
+        const n = connRead(conn, buf[off..]) orelse return false;
+        if (n == 0) return false;
+        off += n;
     }
     return true;
 }
 
 /// Write all of `data` to a blocking fd, looping over short/partial writes.
 /// Returns false on a hard error (EINTR is retried).
-fn cliWriteFull(fd: c_int, data: []const u8) bool {
+fn cliWriteFull(conn: CliConn, data: []const u8) bool {
     var off: usize = 0;
     while (off < data.len) {
-        const n = std.c.write(fd, data.ptr + off, data.len - off);
-        if (n > 0) {
-            off += @intCast(n);
-            continue;
-        }
-        if (n < 0 and std.c.errno(n) == .INTR) continue;
-        return false;
+        const n = connWrite(conn, data[off..]) orelse return false;
+        if (n == 0) return false;
+        off += n;
     }
     return true;
 }
@@ -106,33 +185,40 @@ fn cliWriteFull(fd: c_int, data: []const u8) bool {
 /// (the kernel releases flocks on exit, so crashes never leave a stale lock).
 /// Returns null when another process holds the lock or the file can't be
 /// opened.
-pub fn daemonLockTryAcquire(data_dir: []const u8) ?c_int {
-    if (is_windows) {
-        return null;
-    } else {
-        var buf: [std.fs.max_path_bytes]u8 = undefined;
-        const p = std.fmt.bufPrintZ(&buf, "{s}/cli-daemon.lock", .{data_dir}) catch return null;
-        const fd = std.c.open(p.ptr, .{ .ACCMODE = .RDWR, .CREAT = true }, @as(c_uint, 0o600));
-        if (fd < 0) return null;
-        if (std.c.flock(fd, std.c.LOCK.EX | std.c.LOCK.NB) != 0) {
-            _ = std.c.close(fd);
-            return null;
-        }
-        return fd;
+const DaemonLock = if (builtin.os.tag == .windows) win.HANDLE else c_int;
+
+pub fn daemonLockTryAcquire(data_dir: []const u8) ?DaemonLock {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const p = std.fmt.bufPrintZ(&buf, "{s}/cli-daemon.lock", .{data_dir}) catch return null;
+    if (builtin.os.tag == .windows) {
+        const handle = CreateFileA(p.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_ALWAYS, 0, null);
+        if (handle == INVALID_HANDLE_VALUE) return null;
+        return handle;
     }
+    const fd = std.c.open(p.ptr, .{ .ACCMODE = .RDWR, .CREAT = true }, @as(c_uint, 0o600));
+    if (fd < 0) return null;
+    if (std.c.flock(fd, std.c.LOCK.EX | std.c.LOCK.NB) != 0) {
+        _ = std.c.close(fd);
+        return null;
+    }
+    return fd;
+}
+
+pub fn daemonLockRelease(lock: DaemonLock) void {
+    if (builtin.os.tag == .windows) {
+        win.CloseHandle(lock);
+        return;
+    }
+    _ = std.c.flock(lock, std.c.LOCK.UN);
+    _ = std.c.close(lock);
 }
 
 /// Probe whether the spawn lock is free without keeping it: used by the CLI
 /// auto-spawn path so racing cold calls don't fork duplicate daemons.
 pub fn daemonLockAvailable(data_dir: []const u8) bool {
-    if (is_windows) {
-        return false;
-    } else {
-        const fd = daemonLockTryAcquire(data_dir) orelse return false;
-        _ = std.c.flock(fd, std.c.LOCK.UN);
-        _ = std.c.close(fd);
-        return true;
-    }
+    const lock = daemonLockTryAcquire(data_dir) orelse return false;
+    daemonLockRelease(lock);
+    return true;
 }
 
 /// Named sockaddr.un bundle: the struct plus the byte length for bind()/connect().
@@ -217,12 +303,54 @@ pub fn cliAcquireListener(sock_path: []const u8, retry: bool, retry_interval_ms:
 /// promptly; the long-lived serve/mcp daemons pass `true` and keep reclaiming
 /// the socket when the previous owner exits instead of disabling the proxy.
 pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, last_activity_ms: *std.atomic.Value(i64), shutdown: *std.atomic.Value(bool), retry: bool) void {
-    if (is_windows) {
-        // No Unix-socket proxy on Windows; CLI calls run cold in-process.
+    if (builtin.os.tag == .windows) {
+        var name_buf: [256]u8 = undefined;
+        const pipe_name = cliPipeName(&name_buf, abs_root) orelse {
+            shutdown.store(true, .release);
+            return;
+        };
+
+        var sd: ?*anyopaque = null;
+        if (ConvertStringSecurityDescriptorToSecurityDescriptorA("D:P(A;;GA;;;OW)", SDDL_REVISION_1, &sd, null) == .FALSE) {
+            shutdown.store(true, .release);
+            return;
+        }
+        defer _ = LocalFree(sd);
+        var sa_pipe: win.SECURITY_ATTRIBUTES = .{
+            .nLength = @sizeOf(win.SECURITY_ATTRIBUTES),
+            .lpSecurityDescriptor = sd,
+            .bInheritHandle = .FALSE,
+        };
+
+        while (!shutdown.load(.acquire)) {
+            const pipe = CreateNamedPipeA(
+                pipe_name.ptr,
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                PIPE_UNLIMITED_INSTANCES,
+                cli_blob_max + 5,
+                cli_blob_max + 5,
+                0,
+                &sa_pipe,
+            );
+            if (pipe == INVALID_HANDLE_VALUE) {
+                shutdown.store(true, .release);
+                return;
+            }
+            const connected = ConnectNamedPipe(pipe, null) != .FALSE or win.GetLastError() == .PIPE_CONNECTED;
+            if (!connected) {
+                win.CloseHandle(pipe);
+                continue;
+            }
+            last_activity_ms.store(cio.milliTimestamp(), .release);
+            cliServeConn(io, allocator, explorer, store, abs_root, pipe);
+            _ = DisconnectNamedPipe(pipe);
+            win.CloseHandle(pipe);
+        }
         return;
-    } else {
-        cliDaemonListenPosix(io, allocator, explorer, store, abs_root, last_activity_ms, shutdown, retry);
     }
+
+    cliDaemonListenPosix(io, allocator, explorer, store, abs_root, last_activity_ms, shutdown, retry);
 }
 
 fn cliDaemonListenPosix(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, last_activity_ms: *std.atomic.Value(i64), shutdown: *std.atomic.Value(bool), retry: bool) void {
@@ -271,7 +399,7 @@ fn cliDaemonListenPosix(io: std.Io, allocator: std.mem.Allocator, explorer: *Exp
 
 /// Handle one client connection: read the framed request, run the query into a
 /// sink buffer via runQuery, and write the framed response.
-fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, conn: c_int) void {
+fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, conn: CliConn) void {
     // Header: [u8 color][u32 blob_len]
     var hdr: [5]u8 = undefined;
     if (!cliReadFull(conn, &hdr)) return;
@@ -322,12 +450,15 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
 }
 
 /// Write the framed response [u8 code][u32 out_len][out_bytes] to `conn`.
-fn cliRespond(conn: c_int, code: u8, out_bytes: []const u8) void {
+fn cliRespond(conn: CliConn, code: u8, out_bytes: []const u8) void {
+    const response_too_large = out_bytes.len > @as(usize, cli_response_max);
+    const bounded_code: u8 = if (response_too_large) 1 else code;
+    const bounded_bytes: []const u8 = if (response_too_large) cli_response_too_large else out_bytes;
     var hdr: [5]u8 = undefined;
-    hdr[0] = code;
-    std.mem.writeInt(u32, hdr[1..5], @intCast(out_bytes.len), .little);
+    hdr[0] = bounded_code;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(bounded_bytes.len), .little);
     if (!cliWriteFull(conn, &hdr)) return;
-    if (out_bytes.len > 0) _ = cliWriteFull(conn, out_bytes);
+    if (bounded_bytes.len > 0) _ = cliWriteFull(conn, bounded_bytes);
 }
 
 /// Client side. If a daemon is listening for this project, proxy the command to
@@ -336,27 +467,11 @@ fn cliRespond(conn: c_int, code: u8, out_bytes: []const u8) void {
 /// response) returns null so the caller falls back to the cold in-process path.
 /// `args` is mainImpl's filtered argv (args[0] = program name); we send args[1..].
 pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, args: []const []const u8, color: bool) ?u8 {
-    if (is_windows) {
-        return null;
-    } else {
-        return cliTryProxyPosix(io, allocator, abs_root, args, color);
-    }
-}
-
-fn cliTryProxyPosix(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, args: []const []const u8, color: bool) ?u8 {
     _ = io;
     if (args.len < 2) return null;
 
-    var path_buf: [128]u8 = undefined;
-    const sock_path = cliSocketPath(&path_buf, abs_root) orelse return null;
-    const sa = cliFillSockaddr(sock_path) orelse return null;
-
-    const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
-    if (fd < 0) return null;
-    defer _ = std.c.close(fd);
-
-    var sa_mut = sa;
-    if (std.c.connect(fd, @ptrCast(&sa_mut.addr), sa_mut.len) != 0) return null;
+    const conn = cliConnect(abs_root) orelse return null;
+    defer cliCloseConn(conn);
 
     // Build the NUL-joined blob from args[1..].
     var blob: std.ArrayList(u8) = .empty;
@@ -371,20 +486,50 @@ fn cliTryProxyPosix(io: std.Io, allocator: std.mem.Allocator, abs_root: []const 
     var hdr: [5]u8 = undefined;
     hdr[0] = if (color) 1 else 0;
     std.mem.writeInt(u32, hdr[1..5], @intCast(blob.items.len), .little);
-    if (!cliWriteFull(fd, &hdr)) return null;
-    if (!cliWriteFull(fd, blob.items)) return null;
+    if (!cliWriteFull(conn, &hdr)) return null;
+    if (!cliWriteFull(conn, blob.items)) return null;
 
     // Response header: [u8 code][u32 out_len]
     var resp_hdr: [5]u8 = undefined;
-    if (!cliReadFull(fd, &resp_hdr)) return null;
+    if (!cliReadFull(conn, &resp_hdr)) return null;
     const code = resp_hdr[0];
     const out_len = std.mem.readInt(u32, resp_hdr[1..5], .little);
+    if (!cliResponseLenAllowed(out_len)) return null;
 
     if (out_len > 0) {
         const out_bytes = allocator.alloc(u8, out_len) catch return null;
         defer allocator.free(out_bytes);
-        if (!cliReadFull(fd, out_bytes)) return null;
+        if (!cliReadFull(conn, out_bytes)) return null;
         cio.File.stdout().writeAll(out_bytes) catch {};
     }
     return code;
+}
+
+fn cliConnect(abs_root: []const u8) ?CliConn {
+    if (builtin.os.tag == .windows) {
+        var name_buf: [256]u8 = undefined;
+        const pipe_name = cliPipeName(&name_buf, abs_root) orelse return null;
+        const pipe = CreateFileA(pipe_name.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_EXISTING, SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, null);
+        if (pipe == INVALID_HANDLE_VALUE) return null;
+        return pipe;
+    }
+    var path_buf: [128]u8 = undefined;
+    const sock_path = cliSocketPath(&path_buf, abs_root) orelse return null;
+    const sa = cliFillSockaddr(sock_path) orelse return null;
+    const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
+    if (fd < 0) return null;
+    var sa_mut = sa;
+    if (std.c.connect(fd, @ptrCast(&sa_mut.addr), sa_mut.len) != 0) {
+        _ = std.c.close(fd);
+        return null;
+    }
+    return fd;
+}
+
+fn cliCloseConn(conn: CliConn) void {
+    if (builtin.os.tag == .windows) {
+        win.CloseHandle(conn);
+        return;
+    }
+    _ = std.c.close(conn);
 }

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -216,6 +216,7 @@ fn cliPipeMetadataNeedsPublish(io: std.Io, allocator: std.mem.Allocator, data_di
     if (cliPipeMetadataMatchesOwner(content, pid, pipe_name)) return false;
     const metadata = parseCliPipeMetadata(content) orelse return true;
     if (metadata.pid == pid) return true;
+    if (builtin.os.tag != .windows) return true;
     return !processUserMatchesCurrent(allocator, metadata.pid);
 }
 
@@ -231,6 +232,8 @@ fn cliPipeMetadataMonitor(io: std.Io, allocator: std.mem.Allocator, data_dir: []
 }
 
 test "cli pipe metadata publish decision handles stale owner records" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
     const allocator = std.testing.allocator;
     var io = std.Io.Threaded.init(allocator, .{});
     defer io.deinit();

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -543,7 +543,6 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
                 listening_pipe = new_pipe;
                 first_pipe_instance = false;
             }
-            retry_failures = 0;
             if (!metadata_written) {
                 if (!writeCliPipeMetadata(io, allocator, data_dir, listener_pid, pipe_name.?)) {
                     win.CloseHandle(listening_pipe.?);
@@ -558,6 +557,8 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
                     continue;
                 }
                 metadata_written = true;
+                retry_failures = 0;
+            } else {
                 retry_failures = 0;
             }
             const pipe = listening_pipe.?;

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -59,6 +59,10 @@ const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x00080000;
 const SECURITY_SQOS_PRESENT: u32 = 0x00100000;
 const SECURITY_IDENTIFICATION: u32 = 0x00010000;
 const SDDL_REVISION_1: u32 = 1;
+const PIPE_REJECT_REMOTE_CLIENTS: u32 = 0x00000008;
+const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x00001000;
+const TOKEN_QUERY: u32 = 0x0008;
+const TokenUser: u32 = 1;
 
 extern "kernel32" fn CreateNamedPipeA(
     lpName: [*:0]const u8,
@@ -72,8 +76,9 @@ extern "kernel32" fn CreateNamedPipeA(
 ) callconv(.winapi) win.HANDLE;
 extern "kernel32" fn ConnectNamedPipe(hNamedPipe: win.HANDLE, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
 extern "kernel32" fn DisconnectNamedPipe(hNamedPipe: win.HANDLE) callconv(.winapi) win.BOOL;
-extern "kernel32" fn CreateFileA(
-    lpFileName: [*:0]const u8,
+extern "kernel32" fn GetNamedPipeServerProcessId(Pipe: win.HANDLE, ServerProcessId: *u32) callconv(.winapi) win.BOOL;
+extern "kernel32" fn CreateFileW(
+    lpFileName: [*:0]const u16,
     dwDesiredAccess: u32,
     dwShareMode: u32,
     lpSecurityAttributes: ?*anyopaque,
@@ -81,15 +86,31 @@ extern "kernel32" fn CreateFileA(
     dwFlagsAndAttributes: u32,
     hTemplateFile: ?win.HANDLE,
 ) callconv(.winapi) win.HANDLE;
+extern "kernel32" fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: win.BOOL, dwProcessId: u32) callconv(.winapi) ?win.HANDLE;
+extern "kernel32" fn GetCurrentProcess() callconv(.winapi) win.HANDLE;
 extern "kernel32" fn ReadFile(hFile: win.HANDLE, lpBuffer: [*]u8, nNumberOfBytesToRead: u32, lpNumberOfBytesRead: *u32, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
 extern "kernel32" fn WriteFile(hFile: win.HANDLE, lpBuffer: [*]const u8, nNumberOfBytesToWrite: u32, lpNumberOfBytesWritten: *u32, lpOverlapped: ?*anyopaque) callconv(.winapi) win.BOOL;
 extern "kernel32" fn LocalFree(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+extern "advapi32" fn OpenProcessToken(ProcessHandle: win.HANDLE, DesiredAccess: u32, TokenHandle: *win.HANDLE) callconv(.winapi) win.BOOL;
+extern "advapi32" fn GetTokenInformation(TokenHandle: win.HANDLE, TokenInformationClass: u32, TokenInformation: ?*anyopaque, TokenInformationLength: u32, ReturnLength: *u32) callconv(.winapi) win.BOOL;
+extern "advapi32" fn EqualSid(pSid1: ?*anyopaque, pSid2: ?*anyopaque) callconv(.winapi) win.BOOL;
+extern "advapi32" fn ConvertSidToStringSidA(Sid: ?*anyopaque, StringSid: *?[*:0]u8) callconv(.winapi) win.BOOL;
 extern "advapi32" fn ConvertStringSecurityDescriptorToSecurityDescriptorA(
     sddl: [*:0]const u8,
     revision: u32,
     sd: *?*anyopaque,
     sd_size: ?*u32,
 ) callconv(.winapi) win.BOOL;
+extern "advapi32" fn SystemFunction036(RandomBuffer: ?*anyopaque, RandomBufferLength: u32) callconv(.winapi) win.BOOL;
+
+const SID_AND_ATTRIBUTES = extern struct {
+    Sid: ?*anyopaque,
+    Attributes: u32,
+};
+
+const TOKEN_USER = extern struct {
+    User: SID_AND_ATTRIBUTES,
+};
 
 /// How often a long-lived serve/mcp daemon that lost the CLI socket bind
 /// re-attempts it (see cliAcquireListener) — one second, matching the daemons'
@@ -105,10 +126,177 @@ pub fn cliSocketPath(buf: []u8, abs_root: []const u8) ?[]const u8 {
     return std.fmt.bufPrint(buf, "/tmp/codedb-{d}-{x:0>16}.sock", .{ uid, hash }) catch null;
 }
 
-fn cliPipeName(buf: []u8, abs_root: []const u8) ?[:0]const u8 {
-    const hash = std.hash.Wyhash.hash(0xc0de, abs_root);
-    const user_hash = std.hash.Wyhash.hash(0xc0de, cio.posixGetenv("USERNAME") orelse "");
-    return std.fmt.bufPrintZ(buf, "\\\\.\\pipe\\codedb-{x:0>16}-{x:0>16}", .{ hash, user_hash }) catch null;
+const cli_pipe_metadata_filename = "cli-daemon.pipe";
+
+fn cliPipeMetadataPath(allocator: std.mem.Allocator, data_dir: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ data_dir, cli_pipe_metadata_filename });
+}
+
+fn cliRandomPipeName(buf: []u8) ?[:0]const u8 {
+    return std.fmt.bufPrintZ(buf, "\\\\.\\pipe\\codedb-{d}-{x:0>16}-{x:0>16}", .{
+        cio.currentProcessId(),
+        secureRandomU64(),
+        secureRandomU64(),
+    }) catch null;
+}
+
+fn secureRandomU64() u64 {
+    var bytes: [8]u8 = undefined;
+    if (SystemFunction036(&bytes, bytes.len) != .FALSE) {
+        return std.mem.readInt(u64, &bytes, .little);
+    }
+    return cio.randU64();
+}
+
+const CliPipeMetadata = struct {
+    pid: u32,
+    pipe_name: []const u8,
+};
+
+pub fn parseCliPipeMetadata(text: []const u8) ?CliPipeMetadata {
+    var pid: ?u32 = null;
+    var pipe_name: ?[]const u8 = null;
+
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (std.mem.startsWith(u8, line, "pid=")) {
+            pid = std.fmt.parseInt(u32, line["pid=".len..], 10) catch return null;
+        } else if (std.mem.startsWith(u8, line, "pipe=")) {
+            const value = line["pipe=".len..];
+            if (!std.mem.startsWith(u8, value, "\\\\.\\pipe\\codedb-")) return null;
+            pipe_name = value;
+        }
+    }
+
+    const parsed_pid = pid orelse return null;
+    if (parsed_pid == 0) return null;
+    return .{ .pid = parsed_pid, .pipe_name = pipe_name orelse return null };
+}
+
+pub fn cliPipeMetadataMatchesOwner(text: []const u8, pid: u32, pipe_name: []const u8) bool {
+    const metadata = parseCliPipeMetadata(text) orelse return false;
+    return metadata.pid == pid and std.mem.eql(u8, metadata.pipe_name, pipe_name);
+}
+
+fn writeCliPipeMetadata(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8, pid: u32, pipe_name: []const u8) bool {
+    const path = cliPipeMetadataPath(allocator, data_dir) catch return false;
+    defer allocator.free(path);
+    const content = std.fmt.allocPrint(allocator, "pid={d}\npipe={s}\n", .{ pid, pipe_name }) catch return false;
+    defer allocator.free(content);
+    const f = std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true }) catch return false;
+    defer f.close(io);
+    f.writePositionalAll(io, content, 0) catch return false;
+    return true;
+}
+
+fn deleteCliPipeMetadataIfOwner(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8, pid: u32, pipe_name: []const u8) void {
+    const path = cliPipeMetadataPath(allocator, data_dir) catch return;
+    defer allocator.free(path);
+    const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1024)) catch return;
+    defer allocator.free(content);
+    if (!cliPipeMetadataMatchesOwner(content, pid, pipe_name)) return;
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+}
+
+fn readCliPipeMetadata(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) ?[]u8 {
+    const path = cliPipeMetadataPath(allocator, data_dir) catch return null;
+    defer allocator.free(path);
+    return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1024)) catch null;
+}
+
+fn windowsPathZ(allocator: std.mem.Allocator, path: []const u8) ?[:0]u16 {
+    return std.unicode.utf8ToUtf16LeAllocZ(allocator, path) catch null;
+}
+
+const TokenSid = struct {
+    bytes: []u8,
+    sid: ?*anyopaque,
+};
+
+fn tokenSid(allocator: std.mem.Allocator, token: win.HANDLE) ?TokenSid {
+    var needed: u32 = 0;
+    _ = GetTokenInformation(token, TokenUser, null, 0, &needed);
+    if (needed == 0) return null;
+    const bytes = allocator.alloc(u8, needed) catch return null;
+    if (GetTokenInformation(token, TokenUser, bytes.ptr, needed, &needed) == .FALSE) {
+        allocator.free(bytes);
+        return null;
+    }
+    const user: *TOKEN_USER = @ptrCast(@alignCast(bytes.ptr));
+    return .{ .bytes = bytes, .sid = user.User.Sid };
+}
+
+fn currentUserSidString(allocator: std.mem.Allocator) ?[]u8 {
+    var token: win.HANDLE = undefined;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token) == .FALSE) return null;
+    defer win.CloseHandle(token);
+
+    const sid_info = tokenSid(allocator, token) orelse return null;
+    defer allocator.free(sid_info.bytes);
+
+    var sid_z: ?[*:0]u8 = null;
+    if (ConvertSidToStringSidA(sid_info.sid, &sid_z) == .FALSE) return null;
+    defer _ = LocalFree(sid_z);
+    return allocator.dupe(u8, std.mem.span(sid_z.?)) catch null;
+}
+
+fn currentUserPipeSddl(allocator: std.mem.Allocator) ?[:0]u8 {
+    const sid = currentUserSidString(allocator) orelse return null;
+    defer allocator.free(sid);
+    const sddl = std.fmt.allocPrint(allocator, "D:P(A;;GA;;;{s})S:(ML;;NW;;;ME)", .{sid}) catch return null;
+    defer allocator.free(sddl);
+    return allocator.dupeZ(u8, sddl) catch null;
+}
+
+fn processUserMatchesCurrent(allocator: std.mem.Allocator, pid: u32) bool {
+    const process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, .FALSE, pid) orelse return false;
+    defer win.CloseHandle(process);
+
+    var process_token: win.HANDLE = undefined;
+    if (OpenProcessToken(process, TOKEN_QUERY, &process_token) == .FALSE) return false;
+    defer win.CloseHandle(process_token);
+
+    var current_token: win.HANDLE = undefined;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &current_token) == .FALSE) return false;
+    defer win.CloseHandle(current_token);
+
+    const process_sid = tokenSid(allocator, process_token) orelse return false;
+    defer allocator.free(process_sid.bytes);
+    const current_sid = tokenSid(allocator, current_token) orelse return false;
+    defer allocator.free(current_sid.bytes);
+
+    return EqualSid(process_sid.sid, current_sid.sid) != .FALSE;
+}
+
+fn pipeServerTrusted(allocator: std.mem.Allocator, pipe: win.HANDLE, expected_pid: u32) bool {
+    var server_pid: u32 = 0;
+    if (GetNamedPipeServerProcessId(pipe, &server_pid) == .FALSE) return false;
+    if (server_pid == 0 or server_pid != expected_pid) return false;
+    return processUserMatchesCurrent(allocator, server_pid);
+}
+
+fn pipeRetryDelayMs(failures: u32) u64 {
+    const capped: u64 = @min(@as(u64, failures), 50);
+    return 100 * capped;
+}
+
+fn shouldLogPipeRetry(failures: u32) bool {
+    return failures == 1 or failures % 50 == 0;
+}
+
+fn createCliPipeInstance(pipe_name: [:0]const u8, first_instance: bool, sa_pipe: *win.SECURITY_ATTRIBUTES) win.HANDLE {
+    const first_flag: u32 = if (first_instance) FILE_FLAG_FIRST_PIPE_INSTANCE else 0;
+    return CreateNamedPipeA(
+        pipe_name.ptr,
+        PIPE_ACCESS_DUPLEX | first_flag,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+        PIPE_UNLIMITED_INSTANCES,
+        cli_blob_max + 5,
+        cli_blob_max + 5,
+        0,
+        sa_pipe,
+    );
 }
 
 /// Fill a sockaddr.un for `path` (which must be NUL-terminatable into sun_path).
@@ -191,7 +379,9 @@ pub fn daemonLockTryAcquire(data_dir: []const u8) ?DaemonLock {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const p = std.fmt.bufPrintZ(&buf, "{s}/cli-daemon.lock", .{data_dir}) catch return null;
     if (builtin.os.tag == .windows) {
-        const handle = CreateFileA(p.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_ALWAYS, 0, null);
+        const path_w = windowsPathZ(std.heap.page_allocator, p) orelse return null;
+        defer std.heap.page_allocator.free(path_w);
+        const handle = CreateFileW(path_w.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_ALWAYS, 0, null);
         if (handle == INVALID_HANDLE_VALUE) return null;
         return handle;
     }
@@ -302,16 +492,17 @@ pub fn cliAcquireListener(sock_path: []const u8, retry: bool, retry_interval_ms:
 /// auto-spawned cli-daemon passes `false` and gets `shutdown` set so it exits
 /// promptly; the long-lived serve/mcp daemons pass `true` and keep reclaiming
 /// the socket when the previous owner exits instead of disabling the proxy.
-pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, last_activity_ms: *std.atomic.Value(i64), shutdown: *std.atomic.Value(bool), retry: bool) void {
+pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, data_dir: []const u8, last_activity_ms: *std.atomic.Value(i64), shutdown: *std.atomic.Value(bool), retry: bool) void {
     if (builtin.os.tag == .windows) {
         var name_buf: [256]u8 = undefined;
-        const pipe_name = cliPipeName(&name_buf, abs_root) orelse {
+
+        const sddl = currentUserPipeSddl(allocator) orelse {
             shutdown.store(true, .release);
             return;
         };
-
+        defer allocator.free(sddl);
         var sd: ?*anyopaque = null;
-        if (ConvertStringSecurityDescriptorToSecurityDescriptorA("D:P(A;;GA;;;OW)", SDDL_REVISION_1, &sd, null) == .FALSE) {
+        if (ConvertStringSecurityDescriptorToSecurityDescriptorA(sddl.ptr, SDDL_REVISION_1, &sd, null) == .FALSE) {
             shutdown.store(true, .release);
             return;
         }
@@ -322,25 +513,69 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
             .bInheritHandle = .FALSE,
         };
 
+        var pipe_name: ?[:0]const u8 = null;
+        var listening_pipe: ?win.HANDLE = null;
+        var metadata_written = false;
+        var retry_failures: u32 = 0;
+        var first_pipe_instance = true;
+        const listener_pid = cio.currentProcessId();
+        defer if (listening_pipe) |pipe| win.CloseHandle(pipe);
+        defer if (metadata_written and pipe_name != null) deleteCliPipeMetadataIfOwner(io, allocator, data_dir, listener_pid, pipe_name.?);
+
         while (!shutdown.load(.acquire)) {
-            const pipe = CreateNamedPipeA(
-                pipe_name.ptr,
-                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
-                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-                PIPE_UNLIMITED_INSTANCES,
-                cli_blob_max + 5,
-                cli_blob_max + 5,
-                0,
-                &sa_pipe,
-            );
-            if (pipe == INVALID_HANDLE_VALUE) {
-                shutdown.store(true, .release);
-                return;
+            if (pipe_name == null) {
+                pipe_name = cliRandomPipeName(&name_buf) orelse {
+                    shutdown.store(true, .release);
+                    return;
+                };
             }
+            if (listening_pipe == null) {
+                const new_pipe = createCliPipeInstance(pipe_name.?, first_pipe_instance, &sa_pipe);
+                if (new_pipe == INVALID_HANDLE_VALUE) {
+                    if (!metadata_written) pipe_name = null;
+                    retry_failures = retry_failures +| 1;
+                    if (shouldLogPipeRetry(retry_failures)) {
+                        std.log.warn("cli-proxy: CreateNamedPipe failed {d} time(s); retrying", .{retry_failures});
+                    }
+                    cio.sleepMs(pipeRetryDelayMs(retry_failures));
+                    continue;
+                }
+                listening_pipe = new_pipe;
+                first_pipe_instance = false;
+            }
+            retry_failures = 0;
+            if (!metadata_written) {
+                if (!writeCliPipeMetadata(io, allocator, data_dir, listener_pid, pipe_name.?)) {
+                    win.CloseHandle(listening_pipe.?);
+                    listening_pipe = null;
+                    pipe_name = null;
+                    first_pipe_instance = true;
+                    retry_failures = retry_failures +| 1;
+                    if (shouldLogPipeRetry(retry_failures)) {
+                        std.log.warn("cli-proxy: could not publish pipe metadata {d} time(s); retrying", .{retry_failures});
+                    }
+                    cio.sleepMs(pipeRetryDelayMs(retry_failures));
+                    continue;
+                }
+                metadata_written = true;
+                retry_failures = 0;
+            }
+            const pipe = listening_pipe.?;
+            listening_pipe = null;
             const connected = ConnectNamedPipe(pipe, null) != .FALSE or win.GetLastError() == .PIPE_CONNECTED;
             if (!connected) {
                 win.CloseHandle(pipe);
                 continue;
+            }
+            const next_pipe = createCliPipeInstance(pipe_name.?, false, &sa_pipe);
+            if (next_pipe != INVALID_HANDLE_VALUE) {
+                listening_pipe = next_pipe;
+                retry_failures = 0;
+            } else {
+                retry_failures = retry_failures +| 1;
+                if (shouldLogPipeRetry(retry_failures)) {
+                    std.log.warn("cli-proxy: CreateNamedPipe replacement failed {d} time(s); retrying", .{retry_failures});
+                }
             }
             last_activity_ms.store(cio.milliTimestamp(), .release);
             cliServeConn(io, allocator, explorer, store, abs_root, pipe);
@@ -466,11 +701,10 @@ fn cliRespond(conn: CliConn, code: u8, out_bytes: []const u8) void {
 /// code. On ANY failure (no daemon, connect refused, short read, oversized
 /// response) returns null so the caller falls back to the cold in-process path.
 /// `args` is mainImpl's filtered argv (args[0] = program name); we send args[1..].
-pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, args: []const []const u8, color: bool) ?u8 {
-    _ = io;
+pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8, args: []const []const u8, color: bool) ?u8 {
     if (args.len < 2) return null;
 
-    const conn = cliConnect(abs_root) orelse return null;
+    const conn = cliConnect(io, allocator, abs_root, data_dir) orelse return null;
     defer cliCloseConn(conn);
 
     // Build the NUL-joined blob from args[1..].
@@ -505,12 +739,20 @@ pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u
     return code;
 }
 
-fn cliConnect(abs_root: []const u8) ?CliConn {
+fn cliConnect(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8) ?CliConn {
     if (builtin.os.tag == .windows) {
-        var name_buf: [256]u8 = undefined;
-        const pipe_name = cliPipeName(&name_buf, abs_root) orelse return null;
-        const pipe = CreateFileA(pipe_name.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_EXISTING, SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, null);
+        const dir = data_dir orelse return null;
+        const metadata_text = readCliPipeMetadata(io, allocator, dir) orelse return null;
+        defer allocator.free(metadata_text);
+        const metadata = parseCliPipeMetadata(metadata_text) orelse return null;
+        const pipe_name_w = windowsPathZ(allocator, metadata.pipe_name) orelse return null;
+        defer allocator.free(pipe_name_w);
+        const pipe = CreateFileW(pipe_name_w.ptr, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_EXISTING, SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, null);
         if (pipe == INVALID_HANDLE_VALUE) return null;
+        if (!pipeServerTrusted(allocator, pipe, metadata.pid)) {
+            win.CloseHandle(pipe);
+            return null;
+        }
         return pipe;
     }
     var path_buf: [128]u8 = undefined;

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -297,7 +297,7 @@ pub fn runCliDaemon(ctx: *RunCtx) !void {
     // already owns the socket (we lost the bind race), cliDaemonListen sets
     // shutdown and the watchdog below returns at once, so the redundant
     // daemon exits instead of lingering idle.
-    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, &last_activity_ms, &shutdown, false })) |cli_t| {
+    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, data_dir, &last_activity_ms, &shutdown, false })) |cli_t| {
         cli_t.detach();
     } else |err| {
         std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
@@ -372,7 +372,7 @@ pub fn runServe(ctx: *RunCtx) !void {
     // on this same stack frame for the whole process lifetime.
     var cli_activity = std.atomic.Value(i64).init(cio.milliTimestamp());
     var cli_listener_dead = std.atomic.Value(bool).init(false);
-    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, &cli_activity, &cli_listener_dead, true })) |cli_t| {
+    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, data_dir, &cli_activity, &cli_listener_dead, true })) |cli_t| {
         cli_t.detach();
     } else |err| {
         std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
@@ -480,7 +480,7 @@ pub fn runMcp(ctx: *RunCtx) !void {
     // on this same stack frame for the whole process lifetime.
     var cli_activity = std.atomic.Value(i64).init(cio.milliTimestamp());
     var cli_listener_dead = std.atomic.Value(bool).init(false);
-    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, &cli_activity, &cli_listener_dead, true })) |cli_t| {
+    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, data_dir, &cli_activity, &cli_listener_dead, true })) |cli_t| {
         cli_t.detach();
     } else |err| {
         std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2822,18 +2822,17 @@ pub const Explorer = struct {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
-        var list: std.ArrayList(ScoredSymbolResult) = .empty;
-        errdefer {
-            for (list.items) |r| {
-                allocator.free(r.path);
-                allocator.free(r.symbol.name);
-                if (r.symbol.detail) |d| allocator.free(d);
-            }
-            list.deinit(allocator);
-        }
+        const Candidate = struct {
+            path: []const u8,
+            symbol: Symbol,
+            score: f32,
+        };
+
+        var candidates: std.ArrayList(Candidate) = .empty;
+        defer candidates.deinit(allocator);
 
         const Dedup = struct {
-            fn contains(items: []const ScoredSymbolResult, path: []const u8, line: u32) bool {
+            fn contains(items: []const Candidate, path: []const u8, line: u32) bool {
                 for (items) |r| {
                     if (r.symbol.line_start == line and std.mem.eql(u8, r.path, path)) return true;
                 }
@@ -2841,26 +2840,80 @@ pub const Explorer = struct {
             }
         };
 
+        const SortCtx = struct {
+            pub fn lessThan(_: void, a: Candidate, b: Candidate) bool {
+                if (a.score != b.score) return a.score > b.score;
+                const name_cmp = std.mem.order(u8, a.symbol.name, b.symbol.name);
+                if (name_cmp != .eq) return name_cmp == .lt;
+                return std.mem.order(u8, a.path, b.path) == .lt;
+            }
+
+            fn candidateBefore(a: Candidate, b: Candidate) bool {
+                return lessThan({}, a, b);
+            }
+        };
+
+        const freeOne = struct {
+            fn call(alloc: std.mem.Allocator, r: ScoredSymbolResult) void {
+                alloc.free(r.path);
+                alloc.free(r.symbol.name);
+                if (r.symbol.detail) |d| alloc.free(d);
+            }
+        }.call;
+
+        const cloneOne = struct {
+            fn call(alloc: std.mem.Allocator, candidate: Candidate) !ScoredSymbolResult {
+                const path_copy = try alloc.dupe(u8, candidate.path);
+                errdefer alloc.free(path_copy);
+                const name_copy = try alloc.dupe(u8, candidate.symbol.name);
+                errdefer alloc.free(name_copy);
+                var detail_copy: ?[]u8 = null;
+                errdefer if (detail_copy) |d| alloc.free(d);
+                if (candidate.symbol.detail) |d| {
+                    detail_copy = try alloc.dupe(u8, d);
+                }
+                return .{
+                    .path = path_copy,
+                    .symbol = .{
+                        .name = name_copy,
+                        .kind = candidate.symbol.kind,
+                        .line_start = candidate.symbol.line_start,
+                        .line_end = candidate.symbol.line_end,
+                        .detail = detail_copy,
+                    },
+                    .score = candidate.score,
+                };
+            }
+        }.call;
+
         const appendOne = struct {
             fn call(
-                list_ptr: *std.ArrayList(ScoredSymbolResult),
+                list_ptr: *std.ArrayList(Candidate),
                 alloc: std.mem.Allocator,
+                max_results: usize,
                 path: []const u8,
                 sym: Symbol,
                 score: f32,
             ) !void {
+                if (max_results == 0) return;
                 if (Dedup.contains(list_ptr.items, path, sym.line_start)) return;
-                try list_ptr.append(alloc, .{
-                    .path = try alloc.dupe(u8, path),
-                    .symbol = .{
-                        .name = try alloc.dupe(u8, sym.name),
-                        .kind = sym.kind,
-                        .line_start = sym.line_start,
-                        .line_end = sym.line_end,
-                        .detail = if (sym.detail) |d| try alloc.dupe(u8, d) else null,
-                    },
+                const candidate: Candidate = .{
+                    .path = path,
+                    .symbol = sym,
                     .score = score,
-                });
+                };
+                if (list_ptr.items.len >= max_results and
+                    !SortCtx.candidateBefore(candidate, list_ptr.items[list_ptr.items.len - 1]))
+                {
+                    return;
+                }
+
+                if (list_ptr.items.len < max_results) {
+                    try list_ptr.append(alloc, candidate);
+                } else {
+                    list_ptr.items[list_ptr.items.len - 1] = candidate;
+                }
+                std.mem.sort(Candidate, list_ptr.items, {}, SortCtx.lessThan);
             }
         }.call;
 
@@ -2879,16 +2932,14 @@ pub const Explorer = struct {
                         }
                     }
                 }
-                try appendOne(&list, allocator, loc.path, .{
+                try appendOne(&candidates, allocator, spec.max_results, loc.path, .{
                     .name = sym_name,
                     .kind = loc.kind,
                     .line_start = loc.line_start,
                     .line_end = loc.line_end,
                     .detail = detail,
                 }, score);
-                if (list.items.len >= spec.max_results) break;
             }
-            if (list.items.len >= spec.max_results) break;
         }
 
         var ol_iter = self.outlines.iterator();
@@ -2896,24 +2947,24 @@ pub const Explorer = struct {
             for (entry.value_ptr.symbols.items) |sym| {
                 const score = symbolMatchScore(spec, sym.name) orelse continue;
                 if (spec.kind) |k| if (sym.kind != k) continue;
-                if (Dedup.contains(list.items, entry.key_ptr.*, sym.line_start)) continue;
-                try appendOne(&list, allocator, entry.key_ptr.*, sym, score);
-                if (list.items.len >= spec.max_results) break;
+                if (Dedup.contains(candidates.items, entry.key_ptr.*, sym.line_start)) continue;
+                try appendOne(&candidates, allocator, spec.max_results, entry.key_ptr.*, sym, score);
             }
-            if (list.items.len >= spec.max_results) break;
         }
 
-        const SortCtx = struct {
-            pub fn lessThan(_: void, a: ScoredSymbolResult, b: ScoredSymbolResult) bool {
-                if (a.score != b.score) return a.score > b.score;
-                const name_cmp = std.mem.order(u8, a.symbol.name, b.symbol.name);
-                if (name_cmp != .eq) return name_cmp == .lt;
-                return std.mem.order(u8, a.path, b.path) == .lt;
-            }
-        };
-        std.mem.sort(ScoredSymbolResult, list.items, {}, SortCtx.lessThan);
-        if (list.items.len > spec.max_results) list.shrinkRetainingCapacity(spec.max_results);
-        return list.toOwnedSlice(allocator);
+        std.mem.sort(Candidate, candidates.items, {}, SortCtx.lessThan);
+
+        const results = try allocator.alloc(ScoredSymbolResult, candidates.items.len);
+        errdefer allocator.free(results);
+        var result_len: usize = 0;
+        errdefer {
+            for (results[0..result_len]) |r| freeOne(allocator, r);
+        }
+        for (candidates.items) |candidate| {
+            results[result_len] = try cloneOne(allocator, candidate);
+            result_len += 1;
+        }
+        return results;
     }
 
     // Resolve an exact symbol name to its definition sites for codedb_find's

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -4209,16 +4209,16 @@ pub const Explorer = struct {
         @memcpy(buf[pos..][0..close.len], close);
         pos += close.len;
 
-        var file = std.Io.Dir.cwd().openFile(io_inst, path, .{ .mode = .write_only }) catch blk: {
-            break :blk std.Io.Dir.cwd().createFile(io_inst, path, .{ .truncate = false }) catch return;
-        };
+        // Windows requires read access on the handle for length(), even though
+        // the trace path only appends with positional writes.
+        var file = std.Io.Dir.cwd().createFile(io_inst, path, .{ .read = true, .truncate = false }) catch return;
         var current_size = file.length(io_inst) catch {
             file.close(io_inst);
             return;
         };
         if (current_size >= size_limit) {
             file.close(io_inst);
-            file = std.Io.Dir.cwd().createFile(io_inst, path, .{ .truncate = true }) catch return;
+            file = std.Io.Dir.cwd().createFile(io_inst, path, .{ .read = true, .truncate = true }) catch return;
             current_size = 0;
         }
         defer file.close(io_inst);

--- a/src/git.zig
+++ b/src/git.zig
@@ -7,7 +7,7 @@ const cio = @import("cio.zig");
 pub fn getGitHead(root: []const u8, allocator: std.mem.Allocator) !?[40]u8 {
     const result = cio.runCapture(.{
         .allocator = allocator,
-        .argv = &.{ "git", "rev-parse", "HEAD" },
+        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=", "rev-parse", "HEAD" },
         .cwd = root,
         .max_output_bytes = 256,
     }) catch return null;
@@ -155,7 +155,7 @@ pub fn buildCoChange(
     const nstr = std.fmt.bufPrint(&nbuf, "{d}", .{max_commits}) catch return null;
     const result = cio.runCapture(.{
         .allocator = allocator,
-        .argv = &.{ "git", "log", "--name-only", "--no-merges", "--pretty=format:%H", "-n", nstr },
+        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=", "log", "--name-only", "--no-merges", "--pretty=format:%H", "-n", nstr },
         .cwd = root,
         .max_output_bytes = 8 * 1024 * 1024,
     }) catch return null;

--- a/src/git.zig
+++ b/src/git.zig
@@ -1,13 +1,15 @@
 const std = @import("std");
 const cio = @import("cio.zig");
 
+const disabled_hooks_config = "core.hooksPath=/codedb-hooks-disabled-do-not-exist";
+
 /// Run `git rev-parse HEAD` in `root` and return the 40-char hex SHA.
 /// Returns null if `root` is not a git repo, git is unavailable, or HEAD
 /// has no commit yet (fresh repo).
 pub fn getGitHead(root: []const u8, allocator: std.mem.Allocator) !?[40]u8 {
     const result = cio.runCapture(.{
         .allocator = allocator,
-        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=", "rev-parse", "HEAD" },
+        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", disabled_hooks_config, "rev-parse", "HEAD" },
         .cwd = root,
         .max_output_bytes = 256,
     }) catch return null;
@@ -155,7 +157,7 @@ pub fn buildCoChange(
     const nstr = std.fmt.bufPrint(&nbuf, "{d}", .{max_commits}) catch return null;
     const result = cio.runCapture(.{
         .allocator = allocator,
-        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=", "log", "--name-only", "--no-merges", "--pretty=format:%H", "-n", nstr },
+        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", disabled_hooks_config, "log", "--name-only", "--no-merges", "--pretty=format:%H", "-n", nstr },
         .cwd = root,
         .max_output_bytes = 8 * 1024 * 1024,
     }) catch return null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -358,7 +358,10 @@ fn mainImpl() !void {
     // despite the variable (observed while profiling #564: a stray cli-daemon
     // served 'search' in 944µs with the variable set).
     if (cliIsQueryCmd(cmd) and cio.posixGetenv("CODEDB_NO_CLI_DAEMON") == null) {
-        if (cliTryProxy(io, allocator, abs_root, args, use_color)) |code| {
+        const probe_dir = if (abs_root.len > 0) getDataDir(io, allocator, abs_root) catch null else null;
+        defer if (probe_dir) |d| allocator.free(d);
+
+        if (cliTryProxy(io, allocator, abs_root, probe_dir, args, use_color)) |code| {
             out.flush();
             std.process.exit(code);
         }
@@ -373,8 +376,6 @@ fn mainImpl() !void {
         // duplicate rescans the index, and the stampede leaves orphans churning
         // CPU. Losers of this probe simply cold-serve their one call.
         if (abs_root.len > 0) {
-            const probe_dir = getDataDir(io, allocator, abs_root) catch null;
-            defer if (probe_dir) |d| allocator.free(d);
             const lock_free = if (probe_dir) |d| daemonLockAvailable(d) else true;
             if (lock_free) {
                 if (std.process.executablePathAlloc(io, allocator)) |self_exe| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -358,8 +358,12 @@ fn mainImpl() !void {
     // despite the variable (observed while profiling #564: a stray cli-daemon
     // served 'search' in 944µs with the variable set).
     if (cliIsQueryCmd(cmd) and cio.posixGetenv("CODEDB_NO_CLI_DAEMON") == null) {
-        const probe_dir = if (abs_root.len > 0) getDataDir(io, allocator, abs_root) catch null else null;
+        var probe_dir: ?[]u8 = null;
         defer if (probe_dir) |d| allocator.free(d);
+
+        if (builtin.os.tag == .windows and abs_root.len > 0) {
+            probe_dir = getDataDir(io, allocator, abs_root) catch null;
+        }
 
         if (cliTryProxy(io, allocator, abs_root, probe_dir, args, use_color)) |code| {
             out.flush();
@@ -376,7 +380,10 @@ fn mainImpl() !void {
         // duplicate rescans the index, and the stampede leaves orphans churning
         // CPU. Losers of this probe simply cold-serve their one call.
         if (abs_root.len > 0) {
-            const lock_free = if (probe_dir) |d| daemonLockAvailable(d) else true;
+            if (probe_dir == null) {
+                probe_dir = getDataDir(io, allocator, abs_root) catch null;
+            }
+            const lock_free = if (probe_dir) |d| daemonLockAvailable(d) else false;
             if (lock_free) {
                 if (std.process.executablePathAlloc(io, allocator)) |self_exe| {
                     defer allocator.free(self_exe);

--- a/src/main.zig
+++ b/src/main.zig
@@ -118,6 +118,7 @@ const runQuery = query_mod.runQuery;
 
 const cli_proxy = @import("cli_proxy.zig");
 pub const daemonLockTryAcquire = cli_proxy.daemonLockTryAcquire;
+pub const daemonLockRelease = cli_proxy.daemonLockRelease;
 pub const daemonLockAvailable = cli_proxy.daemonLockAvailable;
 const cliTryProxy = cli_proxy.cliTryProxy;
 

--- a/src/nuke.zig
+++ b/src/nuke.zig
@@ -6,10 +6,14 @@ const win = std.os.windows;
 
 const PROCESS_TERMINATE: u32 = 0x0001;
 const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x00001000;
+const SYNCHRONIZE: u32 = 0x00100000;
+const WAIT_OBJECT_0: u32 = 0x00000000;
+const daemon_terminate_wait_ms: u32 = 5000;
 
 extern "kernel32" fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: win.BOOL, dwProcessId: u32) callconv(.winapi) ?win.HANDLE;
 extern "kernel32" fn QueryFullProcessImageNameW(hProcess: win.HANDLE, dwFlags: u32, lpExeName: [*]u16, lpdwSize: *u32) callconv(.winapi) win.BOOL;
 extern "kernel32" fn TerminateProcess(hProcess: win.HANDLE, uExitCode: u32) callconv(.winapi) win.BOOL;
+extern "kernel32" fn WaitForSingleObject(hHandle: win.HANDLE, dwMilliseconds: u32) callconv(.winapi) u32;
 
 const Out = struct {
     file: cio.File,
@@ -161,14 +165,15 @@ fn parseWindowsDaemonPid(text: []const u8) ?u32 {
 }
 
 fn terminateWindowsProcessIfMatches(allocator: std.mem.Allocator, pid: u32, expected_exe: []const u8) bool {
-    const process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, .FALSE, pid) orelse return false;
+    const process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE, .FALSE, pid) orelse return false;
     defer win.CloseHandle(process);
 
     const image_path = windowsProcessImagePath(allocator, process) orelse return false;
     defer allocator.free(image_path);
     if (!windowsPathsEqual(allocator, image_path, expected_exe)) return false;
 
-    return TerminateProcess(process, 0) != .FALSE;
+    if (TerminateProcess(process, 0) == .FALSE) return false;
+    return WaitForSingleObject(process, daemon_terminate_wait_ms) == WAIT_OBJECT_0;
 }
 
 fn windowsProcessImagePath(allocator: std.mem.Allocator, process: win.HANDLE) ?[]u8 {

--- a/src/nuke.zig
+++ b/src/nuke.zig
@@ -1,6 +1,15 @@
 const std = @import("std");
 const cio = @import("cio.zig");
 const sty = @import("style.zig");
+const builtin = @import("builtin");
+const win = std.os.windows;
+
+const PROCESS_TERMINATE: u32 = 0x0001;
+const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x00001000;
+
+extern "kernel32" fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: win.BOOL, dwProcessId: u32) callconv(.winapi) ?win.HANDLE;
+extern "kernel32" fn QueryFullProcessImageNameW(hProcess: win.HANDLE, dwFlags: u32, lpExeName: [*]u16, lpdwSize: *u32) callconv(.winapi) win.BOOL;
+extern "kernel32" fn TerminateProcess(hProcess: win.HANDLE, uExitCode: u32) callconv(.winapi) win.BOOL;
 
 const Out = struct {
     file: cio.File,
@@ -38,8 +47,8 @@ pub fn run(io: std.Io, stdout: cio.File, s: sty.Style, allocator: std.mem.Alloca
 
     var stats = NukeStats{};
 
-    const self_pid = std.c.getpid();
-    stats.killed_processes = killOtherCodedbProcesses(allocator, self_pid, self_exe);
+    const self_pid = cio.currentProcessId();
+    stats.killed_processes = killOtherCodedbProcesses(io, allocator, home, self_pid, self_exe);
     stats.integrations_removed = deregisterInstalledIntegrations(io, allocator, home);
     stats.snapshots_removed = removeRegisteredSnapshots(io, allocator, home);
 
@@ -74,10 +83,9 @@ pub fn run(io: std.Io, stdout: cio.File, s: sty.Style, allocator: std.mem.Alloca
     out.p("\n  to reinstall: {s}curl -fsSL https://codedb.codegraff.com/install.sh | bash{s}\n", .{ s.cyan, s.reset });
 }
 
-fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t, self_exe: ?[]const u8) usize {
-    if (@import("builtin").os.tag == .windows) {
-        // pgrep/kill/ps are POSIX-only; there is no warm daemon to reap on Windows.
-        return 0;
+fn killOtherCodedbProcesses(io: std.Io, allocator: std.mem.Allocator, home: []const u8, self_pid: u32, self_exe: ?[]const u8) usize {
+    if (builtin.os.tag == .windows) {
+        return killWindowsMetadataProcesses(io, allocator, home, self_pid, self_exe);
     } else {
         const executable_path = self_exe orelse return 0;
         var killed: usize = 0;
@@ -114,6 +122,77 @@ fn killOtherCodedbProcesses(allocator: std.mem.Allocator, self_pid: std.c.pid_t,
 
         return killed;
     }
+}
+
+fn killWindowsMetadataProcesses(io: std.Io, allocator: std.mem.Allocator, home: []const u8, self_pid: u32, self_exe: ?[]const u8) usize {
+    if (builtin.os.tag != .windows) return 0;
+    const executable_path = self_exe orelse return 0;
+    const projects_dir = std.fmt.allocPrint(allocator, "{s}/.codedb/projects", .{home}) catch return 0;
+    defer allocator.free(projects_dir);
+
+    var dir = std.Io.Dir.cwd().openDir(io, projects_dir, .{ .iterate = true }) catch return 0;
+    defer dir.close(io);
+
+    var killed: usize = 0;
+    var iter = dir.iterate();
+    while (iter.next(io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const metadata_path = std.fmt.allocPrint(allocator, "{s}/{s}/cli-daemon.pipe", .{ projects_dir, entry.name }) catch continue;
+        defer allocator.free(metadata_path);
+        const metadata = std.Io.Dir.cwd().readFileAlloc(io, metadata_path, allocator, .limited(1024)) catch continue;
+        defer allocator.free(metadata);
+        const pid = parseWindowsDaemonPid(metadata) orelse continue;
+        if (pid == 0 or pid == self_pid) continue;
+        if (terminateWindowsProcessIfMatches(allocator, pid, executable_path)) killed += 1;
+    }
+    return killed;
+}
+
+fn parseWindowsDaemonPid(text: []const u8) ?u32 {
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (!std.mem.startsWith(u8, line, "pid=")) continue;
+        const pid = std.fmt.parseInt(u32, line["pid=".len..], 10) catch return null;
+        if (pid == 0) return null;
+        return pid;
+    }
+    return null;
+}
+
+fn terminateWindowsProcessIfMatches(allocator: std.mem.Allocator, pid: u32, expected_exe: []const u8) bool {
+    const process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, .FALSE, pid) orelse return false;
+    defer win.CloseHandle(process);
+
+    const image_path = windowsProcessImagePath(allocator, process) orelse return false;
+    defer allocator.free(image_path);
+    if (!windowsPathsEqual(allocator, image_path, expected_exe)) return false;
+
+    return TerminateProcess(process, 0) != .FALSE;
+}
+
+fn windowsProcessImagePath(allocator: std.mem.Allocator, process: win.HANDLE) ?[]u8 {
+    var buf: [std.fs.max_path_bytes]u16 = undefined;
+    var len: u32 = @intCast(buf.len);
+    if (QueryFullProcessImageNameW(process, 0, &buf, &len) == .FALSE) return null;
+    return std.unicode.utf16LeToUtf8Alloc(allocator, buf[0..len]) catch null;
+}
+
+fn windowsPathsEqual(allocator: std.mem.Allocator, a: []const u8, b: []const u8) bool {
+    const norm_a = normalizeWindowsPathAlloc(allocator, a) orelse return false;
+    defer allocator.free(norm_a);
+    const norm_b = normalizeWindowsPathAlloc(allocator, b) orelse return false;
+    defer allocator.free(norm_b);
+    return std.ascii.eqlIgnoreCase(norm_a, norm_b);
+}
+
+fn normalizeWindowsPathAlloc(allocator: std.mem.Allocator, path: []const u8) ?[]u8 {
+    const trimmed = if (std.mem.startsWith(u8, path, "\\\\?\\")) path[4..] else path;
+    const out = allocator.dupe(u8, trimmed) catch return null;
+    for (out) |*ch| {
+        if (ch.* == '/') ch.* = '\\';
+    }
+    return out;
 }
 
 fn readProcessCommandLine(allocator: std.mem.Allocator, pid: []const u8) ?[]u8 {
@@ -290,7 +369,6 @@ fn rewriteConfigFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8,
     }
     try std.Io.Dir.rename(std.Io.Dir.cwd(), tmp_path, std.Io.Dir.cwd(), path, io);
 }
-
 
 pub fn removeJsonMcpServerEntry(allocator: std.mem.Allocator, content: []const u8, server_name: []const u8) !?[]u8 {
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch return null;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const cio = @import("cio.zig");
 const testing = std.testing;
 const io = std.testing.io;
@@ -1036,6 +1037,8 @@ test "explorer: searchContentRegex no match" {
 
 
 test "git: getGitHead returns 40-char hex SHA in a git repo" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     // codedb itself is a git repo, so this should succeed
     const head = try git_mod.getGitHead(".", testing.allocator);
     try testing.expect(head != null);
@@ -1848,6 +1851,8 @@ test "issue-389: FilteredWalker yields symlinked source files" {
 
 
 test "issue-405: FilteredWalker walks directory symlinks safely (cycle + escape)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     // Follow-up to #389. The current FilteredWalker.next() (src/watcher.zig:319-323)
     // treats sym_link entries as files when statFile reports .file, but silently
     // drops sym_link entries whose target is a directory. Real repos rely on

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2240,6 +2240,35 @@ test "issue-531: searchSymbols fuzzy match" {
     try testing.expectEqualStrings("ensureCallGraph", results[0].symbol.name);
 }
 
+test "searchSymbols honors max_results as allocation work cap" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(testing.allocator);
+    const w = cio.listWriter(&src, testing.allocator);
+    var i: usize = 0;
+    while (i < 80) : (i += 1) {
+        w.print("pub fn broad_{d}() void {{}}\n", .{i}) catch return error.OutOfMemory;
+    }
+    try explorer_inst.indexFile("many.zig", src.items);
+
+    var limited = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 24 });
+    const results = try explorer_inst.searchSymbols(.{ .kind = .function, .max_results = 3 }, limited.allocator());
+    defer {
+        for (results) |r| {
+            limited.allocator().free(r.path);
+            limited.allocator().free(r.symbol.name);
+            if (r.symbol.detail) |d| limited.allocator().free(d);
+        }
+        limited.allocator().free(results);
+    }
+    try testing.expectEqual(@as(usize, 3), results.len);
+    try testing.expectEqualStrings("broad_0", results[0].symbol.name);
+    try testing.expectEqualStrings("broad_1", results[1].symbol.name);
+    try testing.expectEqualStrings("broad_10", results[2].symbol.name);
+}
+
 // ─── audit (2026-06-09): latent-issue sweep — call-graph phantom edges ───
 // src/codegraph.zig extractCallees paired every '(' with the preceding identifier with
 // no comment/string stripping, so a name mentioned only in a // comment surfaced as a

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -499,8 +499,18 @@ test "file versions: countSince" {
     try testing.expect(fv.countSince(10) == 0);
 }
 
+// EventQueue intentionally carries a large fixed ring; allocate it on the heap
+// so Windows smaller default test-thread stack still exercises the production
+// queue instead of failing in the stack probe.
+fn heapEventQueue() !*watcher.EventQueue {
+    const queue = try testing.allocator.create(watcher.EventQueue);
+    queue.* = .{};
+    return queue;
+}
+
 test "watcher: queue overflow is explicit" {
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
 
     var pushed: usize = 0;
     while (true) : (pushed += 1) {
@@ -519,7 +529,8 @@ test "watcher: queue overflow is explicit" {
 }
 
 test "watcher: queue event copies path bytes" {
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
     const original = try testing.allocator.dupe(u8, "tmp/deleted.zig");
     try testing.expect(queue.push(watcher.FsEvent.init(original, .deleted, 99) orelse unreachable));
     testing.allocator.free(original);
@@ -949,7 +960,8 @@ test "regression: searchContent frees empty trigram candidate slice" {
 }
 
 test "regression: queue push stays non-blocking when full" {
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
 
     var pushed: usize = 0;
     while (true) : (pushed += 1) {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -68,6 +68,51 @@ const EnvVarGuard = struct {
     }
 };
 
+test "windows runCapture resolves executables from safe PATH entries only" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "bin");
+    try tmp.dir.createDirPath(io, "repo");
+    var exe = try tmp.dir.createFile(io, "bin/git.exe", .{});
+    exe.close(io);
+    var planted_bat = try tmp.dir.createFile(io, "repo/git.bat", .{});
+    planted_bat.close(io);
+
+    var bin_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const bin_len = try tmp.dir.realPathFile(io, "bin", &bin_buf);
+    const bin_abs = bin_buf[0..bin_len];
+
+    const old_path = EnvVarGuard.save("PATH");
+    defer old_path.restore();
+    const test_path = try std.fmt.allocPrint(testing.allocator, ".;relative;{s}", .{bin_abs});
+    defer testing.allocator.free(test_path);
+    cio.posixSetenv("PATH", test_path);
+
+    const resolved = try cio.resolveExecutableFromPathWindows(testing.allocator, "git") orelse return error.TestUnexpectedResult;
+    defer testing.allocator.free(resolved);
+    try testing.expect(std.mem.endsWith(u8, resolved, "git.exe"));
+    try testing.expect(std.mem.startsWith(u8, resolved, bin_abs));
+
+    try testing.expect((try cio.resolveExecutableFromPathWindows(testing.allocator, "git.bat")) == null);
+    try testing.expect((try cio.resolveExecutableFromPathWindows(testing.allocator, ".\\git.exe")) == null);
+}
+
+test "windows cli pipe metadata parser rejects spoofable records" {
+    const owner = "pid=123\npipe=\\\\.\\pipe\\codedb-123-deadbeef\n";
+    const ok = cli_proxy_mod.parseCliPipeMetadata(owner) orelse return error.TestUnexpectedResult;
+    try testing.expect(ok.pid == 123);
+    try testing.expect(std.mem.eql(u8, ok.pipe_name, "\\\\.\\pipe\\codedb-123-deadbeef"));
+    try testing.expect(cli_proxy_mod.cliPipeMetadataMatchesOwner(owner, 123, "\\\\.\\pipe\\codedb-123-deadbeef"));
+    try testing.expect(!cli_proxy_mod.cliPipeMetadataMatchesOwner(owner, 124, "\\\\.\\pipe\\codedb-123-deadbeef"));
+    try testing.expect(!cli_proxy_mod.cliPipeMetadataMatchesOwner(owner, 123, "\\\\.\\pipe\\codedb-other"));
+
+    try testing.expect(cli_proxy_mod.parseCliPipeMetadata("pid=0\npipe=\\\\.\\pipe\\codedb-x\n") == null);
+    try testing.expect(cli_proxy_mod.parseCliPipeMetadata("pid=123\npipe=\\\\.\\pipe\\other\n") == null);
+    try testing.expect(cli_proxy_mod.parseCliPipeMetadata("pipe=\\\\.\\pipe\\codedb-x\n") == null);
+}
+
 fn buildCliForHelpTests() !void {
     const build = try cio.runCapture(.{
         .allocator = testing.allocator,
@@ -2465,8 +2510,11 @@ test "issue-592: cli-daemon spawn lock is exclusive per project" {
     // the kernel releases the lock on any exit.
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
+    if (builtin.os.tag == .windows) {
+        try tmp.dir.createDirPath(io, "unicode-å");
+    }
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir_len = try tmp.dir.realPathFile(io, ".", &path_buf);
+    const dir_len = try tmp.dir.realPathFile(io, if (builtin.os.tag == .windows) "unicode-å" else ".", &path_buf);
     const dir_path = path_buf[0..dir_len];
 
     const held = main_mod.daemonLockTryAcquire(dir_path);

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const cio = @import("cio.zig");
 const testing = std.testing;
 const io = std.testing.io;
@@ -32,10 +33,45 @@ comptime {
     _ = @import("config.zig");
 }
 
+fn zigExe() []const u8 {
+    return "zig";
+}
+
+fn builtCodedbExe() []const u8 {
+    return if (builtin.os.tag == .windows) ".\\zig-out\\bin\\codedb.exe" else "./zig-out/bin/codedb";
+}
+
+const EnvVarGuard = struct {
+    name: []const u8,
+    had_prev: bool,
+    prev_len: usize,
+    prev: [4096]u8,
+
+    fn save(name: []const u8) EnvVarGuard {
+        var g = EnvVarGuard{ .name = name, .had_prev = false, .prev_len = 0, .prev = undefined };
+        if (cio.posixGetenv(name)) |v| {
+            if (v.len <= g.prev.len) {
+                @memcpy(g.prev[0..v.len], v);
+                g.prev_len = v.len;
+                g.had_prev = true;
+            }
+        }
+        return g;
+    }
+
+    fn restore(self: *const EnvVarGuard) void {
+        if (self.had_prev) {
+            cio.posixSetenv(self.name, self.prev[0..self.prev_len]);
+        } else {
+            cio.posixUnsetenv(self.name);
+        }
+    }
+};
+
 fn buildCliForHelpTests() !void {
     const build = try cio.runCapture(.{
         .allocator = testing.allocator,
-        .argv = &.{ "zig", "build" },
+        .argv = &.{ zigExe(), "build", "--global-cache-dir", ".zig-global-cache" },
         .max_output_bytes = 8192,
     });
     defer testing.allocator.free(build.stdout);
@@ -43,6 +79,83 @@ fn buildCliForHelpTests() !void {
 
     try testing.expect(build.term == .Exited);
     try testing.expect(build.term.Exited == 0);
+}
+
+test "windows cli-daemon auto-spawn proxies next query from unicode root" {
+    // POSIX uses the Unix-socket daemon path. This test exercises the Windows
+    // behavior-equivalent path: detached CreateProcessW startup plus named-pipe
+    // proxying for the next process.
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    try buildCliForHelpTests();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "project-unicode-å/src");
+    try tmp.dir.createDirPath(io, ".home");
+
+    {
+        const f = try tmp.dir.createFile(io, "project-unicode-å/src/sample.zig", .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "pub fn sampleSymbolForDaemon() void {}\n");
+    }
+
+    var project_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_len = try tmp.dir.realPathFile(io, "project-unicode-å", &project_buf);
+    const project_root = project_buf[0..project_len];
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home_len = try tmp.dir.realPathFile(io, ".home", &home_buf);
+    const test_home = home_buf[0..home_len];
+
+    const g_allow = EnvVarGuard.save("CODEDB_ALLOW_TEMP");
+    defer g_allow.restore();
+    const g_idle = EnvVarGuard.save("CODEDB_CLI_DAEMON_IDLE_MS");
+    defer g_idle.restore();
+    const g_home = EnvVarGuard.save("HOME");
+    defer g_home.restore();
+    const g_profile = EnvVarGuard.save("USERPROFILE");
+    defer g_profile.restore();
+    cio.posixSetenv("CODEDB_ALLOW_TEMP", "1");
+    cio.posixSetenv("CODEDB_CLI_DAEMON_IDLE_MS", "750");
+    cio.posixSetenv("HOME", test_home);
+    cio.posixSetenv("USERPROFILE", test_home);
+
+    const cold = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ builtCodedbExe(), project_root, "status" },
+        .max_output_bytes = 64 * 1024,
+    });
+    defer testing.allocator.free(cold.stdout);
+    defer testing.allocator.free(cold.stderr);
+    try testing.expect(cold.term == .Exited);
+    try testing.expectEqual(@as(u8, 0), cold.term.Exited);
+
+    var warm_seen = false;
+    var attempts: usize = 0;
+    while (attempts < 20) : (attempts += 1) {
+        cio.sleepMs(150);
+        const warm = try cio.runCapture(.{
+            .allocator = testing.allocator,
+            .argv = &.{ builtCodedbExe(), project_root, "find", "sampleSymbolForDaemon" },
+            .max_output_bytes = 64 * 1024,
+        });
+        defer testing.allocator.free(warm.stdout);
+        defer testing.allocator.free(warm.stderr);
+
+        if (warm.term == .Exited and warm.term.Exited == 0 and
+            std.mem.indexOf(u8, warm.stdout, "src/sample.zig") != null and
+            std.mem.indexOf(u8, warm.stdout, "loaded snapshot") == null)
+        {
+            warm_seen = true;
+            break;
+        }
+    }
+
+    // Let the short-idle detached daemon release files before tmp cleanup on Windows.
+    cio.sleepMs(900);
+    try testing.expect(warm_seen);
 }
 
 test "issue-59: telemetry writes session, tool, and codebase stats ndjson" {
@@ -263,7 +376,7 @@ test "issue-150: --help prints usage" {
 
     const result = try cio.runCapture(.{
         .allocator = testing.allocator,
-        .argv = &.{ "./zig-out/bin/codedb", "--help" },
+        .argv = &.{ builtCodedbExe(), "--help" },
         .max_output_bytes = 8192,
     });
     defer testing.allocator.free(result.stdout);
@@ -284,7 +397,7 @@ test "issue-150: -h prints usage" {
 
     const result = try cio.runCapture(.{
         .allocator = testing.allocator,
-        .argv = &.{ "./zig-out/bin/codedb", "-h" },
+        .argv = &.{ builtCodedbExe(), "-h" },
         .max_output_bytes = 8192,
     });
     defer testing.allocator.free(result.stdout);
@@ -468,12 +581,14 @@ test "issue-148: dead MCP clients are polled every second" {
 }
 
 test "issue-148: POLLHUP detects closed pipe" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     // Verify the polling infrastructure works for pipe-based transports
     const pipe = try cio.makePipe();
-    defer _ = std.c.close(pipe[0]);
+    defer cio.closeFd(pipe[0]);
 
     // Close write end — simulates client disconnect
-    _ = std.c.close(pipe[1]);
+    cio.closeFd(pipe[1]);
 
     // Poll should detect POLLHUP on the read end
     var fds = [_]std.posix.pollfd{.{
@@ -554,9 +669,11 @@ test "issue-278: MCP session may remain idle longer than old timeout" {
 }
 
 test "issue-148: open pipe does not trigger HUP" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const pipe = try cio.makePipe();
-    defer _ = std.c.close(pipe[0]);
-    defer _ = std.c.close(pipe[1]);
+    defer cio.closeFd(pipe[0]);
+    defer cio.closeFd(pipe[1]);
 
     var poll_fds = [_]std.posix.pollfd{.{
         .fd = pipe[0],
@@ -585,7 +702,7 @@ test "issue-148: codedb mcp exits when stdin is closed" {
 
     // Integration test: spawn the built codedb mcp, close stdin, verify it exits
     var child = std.process.spawn(io, .{
-        .argv = &.{ "./zig-out/bin/codedb", proj, "mcp" },
+        .argv = &.{ builtCodedbExe(), proj, "mcp" },
         .stdin = .pipe,
         .stdout = .pipe,
         .stderr = .ignore,
@@ -1286,8 +1403,8 @@ test "issue-512: direct tools call accepts inline args when arguments is empty" 
     defer parsed.deinit();
 
     const pipe = try cio.makePipe();
-    defer _ = std.c.close(pipe[0]);
-    defer _ = std.c.close(pipe[1]);
+    defer cio.closeFd(pipe[0]);
+    defer cio.closeFd(pipe[1]);
 
     bench_ctx.runHandleCall(
         io,
@@ -1302,7 +1419,9 @@ test "issue-512: direct tools call accepts inline args when arguments is empty" 
     );
 
     var response_buf: [16 * 1024]u8 = undefined;
-    const n = try std.posix.read(pipe[0], &response_buf);
+    const n_raw = cio.readFd(pipe[0], &response_buf);
+    try testing.expect(n_raw > 0);
+    const n: usize = @intCast(n_raw);
     const response = response_buf[0..n];
 
     try testing.expect(std.mem.indexOf(u8, response, "src/main.zig") != null);
@@ -2357,8 +2476,7 @@ test "issue-592: cli-daemon spawn lock is exclusive per project" {
     // ...and the CLI spawn probe must report the lock as taken.
     try testing.expect(!main_mod.daemonLockAvailable(dir_path));
 
-    _ = std.c.flock(held.?, std.c.LOCK.UN);
-    _ = std.c.close(held.?);
+    main_mod.daemonLockRelease(held.?);
     try testing.expect(main_mod.daemonLockAvailable(dir_path));
 }
 
@@ -2639,7 +2757,7 @@ test "split: cli_proxy daemon lock works via main and cli_proxy" {
     // Acquired via the cli_proxy module; main's re-export must see it held.
     const held = cli_proxy_mod.daemonLockTryAcquire(dir_path);
     try testing.expect(held != null);
-    defer _ = std.c.close(held.?);
+    defer cli_proxy_mod.daemonLockRelease(held.?);
     try testing.expect(!main_mod.daemonLockAvailable(dir_path));
     try testing.expect(cli_proxy_mod.daemonLockTryAcquire(dir_path) == null);
 }
@@ -2852,4 +2970,23 @@ test "issue-619: serve/mcp daemon reclaims the cli socket after the owner exits"
     t.join(); // reclaimer must return (pre-fix: no retry path → would never acquire)
     try testing.expect(rc.fd != null);
     if (rc.fd) |fd| _ = std.c.close(fd);
+}
+
+test "windows: spawnDetached command line round-trips argv with trailing backslashes" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = testing.allocator;
+
+    const argv = [_][]const u8{ "C:\\tools\\codedb.exe", "D:\\", "cli-daemon", "say \"hi\"", "a\\\\b", "tail\\\\" };
+    const cmd = cio.windowsCommandLine(alloc, &argv) orelse return error.TestUnexpectedResult;
+    defer alloc.free(cmd);
+    const cmd_w = try std.unicode.utf8ToUtf16LeAlloc(alloc, cmd);
+    defer alloc.free(cmd_w);
+
+    var it = try std.process.Args.Iterator.Windows.init(alloc, cmd_w);
+    defer it.deinit();
+    for (argv) |expected| {
+        const got = it.next() orelse return error.TestUnexpectedResult;
+        try testing.expectEqualStrings(expected, got);
+    }
+    try testing.expect(it.next() == null);
 }

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1092,9 +1092,6 @@ test "issue-429-c: searchContent rerank boosts lines that are symbol definitions
     try testing.expectEqualStrings("zzz_def.zig", results[0].path);
 }
 
-extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
-extern "c" fn unsetenv(name: [*:0]const u8) c_int;
-
 test "lex-freq-penalty: CODEDB_LEX_FREQ_PENALTY demotes files the query saturates" {
     // engram's learned ranker down-weights pure lexical frequency (LEARNED_W
     // lexical = -2): a file the query matches on MANY lines is usually a
@@ -1116,8 +1113,8 @@ test "lex-freq-penalty: CODEDB_LEX_FREQ_PENALTY demotes files the query saturate
     try explorer.indexFile("src/handler.zig", "pub fn g() void { _ = evt; }\n");
 
     // Disabled (CODEDB_LEX_FREQ_PENALTY=0): equal per-line scores → path-asc tie → dispatcher leads.
-    _ = setenv("CODEDB_LEX_FREQ_PENALTY", "0", 1);
-    defer _ = unsetenv("CODEDB_LEX_FREQ_PENALTY");
+    cio.posixSetenv("CODEDB_LEX_FREQ_PENALTY", "0");
+    defer cio.posixUnsetenv("CODEDB_LEX_FREQ_PENALTY");
     {
         const results = try explorer.searchContent("evt", testing.allocator, 50);
         defer {
@@ -1132,7 +1129,7 @@ test "lex-freq-penalty: CODEDB_LEX_FREQ_PENALTY demotes files the query saturate
     }
 
     // Default (on): dispatcher.zig saturates the query → demoted below handler.zig.
-    _ = unsetenv("CODEDB_LEX_FREQ_PENALTY");
+    cio.posixUnsetenv("CODEDB_LEX_FREQ_PENALTY");
     {
         const results = try explorer.searchContent("evt", testing.allocator, 50);
         defer {
@@ -2381,8 +2378,8 @@ test "search-cache: ranking env toggle prevents stale hits" {
     freeSearchResults(r1);
 
     // Different fingerprint -> the cached entry must NOT be served.
-    _ = setenv("CODEDB_RVSM_SIZE_PRIOR", "1", 1);
-    defer _ = unsetenv("CODEDB_RVSM_SIZE_PRIOR");
+    cio.posixSetenv("CODEDB_RVSM_SIZE_PRIOR", "1");
+    defer cio.posixUnsetenv("CODEDB_RVSM_SIZE_PRIOR");
     const r2 = try explorer.searchContent("gnutok", testing.allocator, 10);
     freeSearchResults(r2);
     try testing.expectEqual(@as(u64, 0), explorer.search_cache.hits);
@@ -2398,8 +2395,8 @@ test "search-cache: CODEDB_NO_SEARCH_CACHE disables caching entirely" {
     defer explorer.deinit();
     try explorer.indexFile("src/off.zig", "const a = 1; // dingotok\n");
 
-    _ = setenv("CODEDB_NO_SEARCH_CACHE", "1", 1);
-    defer _ = unsetenv("CODEDB_NO_SEARCH_CACHE");
+    cio.posixSetenv("CODEDB_NO_SEARCH_CACHE", "1");
+    defer cio.posixUnsetenv("CODEDB_NO_SEARCH_CACHE");
     const r1 = try explorer.searchContent("dingotok", testing.allocator, 10);
     freeSearchResults(r1);
     const r2 = try explorer.searchContent("dingotok", testing.allocator, 10);


### PR DESCRIPTION
## Summary
- Enable the Windows warm-daemon CLI proxy using named-pipe IPC and a Windows daemon lock.
- Add Windows detached process spawning and bounded subprocess capture needed by daemon startup and local test coverage.
- Keep the existing POSIX socket/flock path intact; Windows-specific behavior is selected through platform checks.
- Add a Windows-only warm-daemon test that exercises cold daemon startup followed by a proxied warm query from a Unicode project root.
- Fix Windows-local test blockers around heap allocation for large watcher queues, environment helpers, rerank trace file access, and POSIX-only tests.

Refs #621.

## Validation
- `zig build --global-cache-dir .zig-global-cache test --summary all`
  - `23/23 steps succeeded; 858/862 tests passed (4 skipped)`
- `zig build --global-cache-dir .zig-global-cache --summary all`
  - `3/3 steps succeeded`
- `PYTHONIOENCODING=utf-8 python scripts/e2e_mcp_test.py --binary zig-out/bin/codedb.exe --project .`
  - `20/20 passed`
