### PR TITLE
release: bump 0.2.5842 version surfaces

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5841",
+    .version = "0.2.5842",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5841",
+  "version": "0.2.5842",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5841";
+pub const semver = "0.2.5842";


### PR DESCRIPTION
Bump embedded semver, `build.zig.zon`, and `codedeebee` to **0.2.5842** so the tag reports the right version.

Merge commit — do not squash.