### PR TITLE
feat(config): per-project disable via .codedbrc + installer --no-register (#640)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -28,6 +28,18 @@ codedb as an MCP server in every client it can find — Claude Code, Codex,
 Gemini CLI, Cursor, opencode. It prints the exact `codedb mcp` command it
 registered.
 
+To install the binary **without touching any client config**, pass
+`--no-register` (or set `CODEDB_NO_REGISTER=1`):
+
+```bash
+curl -fsSL https://codedb.codegraff.com/install.sh | bash -s -- --no-register
+```
+
+then register it only where you want it, e.g. per-project:
+`claude mcp add codedb -s project -- codedb mcp`. To keep codedb out of an
+individual project instead, drop a `.codedbrc` with `disable = true` at that
+project's root (see §4).
+
 If you prefer to wire it up by hand, the client-specific snippets below
 all work directly.
 
@@ -173,6 +185,8 @@ comments. Unknown keys are ignored.
 max_cached   = 16384   # in-memory ContentCache size (files); default 16384
 max_versions = 100     # versions kept per file in the change log; default 100
 rerank_trace = false   # write per-search rerank-trace.jsonl (debug only)
+disable      = false   # true opts this project out entirely: the MCP server
+                       # serves no tools and nothing is indexed or written (#640)
 ```
 
 Pass an alternative path with `--config-file <path>` to the CLI for

--- a/install/install.sh
+++ b/install/install.sh
@@ -324,6 +324,15 @@ print_hook_notes() {
 }
 
 main() {
+  # --no-register / CODEDB_NO_REGISTER=1: install the binary but skip MCP
+  # client registration entirely (#640); register per-project instead.
+  NO_REGISTER="${CODEDB_NO_REGISTER:-0}"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --no-register) NO_REGISTER=1 ;;
+    esac
+  done
   local platform version ext=""
   platform="$(detect_platform)"
 
@@ -394,17 +403,24 @@ main() {
     printf "$checksum_notice"
   fi
 
-  # Register MCP server in coding tools
-  echo ""
-  printf "  ${W}registering integrations${N}\n"
-  echo ""
-  register_claude "$dest"
-  register_codex "$dest"
-  register_gemini "$dest"
-  register_cursor "$dest"
-  register_windsurf_devin "$dest"
-  register_hooks
-  print_hook_notes "$dest"
+  # Register MCP server in coding tools — skippable via --no-register or
+  # CODEDB_NO_REGISTER=1 (#640)
+  if [ "$NO_REGISTER" = "1" ] || [ "$NO_REGISTER" = "true" ]; then
+    echo ""
+    printf "  ${D}skipped MCP registration (--no-register / CODEDB_NO_REGISTER=1)${N}\n"
+    printf "  ${D}register per-project later, e.g.: claude mcp add codedb -s project -- $dest mcp${N}\n"
+  else
+    echo ""
+    printf "  ${W}registering integrations${N}\n"
+    echo ""
+    register_claude "$dest"
+    register_codex "$dest"
+    register_gemini "$dest"
+    register_cursor "$dest"
+    register_windsurf_devin "$dest"
+    register_hooks
+    print_hook_notes "$dest"
+  fi
 
   # Check PATH
   case ":$PATH:" in
@@ -422,4 +438,4 @@ main() {
   echo ""
 }
 
-main
+main "$@"

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -403,7 +403,13 @@ pub fn runMcp(ctx: *RunCtx) !void {
 
     const root_from_cwd = mcp_deferred_root;
 
-    saveProjectInfo(io, allocator, data_dir, abs_root) catch {};
+    // #640: a .codedbrc `disable = true` at the root opts the project out of
+    // codedb entirely. Stay alive and protocol-correct (initialize / ping /
+    // empty tools/list — run() re-probes the root), but never scan, watch,
+    // warm, register the project, or write anything.
+    const project_disabled = Config.projectDisabled(io, allocator, abs_root);
+
+    if (!project_disabled) saveProjectInfo(io, allocator, data_dir, abs_root) catch {};
 
     // Set up query tracking WAL
     const query_log = std.fmt.allocPrint(allocator, "{s}/queries.log", .{data_dir}) catch null;
@@ -426,12 +432,15 @@ pub fn runMcp(ctx: *RunCtx) !void {
     queue.* = watcher.EventQueue{};
 
     var scan_thread: ?std.Thread = null;
-    var watch_thread: std.Thread = undefined;
+    var watch_thread: ?std.Thread = null;
 
     var deferred: mcp_server.DeferredScan = undefined;
     var maybe_deferred: ?*mcp_server.DeferredScan = null;
 
-    if (root_from_cwd) {
+    if (project_disabled) {
+        std.log.info("codedb mcp: project disabled by .codedbrc — serving no tools, not indexing", .{});
+        mcp_server.setScanState(.ready);
+    } else if (root_from_cwd) {
         deferred = .{
             .io = io,
             .allocator = allocator,
@@ -480,12 +489,14 @@ pub fn runMcp(ctx: *RunCtx) !void {
     // on this same stack frame for the whole process lifetime.
     var cli_activity = std.atomic.Value(i64).init(cio.milliTimestamp());
     var cli_listener_dead = std.atomic.Value(bool).init(false);
-    if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, &cli_activity, &cli_listener_dead, true })) |cli_t| {
-        cli_t.detach();
-    } else |err| {
-        std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
+    if (!project_disabled) {
+        if (std.Thread.spawn(.{}, cliDaemonListen, .{ io, allocator, explorer, store, abs_root, &cli_activity, &cli_listener_dead, true })) |cli_t| {
+            cli_t.detach();
+        } else |err| {
+            std.log.warn("cli-proxy: could not start listener: {s}", .{@errorName(err)});
+        }
+        spawnWarmup(io, allocator, explorer, data_dir, abs_root, &shutdown);
     }
-    spawnWarmup(io, allocator, explorer, data_dir, abs_root, &shutdown);
     mcp_server.run(io, allocator, store, explorer, &agents, abs_root, cfg.max_cached, &telem, maybe_deferred, &shutdown);
 
     shutdown.store(true, .release);
@@ -493,6 +504,6 @@ pub fn runMcp(ctx: *RunCtx) !void {
     if (maybe_deferred) |d| {
         if (d.scan_thread) |st| st.join();
     }
-    watch_thread.join();
+    if (watch_thread) |wt| wt.join();
     idle_thread.join();
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -21,6 +21,11 @@ pub const Config = struct {
     /// <data_dir>/rerank-traces.jsonl. v0 logger for offline rerank-tuning
     /// experiments. Off by default — opt in via .codedbrc.
     rerank_trace: bool = false,
+    /// When true, codedb ignores this project entirely: the MCP server stays
+    /// alive but advertises no tools and never scans or writes, and CLI
+    /// commands refuse the root. Per-project opt-out for auto-indexing and
+    /// auto-registration (#640).
+    disable: bool = false,
 
     pub const default: Config = .{};
 
@@ -43,6 +48,8 @@ pub const Config = struct {
                 if (cfg.max_cached == 0) return error.InvalidMaxCached;
             } else if (std.mem.eql(u8, key, "rerank_trace")) {
                 cfg.rerank_trace = parseBool(val) catch return error.InvalidRerankTrace;
+            } else if (std.mem.eql(u8, key, "disable")) {
+                cfg.disable = parseBool(val) catch return error.InvalidDisable;
             }
         }
         return cfg;
@@ -94,6 +101,17 @@ pub const Config = struct {
         const f = std.Io.Dir.cwd().openFile(io, ".codedbrc", .{}) catch return false;
         f.close(io);
         return true;
+    }
+
+    /// Probe `<root>/.codedbrc` for `disable = true` — the per-project
+    /// opt-out (#640). Any read or parse failure counts as "not disabled" so
+    /// a malformed config can never brick unrelated commands.
+    pub fn projectDisabled(io: std.Io, alloc: std.mem.Allocator, root: []const u8) bool {
+        if (root.len == 0) return false;
+        const path = std.fmt.allocPrint(alloc, "{s}/.codedbrc", .{root}) catch return false;
+        defer alloc.free(path);
+        const cfg = loadFromPath(io, alloc, path) catch return false;
+        return cfg.disable;
     }
 };
 
@@ -154,4 +172,12 @@ test "config: rerank_trace defaults off and parses true/false" {
     try testing.expect(cfg_off.rerank_trace == false);
 
     try testing.expectError(error.InvalidRerankTrace, Config.parse("rerank_trace = maybe\n"));
+}
+
+test "issue-640: disable key parses and defaults off" {
+    try testing.expect(!Config.default.disable);
+    try testing.expect((try Config.parse("disable = true\n")).disable);
+    try testing.expect((try Config.parse("disable = 1\n")).disable);
+    try testing.expect(!(try Config.parse("disable = false\n")).disable);
+    try testing.expectError(error.InvalidDisable, Config.parse("disable = maybe\n"));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -307,6 +307,15 @@ fn mainImpl() !void {
         });
         out.exitWithFlush(1);
     }
+    // #640: per-project opt-out. Non-mcp commands refuse a disabled project;
+    // `mcp` proceeds and serves an empty tool surface instead (see runMcp) —
+    // exiting here would surface as a connection error in MCP clients.
+    if (!std.mem.eql(u8, cmd, "mcp") and Config.projectDisabled(io, allocator, abs_root)) {
+        out.p("{s}\xe2\x9c\x97{s} codedb is disabled for this project ({s}.codedbrc{s}: disable = true)\n", .{
+            s.red, s.reset, s.bold, s.reset,
+        });
+        out.exitWithFlush(1);
+    }
 
     // #553: `status` must be a cheap, fast-exiting metadata query. It previously
     // fell through to the full index bootstrap below (snapshot mmap, or — with no

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -24,6 +24,7 @@ const snapshot_mod = @import("snapshot.zig");
 const telemetry_mod = @import("telemetry.zig");
 const git_mod = @import("git.zig");
 const root_policy = @import("root_policy.zig");
+const config_mod = @import("config.zig");
 const release_info = @import("release_info.zig");
 pub const DeferredScan = struct {
     io: std.Io,
@@ -61,6 +62,12 @@ pub fn triggerDeferredScanWithFallback(
         path = fallback_cwd;
     }
     if (path.len == 0) return false;
+    // #640: a root whose .codedbrc says `disable = true` must never be
+    // scanned, whichever way it arrived (roots/list or cwd fallback).
+    if (config_mod.Config.projectDisabled(ds.io, ds.allocator, path)) {
+        std.log.info("codedb mcp: root \"{s}\" disabled by .codedbrc — not indexing", .{path});
+        return false;
+    }
     if (ds.triggered.swap(true, .acq_rel)) return false;
     ds.triggerFn(ds, path);
     return true;
@@ -385,6 +392,8 @@ const ProjectCache = struct {
     ) !ProjectCtx {
         const p = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
         if (!root_policy.isIndexableRoot(p))
+            return error.PathNotAllowed;
+        if (config_mod.Config.projectDisabled(io, self.alloc, p))
             return error.PathNotAllowed;
 
         self.mu.lock();
@@ -965,6 +974,11 @@ pub fn run(
         .discriminated_opt_in = discriminated_opt_in,
     }) catch tools_list;
     defer if (tools_list_response.ptr != tools_list.ptr) alloc.free(tools_list_response);
+    // #640: a project with `disable = true` in its .codedbrc opts out of
+    // codedb entirely. The server stays alive and protocol-correct
+    // (initialize/ping), but advertises zero tools and refuses tools/call, so
+    // clients load no tool schemas and nothing is ever scanned or written.
+    const project_disabled = config_mod.Config.projectDisabled(io, alloc, default_path);
     var session = Session{
         .alloc = alloc,
         .stdout = stdout,
@@ -1031,8 +1045,12 @@ pub fn run(
                 requestRoots(&session);
             }
         } else if (mcpj.eql(method, "tools/list")) {
-            if (!is_notification) writeResult(alloc, stdout, id, tools_list_response);
+            if (!is_notification) writeResult(alloc, stdout, id, if (project_disabled) "{\"tools\":[]}" else tools_list_response);
         } else if (mcpj.eql(method, "tools/call")) {
+            if (project_disabled) {
+                if (!is_notification) writeError(alloc, stdout, id, -32000, "codedb is disabled for this project (.codedbrc: disable = true)");
+                continue;
+            }
             handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, session.edit_agent_id, &session.governor);
         } else if (mcpj.eql(method, "ping")) {
             if (!is_notification) writeResult(alloc, stdout, id, "{}");
@@ -4078,6 +4096,11 @@ fn handleIndex(
         out.appendSlice(alloc, abs_path) catch {};
         return;
     }
+    if (config_mod.Config.projectDisabled(io, alloc, abs_path)) {
+        out.appendSlice(alloc, "error: project disabled by .codedbrc: ") catch {};
+        out.appendSlice(alloc, abs_path) catch {};
+        return;
+    }
 
     // Verify it's a directory
     var check_dir = std.Io.Dir.cwd().openDir(io, abs_path, .{}) catch {
@@ -5986,4 +6009,36 @@ test "codedb_snapshot cache reuses output until store seq changes" {
     bench_ctx.runDispatch(io, alloc, .codedb_snapshot, args, &third, &store, &explorer, &agents);
     try testing.expect(std.mem.indexOf(u8, third.items, "changed") != null);
     try testing.expect(!std.mem.eql(u8, first.items, third.items));
+}
+
+test "issue-640: .codedbrc disable=true opts a project out of ProjectCache" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(io, .{ .sub_path = ".codedbrc", .data = "disable = true\n" });
+
+    var project_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_path_len = try tmp.dir.realPathFile(io, ".", &project_path_buf);
+    const project_path = project_path_buf[0..project_path_len];
+
+    try testing.expect(config_mod.Config.projectDisabled(io, testing.allocator, project_path));
+
+    var default_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const default_path_len = try std.Io.Dir.cwd().realPathFile(io, ".", &default_path_buf);
+    const default_path = default_path_buf[0..default_path_len];
+
+    var default_explorer = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer default_explorer.deinit();
+    var default_store = Store.init(testing.allocator);
+    defer default_store.deinit();
+
+    var cache = ProjectCache.init(testing.allocator, default_path, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer cache.deinit();
+
+    try testing.expectError(error.PathNotAllowed, cache.get(io, project_path, &default_explorer, &default_store));
+
+    // Removing the marker clears the opt-out.
+    try tmp.dir.deleteFile(io, ".codedbrc");
+    try testing.expect(!config_mod.Config.projectDisabled(io, testing.allocator, project_path));
 }


### PR DESCRIPTION
Fixes #640.

## Problem

Two annoyances reported in #640:
1. `install.sh` auto-registers codedb at **user scope** in every detected client, so its ~23 tool schemas load in *every* project — context cost even where codedb isn't wanted.
2. codedb auto-indexes whatever project it starts in and drops a `codedb.snapshot` there (plus a `.gitignore` edit).

## Fix

Two independent escape hatches:

**Per-project: `.codedbrc` with `disable = true`** — codedb ignores the project entirely:
- MCP server stays alive and protocol-correct (initialize/ping), but `tools/list` returns `{"tools":[]}` (zero schemas → zero context) and `tools/call` is refused.
- Nothing is scanned, watched, warmed, or written — no `codedb.snapshot`, no `.gitignore` edit, no project registration in the central list.
- All entry points gate on the same probe: CLI root validation, deferred-scan triggers (roots/list handshake + cwd fallback), `ProjectCache.get` (per-call `project=` switching), and `codedb_index`.
- CLI commands print `✗ codedb is disabled for this project (.codedbrc: disable = true)` and exit 1.
- Malformed/unreadable configs count as *not disabled* — a typo can't brick unrelated commands.

**Install-time: `--no-register` / `CODEDB_NO_REGISTER=1`** — installs the binary without touching any client config; prints the per-project registration command instead (`claude mcp add codedb -s project -- codedb mcp`).

## Validation

- `zig build test`: **23/23 steps, 888/888 tests** (new: `issue-640` tests in config.zig + mcp.zig).
- Live check against the built binary: disabled project → `tools/list` = `{"tools": []}`, no snapshot created, CLI exit 1 with the message above; marker removed → 23 tools served again.
- `bash -n install.sh` clean; registration block unchanged when the flag is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)