### PR TITLE
feat(search): rank the defining file first in codedb_search (#2, def-first)

### DIFF
--- a/src/explore.zig
+++ b/src/explore.zig
@@ -3750,6 +3750,7 @@ pub const Explorer = struct {
             // if a file's hits were ever non-contiguous).
             hits_end: usize,
             is_doc: bool,
+            defines: bool,
         };
 
         var tier0_files_buf: [512]Tier0File = undefined;
@@ -3806,6 +3807,7 @@ pub const Explorer = struct {
                     .first_seen = run_start,
                     .hits_end = run_end,
                     .is_doc = isDocLanguage(detectLanguage(hit_path)),
+                    .defines = self.fileDefinesSymbol(hit_path, query),
                 };
                 tier0_files_len += 1;
             }
@@ -3857,7 +3859,9 @@ pub const Explorer = struct {
             var priors_buf: [512]f32 = undefined;
             var order_buf: [512]u32 = undefined;
             for (tier0_files, 0..) |stats, i| {
-                priors_buf[i] = RankCtx.prior(stats.path, query);
+                var pr = RankCtx.prior(stats.path, query);
+                if (stats.defines) pr += 20.0; // float the actual definition above mentions
+                priors_buf[i] = pr;
                 order_buf[i] = @intCast(i);
             }
             const order = order_buf[0..tier0_files.len];

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -1900,6 +1900,28 @@ test "audit: searchContent tier0 use_line_hits early-return skips rerank basenam
 
 // src/explore.zig renderPlainSearch — the MCP codedb_search fast-path rendered in raw
 // hit-count order with no basename prior, so a noise file outranked the canonical match.
+test "def-first: renderPlainSearch ranks the defining file above higher-count mentions" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+
+    // core.zig DEFINES frobnicate (basename != query, a single hit).
+    try explorer.indexFile("src/core.zig", "pub fn frobnicate() void {}\n");
+    // callers.zig merely mentions it many times (no definition, higher count).
+    try explorer.indexFile("src/callers.zig", "frobnicate();\nfrobnicate();\nfrobnicate();\nfrobnicate();\nfrobnicate();\n");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    const rendered = try explorer.renderPlainSearch("frobnicate", testing.allocator, &out, 2, false);
+    try testing.expect(rendered);
+
+    const ci = std.mem.indexOf(u8, out.items, "src/core.zig");
+    const ai = std.mem.indexOf(u8, out.items, "src/callers.zig");
+    try testing.expect(ci != null and ai != null);
+    // the file that DEFINES frobnicate must render before the high-count mentions
+    try testing.expect(ci.? < ai.?);
+}
+
 test "audit: renderPlainSearch fast-path ranks lexical count over canonical basename" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();


### PR DESCRIPTION
The **def-first ranking** (#2), done properly this time — with a *pinned, deterministic* eval instead of the drifting one that sank the first attempt.

## Problem
`codedb_search`'s fast path (`renderPlainSearchUncached`) ordered results by **hit count + basename prior**, with no definition-awareness. So a file that merely *mentions* a symbol many times (tests, callers, docs) outranked the file that actually **defines** it — whenever the def file's basename didn't match the query. The rich def-first ranking (+5 def boost, test/doc demotion) existed only in `searchContentRanked`, which `codedb_search` never calls.

## Fix
Give tier0 a `defines` flag (via the existing `fileDefinesSymbol`) and add **+20** to the rank prior for files that define the queried symbol — larger than the basename-match prior (+15), so a non-canonically-named definition still wins. **Same result set, better order.**

## Measurement — pinned eval
The first attempt *looked* like a regression (8→7) because the eval read codedb's on-disk snapshot, which **re-indexes as files change** — so scores drifted even with code reverted. This eval fixes that: **frozen corpus + isolated `$HOME`**, so the index can't drift and only the *binary* differs between A/B. Verified deterministic (identical across repeated runs).

| | def-file-#1 | def-file-top3 |
|---|---|---|
| baseline | 8/10 | 9/10 |
| **this PR** | **9/10** | 9/10 |

`searchContentRanked` went pos 3 → **#1**; **zero regressions** across all 10 symbol queries.

## Validation
- Full `zig build test` green.
- New regression test `def-first: renderPlainSearch ranks the defining file above higher-count mentions` — **fails on baseline, passes with the fix** (verified).

## Known follow-up
The one remaining holdout (`renderPlainSearch` as a query) bails to `searchContentAuto`, a *different* path where docs aren't demoted (CHANGELOG/`*.md` rank above the def) and this boost doesn't apply. Diagnosed, tracked for a later pass — it's a separate path, not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)