### PR TITLE
security: block case variants of sensitive paths

### DIFF
--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -612,12 +612,28 @@ def run_scenario_6_agent_route_no_index(binary: str, project: str) -> list[TestR
         root = Path(tmp)
         (root / "pyproject.toml").write_text("[project]\nname = 'agent-route'\nversion = '0'\n")
         (root / "keep.py").write_text("def keep():\n    return 'keep'\n")
+        secret_canary = "uppercase_secret_canary_706"
+        (root / "PRIVATE_KEY.PEM").write_text(secret_canary)
         p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
 
         try:
             r = t("initial scan completes")
             if not do_initialize(p, with_roots=False) or not wait_for_scan(p):
                 r.fail("MCP server did not become ready")
+                return results
+            r.ok()
+
+            r = t("uppercase private-key path is blocked from MCP read")
+            read_text = tool_text(p.call_tool("codedb_read", {"path": "PRIVATE_KEY.PEM"}))
+            if "access to sensitive file blocked" not in read_text or secret_canary in read_text:
+                r.fail(f"sensitive read was not blocked: {read_text[:240]!r}")
+                return results
+            r.ok()
+
+            r = t("uppercase private-key contents are absent from search")
+            search_text = tool_text(p.call_tool("codedb_search", {"query": secret_canary}))
+            if not search_text.startswith("0 results") or "PRIVATE_KEY.PEM" in search_text:
+                r.fail(f"sensitive file entered the index: {search_text[:240]!r}")
                 return results
             r.ok()
 

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1473,28 +1473,44 @@ fn resolveSafeSnapshotPath(io: std.Io, root_dir: std.Io.Dir, canonical_root: []c
 /// snapshot or live-indexed. Single implementation of this security filter;
 /// `watcher.isSensitivePath` delegates here (parity-tested in test_snapshot.zig
 /// "issue-528: isSensitivePath parity").
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    if (value.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}
+
+fn hasSensitiveExtension(basename: []const u8) bool {
+    const extensions = [_][]const u8{ ".env", ".pem", ".key", ".p12", ".pfx", ".jks" };
+    for (extensions) |extension| {
+        if (endsWithIgnoreCase(basename, extension)) return true;
+    }
+    return false;
+}
+
+fn hasSensitiveDirectory(path: []const u8) bool {
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (std.ascii.eqlIgnoreCase(component, ".ssh") or
+            std.ascii.eqlIgnoreCase(component, ".gnupg") or
+            std.ascii.eqlIgnoreCase(component, ".aws")) return true;
+    }
+    return false;
+}
+
 pub fn isSensitivePath(path: []const u8) bool {
     const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
     // Fast path: most source files have extensions like .zig, .ts, .py — none start with '.'
     // or match sensitive patterns. Skip the full check for common cases.
     if (basename.len == 0) return false;
-    const first = basename[0];
+    const first = std.ascii.toLower(basename[0]);
     // Only check sensitive names if basename starts with '.', 'c', 's', 'i' or has key/cert extension
     if (first != '.' and first != 'c' and first != 's' and first != 'i') {
         // Still need to check extensions and directory patterns
-        if (std.mem.endsWith(u8, basename, ".env") or
-            std.mem.endsWith(u8, basename, ".pem") or
-            std.mem.endsWith(u8, basename, ".key") or
-            std.mem.endsWith(u8, basename, ".p12") or
-            std.mem.endsWith(u8, basename, ".pfx") or
-            std.mem.endsWith(u8, basename, ".jks")) return true;
-        if (std.mem.indexOf(u8, path, ".ssh/") != null or
-            std.mem.indexOf(u8, path, ".gnupg/") != null or
-            std.mem.indexOf(u8, path, ".aws/") != null) return true;
+        if (hasSensitiveExtension(basename)) return true;
+        if (hasSensitiveDirectory(path)) return true;
         return false;
     }
     // .env, .env.<token>; do NOT match .envoy, .envrc, .environment, etc.
-    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
+    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[0..4], ".env") and
         (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
     // Exact matches
     const sensitive_names = [_][]const u8{
@@ -1504,17 +1520,10 @@ pub fn isSensitivePath(path: []const u8) bool {
         "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
     };
     for (sensitive_names) |name| {
-        if (std.mem.eql(u8, basename, name)) return true;
+        if (std.ascii.eqlIgnoreCase(basename, name)) return true;
     }
-    if (std.mem.endsWith(u8, basename, ".env") or
-        std.mem.endsWith(u8, basename, ".pem") or
-        std.mem.endsWith(u8, basename, ".key") or
-        std.mem.endsWith(u8, basename, ".p12") or
-        std.mem.endsWith(u8, basename, ".pfx") or
-        std.mem.endsWith(u8, basename, ".jks")) return true;
-    if (std.mem.indexOf(u8, path, ".ssh/") != null or
-        std.mem.indexOf(u8, path, ".gnupg/") != null or
-        std.mem.indexOf(u8, path, ".aws/") != null) return true;
+    if (hasSensitiveExtension(basename)) return true;
+    if (hasSensitiveDirectory(path)) return true;
     return false;
 }
 fn endsWith(s: []const u8, suffix: []const u8) bool {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -361,6 +361,11 @@ test "issue-93: isSensitivePath blocks .env and credentials" {
     try testing.expect(watcher.isSensitivePath("keystore.jks"));
     try testing.expect(watcher.isSensitivePath("identity.pfx"));
     try testing.expect(watcher.isSensitivePath(".ssh/known_hosts"));
+    try testing.expect(watcher.isSensitivePath("CERT.PEM"));
+    try testing.expect(watcher.isSensitivePath("server.KeY"));
+    try testing.expect(watcher.isSensitivePath("KEYSTORE.JKS"));
+    try testing.expect(watcher.isSensitivePath("Credentials.JSON"));
+    try testing.expect(watcher.isSensitivePath(".SSH/known_hosts"));
     // Normal files should NOT be blocked
     try testing.expect(!watcher.isSensitivePath("main.zig"));
     try testing.expect(!watcher.isSensitivePath("src/server.zig"));

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -1049,11 +1049,19 @@ test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
         "cert.pem",                     "keystore.jks",       "identity.pfx",
         "bundle.p12",                   "config/.env.local",  "a/b/secrets.yaml",
         "deep/nested/.ssh/known_hosts", ".gnupg/secring.gpg", "x/.aws/credentials",
+        // case variants must not bypass the canonical filter
+        ".ENV",                         ".Env.Production",    "CONFIG.ENV",
+        "CERT.PEM",                     "server.KeY",         "bundle.P12",
+        "identity.PfX",                 "keystore.JKS",       "Credentials.JSON",
+        "Service-Account.JSON",         "SECRETS.YAML",       "ID_RSA",
+        "deep/.SSH/id_ed25519",         "x/.GnUpG/private",   "config/.AWS/credentials",
         // non-secrets — both copies must allow (esp. the .env-prefix edge cases)
         ".envoy.json",                  ".environment",       ".envrc",
+        ".EnVoY.json",                  ".ENVIRONMENT",       ".EnVrC",
         ".envconfig.yaml",              "main.zig",           "src/server.zig",
         "README.md",                    "package.json",       "id_rsa.pub",
         "envvars.ts",                   "Makefile",           "Dockerfile",
+        "src/PUBLIC.PEM.txt",
     };
     for (cases) |p| {
         try testing.expectEqual(watcher.isSensitivePath(p), snapshot_mod.isSensitivePath(p));
@@ -1064,7 +1072,13 @@ test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
     try testing.expect(snapshot_mod.isSensitivePath("credentials.json"));
     try testing.expect(snapshot_mod.isSensitivePath("deep/.ssh/id_rsa"));
     try testing.expect(snapshot_mod.isSensitivePath("keystore.jks")); // fast-path ext
+    try testing.expect(snapshot_mod.isSensitivePath("CERT.PEM"));
+    try testing.expect(snapshot_mod.isSensitivePath("server.KeY"));
+    try testing.expect(snapshot_mod.isSensitivePath("Credentials.JSON"));
+    try testing.expect(!snapshot_mod.isSafeSnapshotPath("keys/PRIVATE_KEY.PEM"));
+    try testing.expect(!snapshot_mod.isSafeSnapshotPath("config/.Env.Local"));
     try testing.expect(!snapshot_mod.isSensitivePath(".envoy.json")); // issue-409
+    try testing.expect(!snapshot_mod.isSensitivePath(".EnVoY.json"));
     try testing.expect(!snapshot_mod.isSensitivePath(".environment"));
     try testing.expect(!snapshot_mod.isSensitivePath("main.zig"));
 }


### PR DESCRIPTION
Fixes #706.

## What changed

- makes the canonical sensitive-path filter case-insensitive for `.env`, `.pem`, `.key`, `.p12`, `.pfx`, and `.jks`
- also blocks case variants of exact credential filenames and `.ssh` / `.gnupg` / `.aws` directory components
- preserves intentional non-secret cases such as `.envoy.json`, `.environment`, `.envrc`, and `PUBLIC.PEM.txt`
- adds an end-to-end canary proving `PRIVATE_KEY.PEM` is excluded from both MCP read and indexed search

`watcher.isSensitivePath` delegates to the snapshot implementation, so this one allocation-free filter covers live indexing, snapshot persistence/load, CLI/MCP reads, and search eligibility. The separate semantic-embedding work can reuse this canonical boundary when it is proposed.

## Verification

- `zig build test-snapshot`
- `zig build test-mcp`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/tmp/codedb-sensitive-ext-20260826` (58/58)
- paired A/B benchmark, 4 counterbalanced pairs: provenance/parity pass and no gated regression over 10%; `codedb_read` -0.58%, `codedb_search` +0.23%, `codedb_snapshot` -1.61% median paired delta