### PR TITLE
feat(mcp): client-aware lean output — stop agents paying for user-only blocks

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -261,7 +261,35 @@ The installer does this for you.
 
 ---
 
-## 7. Going deeper
+## 7. Response verbosity — lean vs rich (token cost)
+
+Every MCP tool result carries the data block the model consumes
+(`audience: assistant`). Interactive clients also get two `audience: user`
+blocks: a colored one-line summary and a follow-up hint. Well-behaved clients
+render those in a preview pane and keep them out of the model context — but
+many forward everything to the model, where they cost output tokens for output
+the model can't render (they add ~34% to a small result like `codedb_symbol`).
+
+codedb decides per session, from the `clientInfo.name` sent at `initialize`:
+
+- **Agent harnesses default lean** (data block only) — `claude-code`, `codex`,
+  and any client not on the rich allowlist.
+- **Human-facing GUI clients get the rich blocks** — currently `claude-ai`
+  (Claude Desktop).
+
+Override the default:
+
+| Env var | Effect |
+|---|---|
+| `CODEDB_MCP_LEAN=1` | Force lean for every client (data block only). |
+| `CODEDB_MCP_RICH=1` | Force rich for every client. |
+| `CODEDB_MCP_RICH_CLIENTS=name1,name2` | Add clients (by `clientInfo.name`, case-insensitive) to the rich allowlist. |
+
+`CODEDB_MCP_LEAN` takes precedence over `CODEDB_MCP_RICH`.
+
+---
+
+## 8. Going deeper
 
 - [Architecture](architecture.md) — engine internals, index layout
 - [CLI reference](cli.md) — every command, every flag

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -521,7 +521,7 @@ pub const BenchContext = struct {
         agents: *AgentRegistry,
         telem: *telemetry_mod.Telemetry,
     ) void {
-        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null, 1, null);
+        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null, 1, null, null);
     }
 
     pub fn runToolCall(
@@ -842,6 +842,7 @@ const Session = struct {
     }
 
     fn deinit(self: *Session) void {
+        if (self.client_name) |cn| self.alloc.free(cn);
         self.freeRoots();
         self.roots.deinit(self.alloc);
     }
@@ -1033,7 +1034,7 @@ pub fn run(
         } else if (mcpj.eql(method, "tools/list")) {
             if (!is_notification) writeResult(alloc, stdout, id, tools_list_response);
         } else if (mcpj.eql(method, "tools/call")) {
-            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, session.edit_agent_id, &session.governor);
+            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, session.edit_agent_id, &session.governor, session.client_name);
         } else if (mcpj.eql(method, "ping")) {
             if (!is_notification) writeResult(alloc, stdout, id, "{}");
         } else {
@@ -1060,7 +1061,11 @@ fn handleInitialize(s: *Session, root: *const std.json.ObjectMap, id: ?std.json.
         const ci = p.object.get("clientInfo") orelse break :client_name;
         if (ci != .object) break :client_name;
         if (mcpj.getStr(&ci.object, "name")) |name| {
-            s.client_name = name;
+            // Own the string: `name` borrows the initialize request's parsed
+            // JSON, freed at the end of this dispatch iteration; the
+            // client-aware block policy reads it on later tools/call requests.
+            if (s.client_name) |old| s.alloc.free(old);
+            s.client_name = s.alloc.dupe(u8, name) catch null;
         }
     }
     // #505 / #506: negotiate the protocol version with the client.
@@ -1197,6 +1202,7 @@ fn handleCall(
     deferred_scan: ?*DeferredScan,
     edit_agent_id: u64,
     governor: ?*ConvergenceGovernor,
+    client_name: ?[]const u8,
 ) void {
     const is_notification = id == null;
 
@@ -1275,7 +1281,7 @@ fn handleCall(
     }
     if (is_notification) return;
 
-    const lean = mcpLeanMode();
+    const lean = !mcpEmitRichBlocks(client_name);
 
     // Block 1: Human-readable colored summary (ANSI — preview pane always
     // renders it). Skipped in lean mode (agents don't render ANSI; the
@@ -5495,22 +5501,56 @@ pub fn appendId(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), id: ?std.json
 // ── MCP UX: 3-block response helpers ────────────────────────────────────────
 // Colors are always on — MCP preview pane always renders ANSI. No TTY check.
 
-var mcp_lean_mode_cached: ?bool = null;
+const McpBlockPolicy = enum { default, lean, rich };
+var mcp_env_policy_cached: ?McpBlockPolicy = null;
 
-/// True when CODEDB_MCP_LEAN is set (any non-empty value). Cached on first
-/// read. When true, MCP responses omit Block 1 (colored summary header) and
-/// Block 3 (guidance hints) — emitting only Block 2 (raw data). Saves
-/// tokens for agent consumers that can't render ANSI and don't need the
-/// hints.
-fn mcpLeanMode() bool {
-    if (mcp_lean_mode_cached) |v| return v;
-    const v = cio.posixGetenv("CODEDB_MCP_LEAN") orelse {
-        mcp_lean_mode_cached = false;
-        return false;
-    };
-    const enabled = v.len > 0 and !std.mem.eql(u8, v, "0") and !std.mem.eql(u8, v, "false");
-    mcp_lean_mode_cached = enabled;
-    return enabled;
+fn mcpEnvTruthy(v: []const u8) bool {
+    return v.len > 0 and !std.mem.eql(u8, v, "0") and !std.mem.eql(u8, v, "false");
+}
+
+/// Global env override for the human-facing summary/guidance blocks.
+/// CODEDB_MCP_LEAN wins over CODEDB_MCP_RICH; each accepts 1/true (on) or
+/// 0/false (off). Cached on first read.
+fn mcpEnvPolicy() McpBlockPolicy {
+    if (mcp_env_policy_cached) |v| return v;
+    var policy: McpBlockPolicy = .default;
+    if (cio.posixGetenv("CODEDB_MCP_LEAN")) |v| {
+        policy = if (mcpEnvTruthy(v)) .lean else .rich;
+    } else if (cio.posixGetenv("CODEDB_MCP_RICH")) |v| {
+        policy = if (mcpEnvTruthy(v)) .rich else .lean;
+    }
+    mcp_env_policy_cached = policy;
+    return policy;
+}
+
+/// Built-in "rich" allowlist: desktop GUI chat clients that render tool
+/// results in a human-facing panel. Agent harnesses (claude-code, codex,
+/// cursor, ...) are intentionally absent — they forward tool text straight
+/// into model context, so they default lean to save output tokens.
+fn mcpBuiltinRichClient(name: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(name, "claude-ai");
+}
+
+/// Decide whether to emit Block 1 (colored summary) + Block 3 (guidance).
+/// Default is LEAN (omit them): agents can't render ANSI and pay output
+/// tokens for a summary that duplicates Block 2. Rich is emitted only for
+/// human-facing GUI clients (built-in allowlist, extended by the
+/// comma-separated CODEDB_MCP_RICH_CLIENTS env). Env policy overrides win.
+pub fn mcpEmitRichBlocks(client_name: ?[]const u8) bool {
+    switch (mcpEnvPolicy()) {
+        .lean => return false,
+        .rich => return true,
+        .default => {},
+    }
+    const name = client_name orelse return false;
+    if (cio.posixGetenv("CODEDB_MCP_RICH_CLIENTS")) |list| {
+        var it = std.mem.tokenizeScalar(u8, list, ',');
+        while (it.next()) |entry| {
+            const trimmed = std.mem.trim(u8, entry, " \t");
+            if (trimmed.len > 0 and std.ascii.eqlIgnoreCase(name, trimmed)) return true;
+        }
+    }
+    return mcpBuiltinRichClient(name);
 }
 
 const MCP_RESET = "\x1b[0m";

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -3058,3 +3058,17 @@ test "windows: spawnDetached command line round-trips argv with trailing backsla
     }
     try testing.expect(it.next() == null);
 }
+
+test "mcp: emit-rich-blocks defaults lean for agent clients, rich for GUI panels" {
+    // Assumes a clean env (no CODEDB_MCP_LEAN/RICH override), as under `zig build test`.
+    // Agent harnesses forward tool text straight into model context, so they
+    // default LEAN — no colored summary / guidance blocks to pay output tokens for.
+    try testing.expect(!mcp_mod.mcpEmitRichBlocks(null)); // no clientInfo -> lean
+    try testing.expect(!mcp_mod.mcpEmitRichBlocks("claude-code"));
+    try testing.expect(!mcp_mod.mcpEmitRichBlocks("codex"));
+    try testing.expect(!mcp_mod.mcpEmitRichBlocks("cursor"));
+    // Desktop GUI chat clients render a human-facing result panel -> rich blocks,
+    // matched case-insensitively.
+    try testing.expect(mcp_mod.mcpEmitRichBlocks("claude-ai"));
+    try testing.expect(mcp_mod.mcpEmitRichBlocks("Claude-AI"));
+}


### PR DESCRIPTION
## Goal
Make codedb cheaper for agents searching code. **Output tokens cost more than input**, so the highest-leverage win is trimming what the tools *emit* without losing signal.

## What agents pay for today
Every MCP result carries the `audience:["assistant"]` data block (what the model consumes) plus two `audience:["user"]` blocks — a colored `✓ … ⚡502µs` summary and a `→ next:` hint. These exist for interactive preview panes, but **most clients forward everything to the model**, where they cost output tokens the model can't render.

Measured on this repo (live MCP calls), the tax is a ~fixed 13–53 tok/call, so it hurts the *cheapest* tools most — the ones codedb steers agents toward:

| Tool | assistant (agent pays) | user-block overhead | % |
|---|---|---|---|
| **codedb_symbol** | ~75 tok | ~39 tok | **34%** |
| codedb_search | ~398 | ~38 | 9% |
| codedb_callers | ~881 | ~34 | 4% |
| codedb_outline | ~1295 | ~53 | 4% |

A lean mode already existed (`CODEDB_MCP_LEAN`) but was **off by default and undocumented**, so agents paid unless they knew the knob.

## Change — client-aware default
Decide per session from `clientInfo.name` (sent at `initialize`):
- **Agent harnesses default LEAN** — `claude-code`, `codex`, unknown clients (they forward tool text into model context). *Confirmed empirically: `claude-code` does not strip `audience:user`.*
- **Human-facing GUI clients get RICH** — `claude-ai` (Claude Desktop).
- **Overrides:** `CODEDB_MCP_LEAN` / `CODEDB_MCP_RICH` force globally (LEAN wins); `CODEDB_MCP_RICH_CLIENTS=a,b` extends the rich allowlist.

Result: `codedb_symbol` drops 115 → **75 tok (−34%)** for the default agent client, with zero loss to the data the model actually uses (the valuable "indexed symbol" nudge lives in the assistant block and is unaffected).

## Latent UAF fixed along the way
`session.client_name` borrowed a slice from the `initialize` request's parsed JSON, which is `defer`-freed at the end of that dispatch iteration. It was only read *during* initialize before; reading it on a later `tools/call` (the new policy) dangled. Now duped into session-owned memory and freed in `Session.deinit`.

## Verification
- End-to-end on the built binary in a clean env: `claude-code`→lean, `claude-ai`→rich, `CODEDB_MCP_LEAN=1`→lean even for `claude-ai`, `CODEDB_MCP_RICH_CLIENTS`→opt-in works.
- Unit test `mcp: emit-rich-blocks defaults lean for agent clients, rich for GUI panels` in `test_mcp.zig`.
- `zig build test` — full suite green (testing allocator clean on the UAF fix).
- Docs: new "Response verbosity — lean vs rich" section in `docs/mcp.md`.

## Note on the allowlist
The rich allowlist is seeded conservatively with `claude-ai`; it's a heuristic the maintainer can tune (via code or `CODEDB_MCP_RICH_CLIENTS`) as real `clientInfo.name` values are confirmed for other GUI clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)