### PR TITLE
feat(search): surface definition site inline for exact-symbol queries (#1)

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1681,8 +1681,36 @@ fn appendSearchSymbolNudge(alloc: std.mem.Allocator, explorer: *Explorer, query:
         alloc.free(results);
     }
     if (results.len == 0) return;
+
+    // Fewer round-trips: `query` is an indexed symbol, so instead of nudging the
+    // agent to make a *second* codedb_symbol call, surface the definition site(s)
+    // inline. Prefer real definitions over import/comment matches (same filter as
+    // renderSymbolDefsFast). One call now answers "where is X defined?".
+    var has_def = false;
+    for (results) |r| {
+        if (r.symbol.kind != .import and r.symbol.kind != .comment_block) {
+            has_def = true;
+            break;
+        }
+    }
+    var total_defs: usize = 0;
+    for (results) |r| {
+        const is_def = r.symbol.kind != .import and r.symbol.kind != .comment_block;
+        if (!has_def or is_def) total_defs += 1;
+    }
     const w = cio.listWriter(out, alloc);
-    w.print("↪ '{s}' is an indexed symbol — codedb_symbol returns its definition and codedb_callers its call sites in one call (no search+read needed).\n", .{query}) catch {};
+    const cap: usize = 3;
+    var shown: usize = 0;
+    for (results) |r| {
+        if (shown >= cap) break;
+        const is_def = r.symbol.kind != .import and r.symbol.kind != .comment_block;
+        if (has_def and !is_def) continue;
+        if (shown == 0) w.print("↪ '{s}' is defined at (codedb_symbol for bodies):\n", .{query}) catch {};
+        w.print("  {s}:{d} ({s})\n", .{ r.path, r.symbol.line_start, @tagName(r.symbol.kind) }) catch {};
+        shown += 1;
+    }
+    if (shown == 0) return;
+    if (total_defs > shown) w.print("  (+{d} more — codedb_symbol '{s}')\n", .{ total_defs - shown, query }) catch {};
 }
 
 // Issue #626 follow-up: codedb_deps is the one structural tool nothing points

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -3058,3 +3058,34 @@ test "windows: spawnDetached command line round-trips argv with trailing backsla
     }
     try testing.expect(it.next() == null);
 }
+
+test "search: exact-symbol query surfaces the definition site inline (fewer round-trips, #1)" {
+    // codedb_search for a bare identifier that is an indexed symbol should lead
+    // with the def location, so the agent doesn't have to make a 2nd
+    // codedb_symbol call just to learn where it is defined.
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/thing.zig", "pub fn parseThing() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const search_json =
+        \\{"query":"parseThing"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, search_json, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_search, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "is defined at") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/thing.zig:1") != null);
+}


### PR DESCRIPTION
**Fewer round-trips = fewer output tokens.** Stacked on #660 (extends the search nudge #660 rewrote).

When `codedb_search`'s query is a bare identifier that resolves to an indexed symbol, the nudge used to just say *"go call codedb_symbol"* — forcing a **second round-trip** (~85 tok response + the agent's own call-emission tokens) purely to learn where the symbol is defined. Now it surfaces the definition site(s) **inline** — `path:line (kind)`, up to 3, `+N more` — reusing the O(1) `findAllSymbols` the nudge already ran.

### Before → after (measured, `claude-code` client)
- `codedb_search "renderPlainSearch"` → previously 444 tok **+ a forced `codedb_symbol` call** (85 tok). Now the first call leads with `src/explore.zig:3688 (function)` — the second call is unnecessary.

### Test
`search: exact-symbol query surfaces the definition site inline` in `test_mcp.zig`. Full `zig build test` green.

> Base is `perf/search-latency-pr-a` (#660) — retarget to `release/0.2.5828` once #660 merges. First of a series on agent-output-token efficiency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)