### PR TITLE
perf: cache validated semantic ANN sidecars

### DIFF
--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -209,6 +209,7 @@ const ProjectCtx = struct {
     store: *Store,
     snapshot_cache: *SnapshotCache,
     deps_cache: *DepsCache,
+    semantic_cache: *semantic_index_mod.SearchCache,
 };
 
 fn getProjectDataDir(allocator: std.mem.Allocator, project_path: []const u8) ?[]u8 {
@@ -313,6 +314,7 @@ const ProjectCache = struct {
         store: Store,
         snapshot_cache: SnapshotCache,
         deps_cache: DepsCache,
+        semantic_cache: semantic_index_mod.SearchCache,
         last_used: i64,
     };
 
@@ -322,6 +324,7 @@ const ProjectCache = struct {
     default_path: []const u8,
     default_snapshot_cache: SnapshotCache,
     default_deps_cache: DepsCache,
+    default_semantic_cache: semantic_index_mod.SearchCache,
     content_cache_capacity: u32,
 
     fn init(alloc_: std.mem.Allocator, default_path_: []const u8, content_cache_capacity_: u32) ProjectCache {
@@ -332,6 +335,7 @@ const ProjectCache = struct {
             .default_path = default_path_,
             .default_snapshot_cache = .{},
             .default_deps_cache = .{},
+            .default_semantic_cache = semantic_index_mod.SearchCache.init(alloc_),
             .content_cache_capacity = content_cache_capacity_,
         };
     }
@@ -339,6 +343,7 @@ const ProjectCache = struct {
     fn deinit(self: *ProjectCache) void {
         self.default_snapshot_cache.deinit(self.alloc);
         self.default_deps_cache.deinit(self.alloc);
+        self.default_semantic_cache.deinit();
         for (&self.entries) |*slot| {
             if (slot.*) |entry| {
                 self.destroyEntry(entry);
@@ -350,6 +355,7 @@ const ProjectCache = struct {
     fn destroyEntry(self: *ProjectCache, entry: *Entry) void {
         entry.snapshot_cache.deinit(self.alloc);
         entry.deps_cache.deinit(self.alloc);
+        entry.semantic_cache.deinit();
         entry.explorer.deinit();
         entry.store.deinit();
         self.alloc.free(entry.path);
@@ -394,7 +400,7 @@ const ProjectCache = struct {
         default_exp: *Explorer,
         default_store: *Store,
     ) !ProjectCtx {
-        const raw_path = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
+        const raw_path = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache, .semantic_cache = &self.default_semantic_cache };
         const parsed_path = local_uri.parseRootReference(self.alloc, raw_path) catch return error.PathNotAllowed;
         defer self.alloc.free(parsed_path);
 
@@ -412,7 +418,7 @@ const ProjectCache = struct {
             if (slot.*) |entry| {
                 if (std.mem.eql(u8, entry.path, canonical_root)) {
                     entry.last_used = now;
-                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache, .deps_cache = &entry.deps_cache };
+                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache, .deps_cache = &entry.deps_cache, .semantic_cache = &entry.semantic_cache };
                 }
             }
         }
@@ -428,6 +434,7 @@ const ProjectCache = struct {
         new_entry.store = Store.init(self.alloc);
         new_entry.snapshot_cache = .{};
         new_entry.deps_cache = .{};
+        new_entry.semantic_cache = semantic_index_mod.SearchCache.init(self.alloc);
         new_entry.last_used = now;
 
         const stable_root = new_entry.explorer.root_dir orelse return error.PathNotAllowed;
@@ -454,7 +461,7 @@ const ProjectCache = struct {
                 self.alloc.free(new_entry.path);
                 self.alloc.destroy(new_entry);
                 if (default_exp.root_path != null and std.mem.eql(u8, canonical_root, default_exp.root_path.?) and default_store.currentSeq() > 0) {
-                    return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
+                    return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache, .semantic_cache = &self.default_semantic_cache };
                 }
                 return error.SnapshotLoadFailed;
             }
@@ -495,7 +502,7 @@ const ProjectCache = struct {
         }
 
         self.entries[target_slot] = new_entry;
-        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store, .snapshot_cache = &new_entry.snapshot_cache, .deps_cache = &new_entry.deps_cache };
+        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store, .snapshot_cache = &new_entry.snapshot_cache, .deps_cache = &new_entry.deps_cache, .semantic_cache = &new_entry.semantic_cache };
     }
 };
 
@@ -1786,6 +1793,7 @@ fn dispatch(
             .store = default_store,
             .snapshot_cache = &cache.default_snapshot_cache,
             .deps_cache = &cache.default_deps_cache,
+            .semantic_cache = &cache.default_semantic_cache,
         };
 
     if (project_path == null and tool == .codedb_deps and args.count() == 1) {
@@ -1851,7 +1859,7 @@ fn dispatch(
         .codedb_glob => handleGlob(alloc, args, out, ctx.explorer),
         .codedb_ls => handleLs(alloc, args, out, ctx.explorer),
         .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", ctx.explorer, out),
-        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer),
+        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer, ctx.semantic_cache),
     }
     appendScanProgressHint(alloc, out, tool);
 }
@@ -3235,9 +3243,10 @@ fn isTestPath(path: []const u8) bool {
 /// must never launch another full filesystem walk or allocate EventQueue's
 /// multi-megabyte ring, and no ANN embedding request is issued before freshness
 /// validation succeeds.
-fn searchSemanticAnnFresh(
+fn searchSemanticAnnOnce(
     io: std.Io,
     allocator: std.mem.Allocator,
+    cache: ?*semantic_index_mod.SearchCache,
     explorer: *Explorer,
     store: *Store,
     project_root: []const u8,
@@ -3245,13 +3254,30 @@ fn searchSemanticAnnFresh(
     task: []const u8,
     k: usize,
 ) !semantic_index_mod.SearchOutput {
-    return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k) catch |err| switch (err) {
+    if (cache) |semantic_cache| {
+        return semantic_index_mod.searchCached(io, allocator, semantic_cache, explorer, store, project_root, data_dir, task, k);
+    }
+    return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k);
+}
+
+fn searchSemanticAnnFresh(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cache: ?*semantic_index_mod.SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !semantic_index_mod.SearchOutput {
+    return searchSemanticAnnOnce(io, allocator, cache, explorer, store, project_root, data_dir, task, k) catch |err| switch (err) {
         error.StaleAnnManifest => {
             if (!explorer.startupReconcilePending()) return err;
             const deadline = cio.milliTimestamp() + @as(i64, @intCast(scan_wait_timeout_ms));
             while (explorer.startupReconcilePending() and cio.milliTimestamp() < deadline) cio.sleepMs(25);
             if (explorer.startupReconcilePending()) return err;
-            return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k);
+            return searchSemanticAnnOnce(io, allocator, cache, explorer, store, project_root, data_dir, task, k);
         },
         else => return err,
     };
@@ -3311,6 +3337,7 @@ const ContextRetrievalProvenance = struct {
     ann_load_ns: u64 = 0,
     ann_search_ns: u64 = 0,
     ann_mmap_backed: bool = false,
+    ann_cache_hit: bool = false,
     ann_vector_space_id: ?u64 = null,
     remote_retention: []const u8 = "not_applicable",
     local_vector_storage: []const u8 = "none",
@@ -3359,7 +3386,15 @@ fn appendStructuredContext(alloc: std.mem.Allocator, out: *std.ArrayList(u8), va
     out.appendSlice(alloc, encoded) catch {};
 }
 
-fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {
+fn handleContext(
+    io: std.Io,
+    alloc: std.mem.Allocator,
+    args: *const std.json.ObjectMap,
+    out: *std.ArrayList(u8),
+    store: *Store,
+    explorer: *Explorer,
+    semantic_cache: ?*semantic_index_mod.SearchCache,
+) void {
     const stable_root = explorer.root_dir orelse {
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
@@ -3653,6 +3688,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         if (searchSemanticAnnFresh(
             io,
             A,
+            semantic_cache,
             explorer,
             store,
             rooted_project,
@@ -3674,6 +3710,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             retrieval.ann_load_ns = ann_result.load_ns;
             retrieval.ann_search_ns = ann_result.search_ns;
             retrieval.ann_mmap_backed = ann_result.mmap_backed;
+            retrieval.ann_cache_hit = ann_result.cache_hit;
             retrieval.ann_vector_space_id = ann_result.vector_space_id;
             retrieval.remote_retention = switch (ann_result.retention) {
                 .none_by_codedb_policy => "none_by_codedb_service_policy",
@@ -3883,7 +3920,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         if (semantic_requested) {
             wh.print("\n## Retrieval privacy\n- local BM25/symbol retrieval ran first\n", .{}) catch {};
             if (std.mem.eql(u8, retrieval.semantic, "ann_applied")) {
-                wh.print("- local OpenPuffer ANN: {s}, {d}D, vector space {x}, {d} indexed code chunks / {d} sidecar bytes\n- remote query embedding: task plus fixed public vector-space calibration / {d} text bytes; remote retention: {s}\n- local vector storage: {s}; mmap={any}; ANN load {d} ns / search {d} ns\n", .{
+                wh.print("- local OpenPuffer ANN: {s}, {d}D, vector space {x}, {d} indexed code chunks / {d} sidecar bytes\n- remote query embedding: task plus fixed public vector-space calibration / {d} text bytes; remote retention: {s}\n- local vector storage: {s}; mmap={any}; cache_hit={any}; ANN load {d} ns / search {d} ns\n", .{
                     retrieval.model orelse semantic_mod.default_model,
                     retrieval.dimensions orelse semantic_mod.default_dimensions,
                     retrieval.ann_vector_space_id orelse 0,
@@ -3893,6 +3930,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                     retrieval.remote_retention,
                     retrieval.local_vector_storage,
                     retrieval.ann_mmap_backed,
+                    retrieval.ann_cache_hit,
                     retrieval.ann_load_ns,
                     retrieval.ann_search_ns,
                 }) catch {};
@@ -5584,7 +5622,7 @@ pub fn runCliTool(
         if (task.items.len == 0) return cliUsage(alloc, out, "context [--semantic] [--json] <task...>");
         m.put(alloc, "task", .{ .string = task.items }) catch return 1;
         loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
-        handleContext(io, alloc, &m, out, store, explorer);
+        handleContext(io, alloc, &m, out, store, explorer, null);
         return finishCli(out, out_start);
     }
     return null;

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -81,6 +81,7 @@ pub const SearchOutput = struct {
     embed_ns: u64,
     search_ns: u64,
     mmap_backed: bool,
+    cache_hit: bool,
     vector_space_id: u64,
 };
 
@@ -123,6 +124,46 @@ const Loaded = struct {
         self.allocator.free(self.records);
         self.allocator.free(self.storage);
         self.* = undefined;
+    }
+};
+
+const FileIdentity = struct {
+    inode: std.Io.File.INode,
+    size: u64,
+    mtime_ns: i96,
+    ctime_ns: i96,
+
+    fn eql(a: FileIdentity, b: FileIdentity) bool {
+        return a.inode == b.inode and a.size == b.size and a.mtime_ns == b.mtime_ns and a.ctime_ns == b.ctime_ns;
+    }
+};
+
+const CachedLoaded = struct {
+    loaded: Loaded,
+    metadata_identity: FileIdentity,
+    slab_identity: FileIdentity,
+    store_seq: u64,
+};
+
+/// One validated immutable semantic sidecar generation per project. Warm
+/// searches take the shared lock, so concurrent users can embed and search in
+/// parallel. Replacement is transactional under the exclusive lock: a stale,
+/// malformed, or concurrently replaced sidecar never evicts the last valid
+/// generation and is never queried.
+pub const SearchCache = struct {
+    mu: cio.RwLock = .{},
+    allocator: std.mem.Allocator,
+    cached: ?CachedLoaded = null,
+
+    pub fn init(allocator: std.mem.Allocator) SearchCache {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *SearchCache) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        if (self.cached) |*cached| cached.loaded.deinit();
+        self.cached = null;
     }
 };
 
@@ -180,6 +221,19 @@ fn fileSize(io: std.Io, path: []const u8) !usize {
     defer file.close(io);
     const stat = try file.stat(io);
     return std.math.cast(usize, stat.size) orelse error.AnnSlabTooLarge;
+}
+
+fn fileIdentity(io: std.Io, path: []const u8) !FileIdentity {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .follow_symlinks = false });
+    defer file.close(io);
+    const stat = try file.stat(io);
+    if (stat.kind != .file) return error.InvalidAnnSidecar;
+    return .{
+        .inode = stat.inode,
+        .size = stat.size,
+        .mtime_ns = stat.mtime.nanoseconds,
+        .ctime_ns = stat.ctime.nanoseconds,
+    };
 }
 
 fn currentSlabName(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !?[]u8 {
@@ -852,35 +906,21 @@ fn validateRecordLineRanges(explorer: *Explorer, records: []const Record) !void 
     }
 }
 
-pub fn search(
-    io: std.Io,
-    allocator: std.mem.Allocator,
-    explorer: *Explorer,
-    store: *Store,
-    project_root: []const u8,
-    data_dir: []const u8,
-    task: []const u8,
-    k: usize,
-) !SearchOutput {
-    const config = semantic.Config.fromEnv();
-    try config.validate();
-    const load_started = cio.nanoTimestamp();
-    var loaded = try loadMetadata(io, allocator, data_dir);
-    defer loaded.deinit();
-
+fn validateLoadedConfig(config: *const semantic.Config, loaded: *const Loaded) !void {
     if (config.dimensions != loaded.dimensions) return error.AnnDimensionsMismatch;
     if (!std.mem.eql(u8, config.model, loaded.model)) return error.AnnModelMismatch;
     if (config.vectorSpaceId() != loaded.vector_space_id) return error.AnnVectorSpaceMismatch;
-    const current_head = try git_mod.getGitHead(project_root, allocator);
-    if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
-    if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
-    // Metadata is attacker-controlled local input. Validate the entire mapping
-    // while the index is still empty so a failure remains transactional and no
-    // forged line can reach rendering arithmetic.
-    try validateRecordLineRanges(explorer, loaded.records);
-    try loaded.loadGraph();
-    const load_ns = elapsedNs(load_started);
+}
 
+fn searchLoaded(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    loaded: *Loaded,
+    task: []const u8,
+    k: usize,
+    load_ns: u64,
+    cache_hit: bool,
+) !SearchOutput {
     const embed_started = cio.nanoTimestamp();
     const query = try semantic.embedQueryAndCalibrationRemote(io, allocator, task);
     defer allocator.free(query.vectors);
@@ -935,8 +975,153 @@ pub fn search(
         .embed_ns = embed_ns,
         .search_ns = search_ns,
         .mmap_backed = loaded.index.isMmapBacked(),
+        .cache_hit = cache_hit,
         .vector_space_id = loaded.vector_space_id,
     };
+}
+
+fn cachedGenerationCurrent(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cached: *const CachedLoaded,
+    config: *const semantic.Config,
+    store: *Store,
+    data_dir: []const u8,
+) !bool {
+    const metadata_path = try sidecarPath(allocator, data_dir);
+    defer allocator.free(metadata_path);
+    const metadata_identity = fileIdentity(io, metadata_path) catch return false;
+    if (!metadata_identity.eql(cached.metadata_identity)) return false;
+    const slab_identity = fileIdentity(io, cached.loaded.slab_path) catch return false;
+    if (!slab_identity.eql(cached.slab_identity)) return false;
+    try validateLoadedConfig(config, &cached.loaded);
+    // The cold/reload path validates Git HEAD, the exact repository content
+    // fingerprint, and every record range together. Warm reuse is then keyed
+    // by Store sequence: a checkout that changes indexed content advances the
+    // watcher sequence, while a commit-only HEAD update with identical content
+    // cannot invalidate the chunk mapping. This avoids a fork+exec on every
+    // query without weakening content freshness.
+    return store.currentSeq() == cached.store_seq;
+}
+
+fn loadValidatedGeneration(
+    io: std.Io,
+    persistent: std.mem.Allocator,
+    temporary: std.mem.Allocator,
+    config: *const semantic.Config,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+) !CachedLoaded {
+    const metadata_path = try sidecarPath(temporary, data_dir);
+    defer temporary.free(metadata_path);
+    const metadata_before = try fileIdentity(io, metadata_path);
+
+    var loaded = try loadMetadata(io, persistent, data_dir);
+    errdefer loaded.deinit();
+    try validateLoadedConfig(config, &loaded);
+    const head_before = try git_mod.getGitHead(project_root, temporary);
+    if (!headsEqual(head_before, loaded.git_head)) return error.StaleAnnGitHead;
+    const seq_before = store.currentSeq();
+    if (try repositoryFingerprint(explorer, store, temporary) != loaded.manifest) return error.StaleAnnManifest;
+    try validateRecordLineRanges(explorer, loaded.records);
+    if (store.currentSeq() != seq_before) return error.StaleAnnManifest;
+
+    const slab_before = try fileIdentity(io, loaded.slab_path);
+    try loaded.loadGraph();
+    const metadata_after = try fileIdentity(io, metadata_path);
+    const slab_after = try fileIdentity(io, loaded.slab_path);
+    if (!metadata_before.eql(metadata_after) or !slab_before.eql(slab_after)) return error.AnnSidecarChangedDuringLoad;
+    const head_after = try git_mod.getGitHead(project_root, temporary);
+    if (!headsEqual(head_before, head_after)) return error.StaleAnnGitHead;
+    const seq_after = store.currentSeq();
+    if (seq_after != seq_before) return error.StaleAnnManifest;
+
+    return .{
+        .loaded = loaded,
+        .metadata_identity = metadata_after,
+        .slab_identity = slab_after,
+        .store_seq = seq_after,
+    };
+}
+
+/// Reuse a fully validated mmap generation for warm MCP queries. The fast
+/// path still checks both sidecar file identities, repository sequence, model,
+/// dimensions, and vector-space identity before any remote query embedding is
+/// issued. Git HEAD, content fingerprint, and record ranges are revalidated
+/// transactionally whenever that warm identity changes.
+pub fn searchCached(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cache: *SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !SearchOutput {
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const load_started = cio.nanoTimestamp();
+
+    cache.mu.lockShared();
+    if (cache.cached) |*cached| {
+        const current = cachedGenerationCurrent(io, allocator, cached, &config, store, data_dir) catch |err| {
+            cache.mu.unlockShared();
+            return err;
+        };
+        if (current) {
+            defer cache.mu.unlockShared();
+            return searchLoaded(io, allocator, &cached.loaded, task, k, elapsedNs(load_started), true);
+        }
+    }
+    cache.mu.unlockShared();
+
+    cache.mu.lock();
+    defer cache.mu.unlock();
+    // Another concurrent cold request may have installed the generation while
+    // this request waited for the exclusive lock.
+    if (cache.cached) |*cached| {
+        if (try cachedGenerationCurrent(io, allocator, cached, &config, store, data_dir)) {
+            return searchLoaded(io, allocator, &cached.loaded, task, k, elapsedNs(load_started), true);
+        }
+    }
+
+    const replacement = try loadValidatedGeneration(io, cache.allocator, allocator, &config, explorer, store, project_root, data_dir);
+    if (cache.cached) |*old| old.loaded.deinit();
+    cache.cached = replacement;
+    return searchLoaded(io, allocator, &cache.cached.?.loaded, task, k, elapsedNs(load_started), false);
+}
+
+pub fn search(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !SearchOutput {
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const load_started = cio.nanoTimestamp();
+    var loaded = try loadMetadata(io, allocator, data_dir);
+    defer loaded.deinit();
+
+    try validateLoadedConfig(&config, &loaded);
+    const current_head = try git_mod.getGitHead(project_root, allocator);
+    if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
+    if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
+    // Metadata is attacker-controlled local input. Validate the entire mapping
+    // while the index is still empty so a failure remains transactional and no
+    // forged line can reach rendering arithmetic.
+    try validateRecordLineRanges(explorer, loaded.records);
+    try loaded.loadGraph();
+    const load_ns = elapsedNs(load_started);
+    return searchLoaded(io, allocator, &loaded, task, k, load_ns, false);
 }
 
 test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" {
@@ -1271,6 +1456,94 @@ test "semantic ANN rejects stale content before mmaping the graph" {
         error.StaleAnnManifest,
         search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find alpha implementation", 5),
     );
+}
+
+test "semantic ANN warm generation invalidates on repository sequence and sidecar identity" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    var source_file = try tmp.dir.createFile(io, "src/a.zig", .{});
+    const content = "pub fn alpha() void {}\n";
+    try source_file.writeStreamingAll(io, content);
+    source_file.close(io);
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.setRoot(io, dir_path);
+    try explorer.indexFile("src/a.zig", content);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = try store.recordSnapshot("src/a.zig", content.len, std.hash.Wyhash.hash(0, content));
+
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const calibration = try testing.allocator.alloc(f32, config.dimensions);
+    defer testing.allocator.free(calibration);
+    @memset(calibration, 0);
+    calibration[0] = 1;
+    var source = ann.Index.init(testing.allocator, config.dimensions, .{ .seed = 41 });
+    defer source.deinit();
+    _ = try source.insert(calibration);
+    const slab_name = "semantic-chunks-v3-ca-ce.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    try source.writeSlabs(slab_path);
+    const manifest = try repositoryFingerprint(&explorer, &store, testing.allocator);
+    const current_head = try git_mod.getGitHead(dir_path, testing.allocator);
+    _ = try writeMetadata(
+        io,
+        testing.allocator,
+        dir_path,
+        config.model,
+        config.dimensions,
+        manifest,
+        config.vectorSpaceId(),
+        calibration,
+        current_head,
+        slab_name,
+        &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }},
+    );
+
+    const cached = try loadValidatedGeneration(
+        io,
+        testing.allocator,
+        testing.allocator,
+        &config,
+        &explorer,
+        &store,
+        dir_path,
+        dir_path,
+    );
+    var cache = SearchCache.init(testing.allocator);
+    defer cache.deinit();
+    cache.cached = cached;
+    try testing.expect(try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+
+    // Even a content-equivalent Store update must force full freshness
+    // revalidation before this generation can be reused.
+    _ = try store.recordSnapshot("src/a.zig", content.len, std.hash.Wyhash.hash(0, content));
+    try testing.expect(!try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+
+    cache.cached.?.store_seq = store.currentSeq();
+    const metadata_path = try sidecarPath(testing.allocator, dir_path);
+    defer testing.allocator.free(metadata_path);
+    var metadata_file = try std.Io.Dir.cwd().openFile(io, metadata_path, .{ .mode = .read_write });
+    defer metadata_file.close(io);
+    try metadata_file.writePositionalAll(io, "X", 0);
+    try metadata_file.sync(io);
+    try testing.expect(!try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+    try testing.expectError(
+        error.InvalidAnnSidecar,
+        searchCached(io, testing.allocator, &cache, &explorer, &store, dir_path, dir_path, "find alpha", 1),
+    );
+    // Failed replacement is transactional: the previously validated mapping
+    // remains owned and can be retired safely on cache destruction.
+    try testing.expect(cache.cached != null);
+    try testing.expect(cache.cached.?.loaded.index.isMmapBacked());
 }
 
 test "semantic build live fingerprint catches unreconciled repository edits" {


### PR DESCRIPTION
## What changed

- retain one fully validated immutable OpenPuffer mmap generation per cached project
- let warm queries share that generation concurrently under an RW lock
- reuse only while metadata/slab inode, size, mtime, ctime, Store sequence, model, dimensions, and vector-space identity still match; transactionally reload changed sidecars/repository state
- revalidate Git HEAD, repository content fingerprint, and every untrusted record range before installing a replacement
- expose `ann_cache_hit` in structured context provenance and Markdown diagnostics
- keep CLI one-shot behavior unchanged and preserve the no-CPU-embedding-fallback policy

## Measured CodeDB-scale result

Fixture: 8,842 chunks / 654 files / 24,583,490-byte sidecar, Qwen3-Embedding-0.6B 512D.

- merged #711 warm load validation: 13.486-25.656 ms
- candidate warm load validation: 0.194-0.328 ms (about 98% lower)
- candidate warm ANN search: 0.818-1.931 ms, mmap-backed
- retained process RSS: 45,328 KiB vs 41,312 KiB base (+3,816 KiB)
- three retrieval probes: exact same top-8 order on base and candidate; expected implementation files remained at ranks 4, 3, and 3
- no CPU embedding fallback in every live response

## Safety / lifecycle

- cold install double-checks metadata and slab identities before/after mmap
- Store sequence is captured around fingerprint/range validation and mmap
- Git HEAD is captured before and after cold install
- malformed/concurrently replaced generations fail transactionally without evicting the previous owned mapping
- sensitive-path filtering remains in the existing metadata loader, record validator, and hit materializer

## Validation

- `zig build test-semantic-index test-mcp`
- `zig build test`
- `zig build -Doptimize=ReleaseSafe`
- x86_64 Linux ReleaseSafe cross-build
- x86_64 Windows ReleaseSafe cross-build
- `zig build bench`
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project <fresh-worktree>`: 75/75

Exact pushed head: `1b8d58218d122c30e39f81a9e30951aa48db5efe`.
