### PR TITLE
fix: harden semantic indexing and retrieval

### DIFF
--- a/src/commands.zig
+++ b/src/commands.zig
@@ -282,7 +282,7 @@ pub fn runSemanticIndex(ctx: *RunCtx) void {
             "  local sidecar: {s}/{s} ({d} bytes total; mmap slab {d} bytes; metadata {d} bytes)\n" ++
             "  persistent vector payload: {d} bytes  remote text sent: {d} bytes\n" ++
             "  vector space: {x}  sensitive paths blocked: {d}  parallel batches: {d}\n" ++
-            "  embedding wall: {d} ms  HNSW insertion: {d} ms  total: {s}\n",
+            "  embedding wall: {d} ms  HNSW insertion: {d} ms  source revalidation: {d} ms  total: {s}\n",
         .{
             ctx.s.green,
             ctx.s.reset,
@@ -304,6 +304,7 @@ pub fn runSemanticIndex(ctx: *RunCtx) void {
             stats.parallel_batches,
             stats.embedding_wall_ns / std.time.ns_per_ms,
             stats.insertion_ns / std.time.ns_per_ms,
+            stats.source_validation_ns / std.time.ns_per_ms,
             sty.formatDuration(&duration_buf, stats.elapsed_ns),
         },
     );

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3485,8 +3485,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     // identifier candidates keep priority under CONTEXT_MAX_CANDIDATES).
     extractContextFallbackWords(task, A, &candidates);
     const pf_cand = cio.nanoTimestamp();
-    if (candidates.items.len == 0) {
-        if (semantic_requested) retrieval.semantic = "no_candidates";
+    if (candidates.items.len == 0 and !semantic_requested) {
         const message = "no candidate identifiers found in task — include symbol names (camelCase or snake_case) or \"quoted strings\" so the composer can extract keywords";
         if (structured) {
             var sections: [2]ContextProvenanceSection = undefined;
@@ -3651,7 +3650,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             use_exact_semantic_fallback = true;
             break :ann_lane;
         };
-        if (semantic_index_mod.search(
+        if (searchSemanticAnnFresh(
             io,
             A,
             explorer,

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -203,15 +203,34 @@ fn appendBoundedDocument(
     candidate: Candidate,
     remaining_batch_bytes: usize,
 ) ![]const u8 {
-    const path_cap = @min(candidate.path.len, 512);
+    const item_cap = @min(max_document_bytes, remaining_batch_bytes);
+    if (item_cap <= 1) return error.BatchTextLimit;
+    const path_cap = @min(candidate.path.len, @min(@as(usize, 512), item_cap - 1));
     const fixed = path_cap + 1;
-    if (remaining_batch_bytes <= fixed) return error.BatchTextLimit;
-    const text_cap = @min(candidate.text.len, @min(max_document_bytes, remaining_batch_bytes - fixed));
+    const text_cap = @min(candidate.text.len, item_cap - fixed);
     const start = out.items.len;
     try out.appendSlice(allocator, candidate.path[0..path_cap]);
     try out.append(allocator, '\n');
     try out.appendSlice(allocator, candidate.text[0..text_cap]);
     return out.items[start..];
+}
+
+test "semantic exact-fallback item cap includes path and separator" {
+    const testing = std.testing;
+    var long_path: [700]u8 = undefined;
+    @memset(&long_path, 'p');
+    var long_text: [max_document_bytes * 2]u8 = undefined;
+    @memset(&long_text, 'x');
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    const item = try appendBoundedDocument(
+        testing.allocator,
+        &out,
+        .{ .path = &long_path, .text = &long_text },
+        max_batch_text_bytes,
+    );
+    try testing.expectEqual(max_document_bytes, item.len);
+    try testing.expectEqual(@as(usize, 512), std.mem.indexOfScalar(u8, item, '\n').?);
 }
 
 const EmbeddingRequest = struct {

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -57,6 +57,7 @@ pub const BuildStats = struct {
     elapsed_ns: u64,
     embedding_wall_ns: u64,
     insertion_ns: u64,
+    source_validation_ns: u64,
     parallel_batches: usize,
     vector_space_id: u64,
 };
@@ -558,6 +559,14 @@ pub fn build(
         for (paths) |path| allocator.free(path);
         allocator.free(paths);
     }
+    var remote_paths: std.ArrayList([]const u8) = .empty;
+    defer remote_paths.deinit(allocator);
+    try remote_paths.ensureTotalCapacity(allocator, paths.len);
+    for (paths) |path| {
+        if (semantic.isRemoteCandidatePathAllowed(path)) remote_paths.appendAssumeCapacity(path);
+    }
+    const source_content_before = try store.semanticContentFingerprintForPaths(remote_paths.items);
+    var embedded_content = Store.semanticContentHasher();
 
     var index = ann.Index.init(allocator, config.dimensions, .{});
     defer index.deinit();
@@ -590,10 +599,16 @@ pub fn build(
             blocked += 1;
             continue;
         }
-        const content = (explorer.getContent(path, allocator) catch null) orelse continue;
+        const content = (try explorer.getContent(path, allocator)) orelse return error.RepositoryChangedDuringAnnBuild;
         defer allocator.free(content);
+        Store.updateSemanticContentFingerprint(
+            &embedded_content,
+            path,
+            std.hash.Wyhash.hash(0, content),
+            @intCast(content.len),
+        );
         if (content.len == 0) continue;
-        var outline = (explorer.getOutline(path, allocator) catch null) orelse continue;
+        var outline = (try explorer.getOutline(path, allocator)) orelse return error.RepositoryChangedDuringAnnBuild;
         defer outline.deinit();
         var cursor = ChunkCursor{ .content = content };
         var chunks_for_file: usize = 0;
@@ -624,10 +639,18 @@ pub fn build(
     if (index.len() == 0) return error.NoSafeAnnRecords;
     if (try index.slabImageSize() > max_slab_bytes) return error.AnnSlabTooLarge;
 
+    const validation_started = cio.nanoTimestamp();
+    if (embedded_content.final() != source_content_before) return error.RepositoryChangedDuringAnnBuild;
+    const source_root = explorer.root_dir orelse return error.InvalidProjectRoot;
+    if (try watcher.liveIndexedContentFingerprint(io, source_root, allocator) != source_content_before) {
+        return error.RepositoryChangedDuringAnnBuild;
+    }
+
     const manifest_after = try repositoryFingerprint(explorer, store, allocator);
     if (manifest_after != manifest_before) return error.RepositoryChangedDuringAnnBuild;
     const git_head_after = try git_mod.getGitHead(project_root, allocator);
     if (!headsEqual(git_head_before, git_head_after)) return error.RepositoryChangedDuringAnnBuild;
+    const source_validation_ns = elapsedNs(validation_started);
 
     const slab_name = try std.fmt.allocPrint(allocator, "{s}{x}-{x}-{x}{s}", .{
         slab_file_prefix,
@@ -686,6 +709,7 @@ pub fn build(
         .elapsed_ns = elapsedNs(started),
         .embedding_wall_ns = embedding_wall_ns,
         .insertion_ns = insertion_ns,
+        .source_validation_ns = source_validation_ns,
         .parallel_batches = parallel_batches,
         .vector_space_id = vector_space_id,
     };
@@ -1247,4 +1271,45 @@ test "semantic ANN rejects stale content before mmaping the graph" {
         error.StaleAnnManifest,
         search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find alpha implementation", 5),
     );
+}
+
+test "semantic build live fingerprint catches unreconciled repository edits" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    var source = try tmp.dir.createFile(io, "src/live.zig", .{});
+    try source.writeStreamingAll(io, "pub fn before() void {}\n");
+    source.close(io);
+    var ignored = try tmp.dir.createFile(io, ".env", .{});
+    try ignored.writeStreamingAll(io, "TEST_ONLY_NOT_A_SECRET=1\n");
+    ignored.close(io);
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPathFile(io, ".", &root_buf)];
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.setRoot(io, root);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try watcher.initialScan(io, &store, &explorer, root, testing.allocator, true);
+
+    const paths = try cloneSortedPaths(&explorer, testing.allocator);
+    defer {
+        for (paths) |path| testing.allocator.free(path);
+        testing.allocator.free(paths);
+    }
+    const indexed = try store.semanticContentFingerprintForPaths(paths);
+    try testing.expectEqual(indexed, try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
+
+    var ignored_changed = try tmp.dir.createFile(io, ".env", .{ .truncate = true });
+    try ignored_changed.writeStreamingAll(io, "TEST_ONLY_NOT_A_SECRET=2\n");
+    ignored_changed.close(io);
+    try testing.expectEqual(indexed, try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
+
+    var changed = try tmp.dir.createFile(io, "src/live.zig", .{ .truncate = true });
+    try changed.writeStreamingAll(io, "pub fn after() void {}\n");
+    changed.close(io);
+    try testing.expect(indexed != try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -66,6 +66,27 @@ const SectionEntry = struct {
     length: u64,
 };
 
+const OutputPathStyle = enum { posix, windows };
+
+fn splitOutputPath(path: []const u8, style: OutputPathStyle) struct { parent: []const u8, name: []const u8 } {
+    const parent = switch (style) {
+        .posix => std.fs.path.dirnamePosix(path),
+        .windows => std.fs.path.dirnameWindows(path),
+    } orelse ".";
+    const name = switch (style) {
+        .posix => std.fs.path.basenamePosix(path),
+        .windows => std.fs.path.basenameWindows(path),
+    };
+    return .{ .parent = parent, .name = name };
+}
+
+fn nativeOutputPathStyle() OutputPathStyle {
+    return switch (builtin.os.tag) {
+        .windows, .uefi => .windows,
+        else => .posix,
+    };
+}
+
 /// Write a portable `.codedb` snapshot file.
 pub fn writeSnapshot(
     io: std.Io,
@@ -89,9 +110,9 @@ pub fn writeSnapshot(
     };
     defer if (owned_source_root) |dir| dir.close(io);
 
-    const sep = std.mem.lastIndexOfScalar(u8, output_path, '/');
-    const output_parent_path = if (sep) |s| if (s == 0) "/" else output_path[0..s] else ".";
-    const output_name = if (sep) |s| output_path[s + 1 ..] else output_path;
+    const output_parts = splitOutputPath(output_path, nativeOutputPathStyle());
+    const output_parent_path = output_parts.parent;
+    const output_name = output_parts.name;
     if (output_name.len == 0) return error.BadPathName;
     const root_snapshot = isRootSnapshot(output_path, root_path);
     var owned_output_dir: ?std.Io.Dir = null;
@@ -463,6 +484,16 @@ pub fn writeSnapshot(
     if (root_snapshot) {
         ensureGitIgnoresSnapshotAtRoot(io, source_root, allocator);
     }
+}
+
+test "snapshot output path split handles POSIX and Windows absolute paths" {
+    const testing = std.testing;
+    const posix = splitOutputPath("/var/cache/codedb.snapshot", .posix);
+    try testing.expectEqualStrings("/var/cache", posix.parent);
+    try testing.expectEqualStrings("codedb.snapshot", posix.name);
+    const windows = splitOutputPath("C:\\cache\\codedb.snapshot", .windows);
+    try testing.expectEqualStrings("C:\\cache", windows.parent);
+    try testing.expectEqualStrings("codedb.snapshot", windows.name);
 }
 
 /// True when `output_path` is the in-tree project-root snapshot

--- a/src/store.zig
+++ b/src/store.zig
@@ -392,6 +392,41 @@ pub const Store = struct {
         return hash.final();
     }
 
+    /// Content-only identity used to compare the indexed Store with a fresh
+    /// capability-relative filesystem walk. Unlike the persisted semantic
+    /// manifest above, this intentionally excludes the process-local Version
+    /// operation: identical repository bytes must compare equal whether they
+    /// came from a cold snapshot, a watcher refresh, or a restored snapshot.
+    pub fn semanticContentFingerprintForPaths(self: *Store, sorted_paths: anytype) !u64 {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        var hash = semanticContentHasher();
+        for (sorted_paths) |path| {
+            const versions = self.files.get(path) orelse return error.MissingContentIdentity;
+            const latest = versions.latest() orelse return error.MissingContentIdentity;
+            if (latest.op == .tombstone or latest.hash == 0) return error.MissingContentIdentity;
+            updateSemanticContentFingerprint(&hash, path, latest.hash, latest.size);
+        }
+        return hash.final();
+    }
+
+    pub fn semanticContentHasher() std.hash.Wyhash {
+        return std.hash.Wyhash.init(0x4344_4253_454d_3031);
+    }
+
+    pub fn updateSemanticContentFingerprint(
+        hash: *std.hash.Wyhash,
+        path: []const u8,
+        content_hash: u64,
+        size: u64,
+    ) void {
+        hash.update(path);
+        hash.update(&.{0});
+        hash.update(std.mem.asBytes(&content_hash));
+        hash.update(std.mem.asBytes(&size));
+    }
+
     pub fn listFiles(self: *Store) ![][]const u8 {
         self.mu.lock();
         defer self.mu.unlock();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1305,6 +1305,56 @@ pub fn initialScan(io: std.Io, store: *Store, explorer: *Explorer, root: []const
     try initialScanWithWorkerCount(io, store, explorer, root, allocator, skip_trigram, worker_count);
 }
 
+/// Re-read the complete indexable repository through the already-open root
+/// capability and return a deterministic content-only fingerprint. The
+/// semantic-index builder uses this immediately before publication so edits,
+/// additions, and deletions that happened during remote embedding cannot
+/// produce a sidecar for a mixed repository generation. Sensitive, ignored,
+/// binary, oversized, and symlink-escaped files follow the exact scan policy.
+pub fn liveIndexedContentFingerprint(
+    io: std.Io,
+    root: std.Io.Dir,
+    allocator: std.mem.Allocator,
+) !u64 {
+    const Identity = struct {
+        path: []u8,
+        content_hash: u64,
+        size: u64,
+    };
+
+    var walker = try FilteredWalker.init(io, root, allocator);
+    defer walker.deinit();
+    var identities: std.ArrayList(Identity) = .empty;
+    defer {
+        for (identities.items) |identity| allocator.free(identity.path);
+        identities.deinit(allocator);
+    }
+
+    while (try walker.next()) |entry| {
+        if (shouldSkipFile(entry.path)) continue;
+        const content = (try readIndexableFile(io, root, entry.path, allocator, entry.size, false)) orelse continue;
+        defer allocator.free(content);
+        const owned_path = try allocator.dupe(u8, entry.path);
+        errdefer allocator.free(owned_path);
+        try identities.append(allocator, .{
+            .path = owned_path,
+            .content_hash = std.hash.Wyhash.hash(0, content),
+            .size = @intCast(content.len),
+        });
+    }
+    std.mem.sort(Identity, identities.items, {}, struct {
+        fn lessThan(_: void, a: Identity, b: Identity) bool {
+            return std.mem.order(u8, a.path, b.path) == .lt;
+        }
+    }.lessThan);
+
+    var hash = Store.semanticContentHasher();
+    for (identities.items) |identity| {
+        Store.updateSemanticContentFingerprint(&hash, identity.path, identity.content_hash, identity.size);
+    }
+    return hash.final();
+}
+
 /// Fast index: parse symbols/outline only, skip expensive word+trigram indexes.
 fn indexFileOutline(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []const u8, allocator: std.mem.Allocator) !void {
     if (shouldSkipFile(path)) return;


### PR DESCRIPTION
## Summary

- revalidate the exact embedded repository bytes and perform a final capability-relative live walk before publishing a semantic sidecar
- keep ignored and sensitive files out of both the build and the revalidation fingerprint
- run semantic-only ANN retrieval even when lexical keyword extraction produces zero candidates
- route ANN queries through the existing bounded startup-reconcile retry
- enforce the documented 2 KiB path-plus-snippet exact-fallback item cap
- split snapshot destinations with target-native POSIX/Windows path semantics
- report semantic-index source-revalidation wall time for future hill climbing

## Verification

- `zig build test`
- `zig build -Doptimize=ReleaseSafe`
- x86_64 Linux ReleaseSafe cross-build
- x86_64 Windows ReleaseSafe cross-build
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project <isolated-worktree>`: 75/75 passed
- live CodeDB corpus build through `Qwen/Qwen3-Embedding-0.6B` at 512D:
  - 8,842 chunks from 654 files
  - 82.5 s total; 80.569 s embedding; 1.847 s HNSW insertion
  - final full source revalidation: 30 ms (0.036% of total)
  - 24,583,490-byte sidecar, mmap-backed
- live zero-keyword query `what does this do?`:
  - `semantic: ann_applied`
  - no CPU embedding fallback
  - ANN load 13.772 ms; ANN search 0.714 ms
- regression proves ordinary source edits invalidate the live fingerprint while `.env` edits remain excluded

## Follow-up hill climb

The scale run shows per-query sidecar load/freshness (13.8 ms) is now the measured local bottleneck, about 19x the graph search itself. That optimization is intentionally separate from this correctness PR.
