### PR TITLE
docs(AGENTS): add Cursor Cloud environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,55 @@ python3 scripts/e2e_mcp_test.py \
 - `src/telemetry.zig` — data collection and transmission (must match docs)
 - `src/snapshot.zig` — sensitive file filtering
 - `install/install.sh` — binary download and config modification
+
+## Cursor Cloud specific instructions
+
+Single-product Zig codebase: one binary `codedb` exposing a CLI, an MCP stdio
+server, and an HTTP server (`:7719`). No external services, DB, or network deps
+— the vendored `nanoregex` under `vendor/` is the only dependency.
+
+### Toolchain
+
+- Requires the exact pinned Zig dev snapshot `0.17.0-dev.813+2153f8143`
+  (`minimum_zig_version` in `build.zig.zon`, also pinned in
+  `.github/workflows/release-binaries.yml`). The startup update script installs
+  it to `~/.local/zig` and symlinks it to `/usr/local/bin/zig`, so `zig` is on
+  `PATH`. A non-matching `zig` will fail the build.
+
+### Build / lint / test / run
+
+- Build (dev/debug): `zig build` → binary at `zig-out/bin/codedb`. See README
+  "Building from Source" for release/cross-compile variants.
+- Lint (format check): `zig fmt --check src`. NOTE: on the current tree this
+  exits non-zero due to **pre-existing** formatting drift in a handful of files
+  (e.g. `src/update.zig`, `src/lib.zig`, `src/watcher.zig`); that drift is not
+  introduced by the environment. Only judge your own changed files.
+- Tests: `zig build test` (or a single split binary, e.g. `zig build test-mcp`;
+  see `build.zig`).
+- E2E MCP harness: `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb
+  --project <repo>` (per the Pre-merge section above).
+- Run the app: one-shot CLI (`codedb <root> tree|search|find|word|outline …`;
+  root arg comes FIRST) works out of the box. Long-running daemons are
+  `codedb serve <root>` (HTTP) and `codedb mcp <root>` (MCP stdio).
+
+### Linux gotchas (important)
+
+- The long-running daemons (`serve` / `mcp`) and the watcher-exercising tests
+  crash on Linux with a `watcher.zig` panic ("integer does not fit in
+  destination type") when arming inotify against the sentinel path
+  `/tmp/codedb-notify`. Root cause: the binary links libc, so `std.posix.errno`
+  uses libc semantics (only `-1` is an error) while `std.os.linux.inotify_add_watch`
+  returns `-errno`; a missing sentinel path yields `-ENOENT`, which is
+  misread as success and then `@intCast` panics. Maintainers develop on macOS
+  (kqueue path), so this Linux-only bug is currently unfixed on `main`.
+- Workaround to run the daemons / full E2E harness without touching source:
+  `: > /tmp/codedb-notify` (create the sentinel file) before starting the
+  process. With it present, the daemon stays up and `e2e_mcp_test.py` passes
+  53/54 (the lone failure is an unrelated `codedb_index` MCP-tool assertion).
+- `zig build test` shows one pre-existing crash on Linux
+  (`test_index … issue-690 incrementalLoop`) from the same inotify bug; the
+  other 981 tests pass.
+- `scripts/e2e_mcp_test.py` creates temp projects in the *parent* of
+  `--project`. `/workspace`'s parent is `/` (not writable), so point
+  `--project` at a copy under a writable parent (e.g. `~/codedb-run`) when
+  running scenarios 5–7.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this Zig codebase and records durable, non-obvious setup guidance in `AGENTS.md`. No source code changed.

The startup update script (registered separately, not committed) installs the exact pinned Zig dev snapshot `0.17.0-dev.813+2153f8143` (from `build.zig.zon` / release CI) to `~/.local/zig` and symlinks it onto `PATH`. The vendored `nanoregex` is the only build dependency.

## What was verified

- **Build:** `zig build` → `zig-out/bin/codedb` (dev/debug).
- **Lint:** `zig fmt --check src` runs. Exits non-zero only due to **pre-existing** formatting drift in ~6 tracked files (not introduced here).
- **Tests:** `zig build test` → 981/982 pass. The one crash is a **pre-existing Linux-only** inotify bug in `src/watcher.zig` (see below).
- **E2E MCP harness:** `scripts/e2e_mcp_test.py` → 53/54 pass (the lone failure is an unrelated `codedb_index` MCP-tool assertion; all live-watch scenarios pass).
- **Run (hello-world):** one-shot CLI (`codedb <root> tree|search|find|word`) indexes 643 files and returns real structural/trigram/word-index results; the `mcp` daemon answers `tools/call` requests.

## Pre-existing Linux daemon crash (documented, not fixed)

The `serve`/`mcp` daemons and watcher-exercising tests panic on Linux (`watcher.zig` "integer does not fit in destination type") when arming inotify against the sentinel path `/tmp/codedb-notify`. Root cause: the binary links libc, so `std.posix.errno` uses libc semantics (only `-1` is an error), but `std.os.linux.inotify_add_watch` returns `-errno`; `-ENOENT` on the missing sentinel is misread as success and `@intCast` panics. Maintainers develop on macOS (kqueue path), so this Linux path is currently unfixed on `main`. Workaround for running daemons/E2E without touching source: `: > /tmp/codedb-notify`. This is documented in `AGENTS.md`.

## Notes

- `AGENTS.md` `## Cursor Cloud specific instructions` captures the toolchain pin, build/lint/test/run commands, the Linux inotify gotcha + workaround, and the fact that `e2e_mcp_test.py` writes temp projects into `--project`'s parent (so run it from a writable-parent dir, not `/workspace`).
- `codedb.snapshot` (generated) was intentionally left unmodified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-394a19b0-8309-4ef0-b73c-0108bbbb3966?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-394a19b0-8309-4ef0-b73c-0108bbbb3966&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

