### PR TITLE
fix(root_policy): index /var/home projects on OSTree without opt-in (#642)

### DIFF
--- a/src/root_policy.zig
+++ b/src/root_policy.zig
@@ -24,6 +24,18 @@ pub fn isIndexableRoot(path: []const u8) bool {
         if (isExactOrChild(path, "/tmp")) return false;
     }
 
+    // OSTree distros (Fedora Silverblue/CoreOS/Nobara) bind-mount /home onto
+    // /var/home, so /var/home/<user>/<project> is a real project path, not a
+    // system dir — and realPathFile canonicalizes /home/<user>/<project> to it
+    // (same as #406/#407 fold /etc→/private/etc, /var→/private/var). Accept it
+    // before the /var system-prefix block below, mirroring the /home + /Users
+    // home-dir rule: allow project subdirs, deny the bare home. No opt-in. (#642)
+    if (std.mem.startsWith(u8, path, "/var/home/")) {
+        const rest = path["/var/home/".len..];
+        // "user" (bare home) → deny; "user/project…" → allow.
+        return std.mem.indexOfScalar(u8, rest, '/') != null;
+    }
+
     const system_prefixes = [_][]const u8{
         "/Applications",
         "/System",
@@ -86,4 +98,3 @@ test "issue-80: /tmp is denied" {
     try testing.expect(!isIndexableRoot("/tmp"));
     try testing.expect(!isIndexableRoot("/tmp/foo"));
 }
-

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -1161,6 +1161,21 @@ test "issue-407: root_policy blocks /var and its non-folders subtree" {
     try testing.expect(!root_policy.isIndexableRoot("/private/var/log"));
 }
 
+test "issue-642: /var/home project dirs are indexable on OSTree (Silverblue/CoreOS)" {
+    // OSTree distros (Fedora Silverblue/CoreOS/Nobara) bind-mount /home onto
+    // /var/home, so /var/home/<user>/<project> is a real project path — and
+    // realPathFile canonicalizes /home/<user>/<project> to it, the same way
+    // #406/#407 turn /etc→/private/etc and /var→/private/var. It must index like
+    // /home does, with no CODEDB_ALLOW_TEMP opt-in.
+    try testing.expect(root_policy.isIndexableRoot("/var/home/xavi/project"));
+    try testing.expect(root_policy.isIndexableRoot("/var/home/xavi/project/src"));
+    // The bare home dir and /var itself stay denied (footgun guard, #174/#407).
+    try testing.expect(!root_policy.isIndexableRoot("/var/home/xavi"));
+    try testing.expect(!root_policy.isIndexableRoot("/var/home"));
+    try testing.expect(!root_policy.isIndexableRoot("/var"));
+    try testing.expect(!root_policy.isIndexableRoot("/var/log"));
+}
+
 test "issue-412: bundle reports 'missing tool' for tool field of wrong type" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();


### PR DESCRIPTION
Fixes #642. Thanks to @XaviCode1000 for the detailed report (and for #643, an alternative approach — see the note at the bottom).

## Problem

On OSTree distros (Fedora Silverblue / CoreOS / Nobara), `/home` is a bind-mount/symlink onto `/var/home`, so a user's project at `/var/home/<user>/<project>` is a **real, permanent home path** — not a temporary or system directory. But `isIndexableRoot` rejected it two ways:

1. The blanket `/var` entry in `system_prefixes` denies everything under `/var`.
2. `--allow-temp` / `CODEDB_ALLOW_TEMP` only bypasses `/tmp` and `/private/tmp`, never `/var`.

There's also a subtler failure the issue hints at: in MCP mode the root is fed through `realPathFile`, which on OSTree **canonicalizes `/home/<user>/<project>` -> `/var/home/<user>/<project>`** (the same normalization that folds `/etc -> /private/etc` in #406 and `/var -> /private/var` in #407). So even the existing `/home/...` allow-rule was bypassed after resolution — indexing failed whether the user passed `/home/...` or `/var/home/...`.

## Fix

Treat `/var/home/<user>/<project>` exactly like the existing `/home/<user>` and `/Users/<user>` home-dir rule — **allow project subdirectories, deny the bare home** — handled before the `/var` system-prefix block. No opt-in required.

```zig
if (std.mem.startsWith(u8, path, "/var/home/")) {
    const rest = path["/var/home/".len..];
    // "user" (bare home) -> deny; "user/project..." -> allow.
    return std.mem.indexOfScalar(u8, rest, '/') != null;
}
```

`/var`, `/var/log`, `/var/lib`, and the bare `/var/home/<user>` stay blocked (the footgun guard from #174/#407 is untouched).

## Test

`test "issue-642: ..."` added to `src/test_mcp.zig` alongside the existing issue-407 `/var` test — red on `main`, green here:

```zig
try testing.expect(root_policy.isIndexableRoot("/var/home/xavi/project"));
try testing.expect(root_policy.isIndexableRoot("/var/home/xavi/project/src"));
try testing.expect(!root_policy.isIndexableRoot("/var/home/xavi")); // bare home
try testing.expect(!root_policy.isIndexableRoot("/var/home"));
try testing.expect(!root_policy.isIndexableRoot("/var"));
try testing.expect(!root_policy.isIndexableRoot("/var/log"));
```

`zig build test` passes locally (all suites green).

## Relationship to #643

@XaviCode1000's #643 implements the issue's **option 1**: allow all of `/var` when `CODEDB_ALLOW_TEMP=1`. That's minimal, but it (a) still requires OSTree users to set an env var to index their *normal* home, and (b) widens the temp opt-in to all of `/var` (e.g. `/var/log`) for CI harnesses that set it.

This PR implements the issue's **option 3** instead: `/var/home/<user>/<project>` indexes out of the box with **no opt-in**, and `/var/log` etc. stay blocked in all cases. Whichever you prefer to land — happy to close this if you'd rather take #643 (retargeted to `release/0.2.5828`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
