### PR TITLE
fix(explore): invalidate + own call graph on file edit (#656)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -702,7 +702,9 @@ pub const CallGraph = struct {
         allocator.free(self.edges);
         codegraph.freeAdjacency(allocator, self.adj);
         codegraph.freeAdjacency(allocator, self.radj);
+        for (self.node_path) |p| allocator.free(p);
         allocator.free(self.node_path);
+        for (self.node_name) |n| allocator.free(n);
         allocator.free(self.node_name);
         allocator.free(self.node_line);
     }
@@ -1506,6 +1508,14 @@ pub const Explorer = struct {
         self.mu.lock();
         defer self.mu.unlock();
         self.bumpSearchGen();
+        if (self.call_graph) |*cg| {
+            cg.deinit(self.allocator);
+            self.call_graph = null;
+        }
+        if (self.call_centrality) |*cc| {
+            cc.deinit();
+            self.call_centrality = null;
+        }
 
         const outline_gop = try self.outlines.getOrPut(path);
         const is_new = !outline_gop.found_existing;
@@ -4590,20 +4600,45 @@ pub const Explorer = struct {
             codegraph.freeAdjacency(self.allocator, adj);
             return;
         };
-        @memcpy(np, node_path.items);
+        var np_filled: usize = 0;
+        for (node_path.items, 0..) |p, i| {
+            np[i] = self.allocator.dupe(u8, p) catch {
+                for (np[0..np_filled]) |s| self.allocator.free(s);
+                self.allocator.free(np);
+                self.allocator.free(edges_owned);
+                codegraph.freeAdjacency(self.allocator, adj);
+                return;
+            };
+            np_filled += 1;
+        }
 
         const nn = self.allocator.alloc([]const u8, n_nodes) catch {
+            for (np) |s| self.allocator.free(s);
+            self.allocator.free(np);
             self.allocator.free(edges_owned);
             codegraph.freeAdjacency(self.allocator, adj);
-            self.allocator.free(np);
             return;
         };
-        @memcpy(nn, node_name.items);
+        var nn_filled: usize = 0;
+        for (node_name.items, 0..) |nm, i| {
+            nn[i] = self.allocator.dupe(u8, nm) catch {
+                for (nn[0..nn_filled]) |s| self.allocator.free(s);
+                self.allocator.free(nn);
+                for (np) |s| self.allocator.free(s);
+                self.allocator.free(np);
+                self.allocator.free(edges_owned);
+                codegraph.freeAdjacency(self.allocator, adj);
+                return;
+            };
+            nn_filled += 1;
+        }
 
         const nl = self.allocator.alloc(u32, n_nodes) catch {
             self.allocator.free(edges_owned);
             codegraph.freeAdjacency(self.allocator, adj);
+            for (np) |s| self.allocator.free(s);
             self.allocator.free(np);
+            for (nn) |s| self.allocator.free(s);
             self.allocator.free(nn);
             return;
         };
@@ -4616,7 +4651,9 @@ pub const Explorer = struct {
         if (node_scores == null) {
             self.allocator.free(edges_owned);
             codegraph.freeAdjacency(self.allocator, adj);
+            for (np) |s| self.allocator.free(s);
             self.allocator.free(np);
+            for (nn) |s| self.allocator.free(s);
             self.allocator.free(nn);
             self.allocator.free(nl);
             return;
@@ -4642,7 +4679,9 @@ pub const Explorer = struct {
         const radj = radj_opt orelse {
             self.allocator.free(edges_owned);
             codegraph.freeAdjacency(self.allocator, adj);
+            for (np) |s| self.allocator.free(s);
             self.allocator.free(np);
+            for (nn) |s| self.allocator.free(s);
             self.allocator.free(nn);
             self.allocator.free(nl);
             return;
@@ -4650,7 +4689,7 @@ pub const Explorer = struct {
 
         if (self.call_centrality == null) {
             var cmap = std.StringHashMap(f32).init(self.allocator);
-            for (np, node_scores.?) |path, score| {
+            for (node_path.items, node_scores.?) |path, score| {
                 if (score == 0) continue;
                 const gop = cmap.getOrPut(path) catch continue;
                 if (!gop.found_existing) gop.value_ptr.* = 0;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2477,3 +2477,32 @@ test "symbol lookups stay correct across the deferred-index restore path" {
     try testing.expectEqual(@as(usize, 1), after.len);
     try testing.expectEqualStrings("a.zig", after[0].path);
 }
+
+test "issue-656: call graph is stale and dangling after a file edit" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+    try explorer_inst.indexFile("calls.zig",
+        \\pub fn alpha() void {}
+        \\pub fn beta() void {}
+    );
+
+    // First query builds the call graph: no alpha -> beta edge yet.
+    const before = try explorer_inst.findCallPath("alpha", "beta", testing.allocator, 4);
+    try testing.expect(before == null);
+
+    // Edit the file so alpha NOW calls beta. The commit path refreshes deps,
+    // the symbol index, and line offsets — but call_graph is never rebuilt,
+    // and worse, its node_name/node_path slices borrow outline memory that
+    // the re-index just freed. A fresh graph resolves the new edge; the
+    // stale/dangling one cannot.
+    try explorer_inst.indexFile("calls.zig",
+        \\pub fn alpha() void {
+        \\    beta();
+        \\}
+        \\pub fn beta() void {}
+    );
+
+    const after = try explorer_inst.findCallPath("alpha", "beta", testing.allocator, 4);
+    defer if (after) |steps| testing.allocator.free(steps);
+    try testing.expect(after != null);
+}


### PR DESCRIPTION
Fixes #656.

## Problem
`Explorer.call_graph` was built once in `ensureCallGraph` and **never invalidated**. The file-commit path (`commitParsedFileOwnedOutline`) refreshes deps, the symbol index, and line offsets — but not `call_graph`/`call_centrality`. So `codedb_callpath` and the graph-distance rerank boost answer from the process-start snapshot and cannot see edges added by an edit.

Worse: `CallGraph.node_path`/`node_name` were **borrowed slices into outline symbol memory** (`CallGraph.deinit` freed only the arrays, not the strings). Re-indexing a file frees those outlines, dangling the name/path tables → **use-after-free** (silently-wrong under the testing allocator, corrupt paths otherwise).

## Fix
1. **Invalidate on commit** — `commitParsedFileOwnedOutline` now `deinit`+`null`s both `call_graph` and `call_centrality` under the exclusive lock, so the next graph query lazily rebuilds (mirrors the existing `bumpSearchGen`/`ensureSymbolIndex` invalidation pattern). Rebuild-per-edit is acceptable: build cost equals the existing first-query cost, and edits are far rarer than queries.
2. **Own the strings** — `ensureCallGraph` now `dupe`s each `node_path`/`node_name` instead of borrowing outline memory, and `CallGraph.deinit` frees them. Every fallible early-return unwinds the partial arrays (no leak, no double-free). The `call_centrality` build loop keeps iterating `node_path.items` so its keys still borrow the stable `self.outlines` keys — preserving the snapshot-restore ownership invariant documented in `snapshot.zig`.

## Test
`test "issue-656: call graph is stale and dangling after a file edit"` (in `src/test_explore.zig`): red on the failing-test commit, green with the fix.

- `zig build test-explore` → **127/127 pass** (was 126/127) under the testing allocator (no leaks/UAF)
- `zig build test` (full suite) → **all pass, 0 failures**

## Provenance
Fix produced by a 3-agent swarm (independent attempts in isolated worktrees, all converged on the same two-part fix); winning `src/explore.zig` delta extracted onto the failing-test branch and independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)