### PR TITLE
perf(explore): searchSymbols binary-insert + complete the total order

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2858,11 +2858,18 @@ pub const Explorer = struct {
         };
 
         const SortCtx = struct {
+            // Total order: score desc, then name, path, line. line_start is
+            // the final tiebreak — without it, same-name symbols in one file
+            // compared equal and their order fell out of hash-map iteration,
+            // the residual nondeterminism the deterministic-ordering rewrite
+            // meant to eliminate.
             pub fn lessThan(_: void, a: Candidate, b: Candidate) bool {
                 if (a.score != b.score) return a.score > b.score;
                 const name_cmp = std.mem.order(u8, a.symbol.name, b.symbol.name);
                 if (name_cmp != .eq) return name_cmp == .lt;
-                return std.mem.order(u8, a.path, b.path) == .lt;
+                const path_cmp = std.mem.order(u8, a.path, b.path);
+                if (path_cmp != .eq) return path_cmp == .lt;
+                return a.symbol.line_start < b.symbol.line_start;
             }
 
             fn candidateBefore(a: Candidate, b: Candidate) bool {
@@ -2925,12 +2932,26 @@ pub const Explorer = struct {
                     return;
                 }
 
-                if (list_ptr.items.len < max_results) {
-                    try list_ptr.append(alloc, candidate);
-                } else {
-                    list_ptr.items[list_ptr.items.len - 1] = candidate;
+                // The list is kept sorted at all times, so placing the new
+                // candidate is a binary search + insert (O(log K) compares +
+                // O(K) moves) instead of the previous full re-sort per
+                // accepted insert (O(K log K) compares). Ties are impossible:
+                // the sort key ends in (path, line) and same-(path, line)
+                // candidates are deduped above.
+                var lo: usize = 0;
+                var hi: usize = list_ptr.items.len;
+                while (lo < hi) {
+                    const mid = lo + (hi - lo) / 2;
+                    if (SortCtx.candidateBefore(candidate, list_ptr.items[mid])) {
+                        hi = mid;
+                    } else {
+                        lo = mid + 1;
+                    }
                 }
-                std.mem.sort(Candidate, list_ptr.items, {}, SortCtx.lessThan);
+                if (list_ptr.items.len >= max_results) {
+                    _ = list_ptr.pop();
+                }
+                try list_ptr.insert(alloc, lo, candidate);
             }
         }.call;
 
@@ -2969,8 +2990,7 @@ pub const Explorer = struct {
             }
         }
 
-        std.mem.sort(Candidate, candidates.items, {}, SortCtx.lessThan);
-
+        // candidates is kept sorted by appendOne — no final sort needed.
         const results = try allocator.alloc(ScoredSymbolResult, candidates.items.len);
         errdefer allocator.free(results);
         var result_len: usize = 0;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2187,6 +2187,30 @@ test "issue-531: searchSymbols prefix match" {
     for (results) |r| try testing.expect(std.mem.startsWith(u8, r.symbol.name, "parse_"));
 }
 
+test "searchSymbols: same-name same-file symbols order by line (total order)" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+    // Two same-name, same-kind symbols in one file: score/name/path all tie,
+    // so only the line_start tiebreak makes their order deterministic.
+    try explorer_inst.indexFile("dup.zig",
+        \\pub fn init() void {}
+        \\pub fn deinit() void {}
+        \\pub fn init() void {}
+    );
+
+    const results = try explorer_inst.searchSymbols(.{ .name = "init", .max_results = 10 }, testing.allocator);
+    defer {
+        for (results) |r| {
+            testing.allocator.free(r.path);
+            testing.allocator.free(r.symbol.name);
+            if (r.symbol.detail) |d| testing.allocator.free(d);
+        }
+        testing.allocator.free(results);
+    }
+    try testing.expect(results.len == 2);
+    try testing.expect(results[0].symbol.line_start < results[1].symbol.line_start);
+}
+
 test "issue-531: searchSymbols pattern and kind filter" {
     var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_inst.deinit();


### PR DESCRIPTION
Second perf round, item 1 (smallest, highest-certainty from the 4-agent speedup survey).

## What

`searchSymbols`' `appendOne` kept its K-bounded candidate buffer sorted by **re-sorting the whole buffer on every accepted insert** — O(K·log K) compares per insert with the default K=50/cap 200 — plus a redundant final sort. Since the buffer is always sorted, placement is a binary search + single insert (O(log K) compares, O(K) moves).

The comparator also gains `line_start` as the final tiebreak. Without it, same-name symbols in the same file (multiple nested `init`s, overload-style patterns) compared **equal**, so their relative order still fell out of hash-map iteration order — the exact residual nondeterminism the deterministic-ordering rewrite (#641) meant to eliminate. With the key ending in (path, line) and same-(path, line) deduped, the order is total and the sorted-insert invariant is airtight.

## Evidence

- **A/B on this repo** (fresh servers, exact/prefix/pattern/fuzzy/kind filters, max_results up to 200): payload bytes **identical on every query**; embedded dispatch timings: warm `prefix:"handle"` 3.1ms → 896µs, `name:"main"` 1.2ms → 931µs.
- Gated bench: `codedb_symbol` +0.23% (the 21-file corpus exact-name case barely touches the insert path — the win scales with match count, i.e. prefix/fuzzy/glob on real indexes).
- `zig build test`: 23/23 steps, **869/873** (4 platform skips) including a new same-name-same-file ordering test. e2e: **20/20**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)