### PR TITLE
feat(search): unify result renderer + trim match lines (#4)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3685,6 +3685,19 @@ pub const Explorer = struct {
         return res;
     }
 
+    /// Trim a source line for search output: strip leading ASCII indentation
+    /// (the line number already locates it) and cap length, to cut agent output
+    /// tokens. Mirrors mcp.zig's trimMatchText (MAX 200 bytes, UTF-8-safe cut).
+    fn trimSearchLine(line: []const u8) struct { text: []const u8, truncated: bool } {
+        var t = line;
+        while (t.len > 0 and (t[0] == ' ' or t[0] == '\t')) t = t[1..];
+        const MAX: usize = 200;
+        if (t.len <= MAX) return .{ .text = t, .truncated = false };
+        var cut: usize = MAX;
+        while (cut > 0 and (t[cut] & 0xC0) == 0x80) cut -= 1;
+        return .{ .text = t[0..cut], .truncated = true };
+    }
+
     pub fn renderPlainSearch(self: *Explorer, query: []const u8, allocator: std.mem.Allocator, out: *std.ArrayList(u8), max_results: usize, paths_only: bool) !bool {
         // Rendered-output cache front door — same generation discipline as
         // searchContent's cache (see that wrapper for the staleness
@@ -3927,7 +3940,12 @@ pub const Explorer = struct {
                     }
                 } else {
                     shown += 1;
-                    try w.print("  {s}:{d}: {s}\n", .{ stats.path, line_span.line, content[line_span.start..line_span.end] });
+                    const mt = trimSearchLine(content[line_span.start..line_span.end]);
+                    if (mt.truncated) {
+                        try w.print("  {s}:{d}: {s}…\n", .{ stats.path, line_span.line, mt.text });
+                    } else {
+                        try w.print("  {s}:{d}: {s}\n", .{ stats.path, line_span.line, mt.text });
+                    }
                 }
                 if (rendered >= max_results) break;
             }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1723,6 +1723,47 @@ pub fn depsHint(result_count: usize) ?[]const u8 {
     return "↪ to see what imports this file (impact/blast radius), use codedb_deps path=<this file>.\n";
 }
 
+/// Cap on printed match-text bytes (~50 tokens) — trims agent output tokens
+/// on search-result rendering without dropping results or reordering them.
+const MAX_MATCH_LINE_BYTES: usize = 200;
+
+/// Strip leading ASCII whitespace (indentation is pure token waste — the
+/// agent already has the line number) and cap at MAX_MATCH_LINE_BYTES,
+/// backing off to a UTF-8 boundary so a multi-byte sequence is never split.
+fn trimMatchText(text: []const u8) struct { text: []const u8, truncated: bool } {
+    var start: usize = 0;
+    while (start < text.len and (text[start] == ' ' or text[start] == '\t')) : (start += 1) {}
+    const trimmed = text[start..];
+    if (trimmed.len <= MAX_MATCH_LINE_BYTES) return .{ .text = trimmed, .truncated = false };
+    var cut = MAX_MATCH_LINE_BYTES;
+    while (cut > 0 and (trimmed[cut] & 0xC0) == 0x80) cut -= 1;
+    return .{ .text = trimmed[0..cut], .truncated = true };
+}
+
+/// Write "<prefix><path>:<line_num>: <trimmed text>" (plus "…" if capped),
+/// WITHOUT a trailing newline — used by callers that append a scope suffix
+/// (" [in <scope> ...]") before the line ends.
+fn appendMatchLineNoNL(w: anytype, prefix: []const u8, path: []const u8, line_num: u32, line_text: []const u8) void {
+    const r = trimMatchText(line_text);
+    if (r.truncated) {
+        w.print("{s}{s}:{d}: {s}\u{2026}", .{ prefix, path, line_num, r.text }) catch {};
+    } else {
+        w.print("{s}{s}:{d}: {s}", .{ prefix, path, line_num, r.text }) catch {};
+    }
+}
+
+/// Render one search-result line: "<prefix><path>:<line>" plus ": <text>" when
+/// line_text is non-null. Trims the match text (see trimMatchText) to save
+/// agent output tokens. prefix is "  " for codedb_search, "- " for bundle, "" for query.
+fn appendMatchLine(w: anytype, prefix: []const u8, path: []const u8, line_num: u32, line_text: ?[]const u8) void {
+    if (line_text) |t| {
+        appendMatchLineNoNL(w, prefix, path, line_num, t);
+        w.print("\n", .{}) catch {};
+    } else {
+        w.print("{s}{s}:{d}\n", .{ prefix, path, line_num }) catch {};
+    }
+}
+
 fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const query = getStr(args, "query") orelse {
         out.appendSlice(alloc, "error: missing 'query' argument") catch {};
@@ -1803,17 +1844,12 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             if (path_glob) |g| if (!globMatch(g, r.path)) continue;
             if (compact and explore_mod.isCommentOrBlank(r.line_text, explore_mod.detectLanguage(r.path))) continue;
             if (paths_only) {
-                w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
+                appendMatchLine(w, "  ", r.path, r.line_num, null);
             } else if (r.scope_name) |sn| {
-                w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
-                    r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
-                }) catch {};
+                appendMatchLineNoNL(w, "  ", r.path, r.line_num, r.line_text);
+                w.print("  [in {s} ({s}, L{d}-L{d})]\n", .{ sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end }) catch {};
             } else {
-                if (paths_only) {
-                    w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
-                } else {
-                    w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
-                }
+                appendMatchLine(w, "  ", r.path, r.line_num, r.line_text);
             }
         }
     } else if (scope) {
@@ -1859,17 +1895,12 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
                 continue;
             }
             if (paths_only) {
-                w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
+                appendMatchLine(w, "  ", r.path, r.line_num, null);
             } else if (r.scope_name) |sn| {
-                w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
-                    r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
-                }) catch {};
+                appendMatchLineNoNL(w, "  ", r.path, r.line_num, r.line_text);
+                w.print("  [in {s} ({s}, L{d}-L{d})]\n", .{ sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end }) catch {};
             } else {
-                if (paths_only) {
-                    w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
-                } else {
-                    w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
-                }
+                appendMatchLine(w, "  ", r.path, r.line_num, r.line_text);
             }
             shown += 1;
         }
@@ -1920,11 +1951,7 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
                 }
                 continue;
             }
-            if (paths_only) {
-                w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
-            } else {
-                w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
-            }
+            appendMatchLine(w, "  ", r.path, r.line_num, if (paths_only) null else r.line_text);
             shown += 1;
         }
         if (shown < visible_total) {
@@ -2047,11 +2074,7 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
                     }
                     continue;
                 }
-                if (paths_only) {
-                    w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
-                } else {
-                    w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
-                }
+                appendMatchLine(w, "  ", r.path, r.line_num, if (paths_only) null else r.line_text);
                 shown += 1;
             }
             if (shown < visible_total) {
@@ -2075,11 +2098,7 @@ fn handleSearch(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
                 }
                 continue;
             }
-            if (paths_only) {
-                w.print("  {s}:{d}\n", .{ r.path, r.line_num }) catch {};
-            } else {
-                w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
-            }
+            appendMatchLine(w, "  ", r.path, r.line_num, if (paths_only) null else r.line_text);
             shown += 1;
         }
         if (shown < visible_total) {
@@ -2174,11 +2193,10 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     for (kept.items) |kept_idx| {
         const r = results[kept_idx];
         if (r.scope_name) |sn| {
-            w.print("  {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
-                r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
-            }) catch {};
+            appendMatchLineNoNL(w, "  ", r.path, r.line_num, r.line_text);
+            w.print("  [in {s} ({s}, L{d}-L{d})]\n", .{ sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end }) catch {};
         } else {
-            w.print("  {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+            appendMatchLine(w, "  ", r.path, r.line_num, r.line_text);
         }
     }
 }
@@ -2673,11 +2691,10 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                         any_callers = true;
                     }
                     if (r.scope_name) |sn| {
-                        wc.print("- {s}:{d}: {s}  [in {s} ({s}, L{d}-L{d})]\n", .{
-                            r.path, r.line_num, r.line_text, sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end,
-                        }) catch {};
+                        appendMatchLineNoNL(wc, "- ", r.path, r.line_num, r.line_text);
+                        wc.print("  [in {s} ({s}, L{d}-L{d})]\n", .{ sn, @tagName(r.scope_kind.?), r.scope_start, r.scope_end }) catch {};
                     } else {
-                        wc.print("- {s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+                        appendMatchLine(wc, "- ", r.path, r.line_num, r.line_text);
                     }
                     shown_for_sym += 1;
                     total_shown += 1;
@@ -4795,7 +4812,7 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
                 for (file_set.items) |p| path_set.put(p, {}) catch {};
                 for (results) |r| {
                     if (path_set.contains(r.path)) {
-                        w.print("{s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+                        appendMatchLine(w, "", r.path, r.line_num, r.line_text);
                         hit_set.put(r.path, {}) catch {};
                     }
                 }
@@ -4813,7 +4830,7 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
                 defer seen.deinit();
                 file_set.clearRetainingCapacity();
                 for (results) |r| {
-                    w.print("{s}:{d}: {s}\n", .{ r.path, r.line_num, r.line_text }) catch {};
+                    appendMatchLine(w, "", r.path, r.line_num, r.line_text);
                     if (!seen.contains(r.path)) {
                         // Dupe path — search results are freed by the defer above,
                         // but file_set must outlive this step for downstream ops


### PR DESCRIPTION
Stacked on #662 (which is stacked on #660). **Rendering-only** — result set and order unchanged.

## What
1. **Consolidate** the ~16 duplicated `path:line[: text]` render sites in `mcp.zig` (scope/regex/glob/plain/query/bundle branches) behind one `appendMatchLine` helper — prefixes (`"  "` / `"- "` / `""`) and the scope suffix preserved; `paths_only` output byte-identical.
2. **Trim the match text** to cut agent output tokens:
   - strip leading indentation (the line number already locates the hit),
   - cap at 200 bytes with a **UTF-8-safe** cut + `…`.
3. **Cover the default path too** — `renderPlainSearch` in `explore.zig` (the mcp helper can't reach across modules), which the mcp-only consolidation missed. This is the highest-traffic path (a bare `codedb_search` query), where deep source indentation was the bulk of the waste.

## Before → after (default path, `ensureTotalCapacity`)
Every result line dropped its leading indentation, e.g.
```
- src/commands.zig:130:             scratch.ensureTotalCapacity(allocator, 256 + hits.len * 80) catch {};
+ src/commands.zig:130: scratch.ensureTotalCapacity(allocator, 256 + hits.len * 80) catch {};
```
Savings scale with hit count and indentation depth; pathological long lines are capped instead of dumping 400+ chars.

## Validation
- `zig build test` — full suite green (no test asserted exact indentation/line-text).
- Trim is applied after ranking/selection, so it cannot change which results are returned or their order.

## Provenance
`mcp.zig` consolidation from a 3-attempt swarm (2 attempts produced real work; winner's diff applied and independently re-verified). The `explore.zig` default-path completion + end-to-end measurement done directly — the swarm's mcp-only change left the most common path untrimmed, which I caught by measuring.

> Base is `feat/search-fewer-roundtrips` (#662). Retarget up the stack as each lands; ultimately → `release/0.2.5828`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)