### PR TITLE
perf(mcp): 2.2× codedb_context — line-offset-cache windows for top sites

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2433,6 +2433,23 @@ pub const Explorer = struct {
         return try allocator.dupe(u8, ref.data);
     }
 
+    pub const LineSpan = LineOffsetCache.Span;
+
+    /// Borrow the canonical cached bytes for `path`. Caller must hold `mu`
+    /// (shared) — the slice is only valid while the lock is held.
+    pub fn cachedContentLocked(self: *Explorer, path: []const u8) ?[]const u8 {
+        return self.contents.get(path);
+    }
+
+    /// Resolve 1-based `target_lines` of `path` to byte spans in `content`
+    /// via the line-offset cache (#611). Pass the canonical cached bytes
+    /// (stable pointer) so the table survives across calls. Returns the
+    /// filled count, or null when the table can't be built (OOM) — callers
+    /// fall back to scanning.
+    pub fn lineSpansFor(self: *Explorer, path: []const u8, content: []const u8, target_lines: []const u32, spans: []LineSpan) ?usize {
+        return self.line_offsets.lineSpans(path, content, target_lines, spans);
+    }
+
     pub const ReadRenderOptions = struct {
         if_hash: ?[]const u8 = null,
         line_start: ?i64 = null,

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2401,6 +2401,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     var arena = std.heap.ArenaAllocator.init(alloc);
     defer arena.deinit();
     const A = arena.allocator();
+    const pf_t0 = cio.nanoTimestamp();
 
     // #531 pick 5 — two-step packing: step 1 renders every section into its
     // own arena buffer; step 2 admits sections by VALUE order under the byte
@@ -2453,6 +2454,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             }
         }
     }
+    const pf_reader = cio.nanoTimestamp();
 
     var candidates: std.ArrayList([]const u8) = .empty;
     extractContextCandidates(task, A, &candidates);
@@ -2463,6 +2465,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         // documented input shape.
         extractContextFallbackWords(task, A, &candidates);
     }
+    const pf_cand = cio.nanoTimestamp();
     if (candidates.items.len == 0) {
         out.appendSlice(alloc, sec_reader.items) catch {};
         out.appendSlice(alloc, "no candidate identifiers found in task — include symbol names (camelCase or snake_case) or \"quoted strings\" so the composer can extract keywords") catch {};
@@ -2511,6 +2514,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             }
         }
     }
+    const pf_kwloop = cio.nanoTimestamp();
 
     // Rank files by a composite score: raw hits, +bonus when the file
     // contains a symbol definition for any keyword (definition beats usage),
@@ -2544,6 +2548,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         }
     }.lt);
     const top_n = @min(ranked.items.len, CONTEXT_TOP_FILES);
+    const pf_rank = cio.nanoTimestamp();
 
     {
         const wh = cio.listWriter(&sec_head, A);
@@ -2686,6 +2691,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             }
         }
     }
+    const pf_render = cio.nanoTimestamp();
 
     if (top_n > 0) {
         const wf = cio.listWriter(&sec_files, A);
@@ -2698,6 +2704,34 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         explorer.mu.lockShared();
         defer explorer.mu.unlockShared();
         for (ranked.items[0..top_n]) |f| {
+            // Fast path: borrow the canonical cached bytes (stable pointer,
+            // no copy) and resolve each hit's [line-2 .. line+2] window via
+            // the line-offset cache (#611) — O(log n) per hit instead of a
+            // whole-file newline walk per hit, which was 63% of
+            // codedb_context. Uncached files (released contents / low-memory)
+            // take the scanning fallback below.
+            if (explorer.cachedContentLocked(f.path)) |content| {
+                for (f.top) |h| {
+                    const want_start: u32 = if (h.line > 2) h.line - 2 else 1;
+                    const want_end: u32 = h.line + 2;
+                    var lines2 = [2]u32{ want_start, want_end };
+                    var spans2: [2]explore_mod.Explorer.LineSpan = undefined;
+                    const n = explorer.lineSpansFor(f.path, content, lines2[0..], spans2[0..]) orelse 0;
+                    if (n > 0 and spans2[0].line == want_start) {
+                        const start_off = spans2[0].start;
+                        // want_end past EOF matches the scanning fallback: the
+                        // window runs to end of file.
+                        const end_off = if (n == 2) spans2[1].end else content.len;
+                        const slice = content[start_off..end_off];
+                        // Cap per-snippet length to keep output bounded.
+                        const cap = @min(slice.len, 480);
+                        wts.print("\n{s}:{d}\n```\n{s}\n```\n", .{ f.path, h.line, slice[0..cap] }) catch {};
+                        continue;
+                    }
+                    wts.print("{s}:{d}  {s}\n", .{ f.path, h.line, h.text }) catch {};
+                }
+                continue;
+            }
             // Fetch full file content once per file, then slice ±2 lines around
             // each hit. Indexed cache hits common files in ~µs; arena owns the
             // dupe so we don't leak.
@@ -2742,6 +2776,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             }
         }
     }
+    const pf_sites = cio.nanoTimestamp();
 
     // Step 2: admit by value order — head (always), files, symbols
     // (rich, falling back to lean), reader.md, callers, calls, snippets —
@@ -2804,6 +2839,12 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     }
     if (top_n == 0) {
         out.appendSlice(alloc, "\n(no content matches — try codedb_search or codedb_word for narrower queries)\n") catch {};
+    }
+    if (cio.posixGetenv("CODEDB_CONTEXT_PROFILE") != null) {
+        std.log.info("ctx-prof ns: reader={d} cand={d} kwloop={d} rank={d} render={d} sites={d} emit={d} total={d}", .{
+            pf_reader - pf_t0, pf_cand - pf_reader, pf_kwloop - pf_cand, pf_rank - pf_kwloop,
+            pf_render - pf_rank, pf_sites - pf_render, cio.nanoTimestamp() - pf_sites, cio.nanoTimestamp() - pf_t0,
+        });
     }
 }
 


### PR DESCRIPTION
## What

`codedb_context` is the heaviest gated bench case (3.6× the next tool) and the flagship first-touch call — and its **"Top sites (±2 lines)" phase was 63% of the wall time**: for every hit in every top file it walked the whole file byte-by-byte from offset 0 to locate the `[line-2 .. line+2]` window.

This PR resolves both window edges through the existing #611 `LineOffsetCache` in O(log n) instead, borrowing the canonical cached bytes (stable pointer — the cache keys on it; also kills the per-file arena copy) under the shared lock the phase already holds. Uncached files (released contents / `CODEDB_LOW_MEMORY`) keep the old scanning path as a fallback, so behavior is unchanged everywhere the fast path can't prove itself.

Two small `Explorer` accessors (`cachedContentLocked`, `lineSpansFor`) expose the existing private machinery; no new data structures.

Also ships **`CODEDB_CONTEXT_PROFILE=1`** — per-phase ns breakdown of the composer on stderr (same pattern as `CODEDB_LOAD_PROFILE`). It's what located this hotspot, and it maps the next ones: the per-keyword search loop (48% of what remains) and the callers/callees render (32%).

## Numbers (CI-identical recipe: `run-bench-json.py` + `compare-bench.py`, same machine)

| | base | head | delta |
|---|---:|---:|---:|
| `codedb_context` avg | 224.8µs | 102.6µs | **−54.4%** |
| phase: sites | 122.9µs | 0.9µs | −99.3% |
| phase profile total | 195.1µs | 70.9µs | −63.7% |

Every other gated tool: OK (no regressions; most improved slightly from run noise).

## Quality

- Slice math is edge-for-edge identical to the scanning loop (EOF-truncated windows, missing trailing newline, hit lines past EOF, empty files — all verified against `lineSpans`'s split semantics).
- The 1-byte `response_bytes` delta in the bench is the response's **own embedded elapsed-time string** (`mcpFormatDuration` at mcp.zig runToolCall/handleCall) rendering fewer digits because the call got faster — confirmed by A/B'ing the binaries: the only differing bytes are the duration digits.
- `zig build test`: 23/23 steps, **865/865**. `e2e_mcp_test.py`: **20/20**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)