### PR TITLE
feat(cli-daemon): explicit socket handover for serve/mcp daemons (#619)

### DIFF
--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -122,6 +122,22 @@ const TOKEN_USER = extern struct {
 /// watchdog cadence and bounded by the previous owner's idle timeout.
 const cli_bind_retry_ms: u64 = 1000;
 
+/// #619 handover: wire-protocol sentinel a starting serve/mcp daemon sends to
+/// the CURRENT socket owner to ask it to give up the socket right away,
+/// instead of the newcomer waiting out the owner's idle timeout / full retry
+/// cadence. Any live owner — an auto-spawned cli-daemon or another serve/mcp
+/// daemon — honors it unconditionally on receipt (cliServeConn): same-uid
+/// access to the socket (chmod 0600) is already the trust boundary for this
+/// protocol, so no extra authentication is layered on top. Exported for
+/// tests. Chosen so it can never collide with a real request blob, which
+/// always starts with a project root path (see cliTryProxy).
+pub const cli_yield_sentinel = "\x01codedb-cli-yield-v1\x01";
+
+/// Settle delay after sending a yield request before the very next bind
+/// attempt: gives the owner a moment to process the sentinel, unbind, and
+/// unlink before we retry, without paying the full retry_interval_ms.
+const cli_yield_settle_ms: u64 = 20;
+
 /// Build the per-project socket path into `buf`. Stays well under sun_path
 /// (104 bytes on macOS / 108 on Linux): "/tmp/codedb-<uid>-<hash16>.sock" is
 /// at most ~40 bytes. Returns null only if formatting somehow overflows `buf`.
@@ -505,6 +521,25 @@ fn cliSocketLive(sa: SockAddr) bool {
     return std.c.connect(fd, @ptrCast(&sa_mut.addr), sa_mut.len) == 0;
 }
 
+/// #619 handover: connect to a LIVE owner and send the yield sentinel
+/// (best-effort — a write failure just means we fall back to the normal
+/// retry cadence). Does not wait for or read the owner's response: the
+/// owner closes and unlinks the socket synchronously before it ever gets a
+/// chance to write one, so waiting on a reply here would just be a way to
+/// hang against a buggy or hostile peer for no benefit.
+fn cliSendYieldRequest(sa: SockAddr) void {
+    const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
+    if (fd < 0) return;
+    defer _ = std.c.close(fd);
+    var sa_mut = sa;
+    if (std.c.connect(fd, @ptrCast(&sa_mut.addr), sa_mut.len) != 0) return;
+    var hdr: [5]u8 = undefined;
+    hdr[0] = 0;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(cli_yield_sentinel.len), .little);
+    if (!cliWriteFull(fd, &hdr)) return;
+    _ = cliWriteFull(fd, cli_yield_sentinel);
+}
+
 /// Acquire the per-project CLI socket and return a listening fd.
 ///
 /// A stale node left by a dead daemon (bind fails but nothing is listening) is
@@ -512,15 +547,18 @@ fn cliSocketLive(sa: SockAddr) bool {
 /// behavior depends on `retry`:
 ///   - retry == false (auto-spawned cli-daemon that lost the race): return null
 ///     immediately so the duplicate exits instead of stealing a live socket.
-///   - retry == true (long-lived serve/mcp daemon): keep re-attempting every
-///     `retry_interval_ms` until the owner exits and the bind succeeds, so CLI
-///     calls stop falling back to a cold re-index once the older owner is gone
-///     (#619 — previously the loser disabled its proxy and never retried).
+///   - retry == true (long-lived serve/mcp daemon): send the owner a one-shot
+///     yield request (#619 handover — see cli_yield_sentinel) so a live owner
+///     gives the socket up right away instead of us waiting out its idle
+///     timeout, then keep re-attempting every `retry_interval_ms` until the
+///     bind succeeds. The request is sent at most once per call so two
+///     daemons racing to start can't ping-pong signals back and forth.
 /// Returns null if `shutdown` is set while waiting.
 pub fn cliAcquireListener(sock_path: []const u8, retry: bool, retry_interval_ms: u64, shutdown: *std.atomic.Value(bool)) ?c_int {
     var z_buf: [128]u8 = undefined;
     const sock_path_z = std.fmt.bufPrintZ(&z_buf, "{s}", .{sock_path}) catch return null;
     const sa = cliFillSockaddr(sock_path) orelse return null;
+    var yield_sent = false;
     while (true) {
         if (cliBindListen(sa, sock_path_z)) |fd| return fd;
         // Bind failed: the path exists. Clear it only when no one is listening
@@ -528,6 +566,11 @@ pub fn cliAcquireListener(sock_path: []const u8, retry: bool, retry_interval_ms:
         if (!cliSocketLive(sa)) {
             _ = std.c.unlink(sock_path_z.ptr);
             if (cliBindListen(sa, sock_path_z)) |fd| return fd;
+        } else if (retry and !yield_sent) {
+            yield_sent = true;
+            cliSendYieldRequest(sa);
+            cio.sleepMs(cli_yield_settle_ms);
+            continue;
         }
         if (!retry) return null;
         if (shutdown.load(.acquire)) return null;
@@ -645,7 +688,7 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
                 }
             }
             last_activity_ms.store(cio.milliTimestamp(), .release);
-            cliServeConn(io, allocator, explorer, store, abs_root, pipe);
+            _ = cliServeConn(io, allocator, explorer, store, abs_root, pipe);
             _ = DisconnectNamedPipe(pipe);
             win.CloseHandle(pipe);
         }
@@ -694,51 +737,71 @@ fn cliDaemonListenPosix(io: std.Io, allocator: std.mem.Allocator, explorer: *Exp
         }
         // Record activity for the cli-daemon idle watchdog before serving.
         last_activity_ms.store(cio.milliTimestamp(), .release);
-        cliServeConn(io, allocator, explorer, store, abs_root, conn);
+        const yield_requested = cliServeConn(io, allocator, explorer, store, abs_root, conn);
         _ = std.c.close(conn);
+        if (yield_requested) {
+            // #619 handover: give the socket up right away. The `defer`
+            // above closes the listener and unlinks the path so the
+            // requesting daemon's next bind attempt succeeds; `shutdown` is
+            // set so any caller watching it (e.g. the cli-daemon idle
+            // watchdog) treats this exactly like a lost bind race.
+            shutdown.store(true, .release);
+            return;
+        }
     }
 }
 
 /// Handle one client connection: read the framed request, run the query into a
 /// sink buffer via runQuery, and write the framed response.
-fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, conn: CliConn) void {
+///
+/// Returns true when the request was the #619 yield sentinel (see
+/// cli_yield_sentinel): the caller must then stop listening and give the
+/// socket up so the requesting daemon can take over.
+fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, store: *Store, abs_root: []const u8, conn: CliConn) bool {
     // Header: [u8 color][u32 blob_len]
     var hdr: [5]u8 = undefined;
-    if (!cliReadFull(conn, &hdr)) return;
+    if (!cliReadFull(conn, &hdr)) return false;
     const color = hdr[0] != 0;
     const blob_len = std.mem.readInt(u32, hdr[1..5], .little);
     if (blob_len == 0 or blob_len > cli_blob_max) {
         cliRespond(conn, 1, "");
-        return;
+        return false;
     }
 
     const blob = allocator.alloc(u8, blob_len) catch {
         cliRespond(conn, 1, "");
-        return;
+        return false;
     };
     defer allocator.free(blob);
-    if (!cliReadFull(conn, blob)) return;
+    if (!cliReadFull(conn, blob)) return false;
+
+    // #619 handover: a starting serve/mcp daemon asking us to give up the
+    // socket. Ack and tell the caller to stop listening — no query dispatch.
+    if (std.mem.eql(u8, blob, cli_yield_sentinel)) {
+        cliRespond(conn, 0, "");
+        return true;
+    }
 
     // Rebuild argv = ["codedb"] ++ split(blob, '\0'), skipping empty fields.
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
     argv.append(allocator, "codedb") catch {
         cliRespond(conn, 1, "");
-        return;
+        return false;
     };
     var it = std.mem.splitScalar(u8, blob, 0);
     while (it.next()) |field| {
         if (field.len == 0) continue;
         argv.append(allocator, field) catch {
             cliRespond(conn, 1, "");
-            return;
+            return false;
         };
     }
 
     const parsed = parsePositional(argv.items);
     if (parsed.usage_exit or !cliIsQueryCmd(parsed.cmd)) {
         cliRespond(conn, 1, "");
-        return;
+        return false;
     }
 
     var sink: std.ArrayList(u8) = .empty;
@@ -749,6 +812,7 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
     out.flush();
 
     cliRespond(conn, code, sink.items);
+    return false;
 }
 
 /// Write the framed response [u8 code][u32 out_len][out_bytes] to `conn`.

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -3040,6 +3040,106 @@ test "issue-619: serve/mcp daemon reclaims the cli socket after the owner exits"
     if (rc.fd) |fd| _ = std.c.close(fd);
 }
 
+// ── #619: cli-daemon socket handover ────────────────────────────────────────
+// The reclaim test above covers a serve/mcp daemon retrying until a dead or
+// idle-exited owner lets go. This test covers the other half: an owner that
+// is still LIVE must be actively signalled to give the socket up right away
+// (freshest-wins), instead of the newcomer waiting out a full retry/idle
+// cadence. cliServeConn is a private helper, so the owner side is simulated
+// here with a tiny raw accept loop that mirrors exactly what it does on
+// receipt of cli_yield_sentinel: read the frame, verify it, then give the
+// socket up (close the listener + unlink the path).
+const CliHandoverOwnerSim = struct {
+    fd: c_int,
+    sock_path: []const u8,
+    sd: *std.atomic.Value(bool),
+    saw_sentinel: bool = false,
+    done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn run(self: *@This()) void {
+        // Mirror the real accept loop: keep accepting connections and only
+        // give the socket up once one of them is the actual yield sentinel.
+        // A plain liveness probe (cliSocketLive — connect then close with no
+        // data) must NOT be mistaken for a yield request.
+        while (true) {
+            const conn = std.c.accept(self.fd, null, null);
+            if (conn < 0) break;
+            var matched = false;
+            var hdr: [5]u8 = undefined;
+            var off: usize = 0;
+            while (off < hdr.len) {
+                const n = std.c.read(conn, hdr[off..].ptr, hdr.len - off);
+                if (n <= 0) break;
+                off += @intCast(n);
+            }
+            if (off == hdr.len) {
+                const blob_len = std.mem.readInt(u32, hdr[1..5], .little);
+                if (blob_len > 0 and blob_len <= 256) {
+                    var buf: [256]u8 = undefined;
+                    var boff: usize = 0;
+                    while (boff < blob_len) {
+                        const n = std.c.read(conn, buf[boff..].ptr, blob_len - boff);
+                        if (n <= 0) break;
+                        boff += @intCast(n);
+                    }
+                    if (boff == blob_len) {
+                        matched = std.mem.eql(u8, buf[0..blob_len], cli_proxy_mod.cli_yield_sentinel);
+                    }
+                }
+            }
+            _ = std.c.close(conn);
+            if (matched) {
+                self.saw_sentinel = true;
+                break;
+            }
+        }
+        // Mirror the real accept loop's response to a yield request: give the
+        // socket up entirely rather than waiting for an idle timeout.
+        _ = std.c.close(self.fd);
+        var zbuf: [128]u8 = undefined;
+        if (std.fmt.bufPrintZ(&zbuf, "{s}", .{self.sock_path})) |z| {
+            _ = std.c.unlink(z.ptr);
+        } else |_| {}
+        self.sd.store(true, .release);
+        self.done.store(true, .release);
+    }
+};
+
+test "issue-619: serve/mcp daemon signals a live owner to yield instead of waiting out the retry cadence" {
+    if (@import("builtin").os.tag == .windows) return; // no unix-socket proxy on Windows
+
+    const abs_root = "/codedb-test-issue619-handover";
+    var pbuf: [128]u8 = undefined;
+    const sock_path = cli_proxy_mod.cliSocketPath(&pbuf, abs_root).?;
+    var zbuf: [128]u8 = undefined;
+    const sock_z = try std.fmt.bufPrintZ(&zbuf, "{s}", .{sock_path});
+    _ = std.c.unlink(sock_z.ptr);
+    defer _ = std.c.unlink(sock_z.ptr);
+
+    // A live owner holds the socket (stands in for an auto-spawned
+    // cli-daemon or another serve/mcp daemon — same code path either way).
+    var owner_sd = std.atomic.Value(bool).init(false);
+    const owner_fd = cli_proxy_mod.cliAcquireListener(sock_path, false, 0, &owner_sd).?;
+    var owner_sim = CliHandoverOwnerSim{ .fd = owner_fd, .sock_path = sock_path, .sd = &owner_sd };
+    const owner_thread = try std.Thread.spawn(.{}, CliHandoverOwnerSim.run, .{&owner_sim});
+
+    // Deliberately large retry interval: without an explicit yield signal,
+    // a passive retrying newcomer could only reclaim the socket after a full
+    // retry_interval_ms sleep (here 3000ms). The #619 handover instead sends
+    // a one-shot yield request the live owner honors immediately, so
+    // acquisition must complete far sooner than that passive cadence.
+    var newcomer_sd = std.atomic.Value(bool).init(false);
+    const start_ms = cio.milliTimestamp();
+    const newcomer_fd = cli_proxy_mod.cliAcquireListener(sock_path, true, 3000, &newcomer_sd);
+    const elapsed_ms = cio.milliTimestamp() - start_ms;
+
+    owner_thread.join();
+    try testing.expect(owner_sim.saw_sentinel); // owner actually received the sentinel frame
+    try testing.expect(newcomer_fd != null); // and the newcomer took the socket over
+    try testing.expect(elapsed_ms < 1500); // far under the passive 3000ms retry cadence
+    if (newcomer_fd) |fd| _ = std.c.close(fd);
+}
+
 test "windows: spawnDetached command line round-trips argv with trailing backslashes" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
     const alloc = testing.allocator;


### PR DESCRIPTION
Completes #619. The retry/reclaim half (a starting serve/mcp daemon eventually reclaims the per-project CLI socket once the old owner idle-exits) shipped earlier; this adds the **explicit handover** so takeover is *immediate* (freshest-wins) instead of waiting out the retry cadence.

## What
POSIX-only (Windows uses a separate named-pipe path with no idle/retry cliff), matching where the socket logic lives (`cliAcquireListener` / `cliDaemonListenPosix`):
- **`cli_yield_sentinel`** — a fixed magic blob that can't collide with a real request (real blobs start with a project-root path).
- **`cliSendYieldRequest`** — connects to the live owner and fire-and-forgets one framed yield request.
- On start, if the socket is held by a **live** owner, `cliAcquireListener` (retry path only) sends the yield **once**, settles ~20ms, then binds — falling back to the existing retry cadence if needed.
- The owner's accept loop detects the sentinel and sets the same `shutdown`/`cli_listener_dead` atomic the existing plumbing already handles: a throwaway `cli-daemon` exits cleanly (lost the race, as before); a `serve`/`mcp` daemon drops only its CLI-proxy thread and keeps running.

## Risk guards
- **Ping-pong:** yield sent at most once per `cliAcquireListener` call (`yield_sent`), so racing starts can't loop.
- **Dead owner:** unchanged — yield only attempted when `cliSocketLive` says the owner is live; the stale-unlink path is untouched.
- **Auto-spawned cli-daemon:** still `retry=false`, never enters the yield branch — gives up immediately, exactly as before.

## Validation
- New test `issue-619: serve/mcp daemon signals a live owner to yield instead of waiting out the retry cadence` — a raw socket-level owner sim asserts the owner receives the sentinel, the newcomer acquires the socket, and does so **well under** (<1500ms) a deliberately large passive retry interval (3000ms) — proving the win is *active signaling*, not polling.
- `zig build test` green; `test-mcp` stable across 5+ repeats (independently re-verified 3×: 149 pass, 0 fail).

Produced by a Sonnet agent; independently re-verified (full suite + flakiness check).

> Note surfaced during the work: the `codedbpro` MCP edit tool mis-resolves paths in git worktrees (writes to the main checkout) — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)