### PR TITLE
fix(#690): refresh the live index after rebuilds

### DIFF
--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -26,6 +26,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -219,7 +220,7 @@ def all_tool_text(resp: dict[str, Any] | None) -> str:
 
 
 def wait_for_scan(p: MCPProcess, timeout: float = 60.0) -> bool:
-    """Poll codedb_status until outlines > 0 (full scan + outline pass done) or timeout."""
+    """Poll codedb_status until the scan is ready with at least one outline."""
     import re
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -227,7 +228,7 @@ def wait_for_scan(p: MCPProcess, timeout: float = 60.0) -> bool:
         if resp and "result" in resp:
             text = all_tool_text(resp)
             m = re.search(r'\boutlines:\s*(\d+)', text)
-            if m and int(m.group(1)) > 0:
+            if m and int(m.group(1)) > 0 and "scan: ready" in text:
                 return True
         time.sleep(1.0)
     return False
@@ -496,6 +497,70 @@ def run_scenario_4_issue512_direct_inline_args(binary: str, project: str) -> lis
     return results
 
 
+def run_scenario_5_issue690_live_index_refresh(binary: str, project: str) -> list[TestResult]:
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S5] {name}")
+        results.append(r)
+        return r
+
+    with tempfile.TemporaryDirectory(prefix="codedb-issue-690-", dir=Path(project).parent) as tmp:
+        root = Path(tmp)
+        (root / "pyproject.toml").write_text("[project]\nname = 'issue-690'\nversion = '0'\n")
+        (root / "initial.py").write_text("def initial():\n    return 'initial'\n")
+        p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
+
+        try:
+            r = t("initial scan completes")
+            if not do_initialize(p, with_roots=False) or not wait_for_scan(p):
+                r.fail("MCP server did not become ready")
+                return results
+            r.ok()
+
+            (root / "cli_added.py").write_text("def cli_added():\n    return 'cli_added'\n")
+
+            r = t("CLI index rebuilds the project")
+            index_run = subprocess.run(
+                [binary, str(root), "index"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "CODEDB_NO_AUTO_UPDATE": "1", "CODEDB_NO_TELEMETRY": "1"},
+            )
+            if index_run.returncode != 0 or "index ready" not in index_run.stdout:
+                r.fail(f"index result: code={index_run.returncode} stdout={index_run.stdout[:160]!r}")
+                return results
+            r.ok()
+
+            r = t("live MCP sees the file after CLI index")
+            outline_text = tool_text(p.call_tool("codedb_outline", {"path": "cli_added.py"}))
+            if "cli_added" not in outline_text or "not indexed" in outline_text:
+                r.fail(f"outline stayed stale: {outline_text[:220]!r}")
+                return results
+            r.ok()
+
+            (root / "tool_added.py").write_text("def tool_added():\n    return 'tool_added'\n")
+
+            r = t("codedb_index rebuilds the project")
+            index_resp = p.call_tool("codedb_index", {"path": str(root)})
+            index_text = tool_text(index_resp)
+            if "indexed:" not in index_text or "error:" in index_text:
+                r.fail(f"index response: {index_text[:220]!r}")
+                return results
+            r.ok()
+
+            r = t("live MCP sees the file after codedb_index")
+            outline_text = tool_text(p.call_tool("codedb_outline", {"path": "tool_added.py"}))
+            if "tool_added" not in outline_text or "not indexed" in outline_text:
+                r.fail(f"outline stayed stale: {outline_text[:220]!r}")
+            else:
+                r.ok()
+        finally:
+            p.close()
+
+    return results
+
+
 # ── Runner ────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -531,6 +596,9 @@ def main() -> int:
 
     print(f"\n{CYAN}── Scenario 4: issue-512 direct inline args ──{RESET}")
     all_results += run_scenario_4_issue512_direct_inline_args(binary, project)
+
+    print(f"\n{CYAN}── Scenario 5: issue-690 live index refresh ──{RESET}")
+    all_results += run_scenario_5_issue690_live_index_refresh(binary, project)
 
     print()
     passed = 0

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -533,7 +533,11 @@ def run_scenario_5_issue690_live_index_refresh(binary: str, project: str) -> lis
             r.ok()
 
             r = t("live MCP sees the file after CLI index")
-            outline_text = tool_text(p.call_tool("codedb_outline", {"path": "cli_added.py"}))
+            try:
+                outline_text = tool_text(p.call_tool("codedb_outline", {"path": "cli_added.py"}))
+            except BrokenPipeError:
+                r.fail(f"MCP process exited during refresh: {p.stderr_lines()[-40:]!r}")
+                return results
             if "cli_added" not in outline_text or "not indexed" in outline_text:
                 r.fail(f"outline stayed stale: {outline_text[:220]!r}")
                 return results
@@ -553,6 +557,16 @@ def run_scenario_5_issue690_live_index_refresh(binary: str, project: str) -> lis
             outline_text = tool_text(p.call_tool("codedb_outline", {"path": "tool_added.py"}))
             if "tool_added" not in outline_text or "not indexed" in outline_text:
                 r.fail(f"outline stayed stale: {outline_text[:220]!r}")
+            else:
+                r.ok()
+
+            (root / "initial.py").unlink()
+
+            r = t("codedb_index removes deleted files from the live MCP")
+            p.call_tool("codedb_index", {"path": str(root)})
+            outline_text = tool_text(p.call_tool("codedb_outline", {"path": "initial.py"}))
+            if "not indexed" not in outline_text:
+                r.fail(f"deleted file stayed indexed: {outline_text[:220]!r}")
             else:
                 r.ok()
         finally:

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -438,8 +438,9 @@ pub fn coldLoadOrScan(
         cio.posixGetenv("CODEDB_NO_AUTO_REFRESH") == null and
         snapshotIsStale(io, abs_root, data_dir, allocator);
 
+    const force_rescan = std.mem.eql(u8, cmd, "index") or std.mem.eql(u8, cmd, "snapshot");
     const snapshot_t0 = cio.nanoTimestamp();
-    const snapshot_loaded = !stale and loadBestSnapshot(io, explorer, store, abs_root, data_dir, git_head, allocator);
+    const snapshot_loaded = !force_rescan and !stale and loadBestSnapshot(io, explorer, store, abs_root, data_dir, git_head, allocator);
     const snapshot_elapsed = cio.nanoTimestamp() - snapshot_t0;
 
     // The word index powers codedb_word and BM25 ranked search. It must be

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -7,6 +7,7 @@ const Store = @import("store.zig").Store;
 const Explorer = @import("explore.zig").Explorer;
 const Out = @import("out.zig").Out;
 const runQuery = @import("query.zig").runQuery;
+const watcher = @import("watcher.zig");
 const cli_args = @import("cli_args.zig");
 const parsePositional = cli_args.parsePositional;
 const cliIsQueryCmd = cli_args.cliIsQueryCmd;
@@ -132,6 +133,7 @@ const cli_bind_retry_ms: u64 = 1000;
 /// tests. Chosen so it can never collide with a real request blob, which
 /// always starts with a project root path (see cliTryProxy).
 pub const cli_yield_sentinel = "\x01codedb-cli-yield-v1\x01";
+pub const cli_refresh_sentinel = "\x01codedb-cli-refresh-v1\x01";
 
 /// Settle delay after sending a yield request before the very next bind
 /// attempt: gives the owner a moment to process the sentinel, unbind, and
@@ -781,6 +783,14 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
         cliRespond(conn, 0, "");
         return true;
     }
+    if (std.mem.eql(u8, blob, cli_refresh_sentinel)) {
+        watcher.refreshIndex(io, store, explorer, abs_root, allocator) catch {
+            cliRespond(conn, 1, "");
+            return false;
+        };
+        cliRespond(conn, 0, "");
+        return false;
+    }
 
     // Rebuild argv = ["codedb"] ++ split(blob, '\0'), skipping empty fields.
     var argv: std.ArrayList([]const u8) = .empty;
@@ -866,6 +876,27 @@ pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u
         cio.File.stdout().writeAll(out_bytes) catch {};
     }
     return code;
+}
+
+pub fn cliNotifyRefresh(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8) ?bool {
+    const conn = cliConnect(io, allocator, abs_root, data_dir) orelse return null;
+    defer cliCloseConn(conn);
+
+    var hdr: [5]u8 = undefined;
+    hdr[0] = 0;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(cli_refresh_sentinel.len), .little);
+    if (!cliWriteFull(conn, &hdr) or !cliWriteFull(conn, cli_refresh_sentinel)) return false;
+
+    var resp_hdr: [5]u8 = undefined;
+    if (!cliReadFull(conn, &resp_hdr)) return false;
+    const out_len = std.mem.readInt(u32, resp_hdr[1..5], .little);
+    if (!cliResponseLenAllowed(out_len)) return false;
+    if (out_len > 0) {
+        const response = allocator.alloc(u8, out_len) catch return false;
+        defer allocator.free(response);
+        if (!cliReadFull(conn, response)) return false;
+    }
+    return resp_hdr[0] == 0;
 }
 
 fn cliConnect(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8) ?CliConn {

--- a/src/main.zig
+++ b/src/main.zig
@@ -125,6 +125,7 @@ pub const daemonLockTryAcquire = cli_proxy.daemonLockTryAcquire;
 pub const daemonLockRelease = cli_proxy.daemonLockRelease;
 pub const daemonLockAvailable = cli_proxy.daemonLockAvailable;
 const cliTryProxy = cli_proxy.cliTryProxy;
+const cliNotifyRefresh = cli_proxy.cliNotifyRefresh;
 
 const bootstrap = @import("bootstrap.zig");
 const loadUserConfig = bootstrap.loadUserConfig;
@@ -507,6 +508,13 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
         // scanned + persisted the on-disk index for this cmd; confirm and exit
         // cleanly. It used to fall through to "unknown command: index" + exit 1
         // even though the index had been built.
+        if (cliNotifyRefresh(io, allocator, abs_root, data_dir)) |refreshed| {
+            if (!refreshed) {
+                out.p("{s}\xe2\x9c\x97{s} index persisted but live daemon refresh failed\n", .{ s.red, s.reset });
+                out.flush();
+                std.process.exit(1);
+            }
+        }
         explorer.mu.lockShared();
         const file_count = explorer.outlines.count();
         explorer.mu.unlockShared();

--- a/src/main.zig
+++ b/src/main.zig
@@ -510,7 +510,7 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
         // even though the index had been built.
         if (cliNotifyRefresh(io, allocator, abs_root, data_dir)) |refreshed| {
             if (!refreshed) {
-                out.p("{s}\xe2\x9c\x97{s} index persisted but live daemon refresh failed\n", .{ s.red, s.reset });
+                out.p("{s}\xe2\x9c\x97{s} index persisted but live daemon refresh failed; restart the codedb daemon to load it\n", .{ s.red, s.reset });
                 out.flush();
                 std.process.exit(1);
             }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -4767,6 +4767,12 @@ fn handleIndex(
     }
 
     cache.invalidate(abs_path);
+    if (std.mem.eql(u8, abs_path, cache.default_path) and getScanState() == .ready) {
+        watcher.refreshIndex(io, default_store, default_explorer, abs_path, alloc) catch {
+            out.appendSlice(alloc, "error: indexed snapshot but failed to refresh live project") catch {};
+            return;
+        };
+    }
     if (std.mem.eql(u8, abs_path, cache.default_path) and
         default_store.currentSeq() == 0 and
         getScanState() == .loading_snapshot)

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3528,3 +3528,36 @@ test "issue-635: files between 512KB and 1MB are silently dropped from the index
     defer testing.allocator.free(big_hits);
     try testing.expect(big_hits.len >= 1); // fails on main: big.zig dropped at the 512KB gate
 }
+
+test "issue-690: refreshIndex skips unchanged files but re-indexes changed ones" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "a.py", .data = "def a():\n    return 1\n" });
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, true, 1);
+
+    // First refresh records real content hashes for entries the initial scan
+    // stored with hash 0; the second must then be a no-op on the store.
+    try watcher.refreshIndex(io, &store, &explorer, root, testing.allocator);
+    const settled_seq = store.currentSeq();
+    try watcher.refreshIndex(io, &store, &explorer, root, testing.allocator);
+    try testing.expectEqual(settled_seq, store.currentSeq());
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "a.py", .data = "def a_changed():\n    return 2\n" });
+    try watcher.refreshIndex(io, &store, &explorer, root, testing.allocator);
+    try testing.expect(store.currentSeq() > settled_seq);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try testing.expect(try explorer.renderOutline("a.py", testing.allocator, &out, false));
+    try testing.expect(std.mem.indexOf(u8, out.items, "a_changed") != null);
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1472,6 +1472,33 @@ fn incrementalDiff(io: std.Io, store: *Store, explorer: *Explorer, queue: *Event
     }
 }
 
+pub fn refreshIndex(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, allocator: std.mem.Allocator) !void {
+    var known = FileMap.init(allocator);
+    defer {
+        var iter = known.keyIterator();
+        while (iter.next()) |path| allocator.free(path.*);
+        known.deinit();
+    }
+
+    {
+        explorer.mu.lockShared();
+        defer explorer.mu.unlockShared();
+        var iter = explorer.outlines.keyIterator();
+        while (iter.next()) |path| {
+            const copy = try allocator.dupe(u8, path.*);
+            errdefer allocator.free(copy);
+            try known.put(copy, .{ .mtime = 0, .size = 0, .hash = 0, .seen = false });
+        }
+    }
+
+    const queue = try allocator.create(EventQueue);
+    defer allocator.destroy(queue);
+    queue.* = EventQueue{};
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    try incrementalDiff(io, store, explorer, queue, &known, root, allocator, arena.allocator());
+}
+
 const skip_extensions = [_][]const u8{
     ".png",     ".jpg",  ".jpeg", ".gif",  ".bmp",   ".ico",   ".icns",  ".webp",
     ".svg",     ".ttf",  ".otf",  ".woff", ".woff2", ".eot",   ".zip",   ".tar",

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1491,6 +1491,18 @@ pub fn refreshIndex(io: std.Io, store: *Store, explorer: *Explorer, root: []cons
         }
     }
 
+    // Seed size/hash from the store's latest version so unchanged files hit
+    // the metadata-only shortcut in incrementalDiff instead of being
+    // re-recorded and re-parsed on every explicit refresh. mtime stays 0 so
+    // every file is still read and hash-checked against current disk content.
+    var seed_iter = known.iterator();
+    while (seed_iter.next()) |kv| {
+        if (store.getLatest(kv.key_ptr.*)) |v| {
+            kv.value_ptr.size = v.size;
+            kv.value_ptr.hash = v.hash;
+        }
+    }
+
     const queue = try allocator.create(EventQueue);
     defer allocator.destroy(queue);
     queue.* = EventQueue{};


### PR DESCRIPTION
Fixes #690.

## Problem

`codedb index` and the `codedb_index` MCP tool rebuilt the persisted snapshot but left an active daemon's in-memory `Explorer` unchanged. Both paths could report success while live queries still returned `file not indexed` until restart.

## Solution

- Force explicit `index` and `snapshot` operations to scan the current filesystem instead of accepting an existing snapshot.
- Reuse the watcher reconciliation path to update added, changed, and deleted files in the active `Explorer`.
- Seed the refresh reconciliation map with the store's latest size and hash, so unchanged files hit the metadata-only shortcut: no new store version, no re-parse. Every file is still read and hash-checked against disk. Entries stored with hash 0 by the initial scan self-heal on the first refresh.
- Notify a live daemon after CLI indexing and fail the command if the daemon accepts the connection but cannot refresh. The failure message names the recovery step (restart the daemon).
- Refresh the default live project after `codedb_index` completes.

Changed subsystems: bootstrap, watcher reconciliation, CLI proxy protocol, MCP indexing, and the MCP end-to-end harness.

## Red to green

Before the fix, the new issue-690 scenario failed twice on v0.2.5838: `index` reported `index ready`, then the same live MCP process returned `error: file not indexed: cli_added.py`.

The store-churn guard `test "issue-690: refreshIndex skips unchanged files but re-indexes changed ones"` (`src/test_index.zig`) fails without the seeding commit and passes with it.

Validation on the current head:

- `zig build test` passes.
- `zig build test-mcp` passes.
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project <repo>` passes, 26/26.
- `zig fmt --check` passes on the touched files.
- `python3 -m py_compile scripts/e2e_mcp_test.py` passes.

One full-suite run hit the known issue-685 watcher graph flake; it passes 3/3 in filtered isolation, unchanged by this branch.

## Review notes

- Failing-test convention: the daemon half of this bug spans two processes (live `codedb mcp` daemon plus a separate CLI `index` run), which a single-process `src/test_*.zig` block cannot express. The failing test is scenario 5 in `scripts/e2e_mcp_test.py`; the in-process refresh path is covered in `src/test_index.zig`.
- Non-default projects: `codedb_index` already invalidates the `ProjectCache` entry, so cached projects reload the fresh snapshot on their next query. Only the default live project needed the in-place refresh.
- The `not indexed` hint (`try codedb_index if the file was added recently`) is left unchanged: it is accurate now that the refresh works.
- Cost note: an explicit refresh reads and hashes every file once; it no longer re-parses or re-records unchanged files.
- Rebased on current `release/0.2.5833-mcp2026`: yes.
- Generated artifacts or lockfiles: none.
- Benchmarks: not applicable to this correctness fix.
- I read and followed `CONTRIBUTING.md`.
