### PR TITLE
watcher: inotify arm panics on every Linux start (raw syscall checked with the libc errno accessor)

### DIFF
--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -508,6 +508,28 @@ fn heapEventQueue() !*watcher.EventQueue {
     return queue;
 }
 
+test "watcher: raw linux syscall failures are detected by the -errno range" {
+    // Regression for the inotify arm crash. `std.posix.errno` is the libc
+    // accessor (fails only on rc == -1), so it classified every raw-syscall
+    // failure as .SUCCESS and let the negative rc reach @intCast: a panic in
+    // Debug/ReleaseSafe, a garbage watch descriptor in ReleaseFast. Triggered
+    // on startup by the optional /tmp/codedb-notify interop file being absent.
+    try testing.expect(!watcher.rawLinuxSyscallFailed(0));
+    try testing.expect(!watcher.rawLinuxSyscallFailed(3));
+    try testing.expect(!watcher.rawLinuxSyscallFailed(std.math.maxInt(i32)));
+
+    // -ENOENT, exactly what inotify_add_watch returns for a missing path.
+    const enoent: usize = @bitCast(@as(isize, -2));
+    try testing.expect(watcher.rawLinuxSyscallFailed(enoent));
+    // The value that used to panic must never be cast to a watch descriptor.
+    try testing.expect(std.math.cast(i32, enoent) == null);
+
+    // Error-range boundaries: -1..-4095 are errno, -4096 and below are not.
+    try testing.expect(watcher.rawLinuxSyscallFailed(@bitCast(@as(isize, -1))));
+    try testing.expect(watcher.rawLinuxSyscallFailed(@bitCast(@as(isize, -4095))));
+    try testing.expect(!watcher.rawLinuxSyscallFailed(@bitCast(@as(isize, -4096))));
+}
+
 test "watcher: queue overflow is explicit" {
     const queue = try heapEventQueue();
     defer testing.allocator.destroy(queue);

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1255,6 +1255,21 @@ const watch_kqueue = switch (builtin.os.tag) {
 };
 const watch_inotify = builtin.os.tag == .linux;
 
+/// True when a RAW `std.os.linux.*` syscall return encodes a failure.
+///
+/// Raw syscalls pack `-errno` into the returned usize. `std.posix.errno` is the
+/// *libc* accessor — in a libc-linked build it reports failure only for
+/// `rc == -1`, which a usize never equals, so it answered `.SUCCESS` for every
+/// raw failure. A missing `/tmp/codedb-notify` (the optional muonry interop
+/// file, which codedb never creates) therefore walked a `-ENOENT` straight into
+/// `@intCast`: a panic in Debug/ReleaseSafe, a truncated garbage watch
+/// descriptor in ReleaseFast. Mirrors std.os.linux.errno's error range without
+/// referencing the linux-only namespace, so it stays testable on every target.
+pub fn rawLinuxSyscallFailed(rc: usize) bool {
+    const signed: isize = @bitCast(rc);
+    return signed > -4096 and signed < 0;
+}
+
 fn raiseNofileLimit() void {
     if (builtin.os.tag == .windows) return;
     var lim = std.posix.getrlimit(.NOFILE) catch return;
@@ -1466,7 +1481,7 @@ const FileChangeWatch = struct {
     fn armInotify(self: *FileChangeWatch, root: []const u8, dirs: *const DirMap) void {
         if (comptime !watch_inotify) return;
         const rc = std.os.linux.inotify_init1(std.os.linux.IN.CLOEXEC);
-        if (std.posix.errno(rc) != .SUCCESS) return;
+        if (rawLinuxSyscallFailed(rc)) return;
         self.inotify_fd = @intCast(rc);
         const mask = std.os.linux.IN.MODIFY | std.os.linux.IN.CREATE | std.os.linux.IN.DELETE |
             std.os.linux.IN.MOVED_FROM | std.os.linux.IN.MOVED_TO | std.os.linux.IN.ATTRIB;
@@ -1490,7 +1505,7 @@ const FileChangeWatch = struct {
         @memcpy(zbuf[0..path.len], path);
         zbuf[path.len] = 0;
         const wd_rc = std.os.linux.inotify_add_watch(self.inotify_fd, @ptrCast(&zbuf), mask);
-        if (std.posix.errno(wd_rc) != .SUCCESS) return;
+        if (rawLinuxSyscallFailed(wd_rc)) return;
         const wd: i32 = @intCast(wd_rc);
         if (rel) |dir_rel| {
             const duped = self.alloc.dupe(u8, dir_rel) catch return;


### PR DESCRIPTION
## Problem

`FileChangeWatch` guards two raw `std.os.linux.*` syscalls with the wrong errno accessor:

```zig
const wd_rc = std.os.linux.inotify_add_watch(...);  // raw syscall: -errno packed into a usize
if (std.posix.errno(wd_rc) != .SUCCESS) return;     // libc accessor: `if (rc == -1) ... else .SUCCESS`
const wd: i32 = @intCast(wd_rc);                    // panics on the negative rc
```

codedb links libc, so `std.posix.errno` resolves to `std.c.errno`, which reports failure only for `rc == -1`. A `usize` never equals `-1`, so **the guard always returned `.SUCCESS`** and the negative rc fell straight through to `@intCast`.

Verified against the pinned toolchain (0.17.0-dev.813+2153f8143):

```
inotify_add_watch("/tmp/definitely-not-here") ->
  rc = 18446744073709551614 (0xfffffffffffffffe)
  std.posix.errno(rc)     = SUCCESS   <-- wrong
  std.os.linux.errno(rc)  = NOENT     <-- correct
```

## Why it fires for everyone on Linux

`armInotify` watches `/tmp/codedb-notify` — the optional muonry interop file, which **codedb itself never creates**. On any machine without muonry that watch returns `-ENOENT` on every arm, so:

- **Debug / ReleaseSafe** — hard panic (`integer does not fit in destination type`) in the watcher thread.
- **ReleaseFast** — `@intCast` is unchecked, so the value truncates to a garbage watch descriptor instead. That is why shipped releases never surfaced it: `/tmp/codedb-notify` also fails silently, and a failing *directory* watch (EACCES, watch-limit ENOSPC) inserts a bogus `wd -> rel` mapping that can misattribute later events.

The kqueue path already tolerated the file's absence (`else |_| {}`); only inotify did not.

## Failing test

Reproduces today on `release/0.2.5842` as a crash in the existing test:

```
$ zig build test-index -Dtest-filter="issue-690"
thread panic: integer does not fit in destination type
src/watcher.zig:1494:25: in addInotifyWatch
src/watcher.zig:1482:29: in armInotify
src/watcher.zig:1336:28: in arm
src/watcher.zig:1621:14: in incrementalLoop
Build Summary: 2/3 tests passed (1 crashed)
```

## Fix

Classify raw returns by the `-errno` range instead. `rawLinuxSyscallFailed` mirrors `std.os.linux.errno` without referencing the linux-only namespace, so the boundary behaviour stays unit-testable on every target. Applied at both call sites — `inotify_init1` had the identical bug.

I scanned `src/` for other raw `std.os.linux.*` call sites; these two are the only ones.

## Verification

- New test `watcher: raw linux syscall failures are detected by the -errno range` pins success values, `-ENOENT`, and the `-1` / `-4095` / `-4096` boundaries.
- Both tests confirmed to actually catch the bug: with the old classification restored, `issue-690` crashes and the new test fails; with the fix, both pass.
- Full suite green: **`zig build test` 25/25 steps, 807/811 passed, 4 skipped, 0 failed, 0 crashed** (previously 1 crash).
- Daemon smoke-tested with `/tmp/codedb-notify` absent — arms and runs clean.
