### PR TITLE
release: merge 0.2.5843 into main

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -53,7 +53,9 @@ jobs:
           echo "$PWD/${head_dir}" >> "$GITHUB_PATH"
 
       - name: Benchmark head
-        run: python3 scripts/run-bench-json.py bench-head.json
+        run: |
+          python3 scripts/test_run_bench_json.py
+          python3 scripts/run-bench-json.py bench-head.json
 
       - name: Benchmark base with its declared compiler
         id: base_bench

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ codedb hot                            # recently modified files
 | `codedb_callers` | Every call site of a symbol — word index ∩ outline scope, in one round-trip |
 | `codedb_explain` | Definition body + callers in one call (CLI aliases: `explain`, `around`) |
 | `codedb_callpath` | Shortest resolved call chain A→B (CLI alias: `path`) |
-| `codedb_context` | Task-shaped composer — pass a NL task, get keywords + symbol defs + ranked files + top snippets in one block; `format=json` adds typed provenance, and `document_hops=1..2` explicitly expands linked Markdown |
+| `codedb_context` | Task-shaped composer — local BM25/symbol retrieval by default; pass `semantic=hybrid` to opt one call into local ANN search using a remote task embedding plus a fixed public calibration string when an explicit sidecar exists, or a bounded transient Qwen rerank otherwise. `format=json` adds typed provenance and retrieval-privacy metadata; `document_hops=1..2` expands linked Markdown |
 | `codedb_hot` | Most recently modified files |
 | `codedb_deps` | Typed dependency graph: imports by default, or Markdown links with `edge_type=documents`; document traversal is capped at 2 hops / 64 files |
 | `codedb_read` | Read file content (line ranges, `if_hash` skip-unchanged, `compact` mode) |
@@ -446,13 +446,85 @@ All threads share a `shutdown: atomic.Value(bool)` for graceful termination.
 
 codedb collects anonymous usage telemetry to improve the tool. Telemetry is **on by default** — written to `~/.codedb/telemetry.ndjson` and periodically synced to the codedb analytics endpoint. **No source code, file contents, file paths, or search queries are collected** — only aggregate tool call counts, latency, and startup stats.
 
+Repository retrieval is local by default. Ordinary `codedb_context` calls use
+the on-device BM25, trigram, symbol, and graph indexes and send no query or
+source text to an embedding service.
+
+An individual call may explicitly request `semantic=hybrid`. In that mode:
+
+- local BM25/symbol retrieval still runs first and remains the failure-safe
+  result;
+- when a fresh local OpenPuffer sidecar exists, codedb sends the task plus a
+  fixed public calibration string in one embedding request, verifies that the
+  provider still represents the same vector space, and searches the stored
+  code chunks locally through a validated mmap-backed graph;
+- without a sidecar, codedb sends the task plus at most 24 locally selected
+  relative paths and bounded snippets, capped at 2 KiB per path+snippet item /
+  8 KiB candidate text total, in one exact-rerank Qwen batch;
+- the hosted codedb embedding service performs transient inference and does
+  not retain request bodies, candidate paths, source snippets, or vectors;
+- no repository archive or server-side repository/vector index is created;
+- provider/network failure keeps the local result and never invokes a CPU
+  embedding fallback.
+
+The optional local ANN is built only by an explicit command:
+
+```bash
+codedb /path/to/repo semantic-index
+```
+
+It splits already-indexable files into bounded 832-byte source chunks, uses
+four concurrent 25-item requests by default (explicitly configurable from one
+to eight), and writes a
+small `semantic-chunks-v3.meta` mapping plus a generation-named `.hmls` mmap
+slab only in codedb's per-project local data directory. The directory and
+files use private permissions (0700/0600 on POSIX).
+On lookup, codedb checks model/vector-space identity, Git/content freshness,
+and the bounded metadata before opening the slab. Metadata heap use is capped
+at 64 MiB and graph-validation reads at 128 MiB; vector slabs remain
+demand-paged rather than being copied into the query process.
+It never scans or uploads `.env`, `.env.*`, `.envrc`, credentials, private keys, or other paths on
+the sensitive-file denylist. Ordinary indexing does not build this sidecar.
+
+The default hosted 0.6B/512-D lane is free to call and requires no API token.
+Its public route cannot select the protected 4B model and enforces the same
+item/body limits at the edge. The general multi-model API remains authenticated.
+
+`format=json` exposes this boundary in the `retrieval` object, including the
+model, dimensions, bounded byte/document counts, retention policy, and failure
+policy. If `CODEDB_EMBEDDINGS_URL` points to a custom provider, codedb labels
+its retention as `custom_endpoint_unverified` because the client cannot prove
+another operator's storage policy.
+
 | Location | Contents | Purpose |
 |----------|----------|---------|
-| `~/.codedb/projects/<hash>/` | Trigram index, frequency table, data log | Persistent index cache |
+| `~/.codedb/projects/<hash>/` | Trigram index, frequency table, data log; optional `semantic-chunks-v3.meta` plus `.hmls` slab | Persistent local indexes |
 | `~/.codedb/telemetry.ndjson` | Aggregate tool calls and startup stats | Local telemetry log |
 | `./codedb.snapshot` | File tree, outlines, content, frequency table | Portable snapshot for instant MCP startup |
 
-**Not stored:** No source code is sent anywhere. No file contents, file paths, or search queries are collected in telemetry. Sensitive files auto-excluded (`.env*`, `credentials.json`, `secrets.*`, `.pem`, `.key`, SSH keys, AWS configs).
+**Not stored:** In the default local mode, no source code is sent anywhere. In
+explicit hybrid/index-build modes, only the bounded transient batches above
+leave the machine; the hosted service does not store them and never creates a
+repository index. The optional ANN vectors and graph remain in the local codedb
+data directory. No file contents, file paths, or search queries are collected
+in telemetry. Sensitive files are auto-excluded from indexing and therefore
+cannot become hybrid candidates (`.env`, `.env.*`, `.envrc`,
+`credentials.json`, `secrets.*`, `.pem`, `.key`, SSH keys, AWS configs).
+The hybrid request builder repeats the canonical safe-path check immediately
+before serialization, so those paths remain blocked even if a stale or
+hand-built in-memory index contains one. Structured provenance reports only
+the aggregate `sensitive_paths_blocked` count, never the rejected path.
+
+Optional hybrid-provider overrides:
+
+```bash
+CODEDB_EMBEDDINGS_URL=https://embeddings.wiki.codes/v1/codedb/embeddings
+CODEDB_EMBEDDINGS_MODEL=Qwen/Qwen3-Embedding-0.6B
+CODEDB_EMBEDDINGS_DIMENSIONS=512
+CODEDB_EMBEDDINGS_TOKEN='optional bearer token for a protected/custom endpoint'
+CODEDB_EMBEDDINGS_TIMEOUT_MS=15000
+CODEDB_SEMANTIC_INDEX_CONCURRENCY=4
+```
 
 To disable telemetry: set `CODEDB_NO_TELEMETRY=1` or pass `--no-telemetry`.
 

--- a/build.zig
+++ b/build.zig
@@ -99,6 +99,11 @@ pub fn build(b: *std.Build) void {
         .{ .name = "test-query", .path = "src/test_query.zig", .needs_nanoregex = true },
         .{ .name = "test-list-dir", .path = "src/test_list_dir.zig", .needs_nanoregex = false },
         .{ .name = "test-semantic", .path = "src/test_semantic.zig", .needs_nanoregex = false },
+        // Keep semantic_index.zig as an explicit root. Zig does not discover
+        // test declarations transitively just because test_ann.zig imports it,
+        // so omitting this entry can make `zig build test` pass without ever
+        // executing the sidecar durability and malformed-input regressions.
+        .{ .name = "test-semantic-index", .path = "src/semantic_index.zig", .needs_nanoregex = true },
         .{ .name = "test-ann", .path = "src/test_ann.zig", .needs_nanoregex = false },
         .{ .name = "test-bench", .path = "src/test_bench.zig", .needs_nanoregex = true },
     };

--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,15 @@ pub fn build(b: *std.Build) void {
     const nanoregex_dep = b.dependency("nanoregex", .{});
     exe.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
 
+    // ── OpenPuffer local ANN dependency ──
+    // Only the pure-Zig library root is linked. Server, S3, Gemini, and
+    // turbopuffer client modules remain outside codedb's graph.
+    const openpuffer_dep = b.dependency("openpuffer", .{ .target = target, .optimize = optimize });
+    const openpuffer_mod = openpuffer_dep.module("openpuffer");
+    exe.root_module.addImport("openpuffer", openpuffer_mod);
+    codedb_mod.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    codedb_mod.addImport("openpuffer", openpuffer_mod);
+
     const install_exe = b.addInstallArtifact(exe, .{});
     b.getInstallStep().dependOn(&install_exe.step);
 
@@ -89,6 +98,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "test-mcp", .path = "src/test_mcp.zig", .needs_nanoregex = true },
         .{ .name = "test-query", .path = "src/test_query.zig", .needs_nanoregex = true },
         .{ .name = "test-list-dir", .path = "src/test_list_dir.zig", .needs_nanoregex = false },
+        .{ .name = "test-semantic", .path = "src/test_semantic.zig", .needs_nanoregex = false },
+        .{ .name = "test-ann", .path = "src/test_ann.zig", .needs_nanoregex = false },
         .{ .name = "test-bench", .path = "src/test_bench.zig", .needs_nanoregex = true },
     };
 
@@ -102,6 +113,7 @@ pub fn build(b: *std.Build) void {
             }),
         });
         if (tf.needs_nanoregex) t.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+        t.root_module.addImport("openpuffer", openpuffer_mod);
         if (test_filter) |f| {
             const filters = b.allocator.alloc([]const u8, 1) catch @panic("oom");
             filters[0] = f;
@@ -123,6 +135,8 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
         }),
     });
+    lib_tests.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    lib_tests.root_module.addImport("openpuffer", openpuffer_mod);
     test_step.dependOn(&b.addRunArtifact(lib_tests).step);
 
     // ── Adversarial tests ──
@@ -135,6 +149,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     adversarial_tests.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    adversarial_tests.root_module.addImport("openpuffer", openpuffer_mod);
     test_step.dependOn(&b.addRunArtifact(adversarial_tests).step);
 
     // ── Benchmarks ──
@@ -149,6 +164,7 @@ pub fn build(b: *std.Build) void {
     });
     const bench_run = b.addRunArtifact(bench);
     bench.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    bench.root_module.addImport("openpuffer", openpuffer_mod);
     bench_run.addPassthruArgs();
     const bench_step = b.step("bench", "Run benchmarks");
     bench_step.dependOn(&bench_run.step);
@@ -164,6 +180,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     bench_edge.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    bench_edge.root_module.addImport("openpuffer", openpuffer_mod);
     const bench_edge_run = b.addRunArtifact(bench_edge);
     bench_edge_run.addPassthruArgs();
     const bench_edge_step = b.step("bench-edge", "Run edge-case benchmarks (synthetic pathological corpus)");
@@ -180,13 +197,11 @@ pub fn build(b: *std.Build) void {
         }),
     });
     benchmark.root_module.addImport("nanoregex", nanoregex_dep.module("nanoregex"));
+    benchmark.root_module.addImport("openpuffer", openpuffer_mod);
     const benchmark_run = b.addRunArtifact(benchmark);
     benchmark_run.addPassthruArgs();
     const benchmark_step = b.step("benchmark", "Run repo benchmark (use -- --root /path/to/repo)");
     benchmark_step.dependOn(&benchmark_run.step);
-
-    // Make module available so dependents don't need to wire it up manually
-    _ = codedb_mod;
 
     // ── WASM build (for Cloudflare Workers) ──
     const wasm = b.addExecutable(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,10 +7,16 @@
         .nanoregex = .{
             .path = "vendor/nanoregex",
         },
+        // Pure-Zig in-process HNSW engine only. The package root is src/lib.zig;
+        // HTTP/S3/cloud clients are not imported by codedb.
+        .openpuffer = .{
+            .path = "vendor/openpuffer",
+        },
     },
     .paths = .{
         "src",
         "vendor/nanoregex",
+        "vendor/openpuffer",
         "build.zig",
         "build.zig.zon",
     },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,42 @@ codedb-cli [root] <command> [args...]
 | `start [root]` | Start the daemon | `codedb-cli start .` |
 | `stop` | Stop the daemon | `codedb-cli stop` |
 
+The native binary also exposes the task composer directly:
+
+```bash
+# Default: entirely local BM25/symbol/graph retrieval
+codedb /path/to/repo context "find the request authentication path"
+
+# Explicit opt-in: local retrieval first, then one transient advisory Qwen batch
+codedb /path/to/repo context --semantic "find the request authentication path"
+
+# Explicit one-time build: bounded code chunks become a local OpenPuffer ANN
+codedb /path/to/repo semantic-index
+
+# Machine-readable privacy, model, byte-count, ranks, and retention metadata
+codedb /path/to/repo context --semantic --json "find the request authentication path"
+```
+
+`--semantic` uses a fresh local OpenPuffer sidecar when one exists: the task and
+a fixed public calibration string leave the machine in one embedding request,
+then vector-space verification, mmap-backed graph search, and fusion run
+locally. Without a sidecar, it sends the task and up to 24 locally selected
+relative paths with bounded snippets for an exact rerank. It never uploads a
+repository archive or creates a server-side index. If the provider fails, the
+command returns the local result and does not run an embedding model on CPU.
+
+`semantic-index` is the only ANN build trigger. It sends bounded 832-byte code
+chunks using four concurrent 25-item requests by default (configurable from one
+to eight) and stores a small mapping plus a generation-named, validated `.hmls`
+mmap slab under codedb's local per-project data directory (0700/0600 on POSIX).
+Queries verify model/vector-space identity and repository freshness before
+mmap. Metadata heap use is capped at 64 MiB, graph validation at 128 MiB, and
+the vector slab stays demand-paged instead of being copied into RSS.
+The default hosted 0.6B/512-D
+lane is free and needs no token. Every cloud-bound path is rechecked against
+the sensitive-file denylist; `.env`, `.env.*`, `.envrc`, credentials, private keys, and unsafe
+paths cannot enter a batch even from a stale index.
+
 ## Daemon Management
 
 ```bash
@@ -90,6 +126,12 @@ codedb-cli stop                       # stop daemon
 |----------|---------|-------------|
 | `CODEDB_PORT` | `7719` | HTTP port for the daemon |
 | `CODEDB_BINARY` | `codedb` | Path to the codedb binary |
+| `CODEDB_EMBEDDINGS_URL` | `https://embeddings.wiki.codes/v1/codedb/embeddings` | Free bounded hosted lane; may be overridden with another HTTPS endpoint |
+| `CODEDB_EMBEDDINGS_MODEL` | `Qwen/Qwen3-Embedding-0.6B` | OpenAI-compatible embedding model name |
+| `CODEDB_EMBEDDINGS_DIMENSIONS` | `512` | Requested embedding dimensions (64-4096) |
+| `CODEDB_EMBEDDINGS_TOKEN` | unset | Optional bearer token for protected/custom endpoints |
+| `CODEDB_EMBEDDINGS_TIMEOUT_MS` | `15000` | Per-request deadline in milliseconds (10-120000) |
+| `CODEDB_SEMANTIC_INDEX_CONCURRENCY` | `4` | Parallel 25-item index batches (clamped to 1-8) |
 
 ## Performance
 

--- a/scripts/compare-bench.py
+++ b/scripts/compare-bench.py
@@ -18,9 +18,27 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_tools(path: str) -> dict[str, dict]:
-    data = json.loads(Path(path).read_text(encoding="utf-8"))
+def load_payload(path: str) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def tool_map(data: dict) -> dict[str, dict]:
     return {tool["tool"]: tool for tool in data["tools"]}
+
+
+def corpus_gate(base: dict, head: dict) -> tuple[bool, str | None]:
+    """Gate latency only when both samples measured identical source bytes.
+
+    The hosted workflow also runs the authoritative counterbalanced benchmark
+    against a frozen base corpus. These one-shot samples remain useful as a
+    whole-tree diagnostic, but comparing their latency is invalid when a PR
+    adds or changes files in the benchmark corpus.
+    """
+    base_hash = base.get("corpus_hash")
+    head_hash = head.get("corpus_hash")
+    if base_hash is not None and head_hash is not None and base_hash != head_hash:
+        return False, f"corpus hash differs ({base_hash} != {head_hash})"
+    return True, None
 
 
 def pct_change(base_ns: int, head_ns: int) -> float:
@@ -37,27 +55,53 @@ def status_for(delta_pct: float, abs_delta_ns: int, threshold_pct: float, min_ab
     return "WAIVED" if waived else "FAIL"
 
 
-def render_markdown(rows: list[tuple[str, int, int, float, int]], threshold_pct: float, min_abs_ns: int, allowed_regressions: set[str] | None = None) -> str:
+def render_markdown(
+    rows: list[tuple[str, int, int, float, int]],
+    threshold_pct: float,
+    min_abs_ns: int,
+    allowed_regressions: set[str] | None = None,
+    *,
+    gated: bool = True,
+    diagnostic_reason: str | None = None,
+) -> str:
     lines = [
         "## Benchmark Regression Report",
         "",
         f"Thresholds: {threshold_pct:.2f}% and {min_abs_ns:,} ns absolute delta",
         "",
-        "`NOISE` means the percentage threshold was exceeded, but the absolute delta was too small to fail CI.",
+    ]
+    if gated:
+        lines.append("`NOISE` means the percentage threshold was exceeded, but the absolute delta was too small to fail CI.")
+    else:
+        lines.extend(
+            [
+                f"Corpus parity: **MISMATCH** — {diagnostic_reason}.",
+                "",
+                "Latency deltas are diagnostic only; the frozen-corpus paired benchmark is the regression gate.",
+            ]
+        )
+    lines.extend([
         "",
         "| Tool | Base (ns) | Head (ns) | Delta | Abs Delta (ns) | Status |",
         "| --- | ---: | ---: | ---: | ---: | --- |",
-    ]
+    ])
     for tool, base_ns, head_ns, delta, abs_delta in rows:
-        status = status_for(delta, abs_delta, threshold_pct, min_abs_ns, waived=tool in (allowed_regressions or set()))
+        status = (
+            status_for(delta, abs_delta, threshold_pct, min_abs_ns, waived=tool in (allowed_regressions or set()))
+            if gated
+            else "DIAGNOSTIC"
+        )
         lines.append(f"| `{tool}` | {base_ns} | {head_ns} | {delta:+.2f}% | {abs_delta:+d} | {status} |")
     return "\n".join(lines) + "\n"
 
 
 def main() -> int:
     args = parse_args()
-    base = load_tools(args.base)
-    head = load_tools(args.head)
+    base_payload = load_payload(args.base)
+    head_payload = load_payload(args.head)
+    base = tool_map(base_payload)
+    head = tool_map(head_payload)
+    gated, diagnostic_reason = corpus_gate(base_payload, head_payload)
 
     # Only compare tools that exist in both base and head.
     # New tools in head (not in base) are skipped — not a regression.
@@ -79,10 +123,17 @@ def main() -> int:
         rows.append((tool, base_ns, head_ns, delta, abs_delta))
         # Only flag as regression if BOTH percentage AND absolute delta exceed thresholds
         # This prevents false positives on fast tools where CI noise dominates
-        if delta > args.threshold_pct and abs_delta > args.min_abs_ns and tool not in args.allow_regression:
+        if gated and delta > args.threshold_pct and abs_delta > args.min_abs_ns and tool not in args.allow_regression:
             failures.append(f"{tool} regressed by {delta:.2f}% ({abs_delta:+d} ns)")
 
-    report = render_markdown(rows, args.threshold_pct, args.min_abs_ns, set(args.allow_regression))
+    report = render_markdown(
+        rows,
+        args.threshold_pct,
+        args.min_abs_ns,
+        set(args.allow_regression),
+        gated=gated,
+        diagnostic_reason=diagnostic_reason,
+    )
     sys.stdout.write(report)
 
     if args.markdown_out:

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -19,6 +19,8 @@ Scenarios covered:
    7. Mid-session live watch: same MCP process, in-place edit + new sibling;
       outline/search/read/symbol see the new contents without restart or
       codedb_index. Reports write-to-visible latency.
+   8. File-symlink privacy boundary: indexing plus raw MCP, CLI, HTTP, and
+      semantic-provider reads reject aliases to outside-root or sensitive data.
 Usage:
   python3 scripts/e2e_mcp_test.py [--binary /path/to/codedb] [--project /path/to/project]
 
@@ -29,8 +31,11 @@ Defaults:
 from __future__ import annotations
 
 import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import http.client
 import json
 import os
+import socket
 import subprocess
 import sys
 import tempfile
@@ -60,7 +65,8 @@ class MCPProcess:
     """Wraps a codedb mcp subprocess; sends/receives JSON-RPC over stdio."""
 
     def __init__(self, binary: str, args: list[str], cwd: str,
-                 command: list[str] | None = None) -> None:
+                 command: list[str] | None = None,
+                 env: dict[str, str] | None = None) -> None:
         """
         command: full argv override (default: [binary, "mcp"] + args).
         Use command=[binary, root, "mcp"] for explicit-root invocation.
@@ -72,6 +78,7 @@ class MCPProcess:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=cwd,
+            env=env,
             text=True,
             bufsize=1,
         )
@@ -439,6 +446,19 @@ def run_scenario_3_no_roots_client(binary: str) -> list[TestResult]:
             r.fail("no response to codedb_search — server may have crashed")
         else:
             r.ok("responded (empty results expected)")
+
+        r = t("no-roots mode cannot read cwd host files")
+        direct = tool_text(p.call_tool("codedb_read", {"path": "etc/passwd", "raw": True}))
+        pipeline = tool_text(p.call_tool("codedb_query", {
+            "pipeline": [{"op": "read", "path": "etc/passwd"}],
+        }))
+        combined = direct + "\n" + pipeline
+        if "root:" in combined or "/bin/" in combined:
+            r.fail(f"host file content escaped no-roots mode: {combined[:300]!r}")
+        elif "project root is not configured" not in direct or "project root is not configured" not in pipeline:
+            r.fail(f"no-roots rejection was not controlled: direct={direct[:160]!r} pipeline={pipeline[:160]!r}")
+        else:
+            r.ok()
 
         r = t("process is still alive")
         poll = p.proc.poll()
@@ -848,6 +868,316 @@ def run_scenario_7_live_watch_mid_session(binary: str, project: str) -> list[Tes
 
     return results
 
+
+def run_scenario_8_symlink_privacy_boundary(binary: str, project: str) -> list[TestResult]:
+    """File aliases must not expose outside-root or sensitive target content."""
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S8] {name}")
+        results.append(r)
+        return r
+
+    with tempfile.TemporaryDirectory(prefix="codedb-symlink-outside-", dir=Path(project).parent) as outside_tmp, \
+         tempfile.TemporaryDirectory(prefix="codedb-symlink-project-", dir=Path(project).parent) as project_tmp:
+        outside = Path(outside_tmp)
+        root = Path(project_tmp)
+        (root / "src").mkdir()
+        (root / ".ssh").mkdir()
+        (root / "pyproject.toml").write_text("[project]\nname = 'symlink-boundary'\nversion = '0'\n")
+        (root / "src" / "target.py").write_text("SAFE_SYMLINK_CANARY = 'safe'\n")
+        (root / "src" / "swap.py").write_text("SAFE_SWAP_CANARY = 'safe-before-retarget'\n")
+        (root / ".env").write_text("SENSITIVE_SYMLINK_CANARY = 'secret'\n")
+        (root / ".ssh" / "config").write_text("SENSITIVE_DIRECTORY_ALIAS_CANARY = 'secret-dir'\n")
+        outside_source = outside / "outside.py"
+        outside_source.write_text("OUTSIDE_SYMLINK_CANARY = 'outside'\n")
+        try:
+            (root / "src" / "safe_alias.py").symlink_to("target.py")
+            (root / "src" / "sensitive_alias.py").symlink_to("../.env")
+            (root / "src" / "outside_alias.py").symlink_to(outside_source)
+            (root / "src" / "sensitive_dir_alias").symlink_to("../.ssh", target_is_directory=True)
+        except OSError as exc:
+            t("symlink fixture supported").ok(f"skipped: {exc}")
+            return results
+
+        p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
+        try:
+            r = t("initial scan completes")
+            if not do_initialize(p, with_roots=False) or not wait_for_scan(p):
+                r.fail("MCP server did not become ready")
+                return results
+            r.ok()
+
+            r = t("cold scan skips every file alias")
+            safe_text = tool_text(p.call_tool("codedb_search", {"query": "SAFE_SYMLINK_CANARY", "max_results": 10}))
+            outside_text = tool_text(p.call_tool("codedb_search", {"query": "OUTSIDE_SYMLINK_CANARY"}))
+            sensitive_text = tool_text(p.call_tool("codedb_search", {"query": "SENSITIVE_SYMLINK_CANARY"}))
+            if "SAFE_SYMLINK_CANARY" not in safe_text or "src/target.py" not in safe_text or "src/safe_alias.py" in safe_text:
+                r.fail(f"file-alias skip policy was not applied: {safe_text[:220]!r}")
+                return results
+            if not outside_text.startswith("0 results") or not sensitive_text.startswith("0 results"):
+                r.fail(f"unsafe alias was searchable: outside={outside_text[:160]!r} sensitive={sensitive_text[:160]!r}")
+                return results
+            r.ok()
+
+            r = t("raw MCP reads reject file aliases")
+            ordinary_read = tool_text(p.call_tool("codedb_read", {"path": "src/target.py", "raw": True}))
+            alias_reads = [
+                tool_text(p.call_tool("codedb_read", {"path": path, "raw": True}))
+                for path in ("src/safe_alias.py", "src/outside_alias.py", "src/sensitive_alias.py", "src/sensitive_dir_alias/config")
+            ]
+            leaked = "\n".join(alias_reads)
+            if "SAFE_SYMLINK_CANARY" not in ordinary_read:
+                r.fail(f"ordinary raw read failed: {ordinary_read[:220]!r}")
+                return results
+            if any(canary in leaked for canary in (
+                "SAFE_SYMLINK_CANARY", "OUTSIDE_SYMLINK_CANARY", "SENSITIVE_SYMLINK_CANARY", "SENSITIVE_DIRECTORY_ALIAS_CANARY",
+            )) or not all("error:" in body for body in alias_reads):
+                r.fail(f"raw MCP alias read was not rejected: {alias_reads!r}")
+                return results
+            r.ok()
+
+            r = t("raw MCP and query pipeline reject traversal and sensitive paths")
+            direct_denied = [
+                tool_text(p.call_tool("codedb_read", {"path": path, "raw": True}))
+                for path in (".env", "../outside.py")
+            ]
+            pipeline_denied = [
+                tool_text(p.call_tool("codedb_query", {"pipeline": [{"op": "read", "path": path}]}))
+                for path in (".env", "../outside.py", "C:\\outside.py", "src/outside_alias.py", "src/sensitive_alias.py", "src/sensitive_dir_alias/config")
+            ]
+            denied_text = "\n".join(direct_denied + pipeline_denied)
+            if any(canary in denied_text for canary in (
+                "OUTSIDE_SYMLINK_CANARY", "SENSITIVE_SYMLINK_CANARY",
+            )) or not all("error" in body.lower() for body in direct_denied + pipeline_denied):
+                r.fail(f"read policy bypassed: direct={direct_denied!r} pipeline={pipeline_denied!r}")
+                return results
+            r.ok()
+
+            r = t("absolute-path rescue is anchored to the Explorer root")
+            inside_abs = tool_text(p.call_tool("codedb_read", {"path": str(root / "src" / "target.py"), "raw": True}))
+            outside_abs = tool_text(p.call_tool("codedb_read", {"path": str(outside_source), "raw": True}))
+            if "SAFE_SYMLINK_CANARY" not in inside_abs or "OUTSIDE_SYMLINK_CANARY" in outside_abs or "error:" not in outside_abs:
+                r.fail(f"absolute rescue boundary failed: inside={inside_abs[:160]!r} outside={outside_abs[:160]!r}")
+                return results
+            r.ok()
+
+            (root / "src" / "incremental_safe.py").symlink_to("target.py")
+            (root / "src" / "incremental_sensitive.py").symlink_to("../.env")
+            (root / "src" / "incremental_outside.py").symlink_to(outside_source)
+            r = t("incremental refresh keeps the same boundary")
+            index_text = tool_text(p.call_tool("codedb_index", {"path": str(root)}))
+            safe_text = tool_text(p.call_tool("codedb_search", {"query": "SAFE_SYMLINK_CANARY", "max_results": 10}))
+            outside_text = tool_text(p.call_tool("codedb_search", {"query": "OUTSIDE_SYMLINK_CANARY"}))
+            sensitive_text = tool_text(p.call_tool("codedb_search", {"query": "SENSITIVE_SYMLINK_CANARY"}))
+            if "error:" in index_text or "SAFE_SYMLINK_CANARY" not in safe_text or "src/incremental_safe.py" in safe_text:
+                r.fail(f"incremental file-alias skip failed: index={index_text[:140]!r} search={safe_text[:180]!r}")
+                return results
+            if not outside_text.startswith("0 results") or not sensitive_text.startswith("0 results"):
+                r.fail(f"incremental unsafe alias was searchable: outside={outside_text[:160]!r} sensitive={sensitive_text[:160]!r}")
+                return results
+            r.ok()
+        finally:
+            p.close()
+
+        # Retarget a path that was a regular indexed file during the live MCP
+        # session. Subsequent cold surfaces and semantic calls must not follow
+        # the replacement alias.
+        (root / "src" / "swap.py").unlink()
+        (root / "src" / "swap.py").symlink_to("../.env")
+
+        home = outside / "home"
+        home.mkdir()
+        safe_env = {
+            **os.environ,
+            "HOME": str(home),
+            "CODEDB_NO_AUTO_UPDATE": "1",
+            "CODEDB_NO_TELEMETRY": "1",
+            "CODEDB_NO_CLI_DAEMON": "1",
+        }
+
+        r = t("CLI reads reject file aliases")
+        ordinary_cli = subprocess.run(
+            [binary, str(root), "read", "src/target.py"],
+            capture_output=True, text=True, env=safe_env, timeout=30,
+        )
+        alias_cli = [
+            subprocess.run(
+                [binary, str(root), "read", path],
+                capture_output=True, text=True, env=safe_env, timeout=30,
+            )
+            for path in ("src/outside_alias.py", "src/sensitive_alias.py", "src/sensitive_dir_alias/config", "src/swap.py", ".env", "../outside.py", "C:\\outside.py")
+        ]
+        cli_leak = "\n".join(run.stdout + run.stderr for run in alias_cli)
+        if ordinary_cli.returncode != 0 or "SAFE_SYMLINK_CANARY" not in ordinary_cli.stdout:
+            r.fail(f"ordinary CLI read failed: code={ordinary_cli.returncode} out={ordinary_cli.stdout[:160]!r} err={ordinary_cli.stderr[-160:]!r}")
+        elif any(run.returncode == 0 for run in alias_cli) or any(canary in cli_leak for canary in (
+            "OUTSIDE_SYMLINK_CANARY", "SENSITIVE_SYMLINK_CANARY",
+        )):
+            r.fail(f"CLI alias read was not rejected: {[(run.returncode, run.stdout[:100], run.stderr[-100:]) for run in alias_cli]!r}")
+        else:
+            r.ok()
+
+        # Exercise the actual TCP route, not just its shared reader. Binding a
+        # temporary socket first asks the OS for a free loopback port.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as port_socket:
+            port_socket.bind(("127.0.0.1", 0))
+            http_port = port_socket.getsockname()[1]
+        serve_env = {**safe_env, "CODEDB_PORT": str(http_port)}
+        serve_proc = subprocess.Popen(
+            [binary, str(root), "serve"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=serve_env,
+        )
+        try:
+            deadline = time.monotonic() + 20
+            while True:
+                try:
+                    health = http.client.HTTPConnection("127.0.0.1", http_port, timeout=1)
+                    health.request("GET", "/health")
+                    health_response = health.getresponse()
+                    health_response.read()
+                    health.close()
+                    if health_response.status == 200:
+                        break
+                except OSError:
+                    pass
+                if serve_proc.poll() is not None or time.monotonic() >= deadline:
+                    raise RuntimeError("codedb serve did not become healthy")
+                time.sleep(0.1)
+
+            def http_read(path: str) -> tuple[int, str]:
+                conn = http.client.HTTPConnection("127.0.0.1", http_port, timeout=5)
+                conn.request("GET", f"/file/read?path={path}")
+                response = conn.getresponse()
+                body = response.read().decode(errors="replace")
+                status = response.status
+                conn.close()
+                return status, body
+
+            ordinary_http = http_read("src/target.py")
+            alias_http = [http_read(path) for path in (
+                "src/outside_alias.py", "src/sensitive_alias.py", "src/sensitive_dir_alias/config", "../outside.py", "C:%5Coutside.py",
+            )]
+            direct_sensitive_http = http_read(".env")
+            r = t("HTTP reads reject file aliases and sensitive paths")
+            http_leak = "\n".join(body for _, body in alias_http)
+            if ordinary_http[0] != 200 or "SAFE_SYMLINK_CANARY" not in ordinary_http[1]:
+                r.fail(f"ordinary HTTP read failed: {ordinary_http!r}")
+            elif any(status not in (403, 404) for status, _ in alias_http) or any(canary in http_leak for canary in (
+                "OUTSIDE_SYMLINK_CANARY", "SENSITIVE_SYMLINK_CANARY",
+                "SENSITIVE_DIRECTORY_ALIAS_CANARY",
+            )):
+                r.fail(f"HTTP alias read was not rejected: {alias_http!r}")
+            elif direct_sensitive_http[0] != 403 or "SENSITIVE_SYMLINK_CANARY" in direct_sensitive_http[1]:
+                r.fail(f"HTTP sensitive-path guard failed: {direct_sensitive_http!r}")
+            else:
+                r.ok()
+        except Exception as exc:
+            r = t("HTTP reads reject file aliases and sensitive paths")
+            r.fail(str(exc))
+        finally:
+            serve_proc.terminate()
+            try:
+                serve_proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                serve_proc.kill()
+                serve_proc.communicate(timeout=5)
+
+        captured: list[bytes] = []
+        captured_lock = threading.Lock()
+
+        class EmbeddingHandler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 - stdlib callback name
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length)
+                with captured_lock:
+                    captured.append(body)
+                payload = json.loads(body)
+                inputs = payload.get("input", [])
+                if isinstance(inputs, str):
+                    inputs = [inputs]
+                response = json.dumps({
+                    "model": "mock-symlink-model",
+                    "data": [
+                        {"index": i, "embedding": [1.0] + [0.0] * 63}
+                        for i in range(len(inputs))
+                    ],
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), EmbeddingHandler)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        try:
+            env = {
+                **safe_env,
+                "CODEDB_EMBEDDINGS_URL": f"http://127.0.0.1:{server.server_port}/v1/embeddings",
+                "CODEDB_EMBEDDINGS_MODEL": "mock-symlink-model",
+                "CODEDB_EMBEDDINGS_TOKEN": "mock-token",
+                "CODEDB_EMBEDDINGS_DIMENSIONS": "64",
+                "CODEDB_EMBEDDINGS_TIMEOUT_MS": "5000",
+                "CODEDB_SEMANTIC_INDEX_CONCURRENCY": "1",
+            }
+            hybrid = MCPProcess(
+                binary, [], cwd="/", env=env,
+                command=[binary, str(root), "mcp", "--no-telemetry"],
+            )
+            hybrid_text = ""
+            try:
+                if do_initialize(hybrid, with_roots=False) and wait_for_scan(hybrid):
+                    hybrid_text = tool_text(hybrid.call_tool("codedb_context", {
+                        "task": "safe swap target implementation",
+                        "semantic": "hybrid",
+                        "max_tokens": 1024,
+                    }))
+            finally:
+                hybrid.close()
+            semantic_run = subprocess.run(
+                [binary, str(root), "semantic-index"],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=60,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=5)
+
+        r = t("semantic endpoint receives no aliased private content")
+        request_text = b"\n".join(captured).decode(errors="replace")
+        if not hybrid_text or "error:" in hybrid_text:
+            r.fail(f"hybrid exact fallback failed: {hybrid_text[:240]!r}")
+        elif semantic_run.returncode != 0 or "semantic ANN ready" not in semantic_run.stdout:
+            r.fail(f"semantic-index failed: code={semantic_run.returncode} stdout={semantic_run.stdout[:180]!r} stderr={semantic_run.stderr[-240:]!r}")
+        elif "SAFE_SYMLINK_CANARY" not in request_text:
+            r.fail("safe indexed content never reached the mock endpoint")
+        elif any(secret in request_text for secret in (
+            "OUTSIDE_SYMLINK_CANARY",
+            "SENSITIVE_SYMLINK_CANARY",
+            "SENSITIVE_DIRECTORY_ALIAS_CANARY",
+            "safe_alias.py",
+            "outside_alias.py",
+            "sensitive_alias.py",
+            "incremental_safe.py",
+            "incremental_outside.py",
+            "incremental_sensitive.py",
+            "SAFE_SWAP_CANARY",
+            "swap.py",
+        )):
+            r.fail(f"private alias leaked to embedding request: {request_text[:600]!r}")
+        else:
+            r.ok(f"captured {len(captured)} filtered embedding request(s)")
+
+    return results
+
 # ── Runner ────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -892,6 +1222,9 @@ def main() -> int:
 
     print(f"\n{CYAN}── Scenario 7: mid-session live watch (same process, no restart) ──{RESET}")
     all_results += run_scenario_7_live_watch_mid_session(binary, project)
+
+    print(f"\n{CYAN}── Scenario 8: file-symlink privacy boundary ──{RESET}")
+    all_results += run_scenario_8_symlink_privacy_boundary(binary, project)
 
     print()
     passed = 0

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -300,6 +300,15 @@ def run_scenario_1_issue346_regression(binary: str, project: str) -> list[TestRe
         else:
             r.ok()
 
+        r = t("roots/list_changed cannot invalidate an active deferred scan")
+        p.send({"jsonrpc": "2.0", "method": "notifications/roots/list_changed", "params": {}})
+        if not reply_roots(p, project, timeout=5.0):
+            r.fail("server did not re-request roots after list_changed")
+        elif p.proc.poll() is not None:
+            r.fail(f"server exited during roots replacement: {p.proc.returncode}")
+        else:
+            r.ok()
+
         r = t("scan completes and files > 0")
         scan_ok = wait_for_scan(p, timeout=90.0)
         if not scan_ok:
@@ -344,6 +353,25 @@ def run_scenario_1_issue346_regression(binary: str, project: str) -> list[TestRe
         text = tool_text(resp)
         if "DeferredScan" not in text:
             r.fail(f"symbol lookup returned: {text[:200]!r}")
+        else:
+            r.ok()
+
+        r = t("deferred-root codedb_word uses the negotiated project")
+        text = tool_text(p.call_tool("codedb_word", {"word": "DeferredScan"}))
+        if "DeferredScan" not in text or "src/mcp.zig" not in text:
+            r.fail(f"word index used a stale cwd/default root: {text[:240]!r}")
+        else:
+            r.ok()
+
+        r = t("deferred-root codedb_context uses the negotiated capability")
+        text = tool_text(p.call_tool("codedb_context", {
+            "task": "explain how DeferredScan activates after the MCP roots handshake",
+            "max_tokens": 1200,
+        }))
+        if "project root" in text.lower() and "not configured" in text.lower():
+            r.fail(f"context retained the spawn cwd instead of the negotiated root: {text[:240]!r}")
+        elif "DeferredScan" not in text:
+            r.fail(f"context missed negotiated-root symbols: {text[:240]!r}")
         else:
             r.ok()
 
@@ -457,6 +485,19 @@ def run_scenario_3_no_roots_client(binary: str) -> list[TestResult]:
             r.fail(f"host file content escaped no-roots mode: {combined[:300]!r}")
         elif "project root is not configured" not in direct or "project root is not configured" not in pipeline:
             r.fail(f"no-roots rejection was not controlled: direct={direct[:160]!r} pipeline={pipeline[:160]!r}")
+        else:
+            r.ok()
+
+        r = t("no-roots mode cannot list or contextualize host cwd")
+        listing = tool_text(p.call_tool("codedb_list_dir", {}))
+        context = tool_text(p.call_tool("codedb_context", {
+            "task": "inspect host filesystem configuration and reader metadata",
+        }))
+        combined = listing + "\n" + context
+        if "project root is not configured" not in listing or "project root is not configured" not in context:
+            r.fail(f"no-roots listing/context rejection was not controlled: list={listing[:160]!r} context={context[:160]!r}")
+        elif "etc/" in combined or "reader.md (hash-verified)" in combined:
+            r.fail(f"host metadata escaped no-roots mode: {combined[:300]!r}")
         else:
             r.ok()
 
@@ -1196,6 +1237,24 @@ def run_scenario_9_bootstrap_temp_read(binary: str) -> list[TestResult]:
         )
         canary = "BOOTSTRAP_TEMP_READ_CANARY = 'rooted'\n"
         (root / "src" / "main.py").write_text(canary)
+
+        cli_env = {**os.environ, "CODEDB_NO_CLI_DAEMON": "1", "CODEDB_QUIET": "1"}
+        implicit = subprocess.run(
+            [binary, "search", "BOOTSTRAP_TEMP_READ_CANARY"],
+            cwd=root, env=cli_env, text=True, capture_output=True, timeout=30,
+        )
+        relative = subprocess.run(
+            [binary, root.name, "search", "BOOTSTRAP_TEMP_READ_CANARY"],
+            cwd=root.parent, env=cli_env, text=True, capture_output=True, timeout=30,
+        )
+        r = t("implicit cwd and relative positional roots cold-scan with the same capability")
+        if implicit.returncode != 0 or "src/main.py" not in implicit.stdout:
+            r.fail(f"implicit-root CLI failed: code={implicit.returncode} out={implicit.stdout[:220]!r} err={implicit.stderr[-220:]!r}")
+            return results
+        if relative.returncode != 0 or "src/main.py" not in relative.stdout:
+            r.fail(f"relative-root CLI failed: code={relative.returncode} out={relative.stdout[:220]!r} err={relative.stderr[-220:]!r}")
+            return results
+        r.ok()
 
         p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
         try:

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -1178,6 +1178,49 @@ def run_scenario_8_symlink_privacy_boundary(binary: str, project: str) -> list[T
 
     return results
 
+
+def run_scenario_9_bootstrap_temp_read(binary: str) -> list[TestResult]:
+    """An admitted temp checkout keeps its root capability on read paths."""
+    results: list[TestResult] = []
+
+    def t(name: str) -> TestResult:
+        r = TestResult(f"[S9] {name}")
+        results.append(r)
+        return r
+
+    with tempfile.TemporaryDirectory(prefix="codedb-bootstrap-read-") as project_tmp:
+        root = Path(project_tmp).resolve()
+        (root / "src").mkdir()
+        (root / "pyproject.toml").write_text(
+            "[project]\nname = 'codedb-bootstrap-read'\nversion = '0'\n"
+        )
+        canary = "BOOTSTRAP_TEMP_READ_CANARY = 'rooted'\n"
+        (root / "src" / "main.py").write_text(canary)
+
+        p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
+        try:
+            r = t("bootstrapable temp root scans successfully")
+            if not do_initialize(p, with_roots=False) or not wait_for_scan(p):
+                r.fail("MCP server did not admit and scan the marked temp checkout")
+                return results
+            r.ok()
+
+            direct = tool_text(p.call_tool("codedb_read", {"path": "src/main.py", "raw": True}))
+            pipeline = tool_text(p.call_tool("codedb_query", {
+                "pipeline": [{"op": "read", "path": "src/main.py"}],
+            }))
+            r = t("direct and pipeline reads retain the admitted root capability")
+            if canary.strip() not in direct or canary.strip() not in pipeline:
+                r.fail(f"admitted temp read failed: direct={direct[:220]!r} pipeline={pipeline[:220]!r}")
+            elif "project root is not configured" in direct.lower() or "project root is not configured" in pipeline.lower():
+                r.fail(f"read surface re-rejected admitted root: direct={direct[:180]!r} pipeline={pipeline[:180]!r}")
+            else:
+                r.ok()
+        finally:
+            p.close()
+
+    return results
+
 # ── Runner ────────────────────────────────────────────────────────────────────
 
 def main() -> int:
@@ -1225,6 +1268,9 @@ def main() -> int:
 
     print(f"\n{CYAN}── Scenario 8: file-symlink privacy boundary ──{RESET}")
     all_results += run_scenario_8_symlink_privacy_boundary(binary, project)
+
+    print(f"\n{CYAN}── Scenario 9: bootstrapable temp-root read parity ──{RESET}")
+    all_results += run_scenario_9_bootstrap_temp_read(binary)
 
     print()
     passed = 0

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -612,12 +612,28 @@ def run_scenario_6_agent_route_no_index(binary: str, project: str) -> list[TestR
         root = Path(tmp)
         (root / "pyproject.toml").write_text("[project]\nname = 'agent-route'\nversion = '0'\n")
         (root / "keep.py").write_text("def keep():\n    return 'keep'\n")
+        secret_canary = "uppercase_secret_canary_706"
+        (root / "PRIVATE_KEY.PEM").write_text(secret_canary)
         p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
 
         try:
             r = t("initial scan completes")
             if not do_initialize(p, with_roots=False) or not wait_for_scan(p):
                 r.fail("MCP server did not become ready")
+                return results
+            r.ok()
+
+            r = t("uppercase private-key path is blocked from MCP read")
+            read_text = tool_text(p.call_tool("codedb_read", {"path": "PRIVATE_KEY.PEM"}))
+            if "access to sensitive file blocked" not in read_text or secret_canary in read_text:
+                r.fail(f"sensitive read was not blocked: {read_text[:240]!r}")
+                return results
+            r.ok()
+
+            r = t("uppercase private-key contents are absent from search")
+            search_text = tool_text(p.call_tool("codedb_search", {"query": secret_canary}))
+            if not search_text.startswith("0 results") or "PRIVATE_KEY.PEM" in search_text:
+                r.fail(f"sensitive file entered the index: {search_text[:240]!r}")
                 return results
             r.ok()
 

--- a/scripts/run-bench-json.py
+++ b/scripts/run-bench-json.py
@@ -109,8 +109,34 @@ def benchmark_provenance(args: argparse.Namespace) -> dict | None:
     }
 
 
+def semantic_safety_commands(build_graph: str, bench_side: str | None) -> tuple[tuple[str, ...], ...]:
+    """Return head-only safety roots supported by the checked-out build graph."""
+    if bench_side == "base" or 'name = "test-semantic-index"' not in build_graph:
+        return ()
+    return (
+        ("zig", "build", "test-semantic-index"),
+        ("zig", "build", "test-explore", "-Dtest-filter=file symlink aliases"),
+    )
+
+
 def main() -> int:
     args = parse_args()
+    # The PR benchmark is the hosted Linux lane available to release branches.
+    # Run the named safety roots whenever the checked-out source graph exposes
+    # the semantic-index step. The unpaired historical-base invocation does
+    # not pass --bench-side, so source capability (not a missing flag) must be
+    # the compatibility gate; old release bases intentionally keep their own
+    # graph unchanged.
+    build_graph = pathlib.Path("build.zig").read_text(encoding="utf-8")
+    for command in semantic_safety_commands(build_graph, args.bench_side):
+        safety = subprocess.run(command, capture_output=True, text=True, check=False)
+        if safety.stdout:
+            sys.stderr.write(safety.stdout)
+        if safety.stderr:
+            sys.stderr.write(safety.stderr)
+        if safety.returncode != 0:
+            sys.stderr.write(f"\n[run-bench-json] {' '.join(command)} exited {safety.returncode}\n")
+            return safety.returncode
     proc = subprocess.run(
         ["zig", "build", "bench", "--", "--json", *args.bench_args],
         capture_output=True,

--- a/scripts/test_compare_bench.py
+++ b/scripts/test_compare_bench.py
@@ -30,6 +30,25 @@ class CompareBenchTests(unittest.TestCase):
         self.assertIn("50,000 ns absolute delta", report)
         self.assertIn("| `codedb_read` | 50580 | 61979 | +22.54% | +11399 | NOISE |", report)
 
+    def test_mismatched_corpus_is_diagnostic_not_a_latency_gate(self) -> None:
+        gated, reason = compare_bench.corpus_gate({"corpus_hash": 1}, {"corpus_hash": 2})
+        self.assertFalse(gated)
+        self.assertIn("corpus hash differs", reason or "")
+        report = compare_bench.render_markdown(
+            [("codedb_context", 300_000, 500_000, 66.67, 200_000)],
+            10.0,
+            50_000,
+            gated=gated,
+            diagnostic_reason=reason,
+        )
+        self.assertIn("Corpus parity: **MISMATCH**", report)
+        self.assertIn("| DIAGNOSTIC |", report)
+
+    def test_matching_corpus_remains_gated(self) -> None:
+        gated, reason = compare_bench.corpus_gate({"corpus_hash": 7}, {"corpus_hash": 7})
+        self.assertTrue(gated)
+        self.assertIsNone(reason)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_run_bench_json.py
+++ b/scripts/test_run_bench_json.py
@@ -12,6 +12,12 @@ assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
+COMPARE_SCRIPT = pathlib.Path(__file__).with_name("compare-bench.py")
+COMPARE_SPEC = importlib.util.spec_from_file_location("compare_bench", COMPARE_SCRIPT)
+assert COMPARE_SPEC is not None and COMPARE_SPEC.loader is not None
+COMPARE_MODULE = importlib.util.module_from_spec(COMPARE_SPEC)
+COMPARE_SPEC.loader.exec_module(COMPARE_MODULE)
+
 
 class SemanticSafetyCommandsTests(unittest.TestCase):
     def test_unpaired_historical_base_without_step_skips_new_safety_root(self) -> None:
@@ -25,6 +31,21 @@ class SemanticSafetyCommandsTests(unittest.TestCase):
     def test_explicit_base_skips_even_when_head_script_is_used(self) -> None:
         graph = '.name = "test-semantic-index",'
         self.assertEqual((), MODULE.semantic_safety_commands(graph, "base"))
+
+
+class WholeTreeComparatorTests(unittest.TestCase):
+    def test_mismatched_corpus_is_diagnostic_not_a_latency_gate(self) -> None:
+        gated, reason = COMPARE_MODULE.corpus_gate({"corpus_hash": 1}, {"corpus_hash": 2})
+        self.assertFalse(gated)
+        report = COMPARE_MODULE.render_markdown(
+            [("codedb_context", 300_000, 500_000, 66.67, 200_000)],
+            10.0,
+            50_000,
+            gated=gated,
+            diagnostic_reason=reason,
+        )
+        self.assertIn("Corpus parity: **MISMATCH**", report)
+        self.assertIn("| DIAGNOSTIC |", report)
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_bench_json.py
+++ b/scripts/test_run_bench_json.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("run-bench-json.py")
+SPEC = importlib.util.spec_from_file_location("run_bench_json", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class SemanticSafetyCommandsTests(unittest.TestCase):
+    def test_unpaired_historical_base_without_step_skips_new_safety_root(self) -> None:
+        self.assertEqual((), MODULE.semantic_safety_commands("const old_graph = true;", None))
+
+    def test_unpaired_head_with_step_runs_both_safety_roots(self) -> None:
+        commands = MODULE.semantic_safety_commands('.name = "test-semantic-index",', None)
+        self.assertEqual("test-semantic-index", commands[0][-1])
+        self.assertEqual("test-explore", commands[1][2])
+
+    def test_explicit_base_skips_even_when_head_script_is_used(self) -> None:
+        graph = '.name = "test-semantic-index",'
+        self.assertEqual((), MODULE.semantic_safety_commands(graph, "base"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ann.zig
+++ b/src/ann.zig
@@ -20,9 +20,13 @@ pub const Options = openpuffer.Options;
 
 pub const Index = struct {
     inner: openpuffer.Hnsw(void),
+    dimensions: u16,
 
     pub fn init(allocator: std.mem.Allocator, dimensions: u16, options: Options) Index {
-        return .{ .inner = openpuffer.Hnsw(void).init(allocator, dimensions, options) };
+        return .{
+            .inner = openpuffer.Hnsw(void).init(allocator, dimensions, options),
+            .dimensions = dimensions,
+        };
     }
 
     pub fn deinit(self: *Index) void {
@@ -35,6 +39,29 @@ pub const Index = struct {
 
     pub fn insert(self: *Index, vector: []const f32) !u32 {
         return self.inner.insert(vector);
+    }
+
+    /// Insert an OpenAI-compatible row-major embedding matrix. This is the
+    /// explicit CodeDB/OpenPuffer contract: exactly `count * dimensions`
+    /// values, the same dimensions the index was initialized with, and stable
+    /// consecutive HNSW ids in response order.
+    pub fn insertEmbeddingBatch(
+        self: *Index,
+        vectors: []const f32,
+        count: usize,
+        dimensions: u16,
+    ) !u32 {
+        if (count == 0) return error.InvalidEmbeddingBatch;
+        if (dimensions != self.dimensions) return error.DimensionMismatch;
+        const expected = std.math.mul(usize, count, dimensions) catch return error.InvalidEmbeddingBatchShape;
+        if (vectors.len != expected) return error.InvalidEmbeddingBatchShape;
+        const first_id = std.math.cast(u32, self.len()) orelse return error.IndexTooLarge;
+        for (0..count) |row_index| {
+            const start = row_index * @as(usize, dimensions);
+            const id = try self.inner.insert(vectors[start..][0..dimensions]);
+            if (id != first_id + row_index) return error.NonConsecutiveEmbeddingIds;
+        }
+        return first_id;
     }
 
     pub fn search(

--- a/src/ann.zig
+++ b/src/ann.zig
@@ -1,0 +1,106 @@
+//! Local ANN building block for codedb semantic retrieval.
+//!
+//! This wraps OpenPuffer's pure-Zig HNSW engine. It deliberately imports only
+//! the in-process index module: no HTTP server, object storage, Gemini client,
+//! or turbopuffer client is linked into codedb.
+
+const std = @import("std");
+const openpuffer = @import("openpuffer");
+
+pub const default_dimensions: u16 = 512;
+/// OpenPuffer's merged codedb real-repository hill climb selected this 512D,
+/// k=24 profile: 34-36% lower ANN p50 with 0.9992 clustered recall@24 and
+/// 0.9958 real-repository exact-neighbor recall. Keep generic OpenPuffer's
+/// wider defaults outside this narrowly measured codedb adapter.
+pub const default_ef_search: u32 = 48;
+pub const default_rerank_multiplier: usize = 2;
+
+pub const SearchResult = openpuffer.SearchResult;
+pub const Options = openpuffer.Options;
+
+pub const Index = struct {
+    inner: openpuffer.Hnsw(void),
+
+    pub fn init(allocator: std.mem.Allocator, dimensions: u16, options: Options) Index {
+        return .{ .inner = openpuffer.Hnsw(void).init(allocator, dimensions, options) };
+    }
+
+    pub fn deinit(self: *Index) void {
+        self.inner.deinit();
+    }
+
+    pub fn len(self: *const Index) usize {
+        return self.inner.len();
+    }
+
+    pub fn insert(self: *Index, vector: []const f32) !u32 {
+        return self.inner.insert(vector);
+    }
+
+    pub fn search(
+        self: *Index,
+        query: []const f32,
+        k: usize,
+        allocator: std.mem.Allocator,
+    ) ![]SearchResult {
+        return self.inner.searchAdvanced(
+            query,
+            k,
+            default_ef_search,
+            default_rerank_multiplier,
+            allocator,
+        );
+    }
+
+    pub fn serializedSize(self: *const Index) usize {
+        return self.inner.serializedSize();
+    }
+
+    pub fn serialize(self: *const Index, allocator: std.mem.Allocator) ![]u8 {
+        return self.inner.serialize(allocator);
+    }
+
+    pub fn load(self: *Index, bytes: []const u8) !void {
+        return self.inner.load(bytes);
+    }
+
+    pub fn vectorConst(self: *const Index, id: u32) []const f32 {
+        return self.inner.vectorConst(id);
+    }
+
+    pub fn hasStoredF32(self: *const Index) bool {
+        return self.inner.hasStoredF32();
+    }
+
+    pub fn isMmapBacked(self: *const Index) bool {
+        return self.inner.isMmapBacked();
+    }
+
+    pub fn slabImageSize(self: *const Index) !usize {
+        return self.inner.slabImageSize();
+    }
+
+    pub fn writeSlabs(self: *const Index, path: []const u8) !void {
+        return self.inner.writeSlabs(path);
+    }
+
+    pub fn loadMmap(self: *Index, path: []const u8) !void {
+        return self.inner.loadMmap(path);
+    }
+
+    pub fn loadSlabsCopy(self: *Index, bytes: []const u8) !void {
+        return self.inner.loadSlabsCopy(bytes);
+    }
+};
+
+/// Persistent vector payload before ArrayList capacity and graph metadata.
+/// OpenPuffer retains one f32 vector for exact rerank and one int8 vector for
+/// traversal: five bytes per dimension per record.
+pub fn vectorPayloadBytes(count: usize, dimensions: u16) !usize {
+    return vectorPayloadBytesWithMode(count, dimensions, true);
+}
+
+pub fn vectorPayloadBytesWithMode(count: usize, dimensions: u16, store_f32: bool) !usize {
+    const bytes_per_dimension: usize = if (store_f32) 5 else 1;
+    return std.math.mul(usize, count, try std.math.mul(usize, dimensions, bytes_per_dimension));
+}

--- a/src/background.zig
+++ b/src/background.zig
@@ -201,23 +201,36 @@ pub fn scanBg(io: std.Io, store: *Store, explorer: *Explorer, root: []const u8, 
     }
 }
 pub fn triggerScanFromRoots(ctx: *mcp_server.DeferredScan, abs_root: []const u8) void {
-    const data_dir = getDataDir(ctx.io, ctx.allocator, abs_root) catch {
-        ctx.triggered.store(false, .release);
-        return;
-    };
-    defer ctx.allocator.free(data_dir);
     ctx.explorer.setRoot(ctx.io, abs_root) catch {
         ctx.triggered.store(false, .release);
         return;
     };
-    const git_head = git_mod.getGitHead(abs_root, ctx.allocator) catch null;
+    // From here onward all asynchronous work borrows the Explorer-owned
+    // canonical path, never Session.roots storage (which a list_changed
+    // notification is allowed to replace immediately).
+    const canonical_root = ctx.explorer.root_path orelse {
+        ctx.triggered.store(false, .release);
+        return;
+    };
+    const data_dir = getDataDir(ctx.io, ctx.allocator, canonical_root) catch {
+        ctx.triggered.store(false, .release);
+        return;
+    };
+    var data_dir_transferred = false;
+    defer if (!data_dir_transferred) ctx.allocator.free(data_dir);
+
+    const git_head = git_mod.getGitHead(canonical_root, ctx.allocator) catch null;
     mcp_server.setScanState(.loading_snapshot);
-    const snapshot_loaded = loadBestSnapshot(ctx.io, ctx.explorer, ctx.store, abs_root, data_dir, git_head, ctx.allocator);
-    ctx.resolved_root = abs_root;
+    const snapshot_loaded = loadBestSnapshot(ctx.io, ctx.explorer, ctx.store, canonical_root, data_dir, git_head, ctx.allocator);
+    ctx.resolved_root = canonical_root;
     ctx.scan_done.store(snapshot_loaded, .release);
     if (!snapshot_loaded) {
         mcp_server.setScanState(.walking);
-        const scan_thread = std.Thread.spawn(.{}, scanBg, .{ ctx.io, ctx.store, ctx.explorer, abs_root, ctx.allocator, ctx.scan_done, ctx.shutdown, data_dir, abs_root, ctx.telem, ctx.startup_t0 }) catch return;
+        const scan_thread = std.Thread.spawn(.{}, deferredScanBg, .{ ctx.io, ctx.store, ctx.explorer, canonical_root, ctx.allocator, ctx.scan_done, ctx.shutdown, data_dir, ctx.telem, ctx.startup_t0 }) catch {
+            ctx.triggered.store(false, .release);
+            return;
+        };
+        data_dir_transferred = true;
         ctx.scan_thread = scan_thread;
     } else {
         const startup_time_ms: u64 = @intCast(@max(cio.milliTimestamp() - ctx.startup_t0, 0));
@@ -226,6 +239,22 @@ pub fn triggerScanFromRoots(ctx: *mcp_server.DeferredScan, abs_root: []const u8)
         compactMcpReadyMemory(ctx.io, ctx.explorer, data_dir, git_head, ctx.allocator);
         mcp_server.setScanState(.ready);
     }
+}
+
+fn deferredScanBg(
+    io: std.Io,
+    store: *Store,
+    explorer: *Explorer,
+    canonical_root: []const u8,
+    allocator: std.mem.Allocator,
+    scan_done: *std.atomic.Value(bool),
+    shutdown: *std.atomic.Value(bool),
+    owned_data_dir: []u8,
+    telem: *telemetry.Telemetry,
+    startup_t0: i64,
+) void {
+    defer allocator.free(owned_data_dir);
+    scanBg(io, store, explorer, canonical_root, allocator, scan_done, shutdown, owned_data_dir, canonical_root, telem, startup_t0);
 }
 
 pub fn watcherDeferredLoop(ctx: *mcp_server.DeferredScan) void {

--- a/src/background.zig
+++ b/src/background.zig
@@ -285,10 +285,16 @@ pub fn watcherDeferredLoop(ctx: *mcp_server.DeferredScan) void {
             return;
         }
     }
-    if (ctx.shutdown.load(.acquire)) return;
+    if (ctx.shutdown.load(.acquire)) {
+        ctx.explorer.finishStartupReconcile();
+        return;
+    }
     // If we exited the loop without ever triggering a scan (give-up path),
     // resolved_root is empty — skip incrementalLoop so we don't crash.
-    if (!ctx.triggered.load(.acquire)) return;
+    if (!ctx.triggered.load(.acquire)) {
+        ctx.explorer.finishStartupReconcile();
+        return;
+    }
     watcher.incrementalLoop(ctx.io, ctx.store, ctx.explorer, ctx.queue, ctx.resolved_root, ctx.shutdown, ctx.scan_done);
 }
 

--- a/src/background.zig
+++ b/src/background.zig
@@ -206,11 +206,14 @@ pub fn triggerScanFromRoots(ctx: *mcp_server.DeferredScan, abs_root: []const u8)
         return;
     };
     defer ctx.allocator.free(data_dir);
+    ctx.explorer.setRoot(ctx.io, abs_root) catch {
+        ctx.triggered.store(false, .release);
+        return;
+    };
     const git_head = git_mod.getGitHead(abs_root, ctx.allocator) catch null;
     mcp_server.setScanState(.loading_snapshot);
     const snapshot_loaded = loadBestSnapshot(ctx.io, ctx.explorer, ctx.store, abs_root, data_dir, git_head, ctx.allocator);
     ctx.resolved_root = abs_root;
-    ctx.explorer.setRoot(ctx.io, abs_root);
     ctx.scan_done.store(snapshot_loaded, .release);
     if (!snapshot_loaded) {
         mcp_server.setScanState(.walking);

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -117,6 +117,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     var explorer = Explorer.init(allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    // The frozen corpus lives under the OS temp root. It contains project
+    // markers and is accepted by the same bootstrap policy as a real temp
+    // checkout, but read surfaces still require this explicit capability.
+    try explorer.setRoot(io, tmp_root);
 
     var agents = AgentRegistry.init(allocator);
     defer agents.deinit();
@@ -182,7 +186,6 @@ fn runCase(
     var response_hash: u64 = 0;
 
     for (0..case.iterations) |_| {
-
         const r = bench_ctx.runToolCall(io, allocator, case.name, case.tool, args, store, explorer, agents, telem);
         total_ns +|= r.dispatch_ns;
         response_bytes = r.response_bytes;
@@ -244,7 +247,6 @@ fn writeBenchTarget(io: std.Io, tmp_root: []const u8) !void {
     defer file.close(io);
     try file.writeStreamingAll(io, "pub const bench_value = 1;\n");
 }
-
 
 fn summarizeCorpus(explorer: *Explorer) struct { files: usize, bytes: u64 } {
     explorer.mu.lockShared();

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -76,23 +76,24 @@ pub fn loadUserConfig(io: std.Io, alloc: std.mem.Allocator, explicit: ?[]const u
     return try Config.loadDefault(io, alloc, explicit, bin_dir);
 }
 
-fn loadSnapshotIfHeadMatches(
+fn loadSnapshotFileIfHeadMatches(
     io: std.Io,
-    snapshot_path: []const u8,
+    snapshot_file: std.Io.File,
     explorer: *Explorer,
     store: *Store,
+    expected_root: []const u8,
     current_git_head: ?[40]u8,
     allocator: std.mem.Allocator,
 ) bool {
-    const snap_head = snapshot_mod.readSnapshotGitHead(io, snapshot_path) orelse {
+    const snap_head = snapshot_mod.readSnapshotGitHeadFromFile(io, snapshot_file) orelse {
         // No git HEAD in snapshot (non-git project or legacy snapshot) — load
         // only when the current project also has no git HEAD.
         if (current_git_head != null) return false;
-        return snapshot_mod.loadSnapshot(io, snapshot_path, explorer, store, allocator);
+        return snapshot_mod.loadSnapshotValidatedFromFile(io, snapshot_file, expected_root, explorer, store, allocator);
     };
     const cur_head = current_git_head orelse return false;
     if (!std.mem.eql(u8, &snap_head, &cur_head)) return false;
-    return snapshot_mod.loadSnapshot(io, snapshot_path, explorer, store, allocator);
+    return snapshot_mod.loadSnapshotValidatedFromFile(io, snapshot_file, expected_root, explorer, store, allocator);
 }
 
 pub fn loadBestSnapshot(
@@ -104,16 +105,28 @@ pub fn loadBestSnapshot(
     current_git_head: ?[40]u8,
     allocator: std.mem.Allocator,
 ) bool {
-    const root_snapshot = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{abs_root}) catch null;
-    defer if (root_snapshot) |p| allocator.free(p);
-    const first_snapshot = root_snapshot orelse "codedb.snapshot";
-    if (loadSnapshotIfHeadMatches(io, first_snapshot, explorer, store, current_git_head, allocator)) {
-        return true;
-    }
+    const root_dir = explorer.root_dir orelse return false;
+    const canonical_root = explorer.root_path orelse return false;
+    if (!project_file.rootMatchesPath(io, root_dir, abs_root)) return false;
 
-    const central_snapshot = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{data_dir}) catch return false;
-    defer allocator.free(central_snapshot);
-    return loadSnapshotIfHeadMatches(io, central_snapshot, explorer, store, current_git_head, allocator);
+    if (root_dir.openFile(io, "codedb.snapshot", .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    })) |root_snapshot| {
+        defer root_snapshot.close(io);
+        if (loadSnapshotFileIfHeadMatches(io, root_snapshot, explorer, store, canonical_root, current_git_head, allocator)) return true;
+    } else |_| {}
+
+    var central_dir = std.Io.Dir.cwd().openDir(io, data_dir, .{ .follow_symlinks = false }) catch return false;
+    defer central_dir.close(io);
+    const central_snapshot = central_dir.openFile(io, "codedb.snapshot", .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch return false;
+    defer central_snapshot.close(io);
+    return loadSnapshotFileIfHeadMatches(io, central_snapshot, explorer, store, canonical_root, current_git_head, allocator);
 }
 
 pub fn getDataDir(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8) ![]u8 {
@@ -379,15 +392,16 @@ pub fn persistWordIndexFromSource(
         }
     }
 
-    var root_dir = try std.Io.Dir.cwd().openDir(io, root_path, .{});
-    defer root_dir.close(io);
+    const root_dir = explorer.root_dir orelse return error.RootNotConfigured;
+    const canonical_root = explorer.root_path orelse return error.RootNotConfigured;
+    if (!project_file.rootMatchesPath(io, root_dir, root_path)) return error.InvalidProjectRoot;
 
     var word_index = WordIndex.init(allocator);
     defer word_index.deinit();
     word_index.skip_file_words = true;
 
     for (paths.items) |path| {
-        const content = project_file.readAllocNoFollow(io, root_dir, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
+        const content = project_file.readAllocNoFollowAtRoot(io, root_dir, canonical_root, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
         errdefer allocator.free(content);
         try word_index.indexFile(path, content);
         allocator.free(content);

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -20,6 +20,7 @@ const sty = @import("style.zig");
 const Out = @import("out.zig").Out;
 const parseSearchArgs = @import("cli_args.zig").parseSearchArgs;
 const cliIsQueryCmd = @import("cli_args.zig").cliIsQueryCmd;
+const project_file = @import("project_file.zig");
 
 /// Cheap freshness probe: true when any indexable source file under abs_root
 /// is newer than the snapshot on disk. Agents edit files all session long —
@@ -386,7 +387,7 @@ pub fn persistWordIndexFromSource(
     word_index.skip_file_words = true;
 
     for (paths.items) |path| {
-        const content = root_dir.readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
+        const content = project_file.readAllocNoFollow(io, root_dir, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
         errdefer allocator.free(content);
         try word_index.indexFile(path, content);
         allocator.free(content);

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -410,6 +410,12 @@ pub fn saveProjectInfo(io: std.Io, allocator: std.mem.Allocator, data_dir: []con
 /// cache snapshot. No-op for `mcp` (runMcp owns its own deferred/eager load).
 /// `freq_table_heap` is owned by the caller (mainImpl) — we only set it so the
 /// caller's deferred resetFrequencyTable/destroy runs for the process lifetime.
+pub fn commandForcesRescan(cmd: []const u8) bool {
+    return std.mem.eql(u8, cmd, "index") or
+        std.mem.eql(u8, cmd, "snapshot") or
+        std.mem.eql(u8, cmd, "semantic-index");
+}
+
 pub fn coldLoadOrScan(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -438,7 +444,9 @@ pub fn coldLoadOrScan(
         cio.posixGetenv("CODEDB_NO_AUTO_REFRESH") == null and
         snapshotIsStale(io, abs_root, data_dir, allocator);
 
-    const force_rescan = std.mem.eql(u8, cmd, "index") or std.mem.eql(u8, cmd, "snapshot");
+    // semantic-index embeds source bytes and persists their content identity;
+    // it must never inherit a snapshot that can lag the live worktree.
+    const force_rescan = commandForcesRescan(cmd);
     const snapshot_t0 = cio.nanoTimestamp();
     const snapshot_loaded = !force_rescan and !stale and loadBestSnapshot(io, explorer, store, abs_root, data_dir, git_head, allocator);
     const snapshot_elapsed = cio.nanoTimestamp() - snapshot_t0;

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -443,7 +443,6 @@ pub fn coldLoadOrScan(
     cmd_args_start: usize,
     abs_root: []const u8,
     data_dir: []const u8,
-    root: []const u8,
     freq_table_heap: *?*[256][256]u16,
 ) !void {
     if (std.mem.eql(u8, cmd, "mcp")) return;
@@ -554,7 +553,7 @@ pub fn coldLoadOrScan(
             break :blk sa.use_regex or std.mem.indexOfScalar(u8, sa.query, ' ') == null;
         };
         if (is_search and !heads_match) {
-            const tmp_tri = try watcher.initialScanWithTrigrams(io, store, explorer, root, allocator, std.heap.c_allocator, search_skips_outlines);
+            const tmp_tri = try watcher.initialScanWithTrigrams(io, store, explorer, abs_root, allocator, std.heap.c_allocator, search_skips_outlines);
             if (tmp_tri) |tri| {
                 tri.writeToDisk(io, data_dir, git_head) catch {};
                 tri.deinit();
@@ -564,7 +563,7 @@ pub fn coldLoadOrScan(
                 }
             }
         } else {
-            try watcher.initialScan(io, store, explorer, root, allocator, true);
+            try watcher.initialScan(io, store, explorer, abs_root, allocator, true);
         }
         const scan_elapsed = cio.nanoTimestamp() - t_scan;
         var dur_buf: [64]u8 = undefined;

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -243,7 +243,7 @@ pub fn isValidMcpFlag(arg: []const u8) bool {
 fn isCommand(arg: []const u8) bool {
     // cli_query_cmds is the shared query-command table (see its doc); only the
     // non-query commands are listed here.
-    const commands = cli_query_cmds ++ [_][]const u8{ "snapshot", "serve", "mcp", "update", "nuke", "codex", "cli-daemon", "index" };
+    const commands = cli_query_cmds ++ [_][]const u8{ "snapshot", "semantic-index", "serve", "mcp", "update", "nuke", "codex", "cli-daemon", "index" };
     for (commands) |c| {
         if (std.mem.eql(u8, arg, c)) return true;
     }

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -282,7 +282,7 @@ pub fn runSemanticIndex(ctx: *RunCtx) void {
             "  local sidecar: {s}/{s} ({d} bytes total; mmap slab {d} bytes; metadata {d} bytes)\n" ++
             "  persistent vector payload: {d} bytes  remote text sent: {d} bytes\n" ++
             "  vector space: {x}  sensitive paths blocked: {d}  parallel batches: {d}\n" ++
-            "  embedding wall: {d} ms  HNSW insertion: {d} ms  total: {s}\n",
+            "  embedding wall: {d} ms  HNSW insertion: {d} ms  source revalidation: {d} ms  total: {s}\n",
         .{
             ctx.s.green,
             ctx.s.reset,
@@ -304,6 +304,7 @@ pub fn runSemanticIndex(ctx: *RunCtx) void {
             stats.parallel_batches,
             stats.embedding_wall_ns / std.time.ns_per_ms,
             stats.insertion_ns / std.time.ns_per_ms,
+            stats.source_validation_ns / std.time.ns_per_ms,
             sty.formatDuration(&duration_buf, stats.elapsed_ns),
         },
     );

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -351,6 +351,7 @@ pub fn runCliDaemon(ctx: *RunCtx) !void {
     const queue = try allocator.create(watcher.EventQueue);
     defer allocator.destroy(queue);
     queue.* = watcher.EventQueue{};
+    explorer.expectStartupReconcile();
     const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done });
     watch_thread.detach();
 
@@ -418,6 +419,7 @@ pub fn runServe(ctx: *RunCtx) !void {
     const queue = try allocator.create(watcher.EventQueue);
     defer allocator.destroy(queue);
     queue.* = watcher.EventQueue{};
+    explorer.expectStartupReconcile();
     const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done });
     defer watch_thread.join();
 
@@ -511,6 +513,7 @@ pub fn runMcp(ctx: *RunCtx) !void {
         deferred.scan_done.* = std.atomic.Value(bool).init(false);
         maybe_deferred = &deferred;
         mcp_server.setScanState(.loading_snapshot);
+        explorer.expectStartupReconcile();
         watch_thread = try std.Thread.spawn(.{}, watcherDeferredLoop, .{&deferred});
     } else {
         const git_head = git_mod.getGitHead(abs_root, allocator) catch null;
@@ -527,6 +530,7 @@ pub fn runMcp(ctx: *RunCtx) !void {
             compactMcpReadyMemory(io, explorer, data_dir, git_head, allocator);
             mcp_server.setScanState(.ready);
         }
+        explorer.expectStartupReconcile();
         watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_done });
     }
 

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -16,6 +16,7 @@ const mcp_server = @import("mcp.zig");
 const telemetry = @import("telemetry.zig");
 const git_mod = @import("git.zig");
 const snapshot_mod = @import("snapshot.zig");
+const semantic_index = @import("semantic_index.zig");
 const update_mod = @import("update.zig");
 const index_mod = @import("index.zig");
 const Config = @import("config.zig").Config;
@@ -257,6 +258,55 @@ pub fn runSnapshot(ctx: *RunCtx) void {
             }
         }
     }
+}
+
+/// Explicitly build the local file-card ANN sidecar. This is never triggered
+/// by an ordinary query because indexing sends bounded, safe code-chunk cards
+/// to the configured embedding endpoint.
+pub fn runSemanticIndex(ctx: *RunCtx) void {
+    const stats = semantic_index.build(
+        ctx.io,
+        ctx.allocator,
+        ctx.explorer,
+        ctx.store,
+        ctx.abs_root,
+        ctx.data_dir,
+    ) catch |err| {
+        ctx.out.p("{s}\xe2\x9c\x97{s} semantic index failed: {s}\n", .{ ctx.s.red, ctx.s.reset, @errorName(err) });
+        ctx.out.flush();
+        std.process.exit(1);
+    };
+    var duration_buf: [64]u8 = undefined;
+    ctx.out.p(
+        "{s}\xe2\x9c\x93{s} {s}semantic ANN ready{s}  {d} chunks from {d} files  {d}D  {s}\n" ++
+            "  local sidecar: {s}/{s} ({d} bytes total; mmap slab {d} bytes; metadata {d} bytes)\n" ++
+            "  persistent vector payload: {d} bytes  remote text sent: {d} bytes\n" ++
+            "  vector space: {x}  sensitive paths blocked: {d}  parallel batches: {d}\n" ++
+            "  embedding wall: {d} ms  HNSW insertion: {d} ms  total: {s}\n",
+        .{
+            ctx.s.green,
+            ctx.s.reset,
+            ctx.s.bold,
+            ctx.s.reset,
+            stats.records,
+            stats.files_indexed,
+            stats.dimensions,
+            stats.model,
+            ctx.data_dir,
+            semantic_index.sidecar_name,
+            stats.file_bytes,
+            stats.graph_bytes,
+            stats.metadata_bytes,
+            stats.vector_payload_bytes,
+            stats.text_bytes_sent,
+            stats.vector_space_id,
+            stats.sensitive_paths_blocked,
+            stats.parallel_batches,
+            stats.embedding_wall_ns / std.time.ns_per_ms,
+            stats.insertion_ns / std.time.ns_per_ms,
+            sty.formatDuration(&duration_buf, stats.elapsed_ns),
+        },
+    );
 }
 
 pub fn runCliDaemon(ctx: *RunCtx) !void {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1798,6 +1798,12 @@ pub const Explorer = struct {
     /// borrowed (value_owned=false) slices into these for restored files, so they
     /// must outlive the cache; munmap'd once here at Explorer.deinit.
     content_section_maps: std.ArrayList([]align(std.heap.page_size_min) const u8) = .empty,
+    /// A snapshot-backed MCP can serve before the watcher's initial diff has
+    /// reconciled edits made after the snapshot. ANN freshness waits for this
+    /// one bounded startup phase only; genuine stale sidecars never trigger a
+    /// second full tree walk from the query path.
+    startup_reconcile_expected: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    startup_reconcile_complete: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     /// Default file-content cache capacity. Was 16384, but on typical
     /// projects (≤2000 files) the cache only ever holds a few hundred
@@ -1806,6 +1812,30 @@ pub const Explorer = struct {
     /// for 99% of repos; large monorepos can override via config or
     /// pass a custom value to Explorer.init.
     pub const DEFAULT_CONTENT_CACHE_CAPACITY: u32 = 4096;
+
+    pub fn expectStartupReconcile(self: *Explorer) void {
+        self.startup_reconcile_complete.store(false, .release);
+        self.startup_reconcile_expected.store(true, .release);
+    }
+
+    pub fn finishStartupReconcile(self: *Explorer) void {
+        self.startup_reconcile_complete.store(true, .release);
+    }
+
+    pub fn startupReconcilePending(self: *const Explorer) bool {
+        return self.startup_reconcile_expected.load(.acquire) and
+            !self.startup_reconcile_complete.load(.acquire);
+    }
+
+    test "ANN startup freshness waits only for an expected watcher reconcile" {
+        var explorer = Explorer.init(std.testing.allocator, 1024 * 1024);
+        defer explorer.deinit();
+        try std.testing.expect(!explorer.startupReconcilePending());
+        explorer.expectStartupReconcile();
+        try std.testing.expect(explorer.startupReconcilePending());
+        explorer.finishStartupReconcile();
+        try std.testing.expect(!explorer.startupReconcilePending());
+    }
 
     /// Establish the project root as one validated filesystem capability.
     /// The final component is never followed, temp-project admission is

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2950,6 +2950,16 @@ pub const Explorer = struct {
         return try cloneOutline(outline, allocator);
     }
 
+    /// Return the live indexed line count without cloning the outline. This is
+    /// used to validate untrusted semantic sidecar ranges before they become
+    /// retrieval hits.
+    pub fn outlineLineCount(self: *Explorer, path: []const u8) ?u32 {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        const outline = self.outlines.getPtr(path) orelse return null;
+        return outline.line_count;
+    }
+
     /// Render the outline for `path` directly into `out` without cloning.
     /// Returns false if the file isn't indexed. Holds the read lock for
     /// the duration of the render — fast on small outlines, marginally

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -14,6 +14,7 @@ const codegraph = @import("codegraph.zig");
 const markdown_graph = @import("markdown_graph.zig");
 const git = @import("git.zig");
 const project_file = @import("project_file.zig");
+const root_policy = @import("root_policy.zig");
 
 pub const DocumentLinkKind = markdown_graph.LinkKind;
 pub const DocumentLink = markdown_graph.Link;
@@ -1806,11 +1807,62 @@ pub const Explorer = struct {
     /// pass a custom value to Explorer.init.
     pub const DEFAULT_CONTENT_CACHE_CAPACITY: u32 = 4096;
 
-    pub fn setRoot(self: *Explorer, io: std.Io, root_path: []const u8) void {
+    /// Establish the project root as one validated filesystem capability.
+    /// The final component is never followed, temp-project admission is
+    /// checked through the opened handle, and replacement is transactional:
+    /// a failed call leaves the previous root intact.
+    pub fn setRoot(self: *Explorer, io: std.Io, root_path: []const u8) !void {
+        if (!root_policy.isAbsoluteRootRequest(root_path)) return error.PathNotAllowed;
+        const new_dir = try std.Io.Dir.cwd().openDir(io, root_path, .{ .follow_symlinks = false });
+        errdefer new_dir.close(io);
+
+        var canonical_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const canonical_len = try new_dir.realPathFile(io, ".", &canonical_buf);
+        const canonical = canonical_buf[0..canonical_len];
+        if (!root_policy.isAdmissibleRootDir(io, new_dir, canonical)) return error.PathNotAllowed;
+        const new_path = try self.allocator.dupe(u8, canonical);
+
+        const old_dir = self.root_dir;
+        const old_path = self.root_path;
         self.io = io;
-        self.root_dir = std.Io.Dir.cwd().openDir(io, root_path, .{}) catch null;
-        if (self.root_path) |old| self.allocator.free(old);
-        self.root_path = self.allocator.dupe(u8, root_path) catch null;
+        self.root_dir = new_dir;
+        self.root_path = new_path;
+        if (old_dir) |dir| dir.close(io);
+        if (old_path) |path| self.allocator.free(path);
+    }
+
+    test "setRoot establishes one no-follow capability and swaps transactionally" {
+        const testing = std.testing;
+        const test_io = testing.io;
+        var first = testing.tmpDir(.{});
+        defer first.cleanup();
+        var second = testing.tmpDir(.{});
+        defer second.cleanup();
+        try first.dir.writeFile(test_io, .{ .sub_path = "build.zig", .data = "// marker\n" });
+        try second.dir.writeFile(test_io, .{ .sub_path = "build.zig", .data = "// marker\n" });
+
+        var first_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const first_len = try first.dir.realPathFile(test_io, ".", &first_buf);
+        var second_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const second_len = try second.dir.realPathFile(test_io, ".", &second_buf);
+
+        var explorer = Explorer.init(testing.allocator, 4);
+        defer explorer.deinit();
+        try explorer.setRoot(test_io, first_buf[0..first_len]);
+        const retired = explorer.root_dir.?;
+        try explorer.setRoot(test_io, second_buf[0..second_len]);
+        if (comptime builtin.os.tag != .windows) {
+            const rc = std.posix.system.fcntl(retired.handle, std.posix.F.GETFD, @as(usize, 0));
+            try testing.expectEqual(std.posix.E.BADF, std.posix.errno(rc));
+        }
+        try testing.expectEqualStrings(second_buf[0..second_len], explorer.root_path.?);
+
+        try first.dir.symLink(test_io, second_buf[0..second_len], "retarget", .{});
+        const alias = try std.fmt.allocPrint(testing.allocator, "{s}/retarget", .{first_buf[0..first_len]});
+        defer testing.allocator.free(alias);
+        if (explorer.setRoot(test_io, alias)) |_| return error.TestUnexpectedResult else |_| {}
+        try testing.expectEqualStrings(second_buf[0..second_len], explorer.root_path.?);
+        try testing.expectError(error.PathNotAllowed, explorer.setRoot(test_io, "relative/project"));
     }
 
     pub fn init(allocator: std.mem.Allocator, content_cache_capacity: u32) Explorer {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -13,6 +13,7 @@ const SparseNgramIndex = idx.SparseNgramIndex;
 const codegraph = @import("codegraph.zig");
 const markdown_graph = @import("markdown_graph.zig");
 const git = @import("git.zig");
+const project_file = @import("project_file.zig");
 
 pub const DocumentLinkKind = markdown_graph.LinkKind;
 pub const DocumentLink = markdown_graph.Link;
@@ -2701,7 +2702,7 @@ pub const Explorer = struct {
             const io = self.io orelse return error.WordIndexIncomplete;
             const dir = self.root_dir orelse return error.WordIndexIncomplete;
             for (paths) |path| {
-                const content = try dir.readFileAlloc(io, path, self.allocator, .limited(64 * 1024 * 1024));
+                const content = try project_file.readAllocNoFollow(io, dir, path, self.allocator, .limited(64 * 1024 * 1024));
                 errdefer self.allocator.free(content);
                 try rebuilt.indexFile(path, content);
                 self.allocator.free(content);
@@ -3178,6 +3179,7 @@ pub const Explorer = struct {
         out: *std.ArrayList(u8),
         opts: ReadRenderOptions,
     ) !bool {
+        if (!project_file.isAllowedPath(path)) return false;
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
@@ -3199,13 +3201,14 @@ pub const Explorer = struct {
 
     /// Get content: zero-copy from cache, or read from disk (caller-owned).
     fn readContentForSearch(self: *Explorer, path: []const u8, allocator: std.mem.Allocator) ?ContentRef {
+        if (!project_file.isAllowedPath(path)) return null;
         if (self.contents.get(path)) |cached| {
             return .{ .data = cached, .owned = false, .allocator = allocator };
         }
         if (builtin.os.tag == .freestanding) return null;
         const io = self.io orelse return null;
-        const dir = self.root_dir orelse std.Io.Dir.cwd();
-        const data = dir.readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
+        const dir = self.root_dir orelse return null;
+        const data = project_file.readAllocNoFollow(io, dir, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
         return .{ .data = data, .owned = true, .allocator = allocator };
     }
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1813,7 +1813,7 @@ pub const Explorer = struct {
     /// a failed call leaves the previous root intact.
     pub fn setRoot(self: *Explorer, io: std.Io, root_path: []const u8) !void {
         if (!root_policy.isAbsoluteRootRequest(root_path)) return error.PathNotAllowed;
-        const new_dir = try std.Io.Dir.cwd().openDir(io, root_path, .{ .follow_symlinks = false });
+        const new_dir = try std.Io.Dir.cwd().openDir(io, root_path, .{ .follow_symlinks = false, .iterate = true });
         errdefer new_dir.close(io);
 
         var canonical_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -1849,6 +1849,12 @@ pub const Explorer = struct {
         var explorer = Explorer.init(testing.allocator, 4);
         defer explorer.deinit();
         try explorer.setRoot(test_io, first_buf[0..first_len]);
+        var root_iter = explorer.root_dir.?.iterate();
+        var saw_marker = false;
+        while (try root_iter.next(test_io)) |entry| {
+            if (std.mem.eql(u8, entry.name, "build.zig")) saw_marker = true;
+        }
+        try testing.expect(saw_marker);
         const retired = explorer.root_dir.?;
         try explorer.setRoot(test_io, second_buf[0..second_len]);
         if (comptime builtin.os.tag != .windows) {
@@ -2753,8 +2759,9 @@ pub const Explorer = struct {
         if (source_paths) |paths| {
             const io = self.io orelse return error.WordIndexIncomplete;
             const dir = self.root_dir orelse return error.WordIndexIncomplete;
+            const canonical_root = self.root_path orelse return error.WordIndexIncomplete;
             for (paths) |path| {
-                const content = try project_file.readAllocNoFollow(io, dir, path, self.allocator, .limited(64 * 1024 * 1024));
+                const content = try project_file.readAllocNoFollowAtRoot(io, dir, canonical_root, path, self.allocator, .limited(64 * 1024 * 1024));
                 errdefer self.allocator.free(content);
                 try rebuilt.indexFile(path, content);
                 self.allocator.free(content);
@@ -3183,6 +3190,15 @@ pub const Explorer = struct {
         return try allocator.dupe(u8, ref.data);
     }
 
+    /// Whether the current project index already contains this relative path.
+    /// This is intentionally metadata-only: direct reads still validate the
+    /// live file handle before serving cached bytes.
+    pub fn hasIndexedPath(self: *Explorer, path: []const u8) bool {
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+        return self.outlines.contains(path);
+    }
+
     pub const LineSpan = LineOffsetCache.Span;
 
     /// Borrow the canonical cached bytes for `path`. Caller must hold `mu`
@@ -3260,7 +3276,8 @@ pub const Explorer = struct {
         if (builtin.os.tag == .freestanding) return null;
         const io = self.io orelse return null;
         const dir = self.root_dir orelse return null;
-        const data = project_file.readAllocNoFollow(io, dir, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
+        const canonical_root = self.root_path orelse return null;
+        const data = project_file.readAllocNoFollowAtRoot(io, dir, canonical_root, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
         return .{ .data = data, .owned = true, .allocator = allocator };
     }
 

--- a/src/git.zig
+++ b/src/git.zig
@@ -3,6 +3,15 @@ const cio = @import("cio.zig");
 
 const disabled_hooks_config = "core.hooksPath=/codedb-hooks-disabled-do-not-exist";
 
+fn parseGitHead(stdout: []const u8) ?[40]u8 {
+    const trimmed = std.mem.trim(u8, stdout, &std.ascii.whitespace);
+    if (trimmed.len != 40) return null;
+    for (trimmed) |c| if (!std.ascii.isHex(c)) return null;
+    var out: [40]u8 = undefined;
+    @memcpy(&out, trimmed[0..40]);
+    return out;
+}
+
 /// Run `git rev-parse HEAD` in `root` and return the 40-char hex SHA.
 /// Returns null if `root` is not a git repo, git is unavailable, or HEAD
 /// has no commit yet (fresh repo).
@@ -21,15 +30,22 @@ pub fn getGitHead(root: []const u8, allocator: std.mem.Allocator) !?[40]u8 {
         else => return null,
     }
 
-    const trimmed = std.mem.trim(u8, result.stdout, &std.ascii.whitespace);
-    if (trimmed.len != 40) return null;
-    for (trimmed) |c| {
-        if (!std.ascii.isHex(c)) return null;
-    }
+    return parseGitHead(result.stdout);
+}
 
-    var out: [40]u8 = undefined;
-    @memcpy(&out, trimmed[0..40]);
-    return out;
+/// Resolve HEAD through an already-open project capability, so a rename and
+/// pathname replacement cannot retarget the background branch probe.
+pub fn getGitHeadDir(io: std.Io, root_dir: std.Io.Dir, allocator: std.mem.Allocator) !?[40]u8 {
+    const result = std.process.run(allocator, io, .{
+        .argv = &.{ "git", "-c", "core.fsmonitor=false", "-c", disabled_hooks_config, "rev-parse", "HEAD" },
+        .cwd = .{ .dir = root_dir },
+        .stdout_limit = .limited(256),
+        .stderr_limit = .limited(256),
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    if (!result.term.success()) return null;
+    return parseGitHead(result.stdout);
 }
 
 pub const CoChangePartner = struct {

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -242,6 +242,26 @@ pub fn loadClimb(io: Io, arena: Allocator, abs_root: []const u8) ![]Rule {
     return out.items;
 }
 
+/// Load project-local ignore policy through an already-established root
+/// capability.  MCP/live callers use this form so neither root replacement
+/// nor a symlinked ignore file can redirect policy reads outside the project.
+pub fn loadProjectRoot(io: Io, arena: Allocator, root_dir: Io.Dir, canonical_root: []const u8) ![]Rule {
+    var out: std.ArrayList(Rule) = .empty;
+    if (project_file.readAllocNoFollowAtRoot(io, root_dir, canonical_root, ".gitignore", arena, .limited(64 * 1024))) |text| {
+        const rules = parse(arena, text, canonical_root) catch &.{};
+        try out.appendSlice(arena, rules);
+    } else |_| {}
+
+    var git_dir = root_dir.openDir(io, ".git", .{ .follow_symlinks = false }) catch return out.items;
+    defer git_dir.close(io);
+    var info_dir = git_dir.openDir(io, "info", .{ .follow_symlinks = false }) catch return out.items;
+    defer info_dir.close(io);
+    const text = project_file.readAllocNoFollow(io, info_dir, "exclude", arena, .limited(64 * 1024)) catch return out.items;
+    const rules = parse(arena, text, canonical_root) catch return out.items;
+    try out.appendSlice(arena, rules);
+    return out.items;
+}
+
 test "star and dir-only and negation" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -7,6 +7,7 @@
 //! `.git` itself is the walker's job, not this file.
 
 const std = @import("std");
+const project_file = @import("project_file.zig");
 const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
@@ -183,7 +184,18 @@ fn parentOf(path: []const u8) ?[]const u8 {
 }
 
 fn loadFile(io: Io, arena: Allocator, path: []const u8, base: []const u8, out: *std.ArrayList(Rule)) void {
-    const text = Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(64 * 1024)) catch return;
+    if (!std.mem.startsWith(u8, path, base) or path.len <= base.len or path[base.len] != '/') return;
+    const rel = path[base.len + 1 ..];
+    var dir = Io.Dir.cwd().openDir(io, base, .{}) catch return;
+    defer dir.close(io);
+    // `base` comes from the canonical list root (or one of its canonical
+    // parents). Validate the opened handle against that identity so a path
+    // retarget between discovery and open cannot re-anchor resolve-beneath to
+    // an attacker-controlled directory.
+    var opened_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const opened_len = dir.realPath(io, &opened_buf) catch return;
+    if (!std.mem.eql(u8, opened_buf[0..opened_len], base)) return;
+    const text = project_file.readAllocNoFollow(io, dir, rel, arena, .limited(64 * 1024)) catch return;
     const extra = parse(arena, text, base) catch return;
     out.appendSlice(arena, extra) catch {};
 }

--- a/src/list_dir.zig
+++ b/src/list_dir.zig
@@ -13,6 +13,7 @@ const Io = std.Io;
 const Allocator = std.mem.Allocator;
 
 const gitignore = @import("gitignore.zig");
+const project_file = @import("project_file.zig");
 
 pub const max_output_chars: usize = 10_000;
 pub const max_walk_items: usize = 20_000;
@@ -141,6 +142,9 @@ fn fill(w: *Walk, node: *Node) !void {
     const abs = if (rel.len == 0) w.root_abs else try join(w.arena, w.root_abs, rel);
     var dir = Io.Dir.cwd().openDir(w.io, abs, .{ .iterate = true, .follow_symlinks = false }) catch return;
     defer dir.close(w.io);
+    var opened_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const opened_len = dir.realPath(w.io, &opened_buf) catch return;
+    if (!std.mem.eql(u8, opened_buf[0..opened_len], abs)) return;
 
     var names: std.ArrayList(struct { name: []const u8, is_dir: bool }) = .empty;
     var it = dir.iterate();
@@ -153,8 +157,7 @@ fn fill(w: *Walk, node: *Node) !void {
         try names.append(w.arena, .{ .name = name, .is_dir = is_dir });
     }
     if (saw_ignore) {
-        const gi = try join(w.arena, abs, ".gitignore");
-        const text = Io.Dir.cwd().readFileAlloc(w.io, gi, w.arena, .limited(64 * 1024)) catch null;
+        const text = project_file.readAllocNoFollow(w.io, dir, ".gitignore", w.arena, .limited(64 * 1024)) catch null;
         if (text) |t| {
             const extra = gitignore.parse(w.arena, t, abs) catch &.{};
             w.rules.appendSlice(w.arena, extra) catch {};
@@ -213,11 +216,10 @@ fn fillSummaries(w: *Walk, node: *Node) !void {
 
 fn isSourceExt(ext: []const u8) bool {
     const src = [_][]const u8{
-        "zig", "c", "h", "cc", "cpp", "cxx", "hpp",
-        "py",  "ts", "tsx", "js",  "jsx", "mjs", "cjs",
-        "go",  "rs", "java", "kt", "swift",
-        "rb",  "php", "cs",  "sh", "bash",
-        "md",  "toml",
+        "zig", "c",  "h",    "cc", "cpp",   "cxx", "hpp",
+        "py",  "ts", "tsx",  "js", "jsx",   "mjs", "cjs",
+        "go",  "rs", "java", "kt", "swift", "rb",  "php",
+        "cs",  "sh", "bash", "md", "toml",
     };
     for (src) |s| if (std.mem.eql(u8, ext, s)) return true;
     return false;

--- a/src/list_dir.zig
+++ b/src/list_dir.zig
@@ -124,11 +124,26 @@ fn isCollapseDir(name: []const u8) bool {
 const Walk = struct {
     io: Io,
     arena: Allocator,
+    root_dir: Io.Dir,
     root_abs: []const u8,
     rules: std.ArrayList(gitignore.Rule),
     items: usize = 0,
     truncated: bool = false,
 };
+
+fn canonicalRelative(root: []const u8, target: []const u8) ?[]const u8 {
+    if (!underRoot(target, root)) return null;
+    var start = root.len;
+    while (start < target.len and std.fs.path.isSep(target[start])) start += 1;
+    return target[start..];
+}
+
+fn openedDirectoryAllowed(w: *Walk, dir: Io.Dir) bool {
+    var opened_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const opened_len = dir.realPath(w.io, &opened_buf) catch return false;
+    const target_rel = canonicalRelative(w.root_abs, opened_buf[0..opened_len]) orelse return false;
+    return target_rel.len == 0 or project_file.isAllowedPath(target_rel);
+}
 
 fn skip(w: *Walk, abs: []const u8, is_dir: bool) !bool {
     if (isGitComponent(std.fs.path.basename(abs))) return true;
@@ -140,24 +155,38 @@ fn fill(w: *Walk, node: *Node) !void {
     node.filled = true;
     const rel = node.rel;
     const abs = if (rel.len == 0) w.root_abs else try join(w.arena, w.root_abs, rel);
-    var dir = Io.Dir.cwd().openDir(w.io, abs, .{ .iterate = true, .follow_symlinks = false }) catch return;
-    defer dir.close(w.io);
-    var opened_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const opened_len = dir.realPath(w.io, &opened_buf) catch return;
-    if (!std.mem.eql(u8, opened_buf[0..opened_len], abs)) return;
+    var owned_dir: ?Io.Dir = null;
+    const dir = if (rel.len == 0) w.root_dir else blk: {
+        const opened = w.root_dir.openDir(w.io, rel, .{ .iterate = true }) catch return;
+        owned_dir = opened;
+        break :blk opened;
+    };
+    defer if (owned_dir) |opened| opened.close(w.io);
+    if (!openedDirectoryAllowed(w, dir)) return;
 
     var names: std.ArrayList(struct { name: []const u8, is_dir: bool }) = .empty;
     var it = dir.iterate();
     var saw_ignore = false;
     while (it.next(w.io) catch null) |ent| {
-        if (ent.kind == .sym_link) continue;
         const name = try w.arena.dupe(u8, ent.name);
+        const child_rel = if (rel.len == 0) name else try join(w.arena, rel, name);
+        if (!project_file.isAllowedPath(child_rel)) continue;
         if (std.mem.eql(u8, name, ".gitignore") and rel.len > 0) saw_ignore = true;
-        const is_dir = ent.kind == .directory;
+        var is_dir = false;
+        if (ent.kind == .directory or ent.kind == .sym_link) {
+            const child_dir = dir.openDir(w.io, name, .{ .iterate = true }) catch continue;
+            defer child_dir.close(w.io);
+            if (!openedDirectoryAllowed(w, child_dir)) continue;
+            is_dir = true;
+        } else if (ent.kind == .file) {
+            const st = dir.statFile(w.io, name, .{ .follow_symlinks = false }) catch continue;
+            if (st.kind != .file) continue;
+        } else continue;
         try names.append(w.arena, .{ .name = name, .is_dir = is_dir });
     }
     if (saw_ignore) {
-        const text = project_file.readAllocNoFollow(w.io, dir, ".gitignore", w.arena, .limited(64 * 1024)) catch null;
+        const ignore_rel = try join(w.arena, rel, ".gitignore");
+        const text = project_file.readAllocNoFollowAtRoot(w.io, w.root_dir, w.root_abs, ignore_rel, w.arena, .limited(64 * 1024)) catch null;
         if (text) |t| {
             const extra = gitignore.parse(w.arena, t, abs) catch &.{};
             w.rules.appendSlice(w.arena, extra) catch {};
@@ -377,11 +406,12 @@ fn budgetExpand(w: *Walk, root: *Node, max_chars: usize) ![]const u8 {
     return std.fmt.allocPrint(arena, "{s}{s}", .{ try renderKids(arena, root), cut });
 }
 
-fn walkTree(io: Io, arena: Allocator, abs: []const u8) !struct { root: *Node, w: Walk } {
-    const climbed = try gitignore.loadClimb(io, arena, abs);
+fn walkTreeRoot(io: Io, arena: Allocator, root_dir: Io.Dir, abs: []const u8) !struct { root: *Node, w: Walk } {
+    const climbed = try gitignore.loadProjectRoot(io, arena, root_dir, abs);
     var w: Walk = .{
         .io = io,
         .arena = arena,
+        .root_dir = root_dir,
         .root_abs = abs,
         .rules = .empty,
     };
@@ -403,7 +433,9 @@ fn stripDot(path: []const u8) []const u8 {
 
 /// Render a listing for an already-resolved absolute directory.
 pub fn listAbs(io: Io, arena: Allocator, abs: []const u8, display: []const u8) ![]const u8 {
-    var walked = try walkTree(io, arena, abs);
+    var root_dir = try Io.Dir.cwd().openDir(io, abs, .{ .iterate = true, .follow_symlinks = false });
+    defer root_dir.close(io);
+    var walked = try walkTreeRoot(io, arena, root_dir, abs);
     const body = try budgetExpand(&walked.w, walked.root, max_output_chars);
     const trimmed = std.mem.trimEnd(u8, body, "\n");
     if (trimmed.len == 0) return std.fmt.allocPrint(arena, "- {s}/", .{display});
@@ -438,29 +470,45 @@ pub const ListError = error{
 /// List `rel` under `project_abs`. `rel` of `.` / empty is the project root.
 /// Caller owns the returned slice (`arena`).
 pub fn listUnder(io: Io, arena: Allocator, project_abs: []const u8, rel: []const u8) ListError![]const u8 {
+    var root_dir = Io.Dir.cwd().openDir(io, project_abs, .{ .iterate = true, .follow_symlinks = false }) catch return error.NotFound;
+    defer root_dir.close(io);
+    return listUnderRoot(io, arena, root_dir, project_abs, rel);
+}
+
+pub fn listUnderRoot(io: Io, arena: Allocator, root_dir: Io.Dir, project_abs: []const u8, rel: []const u8) ListError![]const u8 {
     const path = stripDot(rel);
     if (!std.mem.eql(u8, path, ".") and !pathSafe(path)) return error.Escape;
+    if (!std.mem.eql(u8, path, ".") and !project_file.isAllowedPath(path)) return error.AccessDenied;
 
-    const resolved = if (std.mem.eql(u8, path, "."))
-        project_abs
-    else
-        std.fmt.allocPrint(arena, "{s}/{s}", .{ project_abs, path }) catch return error.NotFound;
+    if (!std.mem.eql(u8, path, ".")) {
+        const requested_stat = root_dir.statFile(io, path, .{ .follow_symlinks = false }) catch |err| switch (err) {
+            error.FileNotFound => return error.NotFound,
+            error.AccessDenied => return error.AccessDenied,
+            else => return error.NotADir,
+        };
+        if (requested_stat.kind == .file) return error.IsAFile;
+    }
 
-    const st = Io.Dir.cwd().statFile(io, resolved, .{}) catch |err| switch (err) {
-        error.FileNotFound => return error.NotFound,
-        error.AccessDenied => return error.AccessDenied,
-        else => return error.NotADir,
-    };
-    if (st.kind == .file) return error.IsAFile;
-    if (st.kind != .directory) return error.NotADir;
-
-    var opened = Io.Dir.cwd().openDir(io, resolved, .{}) catch return error.NotADir;
-    defer opened.close(io);
+    const opened = if (std.mem.eql(u8, path, ".")) root_dir else root_dir.openDir(io, path, .{ .iterate = true }) catch return error.NotADir;
+    defer if (!std.mem.eql(u8, path, ".")) opened.close(io);
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const n = opened.realPath(io, &buf) catch return error.NotADir;
     const abs = buf[0..n];
     if (!underRoot(abs, project_abs)) return error.Escape;
-    return listAbs(io, arena, abs, path) catch return error.NotADir;
+    const target_rel = canonicalRelative(project_abs, abs) orelse return error.Escape;
+    if (target_rel.len != 0 and !project_file.isAllowedPath(target_rel)) return error.AccessDenied;
+    var walked = walkTreeRoot(io, arena, root_dir, project_abs) catch return error.NotADir;
+    const root = if (std.mem.eql(u8, path, ".")) walked.root else blk: {
+        const node = newNode(arena, std.fs.path.basename(path), path, true, 0, null) catch return error.NotFound;
+        fill(&walked.w, node) catch return error.NotADir;
+        fillSummaries(&walked.w, node) catch return error.NotADir;
+        sortKids(node);
+        break :blk node;
+    };
+    const body = budgetExpand(&walked.w, root, max_output_chars) catch return error.NotADir;
+    const trimmed = std.mem.trimEnd(u8, body, "\n");
+    if (trimmed.len == 0) return std.fmt.allocPrint(arena, "- {s}/", .{path}) catch return error.NotFound;
+    return std.fmt.allocPrint(arena, "- {s}/\n{s}", .{ path, trimmed }) catch return error.NotFound;
 }
 
 pub fn errorText(err: ListError) []const u8 {
@@ -548,6 +596,41 @@ test "listUnder refuses a file and an escaped path" {
     try std.testing.expect(std.mem.indexOf(u8, listing, "only.txt") != null);
     const nested = try listUnder(io, a, abs, "sub");
     try std.testing.expectEqualStrings("- sub/", nested);
+}
+
+test "listUnderRoot filters sensitive names and sensitive directory aliases" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "safe.txt", .data = "ok" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".env", .data = "SECRET=x" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "private_key.pem", .data = "key" });
+    try tmp.dir.createDirPath(io, ".ssh");
+    try tmp.dir.writeFile(io, .{ .sub_path = ".ssh/config", .data = "secret" });
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/main.zig", .data = "pub fn main() void {}" });
+    tmp.dir.symLink(io, ".ssh", "aliasdir", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    try tmp.dir.symLink(io, "src", "safealias", .{});
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const listing = try listUnderRoot(io, arena_state.allocator(), tmp.dir, root, ".");
+    try std.testing.expect(std.mem.indexOf(u8, listing, "safe.txt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, listing, "safealias/") != null);
+    try std.testing.expect(std.mem.indexOf(u8, listing, ".env") == null);
+    try std.testing.expect(std.mem.indexOf(u8, listing, "private_key.pem") == null);
+    try std.testing.expect(std.mem.indexOf(u8, listing, ".ssh") == null);
+    try std.testing.expect(std.mem.indexOf(u8, listing, "aliasdir") == null);
+    try std.testing.expectError(error.AccessDenied, listUnderRoot(io, arena_state.allocator(), tmp.dir, root, ".ssh"));
+    try std.testing.expectError(error.AccessDenied, listUnderRoot(io, arena_state.allocator(), tmp.dir, root, "aliasdir"));
+    const safe_alias = try listUnderRoot(io, arena_state.allocator(), tmp.dir, root, "safealias");
+    try std.testing.expect(std.mem.indexOf(u8, safe_alias, "main.zig") != null);
 }
 
 test "empty directory is a header only" {

--- a/src/list_dir.zig
+++ b/src/list_dir.zig
@@ -131,17 +131,34 @@ const Walk = struct {
     truncated: bool = false,
 };
 
-fn canonicalRelative(root: []const u8, target: []const u8) ?[]const u8 {
+fn isPortablePathSep(ch: u8) bool {
+    return ch == '/' or ch == '\\';
+}
+
+fn canonicalRelative(root: []const u8, target: []const u8, normalized: []u8) ?[]const u8 {
     if (!underRoot(target, root)) return null;
     var start = root.len;
-    while (start < target.len and std.fs.path.isSep(target[start])) start += 1;
-    return target[start..];
+    while (start < target.len and isPortablePathSep(target[start])) start += 1;
+    const rel = target[start..];
+    if (rel.len > normalized.len) return null;
+    for (rel, normalized[0..rel.len]) |ch, *out| out.* = if (isPortablePathSep(ch)) '/' else ch;
+    return normalized[0..rel.len];
+}
+
+test "Windows canonical paths are slash-normalized before list policy checks" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const rel = canonicalRelative("C:\\repo", "C:\\repo\\safe\\.ssh", &buf) orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("safe/.ssh", rel);
+    try std.testing.expect(!project_file.isAllowedPath(rel));
+    try std.testing.expect(!underRoot("C:\\repo-other\\src", "C:\\repo"));
 }
 
 fn openedDirectoryAllowed(w: *Walk, dir: Io.Dir) bool {
     var opened_buf: [std.fs.max_path_bytes]u8 = undefined;
     const opened_len = dir.realPath(w.io, &opened_buf) catch return false;
-    const target_rel = canonicalRelative(w.root_abs, opened_buf[0..opened_len]) orelse return false;
+    var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_rel = canonicalRelative(w.root_abs, opened_buf[0..opened_len], &normalized_buf) orelse return false;
     return target_rel.len == 0 or project_file.isAllowedPath(target_rel);
 }
 
@@ -456,7 +473,8 @@ fn pathSafe(path: []const u8) bool {
 
 fn underRoot(abs: []const u8, root: []const u8) bool {
     if (!std.mem.startsWith(u8, abs, root)) return false;
-    return abs.len == root.len or abs[root.len] == '/';
+    if (abs.len == root.len) return true;
+    return root.len > 0 and (isPortablePathSep(root[root.len - 1]) or isPortablePathSep(abs[root.len]));
 }
 
 pub const ListError = error{
@@ -495,7 +513,8 @@ pub fn listUnderRoot(io: Io, arena: Allocator, root_dir: Io.Dir, project_abs: []
     const n = opened.realPath(io, &buf) catch return error.NotADir;
     const abs = buf[0..n];
     if (!underRoot(abs, project_abs)) return error.Escape;
-    const target_rel = canonicalRelative(project_abs, abs) orelse return error.Escape;
+    var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_rel = canonicalRelative(project_abs, abs, &normalized_buf) orelse return error.Escape;
     if (target_rel.len != 0 and !project_file.isAllowedPath(target_rel)) return error.AccessDenied;
     var walked = walkTreeRoot(io, arena, root_dir, project_abs) catch return error.NotADir;
     const root = if (std.mem.eql(u8, path, ".")) walked.root else blk: {

--- a/src/local_uri.zig
+++ b/src/local_uri.zig
@@ -1,0 +1,134 @@
+//! Strict conversion of MCP local-file roots to native absolute paths.
+//! Root URIs are untrusted protocol input: only `file://` is accepted, percent
+//! escapes are decoded once, and traversal/relative spellings are rejected
+//! before the filesystem capability constructor sees them.
+const std = @import("std");
+
+pub const ParseError = error{
+    UnsupportedScheme,
+    UnsupportedAuthority,
+    InvalidEncoding,
+    RelativePath,
+    Traversal,
+    InvalidPath,
+    OutOfMemory,
+};
+
+fn hexNibble(c: u8) ?u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => null,
+    };
+}
+
+fn decode(allocator: std.mem.Allocator, encoded: []const u8) ParseError![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.ensureTotalCapacity(allocator, encoded.len);
+    var i: usize = 0;
+    while (i < encoded.len) {
+        if (encoded[i] != '%') {
+            if (encoded[i] == 0 or encoded[i] == '?' or encoded[i] == '#') return error.InvalidPath;
+            out.appendAssumeCapacity(encoded[i]);
+            i += 1;
+            continue;
+        }
+        if (i + 2 >= encoded.len) return error.InvalidEncoding;
+        const hi = hexNibble(encoded[i + 1]) orelse return error.InvalidEncoding;
+        const lo = hexNibble(encoded[i + 2]) orelse return error.InvalidEncoding;
+        const value = (hi << 4) | lo;
+        if (value == 0 or value == '?' or value == '#') return error.InvalidPath;
+        out.appendAssumeCapacity(value);
+        i += 3;
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn hasTraversal(path: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, path, "/\\");
+    while (it.next()) |part| if (std.mem.eql(u8, part, "..")) return true;
+    return false;
+}
+
+fn isWindowsAbsolute(path: []const u8) bool {
+    return path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and (path[2] == '/' or path[2] == '\\');
+}
+
+pub fn parseLocalFileUriForOs(
+    allocator: std.mem.Allocator,
+    uri: []const u8,
+    os_tag: std.Target.Os.Tag,
+) ParseError![]u8 {
+    if (!std.mem.startsWith(u8, uri, "file://")) return error.UnsupportedScheme;
+    const remainder = uri[7..];
+    const slash = std.mem.indexOfScalar(u8, remainder, '/');
+    const authority = if (slash) |at| remainder[0..at] else remainder;
+    const encoded_path = if (slash) |at| remainder[at..] else "";
+
+    if (os_tag != .windows and authority.len != 0) return error.UnsupportedAuthority;
+    if (os_tag == .windows and authority.len != 0) {
+        if (encoded_path.len < 2) return error.RelativePath;
+        const decoded = try decode(allocator, encoded_path);
+        defer allocator.free(decoded);
+        if (hasTraversal(decoded)) return error.Traversal;
+        var native = std.ArrayList(u8).empty;
+        errdefer native.deinit(allocator);
+        try native.appendSlice(allocator, "\\\\");
+        try native.appendSlice(allocator, authority);
+        for (decoded) |ch| try native.append(allocator, if (ch == '/') '\\' else ch);
+        return native.toOwnedSlice(allocator);
+    }
+
+    const decoded = try decode(allocator, encoded_path);
+    errdefer allocator.free(decoded);
+    if (hasTraversal(decoded)) return error.Traversal;
+    if (os_tag == .windows) {
+        const drive_path = if (decoded.len >= 3 and decoded[0] == '/' and decoded[2] == ':') decoded[1..] else decoded;
+        if (!isWindowsAbsolute(drive_path)) return error.RelativePath;
+        const native = try allocator.dupe(u8, drive_path);
+        for (native) |*ch| if (ch.* == '/') {
+            ch.* = '\\';
+        };
+        allocator.free(decoded);
+        return native;
+    }
+    if (decoded.len == 0 or decoded[0] != '/') return error.RelativePath;
+    return decoded;
+}
+
+pub fn parseLocalFileUri(allocator: std.mem.Allocator, uri: []const u8) ParseError![]u8 {
+    return parseLocalFileUriForOs(allocator, uri, @import("builtin").os.tag);
+}
+
+pub fn parseRootReference(allocator: std.mem.Allocator, value: []const u8) ParseError![]u8 {
+    if (std.mem.indexOf(u8, value, "://") != null or std.mem.startsWith(u8, value, "file:")) {
+        return parseLocalFileUri(allocator, value);
+    }
+    if (!std.fs.path.isAbsolute(value)) return error.RelativePath;
+    if (hasTraversal(value)) return error.Traversal;
+    return allocator.dupe(u8, value);
+}
+
+test "local file URI parser decodes spaces and rejects unsafe forms" {
+    const a = std.testing.allocator;
+    const path = try parseLocalFileUriForOs(a, "file:///Users/me/My%20Repo", .macos);
+    defer a.free(path);
+    try std.testing.expectEqualStrings("/Users/me/My Repo", path);
+    try std.testing.expectError(error.UnsupportedScheme, parseLocalFileUriForOs(a, "https://example/repo", .macos));
+    try std.testing.expectError(error.UnsupportedAuthority, parseLocalFileUriForOs(a, "file://server/share", .macos));
+    try std.testing.expectError(error.Traversal, parseLocalFileUriForOs(a, "file:///Users/me/%2e%2e/.ssh", .macos));
+    try std.testing.expectError(error.InvalidEncoding, parseLocalFileUriForOs(a, "file:///bad%2", .macos));
+}
+
+test "Windows drive and UNC file URIs convert without POSIX assumptions" {
+    const a = std.testing.allocator;
+    const drive = try parseLocalFileUriForOs(a, "file:///C:/My%20Repo", .windows);
+    defer a.free(drive);
+    try std.testing.expectEqualStrings("C:\\My Repo", drive);
+    const unc = try parseLocalFileUriForOs(a, "file://server/share/repo", .windows);
+    defer a.free(unc);
+    try std.testing.expectEqualStrings("\\\\server\\share\\repo", unc);
+    try std.testing.expectError(error.RelativePath, parseLocalFileUriForOs(a, "file://relative", .windows));
+}

--- a/src/local_uri.zig
+++ b/src/local_uri.zig
@@ -67,19 +67,11 @@ pub fn parseLocalFileUriForOs(
     const authority = if (slash) |at| remainder[0..at] else remainder;
     const encoded_path = if (slash) |at| remainder[at..] else "";
 
-    if (os_tag != .windows and authority.len != 0) return error.UnsupportedAuthority;
-    if (os_tag == .windows and authority.len != 0) {
-        if (encoded_path.len < 2) return error.RelativePath;
-        const decoded = try decode(allocator, encoded_path);
-        defer allocator.free(decoded);
-        if (hasTraversal(decoded)) return error.Traversal;
-        var native = std.ArrayList(u8).empty;
-        errdefer native.deinit(allocator);
-        try native.appendSlice(allocator, "\\\\");
-        try native.appendSlice(allocator, authority);
-        for (decoded) |ch| try native.append(allocator, if (ch == '/') '\\' else ch);
-        return native.toOwnedSlice(allocator);
-    }
+    // MCP roots are local filesystem capabilities. A non-empty file URI
+    // authority is a UNC/network root on Windows and can trigger SMB access
+    // merely by opening it. Reject it during protocol parsing, before Explorer
+    // or the root policy performs any filesystem operation.
+    if (authority.len != 0) return error.UnsupportedAuthority;
 
     const decoded = try decode(allocator, encoded_path);
     errdefer allocator.free(decoded);
@@ -122,13 +114,11 @@ test "local file URI parser decodes spaces and rejects unsafe forms" {
     try std.testing.expectError(error.InvalidEncoding, parseLocalFileUriForOs(a, "file:///bad%2", .macos));
 }
 
-test "Windows drive and UNC file URIs convert without POSIX assumptions" {
+test "Windows drive file URIs convert while UNC authorities fail closed" {
     const a = std.testing.allocator;
     const drive = try parseLocalFileUriForOs(a, "file:///C:/My%20Repo", .windows);
     defer a.free(drive);
     try std.testing.expectEqualStrings("C:\\My Repo", drive);
-    const unc = try parseLocalFileUriForOs(a, "file://server/share/repo", .windows);
-    defer a.free(unc);
-    try std.testing.expectEqualStrings("\\\\server\\share\\repo", unc);
-    try std.testing.expectError(error.RelativePath, parseLocalFileUriForOs(a, "file://relative", .windows));
+    try std.testing.expectError(error.UnsupportedAuthority, parseLocalFileUriForOs(a, "file://server/share/repo", .windows));
+    try std.testing.expectError(error.UnsupportedAuthority, parseLocalFileUriForOs(a, "file://relative", .windows));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -483,7 +483,7 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
     defer if (rerank_trace_path) |p| allocator.free(p);
     if (rerank_trace_path) |p| explorer.rerank_trace_path = p;
 
-    try explorer.setRoot(io, root);
+    if (!mcp_deferred_root) try explorer.setRoot(io, abs_root);
     defer explorer.deinit();
 
     // Per-project frequency table for sparse n-gram boundary selection.
@@ -495,7 +495,7 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
         allocator.destroy(ft);
     };
 
-    try bootstrap.coldLoadOrScan(io, allocator, &store, &explorer, &out, s, cmd, args, cmd_args_start, abs_root, data_dir, root, &freq_table_heap);
+    try bootstrap.coldLoadOrScan(io, allocator, &store, &explorer, &out, s, cmd, args, cmd_args_start, abs_root, data_dir, &freq_table_heap);
     var ctx = commands.RunCtx{
         .io = io,
         .allocator = allocator,

--- a/src/main.zig
+++ b/src/main.zig
@@ -520,6 +520,8 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
         commands.runBenchEngine(&ctx);
     } else if (std.mem.eql(u8, cmd, "snapshot")) {
         commands.runSnapshot(&ctx);
+    } else if (std.mem.eql(u8, cmd, "semantic-index")) {
+        commands.runSemanticIndex(&ctx);
     } else if (std.mem.eql(u8, cmd, "cli-daemon")) {
         try commands.runCliDaemon(&ctx);
     } else if (std.mem.eql(u8, cmd, "serve")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -483,7 +483,7 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
     defer if (rerank_trace_path) |p| allocator.free(p);
     if (rerank_trace_path) |p| explorer.rerank_trace_path = p;
 
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     defer explorer.deinit();
 
     // Per-project frequency table for sparse n-gram boundary selection.

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -209,6 +209,7 @@ const ProjectCtx = struct {
     store: *Store,
     snapshot_cache: *SnapshotCache,
     deps_cache: *DepsCache,
+    semantic_cache: *semantic_index_mod.SearchCache,
 };
 
 fn getProjectDataDir(allocator: std.mem.Allocator, project_path: []const u8) ?[]u8 {
@@ -313,6 +314,7 @@ const ProjectCache = struct {
         store: Store,
         snapshot_cache: SnapshotCache,
         deps_cache: DepsCache,
+        semantic_cache: semantic_index_mod.SearchCache,
         last_used: i64,
     };
 
@@ -322,6 +324,7 @@ const ProjectCache = struct {
     default_path: []const u8,
     default_snapshot_cache: SnapshotCache,
     default_deps_cache: DepsCache,
+    default_semantic_cache: semantic_index_mod.SearchCache,
     content_cache_capacity: u32,
 
     fn init(alloc_: std.mem.Allocator, default_path_: []const u8, content_cache_capacity_: u32) ProjectCache {
@@ -332,6 +335,7 @@ const ProjectCache = struct {
             .default_path = default_path_,
             .default_snapshot_cache = .{},
             .default_deps_cache = .{},
+            .default_semantic_cache = semantic_index_mod.SearchCache.init(alloc_),
             .content_cache_capacity = content_cache_capacity_,
         };
     }
@@ -339,6 +343,7 @@ const ProjectCache = struct {
     fn deinit(self: *ProjectCache) void {
         self.default_snapshot_cache.deinit(self.alloc);
         self.default_deps_cache.deinit(self.alloc);
+        self.default_semantic_cache.deinit();
         for (&self.entries) |*slot| {
             if (slot.*) |entry| {
                 self.destroyEntry(entry);
@@ -350,6 +355,7 @@ const ProjectCache = struct {
     fn destroyEntry(self: *ProjectCache, entry: *Entry) void {
         entry.snapshot_cache.deinit(self.alloc);
         entry.deps_cache.deinit(self.alloc);
+        entry.semantic_cache.deinit();
         entry.explorer.deinit();
         entry.store.deinit();
         self.alloc.free(entry.path);
@@ -394,7 +400,7 @@ const ProjectCache = struct {
         default_exp: *Explorer,
         default_store: *Store,
     ) !ProjectCtx {
-        const raw_path = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
+        const raw_path = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache, .semantic_cache = &self.default_semantic_cache };
         const parsed_path = local_uri.parseRootReference(self.alloc, raw_path) catch return error.PathNotAllowed;
         defer self.alloc.free(parsed_path);
 
@@ -412,7 +418,7 @@ const ProjectCache = struct {
             if (slot.*) |entry| {
                 if (std.mem.eql(u8, entry.path, canonical_root)) {
                     entry.last_used = now;
-                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache, .deps_cache = &entry.deps_cache };
+                    return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache, .deps_cache = &entry.deps_cache, .semantic_cache = &entry.semantic_cache };
                 }
             }
         }
@@ -428,6 +434,7 @@ const ProjectCache = struct {
         new_entry.store = Store.init(self.alloc);
         new_entry.snapshot_cache = .{};
         new_entry.deps_cache = .{};
+        new_entry.semantic_cache = semantic_index_mod.SearchCache.init(self.alloc);
         new_entry.last_used = now;
 
         const stable_root = new_entry.explorer.root_dir orelse return error.PathNotAllowed;
@@ -454,7 +461,7 @@ const ProjectCache = struct {
                 self.alloc.free(new_entry.path);
                 self.alloc.destroy(new_entry);
                 if (default_exp.root_path != null and std.mem.eql(u8, canonical_root, default_exp.root_path.?) and default_store.currentSeq() > 0) {
-                    return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
+                    return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache, .semantic_cache = &self.default_semantic_cache };
                 }
                 return error.SnapshotLoadFailed;
             }
@@ -495,7 +502,7 @@ const ProjectCache = struct {
         }
 
         self.entries[target_slot] = new_entry;
-        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store, .snapshot_cache = &new_entry.snapshot_cache, .deps_cache = &new_entry.deps_cache };
+        return ProjectCtx{ .explorer = &new_entry.explorer, .store = &new_entry.store, .snapshot_cache = &new_entry.snapshot_cache, .deps_cache = &new_entry.deps_cache, .semantic_cache = &new_entry.semantic_cache };
     }
 };
 
@@ -1786,6 +1793,7 @@ fn dispatch(
             .store = default_store,
             .snapshot_cache = &cache.default_snapshot_cache,
             .deps_cache = &cache.default_deps_cache,
+            .semantic_cache = &cache.default_semantic_cache,
         };
 
     if (project_path == null and tool == .codedb_deps and args.count() == 1) {
@@ -1851,7 +1859,7 @@ fn dispatch(
         .codedb_glob => handleGlob(alloc, args, out, ctx.explorer),
         .codedb_ls => handleLs(alloc, args, out, ctx.explorer),
         .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", ctx.explorer, out),
-        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer),
+        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer, ctx.semantic_cache),
     }
     appendScanProgressHint(alloc, out, tool);
 }
@@ -3235,9 +3243,10 @@ fn isTestPath(path: []const u8) bool {
 /// must never launch another full filesystem walk or allocate EventQueue's
 /// multi-megabyte ring, and no ANN embedding request is issued before freshness
 /// validation succeeds.
-fn searchSemanticAnnFresh(
+fn searchSemanticAnnOnce(
     io: std.Io,
     allocator: std.mem.Allocator,
+    cache: ?*semantic_index_mod.SearchCache,
     explorer: *Explorer,
     store: *Store,
     project_root: []const u8,
@@ -3245,13 +3254,30 @@ fn searchSemanticAnnFresh(
     task: []const u8,
     k: usize,
 ) !semantic_index_mod.SearchOutput {
-    return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k) catch |err| switch (err) {
+    if (cache) |semantic_cache| {
+        return semantic_index_mod.searchCached(io, allocator, semantic_cache, explorer, store, project_root, data_dir, task, k);
+    }
+    return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k);
+}
+
+fn searchSemanticAnnFresh(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cache: ?*semantic_index_mod.SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !semantic_index_mod.SearchOutput {
+    return searchSemanticAnnOnce(io, allocator, cache, explorer, store, project_root, data_dir, task, k) catch |err| switch (err) {
         error.StaleAnnManifest => {
             if (!explorer.startupReconcilePending()) return err;
             const deadline = cio.milliTimestamp() + @as(i64, @intCast(scan_wait_timeout_ms));
             while (explorer.startupReconcilePending() and cio.milliTimestamp() < deadline) cio.sleepMs(25);
             if (explorer.startupReconcilePending()) return err;
-            return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k);
+            return searchSemanticAnnOnce(io, allocator, cache, explorer, store, project_root, data_dir, task, k);
         },
         else => return err,
     };
@@ -3311,6 +3337,7 @@ const ContextRetrievalProvenance = struct {
     ann_load_ns: u64 = 0,
     ann_search_ns: u64 = 0,
     ann_mmap_backed: bool = false,
+    ann_cache_hit: bool = false,
     ann_vector_space_id: ?u64 = null,
     remote_retention: []const u8 = "not_applicable",
     local_vector_storage: []const u8 = "none",
@@ -3359,7 +3386,15 @@ fn appendStructuredContext(alloc: std.mem.Allocator, out: *std.ArrayList(u8), va
     out.appendSlice(alloc, encoded) catch {};
 }
 
-fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {
+fn handleContext(
+    io: std.Io,
+    alloc: std.mem.Allocator,
+    args: *const std.json.ObjectMap,
+    out: *std.ArrayList(u8),
+    store: *Store,
+    explorer: *Explorer,
+    semantic_cache: ?*semantic_index_mod.SearchCache,
+) void {
     const stable_root = explorer.root_dir orelse {
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
@@ -3653,6 +3688,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         if (searchSemanticAnnFresh(
             io,
             A,
+            semantic_cache,
             explorer,
             store,
             rooted_project,
@@ -3674,6 +3710,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             retrieval.ann_load_ns = ann_result.load_ns;
             retrieval.ann_search_ns = ann_result.search_ns;
             retrieval.ann_mmap_backed = ann_result.mmap_backed;
+            retrieval.ann_cache_hit = ann_result.cache_hit;
             retrieval.ann_vector_space_id = ann_result.vector_space_id;
             retrieval.remote_retention = switch (ann_result.retention) {
                 .none_by_codedb_policy => "none_by_codedb_service_policy",
@@ -3883,7 +3920,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         if (semantic_requested) {
             wh.print("\n## Retrieval privacy\n- local BM25/symbol retrieval ran first\n", .{}) catch {};
             if (std.mem.eql(u8, retrieval.semantic, "ann_applied")) {
-                wh.print("- local OpenPuffer ANN: {s}, {d}D, vector space {x}, {d} indexed code chunks / {d} sidecar bytes\n- remote query embedding: task plus fixed public vector-space calibration / {d} text bytes; remote retention: {s}\n- local vector storage: {s}; mmap={any}; ANN load {d} ns / search {d} ns\n", .{
+                wh.print("- local OpenPuffer ANN: {s}, {d}D, vector space {x}, {d} indexed code chunks / {d} sidecar bytes\n- remote query embedding: task plus fixed public vector-space calibration / {d} text bytes; remote retention: {s}\n- local vector storage: {s}; mmap={any}; cache_hit={any}; ANN load {d} ns / search {d} ns\n", .{
                     retrieval.model orelse semantic_mod.default_model,
                     retrieval.dimensions orelse semantic_mod.default_dimensions,
                     retrieval.ann_vector_space_id orelse 0,
@@ -3893,6 +3930,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                     retrieval.remote_retention,
                     retrieval.local_vector_storage,
                     retrieval.ann_mmap_backed,
+                    retrieval.ann_cache_hit,
                     retrieval.ann_load_ns,
                     retrieval.ann_search_ns,
                 }) catch {};
@@ -5584,7 +5622,7 @@ pub fn runCliTool(
         if (task.items.len == 0) return cliUsage(alloc, out, "context [--semantic] [--json] <task...>");
         m.put(alloc, "task", .{ .string = task.items }) catch return 1;
         loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
-        handleContext(io, alloc, &m, out, store, explorer);
+        handleContext(io, alloc, &m, out, store, explorer, null);
         return finishCli(out, out_start);
     }
     return null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -27,6 +27,8 @@ const git_mod = @import("git.zig");
 const root_policy = @import("root_policy.zig");
 const release_info = @import("release_info.zig");
 const mcp_list_dir = @import("mcp_list_dir.zig");
+const project_file_read = @import("project_file.zig");
+const project_path_policy = @import("project_path.zig");
 pub const DeferredScan = struct {
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -3577,11 +3579,18 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         file.semantic_rank = rank;
     }
     if (semantic_requested) {
-        for (ranked.items) |file| {
-            if (!semantic_mod.isRemoteCandidatePathAllowed(file.path)) {
+        // Count excluded indexed paths before retrieval materialization. The
+        // shared Explorer read boundary now rejects sensitive cached entries,
+        // so waiting until `ranked` would under-report paths that were safely
+        // suppressed before their content could become a candidate.
+        explorer.mu.lockShared();
+        var indexed_paths = explorer.outlines.keyIterator();
+        while (indexed_paths.next()) |path| {
+            if (!semantic_mod.isRemoteCandidatePathAllowed(path.*)) {
                 retrieval.sensitive_paths_blocked += 1;
             }
         }
+        explorer.mu.unlockShared();
     }
 
     var use_exact_semantic_fallback = false;
@@ -4572,8 +4581,20 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         appendBundleArgKeysDiagnostic(alloc, out, args);
         return;
     };
+    const read_root = explorer.root_dir orelse {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    };
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root: []const u8 = if (std.Io.Dir.cwd().realPathFile(io, ".", &root_buf)) |n| root_buf[0..n] else |_| "";
+    const root_len = read_root.realPath(io, &root_buf) catch {
+        out.appendSlice(alloc, "error: project root is not available") catch {};
+        return;
+    };
+    const root = root_buf[0..root_len];
+    if (!root_policy.isIndexableRoot(root)) {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    }
     const path = projectRelPath(path_arg, root) orelse {
         out.appendSlice(alloc, "error: path traversal not allowed") catch {};
         return;
@@ -4582,6 +4603,14 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         out.appendSlice(alloc, "error: access to sensitive file blocked") catch {};
         return;
     }
+    _ = project_file_read.statNoFollow(io, read_root, path) catch {
+        out.appendSlice(alloc, "error: failed to read file: ") catch {};
+        out.appendSlice(alloc, path) catch {};
+        // Preserve the established miss ergonomics while still failing closed:
+        // suggestions are derived only from indexed paths, never from this read.
+        appendFuzzyPathSuggestions(alloc, out, explorer, path);
+        return;
+    };
 
     // Line range params
     const line_start_raw = getInt(args, "line_start");
@@ -4650,8 +4679,7 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         // server's cwd. For a project=/remote-cache explorer, cwd would serve
         // the user's own file of the same relative path under the other
         // project's label (mirrors explore.readContentForSearch).
-        const read_root = explorer.root_dir orelse std.Io.Dir.cwd();
-        break :blk read_root.readFileAlloc(io, path, alloc, .limited(10 * 1024 * 1024)) catch {
+        break :blk project_file_read.readAllocNoFollow(io, read_root, path, alloc, .limited(10 * 1024 * 1024)) catch {
             out.appendSlice(alloc, "error: failed to read file: ") catch {};
             out.appendSlice(alloc, path) catch {};
             // Issue #356-p3: fuzzy fallback so a mistyped path is recoverable
@@ -6023,6 +6051,31 @@ fn handleQuery(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *
             }
             const max_lines: usize = if (getInt(step, "lines")) |n| @intCast(@max(1, @min(n, 200))) else 50;
             for (file_set.items) |path| {
+                const query_root = explorer.root_dir orelse {
+                    w.print("error: project root is not configured\n", .{}) catch {};
+                    finishQueryWithFailure(alloc, out, step_i, "project root is not configured", step, file_set.items);
+                    return;
+                };
+                const query_io = explorer.io orelse {
+                    w.print("error: project root is not configured\n", .{}) catch {};
+                    finishQueryWithFailure(alloc, out, step_i, "project root is not configured", step, file_set.items);
+                    return;
+                };
+                if (!project_file_read.rootIsAllowed(query_io, query_root)) {
+                    w.print("error: project root is not configured\n", .{}) catch {};
+                    finishQueryWithFailure(alloc, out, step_i, "project root is not configured", step, file_set.items);
+                    return;
+                }
+                if (!project_file_read.isAllowedPath(path)) {
+                    w.print("error: read path is not an allowed project file: {s}\n", .{path}) catch {};
+                    finishQueryWithFailure(alloc, out, step_i, "read path is not allowed", step, file_set.items);
+                    return;
+                }
+                _ = project_file_read.statNoFollow(query_io, query_root, path) catch {
+                    w.print("error: read path is not an allowed project file: {s}\n", .{path}) catch {};
+                    finishQueryWithFailure(alloc, out, step_i, "read path is not allowed", step, file_set.items);
+                    return;
+                };
                 const content = explorer.getContent(path, alloc) catch continue;
                 if (content) |data| {
                     defer alloc.free(data);
@@ -6256,17 +6309,7 @@ pub fn globMatch(pattern: []const u8, path: []const u8) bool {
 }
 
 pub fn isPathSafe(path: []const u8) bool {
-    if (path.len == 0) return false;
-    if (path[0] == '/') return false;
-    // Block null bytes (path truncation attack)
-    if (std.mem.indexOfScalar(u8, path, 0) != null) return false;
-    // Block backslash separators
-    if (std.mem.indexOfScalar(u8, path, '\\') != null) return false;
-    var it = std.mem.splitScalar(u8, path, '/');
-    while (it.next()) |component| {
-        if (std.mem.eql(u8, component, "..")) return false;
-    }
-    return true;
+    return project_path_policy.isNormalizedRelative(path);
 }
 
 /// Map a read/edit `path` argument to a project-relative path that is safe to
@@ -7057,6 +7100,10 @@ test "issue-353: project cache invalidation reloads newly written snapshots" {
     var snapshot_src = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_src.deinit();
     snapshot_src.setRoot(io, project_path);
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "src/old.zig",
+        .data = "pub fn oldSymbol() void {}\n",
+    });
     try snapshot_src.indexFile("src/old.zig", "pub fn oldSymbol() void {}\n");
     try snapshot_mod.writeProjectCacheSnapshot(io, &snapshot_src, project_path, testing.allocator);
 
@@ -7074,6 +7121,10 @@ test "issue-353: project cache invalidation reloads newly written snapshots" {
     var snapshot_next = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_next.deinit();
     snapshot_next.setRoot(io, project_path);
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "src/new.zig",
+        .data = "pub fn newSymbol() void {}\n",
+    });
     try snapshot_next.indexFile("src/new.zig", "pub fn newSymbol() void {}\n");
     try snapshot_mod.writeProjectCacheSnapshot(io, &snapshot_next, project_path, testing.allocator);
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3229,6 +3229,34 @@ fn isTestPath(path: []const u8) bool {
     return false;
 }
 
+/// A persisted ANN can be newer than the snapshot selected at MCP startup.
+/// Wait only for the already-running watcher's bounded startup reconcile, then
+/// retry once. A genuinely stale sidecar returns immediately: query handling
+/// must never launch another full filesystem walk or allocate EventQueue's
+/// multi-megabyte ring, and no ANN embedding request is issued before freshness
+/// validation succeeds.
+fn searchSemanticAnnFresh(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !semantic_index_mod.SearchOutput {
+    return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k) catch |err| switch (err) {
+        error.StaleAnnManifest => {
+            if (!explorer.startupReconcilePending()) return err;
+            const deadline = cio.milliTimestamp() + @as(i64, @intCast(scan_wait_timeout_ms));
+            while (explorer.startupReconcilePending() and cio.milliTimestamp() < deadline) cio.sleepMs(25);
+            if (explorer.startupReconcilePending()) return err;
+            return semantic_index_mod.search(io, allocator, explorer, store, project_root, data_dir, task, k);
+        },
+        else => return err,
+    };
+}
+
 const ContextEvidenceItem = struct {
     path: []const u8,
     source_path: ?[]const u8 = null,

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -30,6 +30,7 @@ const mcp_list_dir = @import("mcp_list_dir.zig");
 const project_file_read = @import("project_file.zig");
 const project_path_policy = @import("project_path.zig");
 const local_uri = @import("local_uri.zig");
+const bootstrap_mod = @import("bootstrap.zig");
 pub const DeferredScan = struct {
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -5174,60 +5175,59 @@ fn handleIndex(
         return;
     };
 
-    // Resolve to absolute path
-    var abs_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const abs_len = std.Io.Dir.cwd().realPathFile(io, path, &abs_buf) catch {
-        out.appendSlice(alloc, "error: cannot resolve path: ") catch {};
+    // Build through one pinned Explorer capability. The old implementation
+    // resolved + check-opened this path, closed the handle, then spawned a
+    // child that reopened the mutable pathname. A rename/symlink swap in that
+    // window could make the child index a different tree than admission saw.
+    var build_store = Store.init(alloc);
+    defer build_store.deinit();
+    var build_explorer = Explorer.init(alloc, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer build_explorer.deinit();
+    build_explorer.setRoot(io, path) catch {
+        out.appendSlice(alloc, "error: project root is not a safely indexable directory: ") catch {};
         out.appendSlice(alloc, path) catch {};
         return;
     };
-    const abs_path = abs_buf[0..abs_len];
-    if (!root_policy.isAdmissibleRoot(io, abs_path)) {
-        out.appendSlice(alloc, "error: refusing to index temporary root: ") catch {};
-        out.appendSlice(alloc, abs_path) catch {};
-        return;
-    }
-
-    // Verify it's a directory
-    var check_dir = std.Io.Dir.cwd().openDir(io, abs_path, .{}) catch {
-        out.appendSlice(alloc, "error: not a directory: ") catch {};
-        out.appendSlice(alloc, abs_path) catch {};
+    const abs_path = alloc.dupe(u8, build_explorer.root_path.?) catch {
+        out.appendSlice(alloc, "error: alloc failed") catch {};
         return;
     };
-    check_dir.close(io);
-
-    // Get the codedb binary path (argv[0] equivalent — use /proc/self or just "codedb")
-    // We spawn `codedb <path> snapshot` to create the snapshot
-    const exe_path = std.process.executablePathAlloc(io, alloc) catch {
-        out.appendSlice(alloc, "error: cannot find codedb binary") catch {};
+    defer alloc.free(abs_path);
+    const data_dir = bootstrap_mod.getDataDir(io, alloc, abs_path) catch {
+        out.appendSlice(alloc, "error: cannot create project data directory") catch {};
         return;
     };
-    defer alloc.free(exe_path);
-
+    defer alloc.free(data_dir);
     const snapshot_path = std.fmt.allocPrint(alloc, "{s}/codedb.snapshot", .{abs_path}) catch {
         out.appendSlice(alloc, "error: alloc failed") catch {};
         return;
     };
     defer alloc.free(snapshot_path);
 
-    const result = cio.runCapture(.{
-        .allocator = alloc,
-        .argv = &.{ exe_path, abs_path, "snapshot", snapshot_path, "--no-live-refresh" },
-        .max_output_bytes = 64 * 1024,
-    }) catch {
-        out.appendSlice(alloc, "error: failed to run indexer") catch {};
-        return;
+    const build_result: ?anyerror = blk: {
+        bootstrap_mod.saveProjectInfo(io, alloc, data_dir, abs_path) catch |err| break :blk err;
+        watcher.initialScan(io, &build_store, &build_explorer, abs_path, alloc, true) catch |err| break :blk err;
+        const git_head = git_mod.getGitHeadDir(io, build_explorer.root_dir.?, alloc) catch null;
+        if (build_explorer.outlines.count() > 0) {
+            bootstrap_mod.persistWordIndexFromSource(io, &build_explorer, abs_path, data_dir, git_head, alloc) catch |err| break :blk err;
+        }
+        const cpu_count = std.Thread.getCpuCount() catch 1;
+        const tri_workers: usize = @min(@as(usize, @intCast(cpu_count)), 8);
+        const trigram = watcher.buildTrigramsFromCache(&build_explorer.contents, alloc, std.heap.c_allocator, tri_workers) catch |err| break :blk err;
+        defer {
+            trigram.deinit();
+            std.heap.c_allocator.destroy(trigram);
+        }
+        trigram.writeToDisk(io, data_dir, git_head) catch |err| break :blk err;
+        build_explorer.buildCallCentrality(alloc);
+        snapshot_mod.writeSnapshotDual(io, &build_explorer, abs_path, snapshot_path, alloc) catch |err| break :blk err;
+        break :blk null;
     };
-    defer alloc.free(result.stdout);
-    defer alloc.free(result.stderr);
-
-    if (result.term.Exited != 0) {
+    if (build_result) |err| {
         out.appendSlice(alloc, "error: indexing failed for ") catch {};
         out.appendSlice(alloc, abs_path) catch {};
-        if (result.stderr.len > 0) {
-            out.appendSlice(alloc, " — ") catch {};
-            out.appendSlice(alloc, result.stderr[0..@min(result.stderr.len, 300)]) catch {};
-        }
+        out.appendSlice(alloc, " — ") catch {};
+        out.appendSlice(alloc, @errorName(err)) catch {};
         return;
     }
 
@@ -5263,32 +5263,8 @@ fn handleIndex(
 
     out.appendSlice(alloc, "indexed: ") catch {};
     out.appendSlice(alloc, abs_path) catch {};
-    if (result.stdout.len > 0) {
-        out.appendSlice(alloc, "\n") catch {};
-        // Strip ANSI escape sequences
-        var i: usize = 0;
-        while (i < result.stdout.len) {
-            if (result.stdout[i] == 0x1b) {
-                i += 1;
-                if (i < result.stdout.len and result.stdout[i] == '[') {
-                    // CSI sequence: skip until final byte (0x40-0x7E per ECMA-48)
-                    i += 1;
-                    while (i < result.stdout.len) {
-                        const ch = result.stdout[i];
-                        i += 1;
-                        if (ch >= 0x40 and ch <= 0x7E) break;
-                    }
-                } else if (i < result.stdout.len) {
-                    // Fe sequence (ESC + one byte) — skip
-                    i += 1;
-                }
-                // Lone ESC at end — already skipped by i += 1 above
-            } else {
-                out.append(alloc, result.stdout[i]) catch {};
-                i += 1;
-            }
-        }
-    }
+    const writer = cio.listWriter(out, alloc);
+    writer.print("\n{d} files", .{build_explorer.outlines.count()}) catch {};
 }
 
 // True when `q` is a single compound identifier — camelCase/PascalCase (an

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3870,7 +3870,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             wsr.print("- {s} ({s}) — {s}:{d}\n", .{ sr.kw, sr.kind, sr.path, sr.line }) catch {};
             wsl.print("- {s} ({s}) — {s}:{d}\n", .{ sr.kw, sr.kind, sr.path, sr.line }) catch {};
             if (inline_bodies) {
-                const body_end: u32 = if (sr.line_end > sr.line) @min(sr.line_end, sr.line + 39) else sr.line;
+                const body_end: u32 = if (sr.line_end > sr.line) @min(sr.line_end, sr.line +| 39) else sr.line;
                 _ = explorer.appendLineRange(sr.path, sr.line, body_end, "       ", A, &sec_syms_rich) catch false;
             }
         }
@@ -4053,7 +4053,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             if (explorer.cachedContentLocked(f.path)) |content| {
                 for (f.top) |h| {
                     const want_start: u32 = if (h.line > 2) h.line - 2 else 1;
-                    const want_end: u32 = h.line + 2;
+                    const want_end: u32 = h.line +| 2;
                     var lines2 = [2]u32{ want_start, want_end };
                     var spans2: [2]explore_mod.Explorer.LineSpan = undefined;
                     const n = explorer.lineSpansFor(f.path, content, lines2[0..], spans2[0..]) orelse 0;
@@ -4083,7 +4083,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                 if (file_content) |content| {
                     // Find the start/end byte offsets of [line-2 .. line+2].
                     const want_start: u32 = if (h.line > 2) h.line - 2 else 1;
-                    const want_end: u32 = h.line + 2;
+                    const want_end: u32 = h.line +| 2;
                     var cur_line: u32 = 1;
                     var i: usize = 0;
                     var captured_start: ?usize = null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -8,7 +8,7 @@ const std = @import("std");
 const testing = std.testing;
 const mcpj = @import("mcp_json.zig");
 pub const Root = struct {
-    uri: []u8,
+    path: []u8,
     name: []u8,
 };
 const Store = @import("store.zig").Store;
@@ -29,6 +29,7 @@ const release_info = @import("release_info.zig");
 const mcp_list_dir = @import("mcp_list_dir.zig");
 const project_file_read = @import("project_file.zig");
 const project_path_policy = @import("project_path.zig");
+const local_uri = @import("local_uri.zig");
 pub const DeferredScan = struct {
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -58,8 +59,7 @@ pub fn triggerDeferredScanWithFallback(
 ) bool {
     var path: []const u8 = "";
     if (indexable_roots.len > 0) {
-        const uri_raw = indexable_roots[0].uri;
-        path = if (std.mem.startsWith(u8, uri_raw, "file://")) uri_raw[7..] else uri_raw;
+        path = indexable_roots[0].path;
     }
     if (path.len == 0 and fallback_cwd.len > 0 and root_policy.isIndexableRoot(fallback_cwd)) {
         path = fallback_cwd;
@@ -393,9 +393,15 @@ const ProjectCache = struct {
         default_exp: *Explorer,
         default_store: *Store,
     ) !ProjectCtx {
-        const p = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
-        if (!root_policy.isAdmissibleRoot(io, p))
-            return error.PathNotAllowed;
+        const raw_path = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
+        const parsed_path = local_uri.parseRootReference(self.alloc, raw_path) catch return error.PathNotAllowed;
+        defer self.alloc.free(parsed_path);
+
+        var candidate = Explorer.init(self.alloc, self.content_cache_capacity);
+        var candidate_live = true;
+        defer if (candidate_live) candidate.deinit();
+        try candidate.setRoot(io, parsed_path);
+        const canonical_root = candidate.root_path orelse return error.PathNotAllowed;
 
         self.mu.lock();
         defer self.mu.unlock();
@@ -403,7 +409,7 @@ const ProjectCache = struct {
         const now = cio.milliTimestamp();
         for (&self.entries) |*slot| {
             if (slot.*) |entry| {
-                if (std.mem.eql(u8, entry.path, p)) {
+                if (std.mem.eql(u8, entry.path, canonical_root)) {
                     entry.last_used = now;
                     return ProjectCtx{ .explorer = &entry.explorer, .store = &entry.store, .snapshot_cache = &entry.snapshot_cache, .deps_cache = &entry.deps_cache };
                 }
@@ -412,23 +418,17 @@ const ProjectCache = struct {
 
         // Cache miss — load from snapshot
         const new_entry = self.alloc.create(Entry) catch return error.OutOfMemory;
-        new_entry.path = self.alloc.dupe(u8, p) catch {
+        new_entry.path = self.alloc.dupe(u8, canonical_root) catch {
             self.alloc.destroy(new_entry);
             return error.OutOfMemory;
         };
-        new_entry.explorer = Explorer.init(self.alloc, self.content_cache_capacity);
-        new_entry.explorer.setRoot(io, p) catch |err| {
-            new_entry.explorer.deinit();
-            self.alloc.free(new_entry.path);
-            self.alloc.destroy(new_entry);
-            return err;
-        };
+        new_entry.explorer = candidate;
+        candidate_live = false;
         new_entry.store = Store.init(self.alloc);
         new_entry.snapshot_cache = .{};
         new_entry.deps_cache = .{};
         new_entry.last_used = now;
 
-        const canonical_root = new_entry.explorer.root_path orelse p;
         const stable_root = new_entry.explorer.root_dir orelse return error.PathNotAllowed;
         if (!snapshot_mod.loadSnapshotValidatedFromRoot(io, stable_root, canonical_root, &new_entry.explorer, &new_entry.store, self.alloc)) {
             // Fallback: try central store at ~/.codedb/projects/{hash}/codedb.snapshot
@@ -452,14 +452,14 @@ const ProjectCache = struct {
                 new_entry.explorer.deinit();
                 self.alloc.free(new_entry.path);
                 self.alloc.destroy(new_entry);
-                if (std.mem.eql(u8, p, self.default_path) and default_store.currentSeq() > 0) {
+                if (default_exp.root_path != null and std.mem.eql(u8, canonical_root, default_exp.root_path.?) and default_store.currentSeq() > 0) {
                     return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
                 }
                 return error.SnapshotLoadFailed;
             }
         }
 
-        loadProjectTrigramFromDiskIfPresent(io, &new_entry.explorer, p, self.alloc);
+        loadProjectTrigramFromDiskIfPresent(io, &new_entry.explorer, canonical_root, self.alloc);
 
         // Release raw file contents retained by the snapshot load — outlines,
         // trigram index, and word index are sufficient for all query tools.
@@ -1087,7 +1087,7 @@ const Session = struct {
 
     fn freeRoots(self: *Session) void {
         for (self.roots.items) |r| {
-            self.alloc.free(r.uri);
+            self.alloc.free(r.path);
             self.alloc.free(r.name);
         }
         self.roots.clearRetainingCapacity();
@@ -1533,19 +1533,25 @@ fn parseRoots(io: std.Io, s: *Session, result: *const std.json.ObjectMap) void {
         const obj = item.object;
         const uri_raw = mcpj.getStr(&obj, "uri") orelse continue;
         const name_raw = mcpj.getStr(&obj, "name") orelse "";
-        // Strip file:// prefix for policy check
-        const path = if (std.mem.startsWith(u8, uri_raw, "file://")) uri_raw[7..] else uri_raw;
-        if (!root_policy.isAdmissibleRoot(io, path)) {
+        const parsed_path = local_uri.parseLocalFileUri(s.alloc, uri_raw) catch {
             std.log.info("codedb mcp: rejected root \"{s}\" (denied by policy)", .{uri_raw});
             continue;
-        }
-        const uri = s.alloc.dupe(u8, uri_raw) catch continue;
-        const name = s.alloc.dupe(u8, name_raw) catch {
-            s.alloc.free(uri);
+        };
+        var probe = Explorer.init(s.alloc, 1);
+        defer probe.deinit();
+        probe.setRoot(io, parsed_path) catch {
+            s.alloc.free(parsed_path);
+            std.log.info("codedb mcp: rejected root \"{s}\" (unsafe root capability)", .{uri_raw});
             continue;
         };
-        s.roots.append(s.alloc, .{ .uri = uri, .name = name }) catch {
-            s.alloc.free(uri);
+        s.alloc.free(parsed_path);
+        const path = s.alloc.dupe(u8, probe.root_path.?) catch continue;
+        const name = s.alloc.dupe(u8, name_raw) catch {
+            s.alloc.free(path);
+            continue;
+        };
+        s.roots.append(s.alloc, .{ .path = path, .name = name }) catch {
+            s.alloc.free(path);
             s.alloc.free(name);
             continue;
         };
@@ -1816,8 +1822,9 @@ fn dispatch(
     }
 
     if (tool == .codedb_word or tool == .codedb_context or (tool == .codedb_search and shouldLoadWordIndexForSearch(args))) {
-        const effective_project = project_path orelse cache.default_path;
-        loadProjectWordIndexFromDiskIfPresent(io, ctx.explorer, effective_project, alloc);
+        if (project_path orelse ctx.explorer.root_path) |effective_project| {
+            loadProjectWordIndexFromDiskIfPresent(io, ctx.explorer, effective_project, alloc);
+        }
     }
 
     switch (tool) {
@@ -1843,7 +1850,7 @@ fn dispatch(
         .codedb_glob => handleGlob(alloc, args, out, ctx.explorer),
         .codedb_ls => handleLs(alloc, args, out, ctx.explorer),
         .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", ctx.explorer, out),
-        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer, project_path orelse cache.default_path),
+        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer),
     }
     appendScanProgressHint(alloc, out, tool);
 }
@@ -3323,7 +3330,7 @@ fn appendStructuredContext(alloc: std.mem.Allocator, out: *std.ArrayList(u8), va
     out.appendSlice(alloc, encoded) catch {};
 }
 
-fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer, project_root: []const u8) void {
+fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer) void {
     const stable_root = explorer.root_dir orelse {
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
@@ -3332,10 +3339,6 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
     };
-    if (!project_file_read.rootMatchesPath(io, stable_root, project_root)) {
-        out.appendSlice(alloc, "error: project root capability mismatch") catch {};
-        return;
-    }
     const task = getStr(args, "task") orelse {
         out.appendSlice(alloc, "error: missing 'task' argument") catch {};
         appendBundleArgKeysDiagnostic(alloc, out, args);
@@ -4603,16 +4606,10 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
     };
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = read_root.realPath(io, &root_buf) catch {
-        out.appendSlice(alloc, "error: project root is not available") catch {};
-        return;
-    };
-    const root = root_buf[0..root_len];
-    if (!project_file_read.rootIsAllowed(io, read_root)) {
+    const root = explorer.root_path orelse {
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
-    }
+    };
     const path = projectRelPath(path_arg, root) orelse {
         out.appendSlice(alloc, "error: path traversal not allowed") catch {};
         return;
@@ -4621,7 +4618,7 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         out.appendSlice(alloc, "error: access to sensitive file blocked") catch {};
         return;
     }
-    _ = project_file_read.statNoFollow(io, read_root, path) catch {
+    _ = project_file_read.statNoFollowAtRoot(io, read_root, root, path) catch {
         out.appendSlice(alloc, "error: failed to read file: ") catch {};
         out.appendSlice(alloc, path) catch {};
         // Preserve the established miss ergonomics while still failing closed:
@@ -4684,7 +4681,9 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
     // Stay on the extractLines path below (do not renderCachedRead here):
     // default ranged reads still need the "N | " prefix, and raw mode
     // must stay byte-exact with no hash header.
-    _ = watcher.indexMissingFile(io, store, explorer, path);
+    if (!explorer.hasIndexedPath(path)) {
+        _ = watcher.indexMissingFile(io, store, explorer, path);
+    }
 
     const cached = explorer.getContent(path, alloc) catch {
         out.appendSlice(alloc, "error: read failed") catch {};
@@ -4697,7 +4696,7 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         // server's cwd. For a project=/remote-cache explorer, cwd would serve
         // the user's own file of the same relative path under the other
         // project's label (mirrors explore.readContentForSearch).
-        break :blk project_file_read.readAllocNoFollow(io, read_root, path, alloc, .limited(10 * 1024 * 1024)) catch {
+        break :blk project_file_read.readAllocNoFollowAtRoot(io, read_root, root, path, alloc, .limited(10 * 1024 * 1024)) catch {
             out.appendSlice(alloc, "error: failed to read file: ") catch {};
             out.appendSlice(alloc, path) catch {};
             // Issue #356-p3: fuzzy fallback so a mistyped path is recoverable
@@ -5582,7 +5581,7 @@ pub fn runCliTool(
         if (task.items.len == 0) return cliUsage(alloc, out, "context [--semantic] [--json] <task...>");
         m.put(alloc, "task", .{ .string = task.items }) catch return 1;
         loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
-        handleContext(io, alloc, &m, out, store, explorer, root);
+        handleContext(io, alloc, &m, out, store, explorer);
         return finishCli(out, out_start);
     }
     return null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -15,6 +15,8 @@ const Store = @import("store.zig").Store;
 const explore_mod = @import("explore.zig");
 const Explorer = explore_mod.Explorer;
 const reader_md = @import("reader_md.zig");
+const semantic_mod = @import("semantic.zig");
+const semantic_index_mod = @import("semantic_index.zig");
 const AgentRegistry = @import("agent.zig").AgentRegistry;
 const snapshot_json = @import("snapshot_json.zig");
 const watcher = @import("watcher.zig");
@@ -675,7 +677,7 @@ pub const tools_list =
     \\{"name":"codedb_callers","description":"Replaces grepping for call sites: PRIMARY tool for finding usages — reach for this FIRST when you need who calls or uses a symbol, instead of grepping with codedb_search. Finds every call site of a named symbol — fuses word-index occurrences with outline scope info. One round-trip vs codedb_word + codedb_outline-per-file. Returns {path, line, snippet, scope_name, scope_kind, scope_lines}. Excludes the symbol's own definition site.","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Symbol name (exact identifier match)"},"max_results":{"type":"integer","description":"Maximum call sites to return (default: 30, raise for hot symbols)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["name"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_callpath","description":"Shortest resolved call chain between two symbols via the local call graph (A→…→B). First move when you need how execution reaches a callee. Returns each hop as path:name@line.","inputSchema":{"type":"object","properties":{"from":{"type":"string","description":"Source symbol name (exact identifier)"},"to":{"type":"string","description":"Target symbol name (exact identifier)"},"max_hops":{"type":"integer","description":"Max call hops to search (default: 12)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["from","to"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_explain","description":"One-shot neighborhood of a symbol: definition body plus every call site. Replaces codedb_symbol body=true then codedb_callers. First move when you know the name.","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Exact symbol name"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["name"]},"annotations":{"readOnlyHint":true}},
-    \\{"name":"codedb_context","description":"Task-shaped composer: pass a natural-language task; returns ONE compact block of definitions, focused bodies, graph neighbors, ranked files, and snippets. Replaces 3-5 sequential search/word/symbol calls — first-touch orientation on a new task.","inputSchema":{"type":"object","properties":{"task":{"type":"string","description":"Natural-language task description (3-1024 chars). Include candidate identifiers (camelCase / snake_case) or \"quoted strings\" so the composer can extract keywords."},"max_tokens":{"type":"integer","description":"Approximate response token budget (compact reserves a conservative ~2.5 bytes/token; min 256). Evidence is admitted monotonically by value; omitted evidence is summarized once."},"detail":{"type":"string","enum":["compact","full"],"description":"compact (default) removes redundant framing and uses focused body/site excerpts. full uses verbose legacy-style sections and a reader.md prepend."},"document_hops":{"type":"integer","description":"Explicitly expand Markdown document links from ranked files (0 default, hard-capped at 2 hops and 64 files)."},"format":{"type":"string","enum":["markdown","json"],"description":"markdown (default) preserves the compact text response. json returns schema-versioned sections, evidence provenance, reader.md validation, and machine-readable token-budget omissions."},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["task"]},"annotations":{"readOnlyHint":true}},
+    \\{"name":"codedb_context","description":"Task-shaped composer: pass a natural-language task; returns ONE compact block of definitions, focused bodies, graph neighbors, ranked files, and snippets. Local BM25/symbol retrieval is always first and is the default. semantic=hybrid searches an explicitly built local OpenPuffer ANN sidecar using one transient remote request containing the task plus a fixed public calibration string; when the sidecar is absent or stale it can rerank up to 24 bounded local candidates instead. The hosted service stores neither the repository, request body, candidate paths, nor vectors. Failure keeps the local result and never runs a CPU model.","inputSchema":{"type":"object","properties":{"task":{"type":"string","description":"Natural-language task description (3-1024 chars). Include candidate identifiers (camelCase / snake_case) or \"quoted strings\" so the composer can extract keywords."},"max_tokens":{"type":"integer","description":"Approximate response token budget (compact reserves a conservative ~2.5 bytes/token; min 256). Evidence is admitted monotonically by value; omitted evidence is summarized once."},"detail":{"type":"string","enum":["compact","full"],"description":"compact (default) removes redundant framing and uses focused body/site excerpts. full uses verbose legacy-style sections and a reader.md prepend."},"document_hops":{"type":"integer","description":"Explicitly expand Markdown document links from ranked files (0 default, hard-capped at 2 hops and 64 files)."},"semantic":{"type":"string","enum":["local","hybrid"],"description":"local (default) keeps all source on-device. hybrid sends the task plus a fixed public calibration string when a compatible local ANN sidecar exists; otherwise it may send the task plus up to 24 locally selected relative paths with bounded snippets. Build the sidecar explicitly with codedb <root> semantic-index. The hosted lane is transient; custom endpoint retention is reported as unverified."},"format":{"type":"string","enum":["markdown","json"],"description":"markdown (default) preserves the compact text response. json returns schema-versioned sections, evidence provenance, reader.md validation, retrieval privacy, and machine-readable token-budget omissions."},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["task"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_hot","description":"Recently modified files, newest first — reach for this to see WHERE work is happening before searching an unfamiliar or mid-sprint codebase.","inputSchema":{"type":"object","properties":{"limit":{"type":"integer","description":"Number of files to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_deps","description":"PRIMARY tool for impact/blast-radius — use this instead of grepping import lines. Dependency graph: who imports a file (default) or what a file imports (direction=depends_on). Set edge_type=documents for Markdown links; document traversal is capped at 2 hops and 64 nodes.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"File path to check dependencies for"},"direction":{"type":"string","enum":["imported_by","depends_on"],"description":"Inbound (default) or outbound edges; for documents these mean linked-by and links-to."},"edge_type":{"type":"string","enum":["imports","documents"],"description":"Typed graph relation (default: imports)."},"transitive":{"type":"boolean","description":"Follow dependency chain transitively (default: false)"},"max_depth":{"type":"integer","description":"Max traversal depth (document edges are always capped at 2)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["path"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_read","description":"Read file contents, optionally a line range. Never dump whole large files — run codedb_outline or codedb_symbol first to pick a tight range. A just-added file is indexed on miss; do not call codedb_index first. Pass if_hash to skip unchanged re-reads; compact=true for minified or long-line files.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"File path relative to project root"},"line_start":{"type":"integer","description":"Start line (1-indexed, inclusive). Omit for full file."},"line_end":{"type":"integer","description":"End line (1-indexed, inclusive). Omit to read to EOF."},"if_hash":{"type":"string","description":"Previous content hash. If unchanged, returns short 'unchanged:HASH' response."},"compact":{"type":"boolean","description":"Skip comment and blank lines (default: false)"},"raw":{"type":"boolean","description":"Byte-exact output: no line-number prefixes and no hash header, so the result can feed an exact-string edit (default: false)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["path"]},"annotations":{"readOnlyHint":true}},
@@ -817,6 +819,7 @@ const mini_prop_descriptions = [_]PropDesc{
     .{ .name = "max_hops", .desc = "Max call hops (default: 12)" },
     .{ .name = "max_tokens", .desc = "Response token budget (min 256, ~2.5 bytes/token)" },
     .{ .name = "detail", .desc = "compact (default) or full sections" },
+    .{ .name = "semantic", .desc = "local (default) or transient hybrid rerank" },
     .{ .name = "direction", .desc = "imported_by (default) or depends_on" },
     .{ .name = "transitive", .desc = "Follow the dependency chain (default: false)" },
     .{ .name = "max_depth", .desc = "Depth cap for transitive (default: unlimited)" },
@@ -828,7 +831,7 @@ const mini_prop_descriptions = [_]PropDesc{
 /// JSON is shared with the core/full profiles, so it is left untouched and
 /// these are swapped in only on the mini path (mirrors slim_descriptions).
 const mini_descriptions = [_]struct { name: []const u8, desc: []const u8 }{
-    .{ .name = "codedb_context", .desc = "Task neighborhood in one call: definitions, bodies, graph neighbors, ranked files. First move on a new task; include likely identifiers. max_tokens caps the budget." },
+    .{ .name = "codedb_context", .desc = "Task neighborhood in one call. Local BM25 is default; semantic=hybrid explicitly opts into transient advisory embeddings. max_tokens caps output." },
     .{ .name = "codedb_explain", .desc = "Symbol neighborhood in one call: definition body plus every call site. First move when you know the name. Replaces symbol --body then callers." },
     .{ .name = "codedb_callpath", .desc = "Shortest resolved call chain A→…→B. First move when you need how execution reaches a callee. Returns each hop as path:name@line." },
     .{ .name = "codedb_list_dir", .desc = "Live folder listing (gitignore, 10k cap). Use instead of bash ls/find/tree; works on unindexed trees. codedb_ls is the indexed one-level listing." },
@@ -1832,7 +1835,7 @@ fn dispatch(
         .codedb_glob => handleGlob(alloc, args, out, ctx.explorer),
         .codedb_ls => handleLs(alloc, args, out, ctx.explorer),
         .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", project_path orelse cache.default_path, out),
-        .codedb_context => handleContext(io, alloc, args, out, ctx.explorer, project_path orelse cache.default_path),
+        .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer, project_path orelse cache.default_path),
     }
     appendScanProgressHint(alloc, out, tool);
 }
@@ -3239,12 +3242,61 @@ const ContextReaderProvenance = struct {
     computed_revision: ?[]const u8 = null,
 };
 
+const ContextRetrievalCandidate = struct {
+    path: []const u8,
+    lexical_rank: ?usize,
+    semantic_rank: ?usize,
+    semantic_score: f32,
+    source: []const u8 = "bounded_exact_rerank",
+    line_start: ?u32 = null,
+    line_end: ?u32 = null,
+};
+
+const ContextRetrievalProvenance = struct {
+    initial: []const u8 = "local_bm25_and_symbols",
+    semantic: []const u8 = "not_requested",
+    fusion: []const u8 = "none",
+    model: ?[]const u8 = null,
+    dimensions: ?u16 = null,
+    rrf_k: f32 = semantic_mod.default_rrf_k,
+    semantic_weight: f32 = semantic_mod.default_semantic_weight,
+    documents_sent: usize = 0,
+    text_bytes_sent: usize = 0,
+    ann_records: usize = 0,
+    ann_index_bytes: usize = 0,
+    ann_load_ns: u64 = 0,
+    ann_search_ns: u64 = 0,
+    ann_mmap_backed: bool = false,
+    ann_vector_space_id: ?u64 = null,
+    remote_retention: []const u8 = "not_applicable",
+    local_vector_storage: []const u8 = "none",
+    failure_policy: []const u8 = "keep_local_bm25_no_cpu_embedding_fallback",
+    sensitive_paths_blocked: usize = 0,
+    detail: ?[]const u8 = null,
+    candidates: []const ContextRetrievalCandidate = &.{},
+};
+
+fn semanticSourcePreview(explorer: *Explorer, allocator: std.mem.Allocator, path: []const u8, target_line: u32) ?[]const u8 {
+    const content = (explorer.getContent(path, allocator) catch null) orelse return null;
+    var line_number: u32 = 1;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| : (line_number +|= 1) {
+        if (line_number < target_line) continue;
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0 and line_number < target_line +| 3) continue;
+        if (trimmed.len == 0) return null;
+        return trimmed[0..@min(trimmed.len, 240)];
+    }
+    return null;
+}
+
 const ContextStructuredOutput = struct {
-    schema_version: u8 = 1,
+    schema_version: u8 = 2,
     format: []const u8 = "codedb_context",
     task: []const u8,
     keywords: []const []const u8,
     reader: ContextReaderProvenance,
+    retrieval: ContextRetrievalProvenance,
     sections: []const ContextProvenanceSection,
     omissions: []const []const u8,
     budget: struct {
@@ -3263,7 +3315,7 @@ fn appendStructuredContext(alloc: std.mem.Allocator, out: *std.ArrayList(u8), va
     out.appendSlice(alloc, encoded) catch {};
 }
 
-fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer, project_root: []const u8) void {
+fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer, project_root: []const u8) void {
     const task = getStr(args, "task") orelse {
         out.appendSlice(alloc, "error: missing 'task' argument") catch {};
         appendBundleArgKeysDiagnostic(alloc, out, args);
@@ -3276,6 +3328,13 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
 
     const max_tokens: ?u32 = if (getInt(args, "max_tokens")) |n| @intCast(@max(256, @min(n, 1_000_000))) else null;
     const document_hops: u32 = if (getInt(args, "document_hops")) |n| @intCast(@max(0, @min(n, 2))) else 0;
+    const semantic_mode = getStr(args, "semantic") orelse "local";
+    if (!std.mem.eql(u8, semantic_mode, "local") and !std.mem.eql(u8, semantic_mode, "hybrid")) {
+        out.appendSlice(alloc, "error: semantic must be 'local' or 'hybrid'") catch {};
+        return;
+    }
+    const semantic_requested = std.mem.eql(u8, semantic_mode, "hybrid");
+    var retrieval: ContextRetrievalProvenance = .{};
     const format = getStr(args, "format") orelse "markdown";
     const structured = std.mem.eql(u8, format, "json");
     if (!structured and !std.mem.eql(u8, format, "markdown")) {
@@ -3375,6 +3434,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     extractContextFallbackWords(task, A, &candidates);
     const pf_cand = cio.nanoTimestamp();
     if (candidates.items.len == 0) {
+        if (semantic_requested) retrieval.semantic = "no_candidates";
         const message = "no candidate identifiers found in task — include symbol names (camelCase or snake_case) or \"quoted strings\" so the composer can extract keywords";
         if (structured) {
             var sections: [2]ContextProvenanceSection = undefined;
@@ -3407,6 +3467,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                     .declared_revision = reader_declared_revision,
                     .computed_revision = reader_computed_revision,
                 },
+                .retrieval = retrieval,
                 .sections = sections[0..section_count],
                 .omissions = &.{},
                 .budget = .{ .max_tokens = max_tokens, .estimated_tokens_used = (task.len + sec_reader.items.len + 3) / 4 },
@@ -3418,7 +3479,11 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         return;
     }
 
-    const PerFileHit = struct { line: u32, text: []const u8 };
+    const PerFileHit = struct {
+        line: u32,
+        text: []const u8,
+        source: enum { lexical, semantic_ann } = .lexical,
+    };
     const PerFile = struct {
         total: u32 = 0,
         bm25: f32 = 0,
@@ -3472,7 +3537,18 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     var symbol_files = std.StringHashMap(void).init(A);
     for (sym_refs.items) |sr| symbol_files.put(sr.path, {}) catch {};
 
-    const FileRank = struct { path: []const u8, hits: u32, score: f32, top: []const PerFileHit };
+    const FileRank = struct {
+        path: []const u8,
+        hits: u32,
+        score: f32,
+        top: []const PerFileHit,
+        lexical_rank: usize = 0,
+        semantic_rank: usize = 0,
+        semantic_score: f32 = 0,
+        hybrid_score: f32 = 0,
+        lexical_present: bool = true,
+        semantic_present: bool = false,
+    };
     var ranked: std.ArrayList(FileRank) = .empty;
     var iter = by_file.iterator();
     while (iter.next()) |entry| {
@@ -3496,6 +3572,249 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             return a.hits > b.hits;
         }
     }.lt);
+    for (ranked.items, 0..) |*file, rank| {
+        file.lexical_rank = rank;
+        file.semantic_rank = rank;
+    }
+    if (semantic_requested) {
+        for (ranked.items) |file| {
+            if (!semantic_mod.isRemoteCandidatePathAllowed(file.path)) {
+                retrieval.sensitive_paths_blocked += 1;
+            }
+        }
+    }
+
+    var use_exact_semantic_fallback = false;
+    if (semantic_requested) ann_lane: {
+        const data_dir = getProjectDataDir(A, project_root) orelse {
+            retrieval.semantic = "unavailable";
+            retrieval.detail = "AnnDataDirUnavailable";
+            use_exact_semantic_fallback = true;
+            break :ann_lane;
+        };
+        if (semantic_index_mod.search(
+            io,
+            A,
+            explorer,
+            store,
+            project_root,
+            data_dir,
+            task,
+            semantic_index_mod.default_search_results,
+        )) |ann_result| {
+            retrieval.semantic = "ann_applied";
+            retrieval.fusion = "top3_lexical_guard_union_rrf";
+            retrieval.semantic_weight = semantic_mod.default_ann_semantic_weight;
+            retrieval.model = ann_result.model;
+            retrieval.dimensions = ann_result.dimensions;
+            // Query + fixed public calibration string share one request. No
+            // repository path or source chunk is transmitted on the ANN lane.
+            retrieval.documents_sent = 2;
+            retrieval.text_bytes_sent = ann_result.text_bytes_sent;
+            retrieval.ann_records = ann_result.records;
+            retrieval.ann_index_bytes = ann_result.index_bytes;
+            retrieval.ann_load_ns = ann_result.load_ns;
+            retrieval.ann_search_ns = ann_result.search_ns;
+            retrieval.ann_mmap_backed = ann_result.mmap_backed;
+            retrieval.ann_vector_space_id = ann_result.vector_space_id;
+            retrieval.remote_retention = switch (ann_result.retention) {
+                .none_by_codedb_policy => "none_by_codedb_service_policy",
+                .custom_endpoint_unverified => "custom_endpoint_unverified",
+            };
+            retrieval.local_vector_storage = "openpuffer_hnsw_mmap_code_chunk_sidecar";
+
+            const lexical_count = ranked.items.len;
+            var ranked_by_path = std.StringHashMap(usize).init(A);
+            for (ranked.items, 0..) |file, index| ranked_by_path.put(file.path, index) catch {};
+            for (ann_result.hits, 0..) |hit, semantic_rank| {
+                if (ranked_by_path.get(hit.path)) |ranked_index| {
+                    const file = &ranked.items[ranked_index];
+                    file.semantic_rank = semantic_rank;
+                    file.semantic_score = 1.0 - hit.distance;
+                    file.semantic_present = true;
+                    var include_line = true;
+                    for (file.top) |site| {
+                        if (site.line >= hit.line_start and site.line <= hit.line_end) include_line = false;
+                    }
+                    if (include_line) {
+                        var merged: std.ArrayList(PerFileHit) = .empty;
+                        merged.appendSlice(A, file.top) catch {};
+                        merged.append(A, .{
+                            .line = hit.line_start,
+                            .text = semanticSourcePreview(explorer, A, hit.path, hit.line_start) orelse "semantic ANN chunk",
+                            .source = .semantic_ann,
+                        }) catch {};
+                        file.top = merged.items;
+                    }
+                    continue;
+                }
+
+                var preview: std.ArrayList(PerFileHit) = .empty;
+                preview.append(A, .{
+                    .line = hit.line_start,
+                    .text = semanticSourcePreview(explorer, A, hit.path, hit.line_start) orelse "semantic ANN chunk",
+                    .source = .semantic_ann,
+                }) catch {};
+                const new_index = ranked.items.len;
+                ranked.append(A, .{
+                    .path = hit.path,
+                    .hits = 0,
+                    .score = 0,
+                    .top = preview.items,
+                    .lexical_rank = lexical_count + semantic_rank,
+                    .semantic_rank = semantic_rank,
+                    .semantic_score = 1.0 - hit.distance,
+                    .lexical_present = false,
+                    .semantic_present = true,
+                }) catch continue;
+                ranked_by_path.put(hit.path, new_index) catch {};
+            }
+
+            for (ranked.items) |*file| {
+                file.hybrid_score = semantic_mod.annRrfScore(
+                    file.lexical_present,
+                    file.lexical_rank,
+                    file.semantic_present,
+                    file.semantic_rank,
+                );
+            }
+
+            if (A.alloc(ContextRetrievalCandidate, ann_result.hits.len) catch null) |provenance| {
+                for (provenance, ann_result.hits, 0..) |*item, hit, semantic_rank| {
+                    const ranked_index = ranked_by_path.get(hit.path);
+                    const file = if (ranked_index) |index| ranked.items[index] else null;
+                    item.* = .{
+                        .path = hit.path,
+                        .lexical_rank = if (file) |candidate| if (candidate.lexical_present) candidate.lexical_rank else null else null,
+                        .semantic_rank = semantic_rank,
+                        .semantic_score = 1.0 - hit.distance,
+                        .source = "local_openpuffer_ann",
+                        .line_start = hit.line_start,
+                        .line_end = hit.line_end,
+                    };
+                }
+                retrieval.candidates = provenance;
+            }
+            std.mem.sort(FileRank, ranked.items, {}, struct {
+                fn lt(_: void, a: FileRank, b: FileRank) bool {
+                    return semantic_mod.annRankComesBefore(
+                        a.lexical_present,
+                        a.lexical_rank,
+                        a.semantic_present,
+                        a.hybrid_score,
+                        a.path,
+                        b.lexical_present,
+                        b.lexical_rank,
+                        b.semantic_present,
+                        b.hybrid_score,
+                        b.path,
+                    );
+                }
+            }.lt);
+        } else |err| {
+            retrieval.semantic = "unavailable";
+            retrieval.detail = @errorName(err);
+            use_exact_semantic_fallback = switch (err) {
+                error.AnnIndexMissing,
+                error.InvalidAnnSidecar,
+                error.UnsupportedAnnSidecarVersion,
+                error.TruncatedAnnSidecar,
+                error.InvalidAnnRecordPath,
+                error.InvalidAnnSlabName,
+                error.AnnRecordMappingMismatch,
+                error.AnnSlabTooLarge,
+                error.AnnDimensionsMismatch,
+                error.AnnModelMismatch,
+                error.AnnVectorSpaceMismatch,
+                error.AnnVectorSpaceCalibrationMismatch,
+                error.StaleAnnGitHead,
+                error.StaleAnnManifest,
+                => true,
+                else => false,
+            };
+        }
+    }
+
+    if (semantic_requested and use_exact_semantic_fallback and ranked.items.len > 0) {
+        var semantic_candidates: std.ArrayList(semantic_mod.Candidate) = .empty;
+        var semantic_candidate_indices: std.ArrayList(usize) = .empty;
+        for (ranked.items, 0..) |file, ranked_index| {
+            if (semantic_candidates.items.len == semantic_mod.max_documents) break;
+            if (!semantic_mod.isRemoteCandidatePathAllowed(file.path)) {
+                continue;
+            }
+            var snippet: std.ArrayList(u8) = .empty;
+            const sw = cio.listWriter(&snippet, A);
+            for (file.top) |hit| {
+                sw.print("L{d}: {s}\n", .{ hit.line, hit.text }) catch {};
+            }
+            semantic_candidates.append(A, .{ .path = file.path, .text = snippet.items }) catch break;
+            semantic_candidate_indices.append(A, ranked_index) catch {
+                _ = semantic_candidates.pop();
+                break;
+            };
+        }
+        if (semantic_candidates.items.len > 0) {
+            if (semantic_mod.scoreRemote(io, A, task, semantic_candidates.items)) |remote| {
+                retrieval.semantic = "applied_exact_fallback";
+                retrieval.fusion = "lexical_authoritative_rrf";
+                retrieval.model = remote.model;
+                retrieval.dimensions = remote.dimensions;
+                retrieval.documents_sent = remote.documents_sent;
+                retrieval.text_bytes_sent = remote.text_bytes_sent;
+                retrieval.remote_retention = switch (remote.retention) {
+                    .none_by_codedb_policy => "none_by_codedb_service_policy",
+                    .custom_endpoint_unverified => "custom_endpoint_unverified",
+                };
+
+                const SemanticOrder = struct { index: usize, score: f32 };
+                const maybe_order = A.alloc(SemanticOrder, remote.documents_sent) catch null;
+                if (maybe_order) |order| {
+                    for (order, 0..) |*item, i| item.* = .{ .index = i, .score = remote.scores[i] };
+                    std.mem.sort(SemanticOrder, order, {}, struct {
+                        fn lt(_: void, a: SemanticOrder, b: SemanticOrder) bool {
+                            if (a.score != b.score) return a.score > b.score;
+                            return a.index < b.index;
+                        }
+                    }.lt);
+                    for (order, 0..) |item, semantic_rank| {
+                        const ranked_index = semantic_candidate_indices.items[item.index];
+                        ranked.items[ranked_index].semantic_rank = semantic_rank;
+                        ranked.items[ranked_index].semantic_score = item.score;
+                        ranked.items[ranked_index].semantic_present = true;
+                    }
+                    for (ranked.items) |*file| {
+                        file.hybrid_score = semantic_mod.advisoryRrfScore(file.lexical_rank, file.semantic_rank);
+                    }
+                    const provenance_candidates = A.alloc(ContextRetrievalCandidate, remote.documents_sent) catch null;
+                    if (provenance_candidates) |items| {
+                        for (items, 0..) |*item, i| {
+                            const file = ranked.items[semantic_candidate_indices.items[i]];
+                            item.* = .{
+                                .path = file.path,
+                                .lexical_rank = file.lexical_rank,
+                                .semantic_rank = file.semantic_rank,
+                                .semantic_score = file.semantic_score,
+                                .source = "bounded_exact_rerank",
+                            };
+                        }
+                        retrieval.candidates = items;
+                    }
+                    std.mem.sort(FileRank, ranked.items, {}, struct {
+                        fn lt(_: void, a: FileRank, b: FileRank) bool {
+                            if (a.hybrid_score != b.hybrid_score) return a.hybrid_score > b.hybrid_score;
+                            return a.lexical_rank < b.lexical_rank;
+                        }
+                    }.lt);
+                }
+            } else |err| {
+                retrieval.semantic = "unavailable";
+                retrieval.detail = @errorName(err);
+            }
+        } else {
+            retrieval.semantic = "no_candidates";
+        }
+    }
     const top_n = @min(ranked.items.len, CONTEXT_TOP_FILES);
     const pf_rank = cio.nanoTimestamp();
 
@@ -3503,6 +3822,37 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
         const wh = cio.listWriter(&sec_head, A);
         wh.print("# Task\n{s}\n\n## Keywords used\n", .{task}) catch {};
         for (candidates.items) |k| wh.print("- {s}\n", .{k}) catch {};
+        if (semantic_requested) {
+            wh.print("\n## Retrieval privacy\n- local BM25/symbol retrieval ran first\n", .{}) catch {};
+            if (std.mem.eql(u8, retrieval.semantic, "ann_applied")) {
+                wh.print("- local OpenPuffer ANN: {s}, {d}D, vector space {x}, {d} indexed code chunks / {d} sidecar bytes\n- remote query embedding: task plus fixed public vector-space calibration / {d} text bytes; remote retention: {s}\n- local vector storage: {s}; mmap={any}; ANN load {d} ns / search {d} ns\n", .{
+                    retrieval.model orelse semantic_mod.default_model,
+                    retrieval.dimensions orelse semantic_mod.default_dimensions,
+                    retrieval.ann_vector_space_id orelse 0,
+                    retrieval.ann_records,
+                    retrieval.ann_index_bytes,
+                    retrieval.text_bytes_sent,
+                    retrieval.remote_retention,
+                    retrieval.local_vector_storage,
+                    retrieval.ann_mmap_backed,
+                    retrieval.ann_load_ns,
+                    retrieval.ann_search_ns,
+                }) catch {};
+            } else if (std.mem.startsWith(u8, retrieval.semantic, "applied")) {
+                wh.print("- bounded exact advisory rerank: {s}, {d}D, {d} relative path + snippet items / {d} text bytes\n- remote retention: {s}; local vector storage: none\n", .{
+                    retrieval.model orelse semantic_mod.default_model,
+                    retrieval.dimensions orelse semantic_mod.default_dimensions,
+                    retrieval.documents_sent,
+                    retrieval.text_bytes_sent,
+                    retrieval.remote_retention,
+                }) catch {};
+            } else {
+                wh.print("- semantic lane: {s}; kept local result; no CPU embedding fallback\n", .{retrieval.semantic}) catch {};
+            }
+            if (retrieval.sensitive_paths_blocked > 0) {
+                wh.print("- sensitive candidate paths blocked before network: {d}\n", .{retrieval.sensitive_paths_blocked}) catch {};
+            }
+        }
     }
 
     if (sym_refs.items.len > 0) {
@@ -3816,7 +4166,12 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             file_items.append(A, .{
                 .path = file.path,
                 .relation = "ranked_candidate",
-                .reason = "lexical and symbol relevance",
+                .reason = if (std.mem.eql(u8, retrieval.semantic, "ann_applied"))
+                    "local lexical/symbol relevance fused with local OpenPuffer ANN"
+                else if (std.mem.startsWith(u8, retrieval.semantic, "applied"))
+                    "local lexical/symbol relevance with advisory semantic rerank"
+                else
+                    "local lexical and symbol relevance",
             }) catch {};
             for (file.top) |hit| {
                 site_items.append(A, .{
@@ -3824,7 +4179,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                     .line_start = if (hit.line > 2) hit.line - 2 else 1,
                     .line_end = hit.line +| 2,
                     .relation = "source_snippet",
-                    .reason = "top lexical site",
+                    .reason = if (hit.source == .semantic_ann) "local OpenPuffer ANN code-chunk match" else "top lexical site",
                 }) catch {};
             }
         }
@@ -3931,6 +4286,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
                 .declared_revision = reader_declared_revision,
                 .computed_revision = reader_computed_revision,
             },
+            .retrieval = retrieval,
             .sections = sections.items,
             .omissions = omissions.items,
             .budget = .{
@@ -5163,13 +5519,21 @@ pub fn runCliTool(
         defer task.deinit(alloc);
         var i = cmd_args_start;
         while (i < args.len) : (i += 1) {
-            if (i > cmd_args_start) task.append(alloc, ' ') catch {};
+            if (std.mem.eql(u8, args[i], "--semantic") or std.mem.eql(u8, args[i], "--hybrid")) {
+                m.put(alloc, "semantic", .{ .string = "hybrid" }) catch return 1;
+                continue;
+            }
+            if (std.mem.eql(u8, args[i], "--json")) {
+                m.put(alloc, "format", .{ .string = "json" }) catch return 1;
+                continue;
+            }
+            if (task.items.len > 0) task.append(alloc, ' ') catch {};
             task.appendSlice(alloc, args[i]) catch {};
         }
-        if (task.items.len == 0) return cliUsage(alloc, out, "context <task...>");
+        if (task.items.len == 0) return cliUsage(alloc, out, "context [--semantic] [--json] <task...>");
         m.put(alloc, "task", .{ .string = task.items }) catch return 1;
         loadProjectWordIndexFromDiskIfPresent(io, explorer, root, alloc);
-        handleContext(io, alloc, &m, out, explorer, root);
+        handleContext(io, alloc, &m, out, store, explorer, root);
         return finishCli(out, out_start);
     }
     return null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3485,8 +3485,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     // identifier candidates keep priority under CONTEXT_MAX_CANDIDATES).
     extractContextFallbackWords(task, A, &candidates);
     const pf_cand = cio.nanoTimestamp();
-    if (candidates.items.len == 0) {
-        if (semantic_requested) retrieval.semantic = "no_candidates";
+    if (candidates.items.len == 0 and !semantic_requested) {
         const message = "no candidate identifiers found in task — include symbol names (camelCase or snake_case) or \"quoted strings\" so the composer can extract keywords";
         if (structured) {
             var sections: [2]ContextProvenanceSection = undefined;
@@ -3651,7 +3650,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             use_exact_semantic_fallback = true;
             break :ann_lane;
         };
-        if (semantic_index_mod.search(
+        if (searchSemanticAnnFresh(
             io,
             A,
             explorer,

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -394,7 +394,7 @@ const ProjectCache = struct {
         default_store: *Store,
     ) !ProjectCtx {
         const p = path orelse return ProjectCtx{ .explorer = default_exp, .store = default_store, .snapshot_cache = &self.default_snapshot_cache, .deps_cache = &self.default_deps_cache };
-        if (!root_policy.isIndexableRoot(p) and !root_policy.isBootstrapableRoot(io, p))
+        if (!root_policy.isAdmissibleRoot(io, p))
             return error.PathNotAllowed;
 
         self.mu.lock();
@@ -417,29 +417,35 @@ const ProjectCache = struct {
             return error.OutOfMemory;
         };
         new_entry.explorer = Explorer.init(self.alloc, self.content_cache_capacity);
-        new_entry.explorer.setRoot(io, p);
+        new_entry.explorer.setRoot(io, p) catch |err| {
+            new_entry.explorer.deinit();
+            self.alloc.free(new_entry.path);
+            self.alloc.destroy(new_entry);
+            return err;
+        };
         new_entry.store = Store.init(self.alloc);
         new_entry.snapshot_cache = .{};
         new_entry.deps_cache = .{};
         new_entry.last_used = now;
 
-        var snap_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const snap_path = std.fmt.bufPrint(&snap_buf, "{s}/codedb.snapshot", .{p}) catch {
-            new_entry.store.deinit();
-            new_entry.explorer.deinit();
-            self.alloc.free(new_entry.path);
-            self.alloc.destroy(new_entry);
-            return error.PathTooLong;
-        };
-
-        if (!snapshot_mod.loadSnapshotValidated(io, snap_path, p, &new_entry.explorer, &new_entry.store, self.alloc)) {
+        const canonical_root = new_entry.explorer.root_path orelse p;
+        const stable_root = new_entry.explorer.root_dir orelse return error.PathNotAllowed;
+        if (!snapshot_mod.loadSnapshotValidatedFromRoot(io, stable_root, canonical_root, &new_entry.explorer, &new_entry.store, self.alloc)) {
             // Fallback: try central store at ~/.codedb/projects/{hash}/codedb.snapshot
-            const hash = std.hash.Wyhash.hash(0, p);
+            const hash = std.hash.Wyhash.hash(0, canonical_root);
             var central_buf: [std.fs.max_path_bytes]u8 = undefined;
             const loaded_central = blk: {
                 const home = cio.homeDir() orelse break :blk false;
-                const central = std.fmt.bufPrint(&central_buf, "{s}/.codedb/projects/{x}/codedb.snapshot", .{ home, hash }) catch break :blk false;
-                break :blk snapshot_mod.loadSnapshotValidated(io, central, p, &new_entry.explorer, &new_entry.store, self.alloc);
+                const central_dir_path = std.fmt.bufPrint(&central_buf, "{s}/.codedb/projects/{x}", .{ home, hash }) catch break :blk false;
+                var central_dir = std.Io.Dir.cwd().openDir(io, central_dir_path, .{ .follow_symlinks = false }) catch break :blk false;
+                defer central_dir.close(io);
+                const central_file = central_dir.openFile(io, "codedb.snapshot", .{
+                    .allow_directory = false,
+                    .follow_symlinks = false,
+                    .resolve_beneath = true,
+                }) catch break :blk false;
+                defer central_file.close(io);
+                break :blk snapshot_mod.loadSnapshotValidatedFromFile(io, central_file, canonical_root, &new_entry.explorer, &new_entry.store, self.alloc);
             };
             if (!loaded_central) {
                 new_entry.store.deinit();
@@ -1529,7 +1535,7 @@ fn parseRoots(io: std.Io, s: *Session, result: *const std.json.ObjectMap) void {
         const name_raw = mcpj.getStr(&obj, "name") orelse "";
         // Strip file:// prefix for policy check
         const path = if (std.mem.startsWith(u8, uri_raw, "file://")) uri_raw[7..] else uri_raw;
-        if (!root_policy.isIndexableRoot(path) and !root_policy.isBootstrapableRoot(io, path)) {
+        if (!root_policy.isAdmissibleRoot(io, path)) {
             std.log.info("codedb mcp: rejected root \"{s}\" (denied by policy)", .{uri_raw});
             continue;
         }
@@ -1836,7 +1842,7 @@ fn dispatch(
         .codedb_query => handleQuery(alloc, args, out, ctx.explorer, ctx.store),
         .codedb_glob => handleGlob(alloc, args, out, ctx.explorer),
         .codedb_ls => handleLs(alloc, args, out, ctx.explorer),
-        .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", project_path orelse cache.default_path, out),
+        .codedb_list_dir => mcp_list_dir.handle(io, alloc, getStr(args, "path") orelse ".", ctx.explorer, out),
         .codedb_context => handleContext(io, alloc, args, out, ctx.store, ctx.explorer, project_path orelse cache.default_path),
     }
     appendScanProgressHint(alloc, out, tool);
@@ -3318,6 +3324,18 @@ fn appendStructuredContext(alloc: std.mem.Allocator, out: *std.ArrayList(u8), va
 }
 
 fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), store: *Store, explorer: *Explorer, project_root: []const u8) void {
+    const stable_root = explorer.root_dir orelse {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    };
+    const rooted_project = explorer.root_path orelse {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    };
+    if (!project_file_read.rootMatchesPath(io, stable_root, project_root)) {
+        out.appendSlice(alloc, "error: project root capability mismatch") catch {};
+        return;
+    }
     const task = getStr(args, "task") orelse {
         out.appendSlice(alloc, "error: missing 'task' argument") catch {};
         appendBundleArgKeysDiagnostic(alloc, out, args);
@@ -3390,7 +3408,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
     var reader_declared_revision: ?[]const u8 = null;
     var reader_computed_revision: ?[]const u8 = null;
     if (reader_md_gate) {
-        var reader_state = reader_md.load(io, alloc, project_root) catch blk: {
+        var reader_state = reader_md.loadFromRoot(io, alloc, stable_root, rooted_project) catch blk: {
             reader_validation = "error";
             break :blk null;
         };
@@ -3595,7 +3613,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
 
     var use_exact_semantic_fallback = false;
     if (semantic_requested) ann_lane: {
-        const data_dir = getProjectDataDir(A, project_root) orelse {
+        const data_dir = getProjectDataDir(A, rooted_project) orelse {
             retrieval.semantic = "unavailable";
             retrieval.detail = "AnnDataDirUnavailable";
             use_exact_semantic_fallback = true;
@@ -3606,7 +3624,7 @@ fn handleContext(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Obj
             A,
             explorer,
             store,
-            project_root,
+            rooted_project,
             data_dir,
             task,
             semantic_index_mod.default_search_results,
@@ -4591,7 +4609,7 @@ fn handleRead(io: std.Io, alloc: std.mem.Allocator, args: *const std.json.Object
         return;
     };
     const root = root_buf[0..root_len];
-    if (!root_policy.isIndexableRoot(root)) {
+    if (!project_file_read.rootIsAllowed(io, read_root)) {
         out.appendSlice(alloc, "error: project root is not configured") catch {};
         return;
     }
@@ -5165,7 +5183,7 @@ fn handleIndex(
         return;
     };
     const abs_path = abs_buf[0..abs_len];
-    if (!root_policy.isIndexableRoot(abs_path) and !root_policy.isBootstrapableRoot(io, abs_path)) {
+    if (!root_policy.isAdmissibleRoot(io, abs_path)) {
         out.appendSlice(alloc, "error: refusing to index temporary root: ") catch {};
         out.appendSlice(alloc, abs_path) catch {};
         return;
@@ -5225,7 +5243,10 @@ fn handleIndex(
         default_store.currentSeq() == 0 and
         getScanState() == .loading_snapshot)
     {
-        default_explorer.setRoot(io, abs_path);
+        default_explorer.setRoot(io, abs_path) catch {
+            out.appendSlice(alloc, "error: indexed snapshot but project root is not safely readable") catch {};
+            return;
+        };
         if (snapshot_mod.loadSnapshotValidated(io, snapshot_path, abs_path, default_explorer, default_store, alloc)) {
             loadProjectTrigramFromDiskIfPresent(io, default_explorer, abs_path, alloc);
             if (default_explorer.outlines.count() > 1000) {
@@ -6939,7 +6960,7 @@ test "issue-258: cached project reads use the project root after contents are re
 
     var snapshot_src = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_src.deinit();
-    snapshot_src.setRoot(io, project_path);
+    try snapshot_src.setRoot(io, project_path);
     try snapshot_src.indexFile("src/main.zig", "const project = \"secondary\";\n");
 
     const snap_path = try std.fmt.allocPrint(testing.allocator, "{s}/codedb.snapshot", .{project_path});
@@ -7000,7 +7021,7 @@ test "ProjectCache loads project from central snapshot cache" {
 
     var snapshot_src = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_src.deinit();
-    snapshot_src.setRoot(io, project_path);
+    try snapshot_src.setRoot(io, project_path);
     try snapshot_src.indexFile("src/main.zig", "pub fn cachedProject() void {}\n");
     try snapshot_mod.writeProjectCacheSnapshot(io, &snapshot_src, project_path, testing.allocator);
 
@@ -7055,13 +7076,13 @@ test "issue-353: explicit default project loads snapshot when default explorer i
 
     var snapshot_src = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_src.deinit();
-    snapshot_src.setRoot(io, project_path);
+    try snapshot_src.setRoot(io, project_path);
     try snapshot_src.indexFile("src/main.zig", "pub fn issue353() void {}\n");
     try snapshot_mod.writeProjectCacheSnapshot(io, &snapshot_src, project_path, testing.allocator);
 
     var default_explorer = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer default_explorer.deinit();
-    default_explorer.setRoot(io, project_path);
+    try default_explorer.setRoot(io, project_path);
     var default_store = Store.init(testing.allocator);
     defer default_store.deinit();
 
@@ -7099,7 +7120,7 @@ test "issue-353: project cache invalidation reloads newly written snapshots" {
 
     var snapshot_src = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_src.deinit();
-    snapshot_src.setRoot(io, project_path);
+    try snapshot_src.setRoot(io, project_path);
     try tmp.dir.writeFile(io, .{
         .sub_path = "src/old.zig",
         .data = "pub fn oldSymbol() void {}\n",
@@ -7120,7 +7141,7 @@ test "issue-353: project cache invalidation reloads newly written snapshots" {
 
     var snapshot_next = Explorer.init(testing.allocator, explore_mod.Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer snapshot_next.deinit();
-    snapshot_next.setRoot(io, project_path);
+    try snapshot_next.setRoot(io, project_path);
     try tmp.dir.writeFile(io, .{
         .sub_path = "src/new.zig",
         .data = "pub fn newSymbol() void {}\n",

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1858,7 +1858,7 @@ fn appendScanProgressHint(alloc: std.mem.Allocator, out: *std.ArrayList(u8), too
 
 fn toolDependsOnScannedIndex(tool: Tool) bool {
     return switch (tool) {
-        .codedb_search, .codedb_word, .codedb_callers, .codedb_callpath, .codedb_explain, .codedb_outline, .codedb_symbol, .codedb_find, .codedb_glob, .codedb_tree, .codedb_ls, .codedb_deps => true,
+        .codedb_search, .codedb_word, .codedb_callers, .codedb_callpath, .codedb_explain, .codedb_outline, .codedb_symbol, .codedb_find, .codedb_glob, .codedb_tree, .codedb_ls, .codedb_deps, .codedb_context => true,
         else => false,
     };
 }

--- a/src/mcp_list_dir.zig
+++ b/src/mcp_list_dir.zig
@@ -3,15 +3,24 @@
 //! 17-line hook.
 const std = @import("std");
 const list_dir = @import("list_dir.zig");
+const Explorer = @import("explore.zig").Explorer;
 
 pub const tool_json =
     \\{"name":"codedb_list_dir","description":"Live BFS directory listing of the filesystem (not the index): honors .gitignore, 10k-character cap, collapsed subtree summaries. Use for any folder including unindexed trees; codedb_ls is indexed children of one directory.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Directory relative to project root. Omit for the project root."},"project":{"type":"string","description":"Optional absolute path to a different project"}},"required":[]}}
 ;
 
-pub fn handle(io: std.Io, alloc: std.mem.Allocator, path: []const u8, project_root: []const u8, out: *std.ArrayList(u8)) void {
+pub fn handle(io: std.Io, alloc: std.mem.Allocator, path: []const u8, explorer: *Explorer, out: *std.ArrayList(u8)) void {
+    const root_dir = explorer.root_dir orelse {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    };
+    const project_root = explorer.root_path orelse {
+        out.appendSlice(alloc, "error: project root is not configured") catch {};
+        return;
+    };
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
-    const text = list_dir.listUnder(io, arena_state.allocator(), project_root, path) catch |err| {
+    const text = list_dir.listUnderRoot(io, arena_state.allocator(), root_dir, project_root, path) catch |err| {
         out.appendSlice(alloc, list_dir.errorText(err)) catch {};
         return;
     };

--- a/src/out.zig
+++ b/src/out.zig
@@ -113,6 +113,7 @@ pub fn printUsage(out: *Out, s: sty.Style) void {
         \\    {s}context{s}  <task...>        task-shaped orientation bundle
         \\    {s}explain{s}  <name>           definition body + callers (alias: around)
         \\    {s}callpath{s} <from> <to>      shortest resolved call chain (alias: path)
+        \\    {s}semantic-index{s}            explicitly build the local code-chunk ANN sidecar
         \\    {s}serve{s}                     HTTP daemon on :6767
         \\    {s}mcp{s}                       JSON-RPC/MCP server over stdio
         \\    {s}update{s}                    self-update to the latest verified release
@@ -120,6 +121,7 @@ pub fn printUsage(out: *Out, s: sty.Style) void {
         \\    {s}codex{s}                     CodeDB-first Codex setup (install|uninstall|verify)
         \\
     , .{
+        s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,
         s.cyan, s.reset,

--- a/src/project_file.zig
+++ b/src/project_file.zig
@@ -1,0 +1,85 @@
+//! Race-resistant reads of project source files.
+//!
+//! File symlinks are deliberately unsupported throughout codedb: indexing,
+//! search fallbacks, and direct read surfaces must all observe the same view.
+//! Opening the final component with `follow_symlinks = false` closes the
+//! check/retarget/open race, while `resolve_beneath` keeps resolution anchored
+//! to the supplied project directory capability.
+const std = @import("std");
+const project_path = @import("project_path.zig");
+const root_policy = @import("root_policy.zig");
+
+pub const isAllowedPath = project_path.isReadable;
+
+pub fn rootIsAllowed(io: std.Io, dir: std.Io.Dir) bool {
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = dir.realPath(io, &root_buf) catch return false;
+    return root_policy.isIndexableRoot(root_buf[0..root_len]);
+}
+
+fn isWithinRoot(root: []const u8, candidate: []const u8) bool {
+    if (!std.mem.startsWith(u8, candidate, root)) return false;
+    if (candidate.len == root.len) return true;
+    return root.len > 0 and (std.fs.path.isSep(root[root.len - 1]) or std.fs.path.isSep(candidate[root.len]));
+}
+
+fn openValidated(
+    io: std.Io,
+    dir: std.Io.Dir,
+    path: []const u8,
+) !std.Io.File {
+    if (!isAllowedPath(path)) return error.AccessDenied;
+    var file = try dir.openFile(io, path, .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    errdefer file.close(io);
+
+    // Validate the object actually opened, not a pre-open realpath. The file
+    // handle cannot be retargeted underneath this check, so an allowed-looking
+    // directory alias such as `alias -> .ssh` cannot bypass the sensitive-path
+    // policy, while safe in-root directory aliases remain usable.
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try dir.realPath(io, &root_buf);
+    const root = root_buf[0..root_len];
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_len = try file.realPath(io, &target_buf);
+    const target = target_buf[0..target_len];
+    if (!isWithinRoot(root, target)) return error.AccessDenied;
+    var rel_start = root.len;
+    while (rel_start < target.len and std.fs.path.isSep(target[rel_start])) rel_start += 1;
+    if (rel_start == target.len) return error.AccessDenied;
+    var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const rel = target[rel_start..];
+    if (rel.len > normalized_buf.len) return error.NameTooLong;
+    for (rel, normalized_buf[0..rel.len]) |ch, *normalized| {
+        normalized.* = if (std.fs.path.isSep(ch)) '/' else ch;
+    }
+    if (!isAllowedPath(normalized_buf[0..rel.len])) return error.AccessDenied;
+
+    return file;
+}
+
+pub fn statNoFollow(io: std.Io, dir: std.Io.Dir, path: []const u8) !std.Io.File.Stat {
+    const file = try openValidated(io, dir, path);
+    defer file.close(io);
+    return file.stat(io);
+}
+
+pub fn readAllocNoFollow(
+    io: std.Io,
+    dir: std.Io.Dir,
+    path: []const u8,
+    allocator: std.mem.Allocator,
+    limit: std.Io.Limit,
+) ![]u8 {
+    const file = try openValidated(io, dir, path);
+    defer file.close(io);
+
+    var reader = file.reader(io, &.{});
+    return reader.interface.allocRemaining(allocator, limit) catch |err| switch (err) {
+        error.ReadFailed => return reader.err.?,
+        error.OutOfMemory, error.StreamTooLong => |e| return e,
+    };
+}

--- a/src/project_file.zig
+++ b/src/project_file.zig
@@ -14,7 +14,21 @@ pub const isAllowedPath = project_path.isReadable;
 pub fn rootIsAllowed(io: std.Io, dir: std.Io.Dir) bool {
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
     const root_len = dir.realPath(io, &root_buf) catch return false;
-    return root_policy.isIndexableRoot(root_buf[0..root_len]);
+    return root_policy.isAdmissibleRoot(io, root_buf[0..root_len]);
+}
+
+/// Compare a path-resolved directory object with an already-open project
+/// capability. The candidate handle is closed before return; callers must use
+/// the stable handle for subsequent I/O, never the path they just checked.
+pub fn rootMatchesPath(io: std.Io, stable: std.Io.Dir, path: []const u8) bool {
+    if (!root_policy.isAbsoluteRootRequest(path)) return false;
+    var candidate = std.Io.Dir.cwd().openDir(io, path, .{ .follow_symlinks = false }) catch return false;
+    defer candidate.close(io);
+    var stable_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const stable_len = stable.realPath(io, &stable_buf) catch return false;
+    var candidate_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const candidate_len = candidate.realPath(io, &candidate_buf) catch return false;
+    return std.mem.eql(u8, stable_buf[0..stable_len], candidate_buf[0..candidate_len]);
 }
 
 fn isWithinRoot(root: []const u8, candidate: []const u8) bool {
@@ -23,9 +37,10 @@ fn isWithinRoot(root: []const u8, candidate: []const u8) bool {
     return root.len > 0 and (std.fs.path.isSep(root[root.len - 1]) or std.fs.path.isSep(candidate[root.len]));
 }
 
-fn openValidated(
+fn openValidatedAtRoot(
     io: std.Io,
     dir: std.Io.Dir,
+    canonical_root: ?[]const u8,
     path: []const u8,
 ) !std.Io.File {
     if (!isAllowedPath(path)) return error.AccessDenied;
@@ -41,8 +56,10 @@ fn openValidated(
     // directory alias such as `alias -> .ssh` cannot bypass the sensitive-path
     // policy, while safe in-root directory aliases remain usable.
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = try dir.realPath(io, &root_buf);
-    const root = root_buf[0..root_len];
+    const root = canonical_root orelse blk: {
+        const root_len = try dir.realPath(io, &root_buf);
+        break :blk root_buf[0..root_len];
+    };
     var target_buf: [std.fs.max_path_bytes]u8 = undefined;
     const target_len = try file.realPath(io, &target_buf);
     const target = target_buf[0..target_len];
@@ -61,8 +78,18 @@ fn openValidated(
     return file;
 }
 
+fn openValidated(io: std.Io, dir: std.Io.Dir, path: []const u8) !std.Io.File {
+    return openValidatedAtRoot(io, dir, null, path);
+}
+
 pub fn statNoFollow(io: std.Io, dir: std.Io.Dir, path: []const u8) !std.Io.File.Stat {
     const file = try openValidated(io, dir, path);
+    defer file.close(io);
+    return file.stat(io);
+}
+
+pub fn statNoFollowAtRoot(io: std.Io, dir: std.Io.Dir, canonical_root: []const u8, path: []const u8) !std.Io.File.Stat {
+    const file = try openValidatedAtRoot(io, dir, canonical_root, path);
     defer file.close(io);
     return file.stat(io);
 }
@@ -75,6 +102,24 @@ pub fn readAllocNoFollow(
     limit: std.Io.Limit,
 ) ![]u8 {
     const file = try openValidated(io, dir, path);
+    defer file.close(io);
+
+    var reader = file.reader(io, &.{});
+    return reader.interface.allocRemaining(allocator, limit) catch |err| switch (err) {
+        error.ReadFailed => return reader.err.?,
+        error.OutOfMemory, error.StreamTooLong => |e| return e,
+    };
+}
+
+pub fn readAllocNoFollowAtRoot(
+    io: std.Io,
+    dir: std.Io.Dir,
+    canonical_root: []const u8,
+    path: []const u8,
+    allocator: std.mem.Allocator,
+    limit: std.Io.Limit,
+) ![]u8 {
+    const file = try openValidatedAtRoot(io, dir, canonical_root, path);
     defer file.close(io);
 
     var reader = file.reader(io, &.{});

--- a/src/project_path.zig
+++ b/src/project_path.zig
@@ -1,0 +1,65 @@
+//! Canonical policy for paths that may address repository source content.
+const std = @import("std");
+
+pub fn isNormalizedRelative(path: []const u8) bool {
+    if (path.len == 0 or path.len > 4096 or std.fs.path.isAbsolute(path)) return false;
+    if (std.mem.indexOfScalar(u8, path, 0) != null or
+        std.mem.indexOfScalar(u8, path, '\\') != null or
+        std.mem.indexOfScalar(u8, path, ':') != null) return false;
+
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (component.len == 0 or std.mem.eql(u8, component, ".") or std.mem.eql(u8, component, "..")) return false;
+    }
+    return true;
+}
+
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    if (value.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}
+
+fn hasSensitiveExtension(basename: []const u8) bool {
+    const extensions = [_][]const u8{ ".env", ".pem", ".key", ".p12", ".pfx", ".jks" };
+    for (extensions) |extension| {
+        if (endsWithIgnoreCase(basename, extension)) return true;
+    }
+    return false;
+}
+
+fn hasSensitiveDirectory(path: []const u8) bool {
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (std.ascii.eqlIgnoreCase(component, ".ssh") or
+            std.ascii.eqlIgnoreCase(component, ".gnupg") or
+            std.ascii.eqlIgnoreCase(component, ".aws")) return true;
+    }
+    return false;
+}
+
+pub fn isSensitive(path: []const u8) bool {
+    const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
+    if (basename.len == 0) return false;
+    const first = std.ascii.toLower(basename[0]);
+    if (first != '.' and first != 'c' and first != 's' and first != 'i') {
+        if (hasSensitiveExtension(basename)) return true;
+        return hasSensitiveDirectory(path);
+    }
+    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[0..4], ".env") and
+        (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
+    const sensitive_names = [_][]const u8{
+        ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
+        "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
+        "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
+        "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
+    };
+    for (sensitive_names) |name| {
+        if (std.ascii.eqlIgnoreCase(basename, name)) return true;
+    }
+    if (hasSensitiveExtension(basename)) return true;
+    return hasSensitiveDirectory(path);
+}
+
+pub fn isReadable(path: []const u8) bool {
+    return isNormalizedRelative(path) and !isSensitive(path);
+}

--- a/src/query.zig
+++ b/src/query.zig
@@ -348,14 +348,15 @@ pub fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
             });
             return 1;
         }
-        var root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
+        const root_dir = explorer.root_dir orelse {
             out.p("{s}\xe2\x9c\x97{s} cannot open project root: {s}{s}{s}\n", .{
                 s.red, s.reset, s.bold, root, s.reset,
             });
             return 1;
         };
-        defer root_dir.close(io);
-        _ = project_file.statNoFollow(io, root_dir, path) catch {
+        const canonical_root = explorer.root_path orelse return 1;
+        if (!project_file.rootMatchesPath(io, root_dir, root)) return 1;
+        _ = project_file.statNoFollowAtRoot(io, root_dir, canonical_root, path) catch {
             out.p("{s}\xe2\x9c\x97{s} file read not allowed: {s}{s}{s}\n", .{
                 s.red, s.reset, s.bold, path, s.reset,
             });
@@ -368,7 +369,7 @@ pub fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
         // from wherever the user happened to invoke it.
         const cached = explorer.getContent(path, allocator) catch null;
         const content_owned = if (cached) |c| c else blk: {
-            break :blk project_file.readAllocNoFollow(io, root_dir, path, allocator, .limited(10 * 1024 * 1024)) catch {
+            break :blk project_file.readAllocNoFollowAtRoot(io, root_dir, canonical_root, path, allocator, .limited(10 * 1024 * 1024)) catch {
                 out.p("{s}\xe2\x9c\x97{s} not indexed and disk read failed: {s}{s}{s}\n", .{
                     s.red, s.reset, s.bold, path, s.reset,
                 });

--- a/src/query.zig
+++ b/src/query.zig
@@ -18,6 +18,7 @@ const parseSearchArgs = cli_args.parseSearchArgs;
 const parseLineRange = cli_args.parseLineRange;
 const hasExtraCliArgs = cli_args.hasExtraCliArgs;
 const list_dir = @import("list_dir.zig");
+const project_file = @import("project_file.zig");
 
 /// Read-only query command dispatch, extracted from mainImpl so the same
 /// rendering code can run inside the warm daemon (writing to a socket)
@@ -347,6 +348,19 @@ pub fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
             });
             return 1;
         }
+        var root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
+            out.p("{s}\xe2\x9c\x97{s} cannot open project root: {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, root, s.reset,
+            });
+            return 1;
+        };
+        defer root_dir.close(io);
+        _ = project_file.statNoFollow(io, root_dir, path) catch {
+            out.p("{s}\xe2\x9c\x97{s} file read not allowed: {s}{s}{s}\n", .{
+                s.red, s.reset, s.bold, path, s.reset,
+            });
+            return 1;
+        };
         const t0 = cio.nanoTimestamp();
         // Prefer indexed content (matches the indexed view), fall back to disk
         // reads anchored at the resolved project root — NOT cwd. Pre-fix, an
@@ -354,14 +368,7 @@ pub fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
         // from wherever the user happened to invoke it.
         const cached = explorer.getContent(path, allocator) catch null;
         const content_owned = if (cached) |c| c else blk: {
-            var root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
-                out.p("{s}\xe2\x9c\x97{s} cannot open project root: {s}{s}{s}\n", .{
-                    s.red, s.reset, s.bold, root, s.reset,
-                });
-                return 1;
-            };
-            defer root_dir.close(io);
-            break :blk root_dir.readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch {
+            break :blk project_file.readAllocNoFollow(io, root_dir, path, allocator, .limited(10 * 1024 * 1024)) catch {
                 out.p("{s}\xe2\x9c\x97{s} not indexed and disk read failed: {s}{s}{s}\n", .{
                     s.red, s.reset, s.bold, path, s.reset,
                 });

--- a/src/reader_md.zig
+++ b/src/reader_md.zig
@@ -58,12 +58,18 @@ fn isWithinProject(root: []const u8, candidate: []const u8) bool {
 /// if the frontmatter can't be parsed, state=stale if the hash drifted, or
 /// state=ready (with body set) if everything checks out.
 pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) !Reader {
-    var root_dir = std.Io.Dir.cwd().openDir(io, project_root, .{}) catch {
+    var root_dir = std.Io.Dir.cwd().openDir(io, project_root, .{ .follow_symlinks = false }) catch {
         return .{ .state = .missing };
     };
     defer root_dir.close(io);
 
-    const raw = project_file.readAllocNoFollow(io, root_dir, ".codedb/reader.md", allocator, .limited(64 * 1024)) catch {
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = root_dir.realPathFile(io, ".", &root_buf) catch return .{ .state = .missing };
+    return loadFromRoot(io, allocator, root_dir, root_buf[0..root_len]);
+}
+
+pub fn loadFromRoot(io: std.Io, allocator: std.mem.Allocator, root_dir: std.Io.Dir, canonical_root: []const u8) !Reader {
+    const raw = project_file.readAllocNoFollowAtRoot(io, root_dir, canonical_root, ".codedb/reader.md", allocator, .limited(64 * 1024)) catch {
         return .{ .state = .missing };
     };
     errdefer allocator.free(raw);
@@ -159,18 +165,6 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) 
     // Resolve each source before reading it. Lexically relative paths can still
     // escape through symlinks, so require the canonical target to remain under
     // the canonical project root and read that checked path.
-    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root_len = root_dir.realPathFile(io, ".", &root_buf) catch {
-        return .{
-            .state = .stale,
-            .raw = raw,
-            .declared_hash = declared_hash_opt,
-            .body = body,
-            .source_files = stored_source_files,
-        };
-    };
-    const canonical_root = root_buf[0..root_len];
-
     // Compute blake2b(16) over: for each f, f.bytes ++ 0x00 ++ file_contents ++ 0x00 0x00
     var h = std.crypto.hash.blake2.Blake2b128.init(.{});
     for (stored_source_files) |rel| {
@@ -195,7 +189,7 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) 
                 .source_files = stored_source_files,
             };
         }
-        const data = project_file.readAllocNoFollow(io, root_dir, rel, allocator, .limited(8 * 1024 * 1024)) catch {
+        const data = project_file.readAllocNoFollowAtRoot(io, root_dir, canonical_root, rel, allocator, .limited(8 * 1024 * 1024)) catch {
             return .{
                 .state = .stale,
                 .raw = raw,

--- a/src/reader_md.zig
+++ b/src/reader_md.zig
@@ -13,6 +13,8 @@
 // blake2b over sorted source-file contents, no third-party deps.
 
 const std = @import("std");
+const project_file = @import("project_file.zig");
+const project_path = @import("project_path.zig");
 
 pub const State = enum { ready, stale, missing, malformed };
 
@@ -61,7 +63,7 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) 
     };
     defer root_dir.close(io);
 
-    const raw = root_dir.readFileAlloc(io, ".codedb/reader.md", allocator, .limited(64 * 1024)) catch {
+    const raw = project_file.readAllocNoFollow(io, root_dir, ".codedb/reader.md", allocator, .limited(64 * 1024)) catch {
         return .{ .state = .missing };
     };
     errdefer allocator.free(raw);
@@ -102,21 +104,10 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) 
             const after_dash = if (std.mem.startsWith(u8, trimmed, "  - ")) trimmed[4..] else trimmed[2..];
             const path = std.mem.trim(u8, after_dash, " \"'");
             if (path.len > 0) {
-                // P1 fix (review I01): reject absolute paths and `..` traversal
-                // so a hostile reader.md can't make codedb read /etc/passwd or
-                // escape the project root. Same posture as `mcp_server.isPathSafe`
-                // (mcp.zig:3725) — except we can't import it cleanly here, so
-                // inline the equivalent check.
-                if (std.fs.path.isAbsolute(path)) {
-                    return .{ .state = .malformed, .raw = raw, .declared_hash = declared_hash_opt };
-                }
-                if (std.mem.indexOf(u8, path, "..") != null) {
-                    // Be conservative: any `..` substring is suspicious. Bare
-                    // file/dir names like `re..fl` are vanishingly rare in code
-                    // and not worth the false-negative risk.
-                    return .{ .state = .malformed, .raw = raw, .declared_hash = declared_hash_opt };
-                }
-                if (std.mem.indexOfScalar(u8, path, 0) != null) {
+                // Use the same normalized-relative and sensitive-name policy
+                // as MCP/CLI/HTTP reads; hostile frontmatter cannot widen the
+                // repository content boundary.
+                if (!project_path.isReadable(path)) {
                     return .{ .state = .malformed, .raw = raw, .declared_hash = declared_hash_opt };
                 }
                 // P1 fix (review I02): cap source_files at 20 entries. A
@@ -204,7 +195,7 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, project_root: []const u8) 
                 .source_files = stored_source_files,
             };
         }
-        const data = std.Io.Dir.cwd().readFileAlloc(io, canonical_source, allocator, .limited(8 * 1024 * 1024)) catch {
+        const data = project_file.readAllocNoFollow(io, root_dir, rel, allocator, .limited(8 * 1024 * 1024)) catch {
             return .{
                 .state = .stale,
                 .raw = raw,
@@ -277,6 +268,43 @@ test "issue-688: source symlink outside project is malformed" {
     var reader = try load(std.testing.io, std.testing.allocator, root_buf[0..root_len]);
     defer reader.free(std.testing.allocator);
     try std.testing.expectEqual(State.malformed, reader.state);
+}
+
+test "reader file symlink is not followed" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "project/.codedb");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "outside-reader.md", .data = "---\nsource_hash: x\nsource_files:\n  - source.zig\n---\nSECRET_READER_BODY\n" });
+    var project_dir = try tmp.dir.openDir(std.testing.io, "project", .{});
+    defer project_dir.close(std.testing.io);
+    project_dir.symLink(std.testing.io, "../../outside-reader.md", ".codedb/reader.md", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try project_dir.realPathFile(std.testing.io, ".", &root_buf)];
+    var reader = try load(std.testing.io, std.testing.allocator, root);
+    defer reader.free(std.testing.allocator);
+    try std.testing.expectEqual(State.missing, reader.state);
+    try std.testing.expect(std.mem.indexOf(u8, reader.raw, "SECRET_READER_BODY") == null);
+}
+
+test "reader declared sensitive source is malformed without reading it" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, ".codedb");
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = ".env", .data = "DECLARED_SOURCE_SECRET\n" });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = ".codedb/reader.md",
+        .data = "---\nsource_hash: blake2b:00000000000000000000000000000000\nsource_files:\n  - .env\n---\nbody\n",
+    });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPathFile(std.testing.io, ".", &root_buf)];
+    var reader = try load(std.testing.io, std.testing.allocator, root);
+    defer reader.free(std.testing.allocator);
+    try std.testing.expectEqual(State.malformed, reader.state);
+    try std.testing.expect(reader.computed_hash == null);
 }
 
 test "blake2b: byte-for-byte parity with canonical Python algorithm" {

--- a/src/root_policy.zig
+++ b/src/root_policy.zig
@@ -27,6 +27,13 @@ pub fn tempIndexingAllowed() bool {
 }
 
 pub fn isIndexableRoot(path: []const u8) bool {
+    return isIndexableRootWithTempOpt(path, tempIndexingAllowed());
+}
+
+/// Pure policy entry point for tests and callers that have already resolved
+/// the explicit temp-root opt-in. Keeping environment reads outside the policy
+/// avoids process-global environment races between parallel Zig tests.
+pub fn isIndexableRootWithTempOpt(path: []const u8, allow_temp: bool) bool {
     if (path.len == 0) return false;
     if (std.mem.eql(u8, path, "/")) return false;
 
@@ -46,7 +53,7 @@ pub fn isIndexableRoot(path: []const u8) bool {
     // (footgun guard) but allowed when temp indexing is opted in (#538, #642)
     // — CI/SWE-bench harnesses clone into /tmp, and macOS TMPDIR resolves
     // under /private/var/folders.
-    if (!tempIndexingAllowed()) {
+    if (!allow_temp) {
         if (isExactOrChild(path, "/private/tmp")) return false;
         if (isExactOrChild(path, "/tmp")) return false;
         if (isExactOrChild(path, "/private/var")) return false;
@@ -232,21 +239,19 @@ test "issue-80: /tmp is denied" {
     try testing.expect(!isIndexableRoot("/tmp/foo"));
 }
 
-test "issue-642: /var is denied by default, indexable with CODEDB_ALLOW_TEMP" {
-    try testing.expect(!isIndexableRoot("/var/tmp"));
-    try testing.expect(!isIndexableRoot("/var/log"));
+test "issue-642: /var is denied by default, indexable with explicit temp opt-in" {
+    try testing.expect(!isIndexableRootWithTempOpt("/var/tmp", false));
+    try testing.expect(!isIndexableRootWithTempOpt("/var/log", false));
     // /var itself (no deeper path) is also denied
-    try testing.expect(!isIndexableRoot("/var"));
+    try testing.expect(!isIndexableRootWithTempOpt("/var", false));
     // ...but OSTree home projects under /var/home never need the opt-in (#642)
     try testing.expect(isIndexableRoot("/var/home/xavi/project"));
 
     // --allow-temp / CODEDB_ALLOW_TEMP=1 unblocks /var the same way it
     // unblocks /tmp (#538): macOS TMPDIR resolves under /private/var/folders
     // and CI workspaces live under /var/lib.
-    cio.posixSetenv("CODEDB_ALLOW_TEMP", "1");
-    defer cio.posixUnsetenv("CODEDB_ALLOW_TEMP");
-    try testing.expect(isIndexableRoot("/var/tmp"));
-    try testing.expect(isIndexableRoot("/private/var/folders/zz/scratch"));
+    try testing.expect(isIndexableRootWithTempOpt("/var/tmp", true));
+    try testing.expect(isIndexableRootWithTempOpt("/private/var/folders/zz/scratch", true));
     // The opt-in still never unblocks the bare OSTree home dir.
-    try testing.expect(!isIndexableRoot("/var/home/xavi"));
+    try testing.expect(!isIndexableRootWithTempOpt("/var/home/xavi", true));
 }

--- a/src/root_policy.zig
+++ b/src/root_policy.zig
@@ -6,10 +6,21 @@ pub fn isExactOrChild(path: []const u8, prefix: []const u8) bool {
     return path.len == prefix.len or path[prefix.len] == '/';
 }
 
+/// Reject Windows network roots and a whole drive before any open/stat call.
+/// This is deliberately syntax-only so tests and protocol admission behave
+/// identically when cross-compiled from a non-Windows host.
+pub fn isForbiddenWindowsRootSyntax(path: []const u8) bool {
+    if (std.mem.startsWith(u8, path, "\\\\") or std.mem.startsWith(u8, path, "//")) return true;
+    if (path.len < 2 or !std.ascii.isAlphabetic(path[0]) or path[1] != ':') return false;
+    if (path.len == 2) return true; // drive-relative `C:`
+    return path.len == 3 and (path[2] == '/' or path[2] == '\\'); // whole drive `C:\\`
+}
+
 /// Root requests are capabilities, not ambient paths.  Reject relative and
 /// dot-dot spellings before opening; callers may retain the canonical path
 /// reported by the resulting handle.
 pub fn isAbsoluteRootRequest(path: []const u8) bool {
+    if (isForbiddenWindowsRootSyntax(path)) return false;
     if (!std.fs.path.isAbsolute(path)) return false;
     var parts = std.mem.tokenizeAny(u8, path, "/\\");
     while (parts.next()) |part| {
@@ -36,6 +47,7 @@ pub fn isIndexableRoot(path: []const u8) bool {
 pub fn isIndexableRootWithTempOpt(path: []const u8, allow_temp: bool) bool {
     if (path.len == 0) return false;
     if (std.mem.eql(u8, path, "/")) return false;
+    if (isForbiddenWindowsRootSyntax(path)) return false;
 
     // OSTree distros (Fedora Silverblue/CoreOS/Nobara) bind-mount /home onto
     // /var/home, so /var/home/<user>/<project> is a real project path, not a
@@ -180,6 +192,20 @@ test "issue-80: normal paths are allowed" {
     try testing.expect(isIndexableRoot("/Users/dev/project"));
     try testing.expect(isIndexableRoot("/home/user/code"));
     try testing.expect(isIndexableRoot("/home/user/code/subdir"));
+}
+
+test "Windows UNC and whole-drive roots are rejected before filesystem access" {
+    try testing.expect(isForbiddenWindowsRootSyntax("\\\\server\\share\\repo"));
+    try testing.expect(isForbiddenWindowsRootSyntax("//server/share/repo"));
+    try testing.expect(isForbiddenWindowsRootSyntax("C:"));
+    try testing.expect(isForbiddenWindowsRootSyntax("C:\\"));
+    try testing.expect(isForbiddenWindowsRootSyntax("d:/"));
+    try testing.expect(!isForbiddenWindowsRootSyntax("C:\\repo"));
+    try testing.expect(!isForbiddenWindowsRootSyntax("d:/repo"));
+    try testing.expect(!isAbsoluteRootRequest("\\\\server\\share\\repo"));
+    try testing.expect(!isAbsoluteRootRequest("C:\\"));
+    try testing.expect(!isIndexableRootWithTempOpt("\\\\server\\share\\repo", true));
+    try testing.expect(!isIndexableRootWithTempOpt("C:\\", true));
 }
 
 test "isTempRoot classification" {

--- a/src/root_policy.zig
+++ b/src/root_policy.zig
@@ -5,6 +5,18 @@ pub fn isExactOrChild(path: []const u8, prefix: []const u8) bool {
     if (!std.mem.startsWith(u8, path, prefix)) return false;
     return path.len == prefix.len or path[prefix.len] == '/';
 }
+
+/// Root requests are capabilities, not ambient paths.  Reject relative and
+/// dot-dot spellings before opening; callers may retain the canonical path
+/// reported by the resulting handle.
+pub fn isAbsoluteRootRequest(path: []const u8) bool {
+    if (!std.fs.path.isAbsolute(path)) return false;
+    var parts = std.mem.tokenizeAny(u8, path, "/\\");
+    while (parts.next()) |part| {
+        if (std.mem.eql(u8, part, "..")) return false;
+    }
+    return true;
+}
 /// Temp-root indexing is an opt-in escape hatch for CI / SWE-bench harnesses
 /// that clone throwaway checkouts under /tmp. Off by default (footgun guard,
 /// #80/#346). Enabled by CODEDB_ALLOW_TEMP=1; the `--allow-temp` CLI flag sets
@@ -100,9 +112,9 @@ fn isBareTempDir(path: []const u8) bool {
 /// checkout rather than a scratch directory. `.git` may be a regular file
 /// (worktrees, submodules), so everything is probed with statFile.
 const project_markers = [_][]const u8{
-    ".git",           "pyproject.toml", "package.json", "Cargo.toml",
-    "go.mod",         "build.zig",      "setup.py",     "pom.xml",
-    "Gemfile",        "composer.json",  "build.gradle", "CMakeLists.txt",
+    ".git",    "pyproject.toml", "package.json", "Cargo.toml",
+    "go.mod",  "build.zig",      "setup.py",     "pom.xml",
+    "Gemfile", "composer.json",  "build.gradle", "CMakeLists.txt",
 };
 
 pub fn looksLikeProject(io: std.Io, path: []const u8) bool {
@@ -116,6 +128,16 @@ pub fn looksLikeProject(io: std.Io, path: []const u8) bool {
     return false;
 }
 
+/// Capability-relative project-marker probe.  Use this after opening a root
+/// so admission describes the directory object we actually hold, rather than
+/// a pathname that may be retargeted between validation and open.
+pub fn looksLikeProjectDir(io: std.Io, dir: std.Io.Dir) bool {
+    for (project_markers) |marker| {
+        if (dir.statFile(io, marker, .{ .follow_symlinks = false })) |_| return true else |_| {}
+    }
+    return false;
+}
+
 /// Out-of-the-box bootstrap exception: a temp root that recognizably holds a
 /// project checkout may be indexed on the fly without CODEDB_ALLOW_TEMP.
 /// Rationale: agent harnesses hard-fail once on a refused call and never
@@ -125,6 +147,24 @@ pub fn looksLikeProject(io: std.Io, path: []const u8) bool {
 pub fn isBootstrapableRoot(io: std.Io, path: []const u8) bool {
     if (isIndexableRoot(path)) return false;
     return isTempRoot(path) and !isBareTempDir(path) and looksLikeProject(io, path);
+}
+
+/// Canonical admission policy for a real project capability. Normal project
+/// roots are accepted directly; recognizable temp checkouts are accepted by
+/// the bootstrap exception. Callers must still possess/resolve the root — this
+/// does not authorize a cwd fallback when no project capability exists.
+pub fn isAdmissibleRoot(io: std.Io, path: []const u8) bool {
+    return isIndexableRoot(path) or isBootstrapableRoot(io, path);
+}
+
+/// Admission for an already-opened, canonical root capability.  This is the
+/// authoritative form used by Explorer.setRoot; it has no check-then-open
+/// window and temp-project markers are read through the stable handle.
+pub fn isAdmissibleRootDir(io: std.Io, dir: std.Io.Dir, canonical_path: []const u8) bool {
+    if (isIndexableRoot(canonical_path)) return true;
+    return isTempRoot(canonical_path) and
+        !isBareTempDir(canonical_path) and
+        looksLikeProjectDir(io, dir);
 }
 
 const testing = std.testing;
@@ -164,9 +204,11 @@ test "bootstrap: project markers enable temp-root indexing, scratch stays refuse
     try dir.writeFile(tio, .{ .sub_path = "package.json", .data = "{}\n" });
     try testing.expect(looksLikeProject(tio, base));
     try testing.expect(isBootstrapableRoot(tio, base));
+    try testing.expect(isAdmissibleRoot(tio, base));
 
     // Already-allowed roots are never "bootstrapable" (no fs probe needed).
     try testing.expect(!isBootstrapableRoot(tio, "/Users/dev/project"));
+    try testing.expect(isAdmissibleRoot(tio, "/Users/dev/project"));
     // Bare temp dirs stay refused even with the marker file present inside
     // the child we just created.
     try testing.expect(!isBootstrapableRoot(tio, "/tmp"));

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -394,9 +394,20 @@ pub fn cosineF32(a: []const f32, b: []const f32) !f32 {
         dot += x * y;
         norm_a += x * x;
         norm_b += y * y;
+        if (!std.math.isFinite(dot) or !std.math.isFinite(norm_a) or !std.math.isFinite(norm_b)) {
+            return error.InvalidEmbeddingNumber;
+        }
     }
     if (norm_a == 0 or norm_b == 0) return error.InvalidEmbeddingVector;
-    return @floatCast(@max(-1.0, @min(1.0, dot / @sqrt(norm_a * norm_b))));
+    const norm_product = norm_a * norm_b;
+    if (!std.math.isFinite(norm_product) or norm_product <= 0) return error.InvalidEmbeddingNumber;
+    const denominator = @sqrt(norm_product);
+    if (!std.math.isFinite(denominator) or denominator == 0) return error.InvalidEmbeddingNumber;
+    const raw = dot / denominator;
+    if (!std.math.isFinite(raw)) return error.InvalidEmbeddingNumber;
+    const narrowed: f32 = @floatCast(@max(-1.0, @min(1.0, raw)));
+    if (!std.math.isFinite(narrowed)) return error.InvalidEmbeddingNumber;
+    return narrowed;
 }
 
 /// Make one batched remote request. The returned scores use `allocator` and
@@ -534,7 +545,11 @@ fn vectorsFromProviderResponse(
         for (embedding_value.array.items, 0..) |value, i| {
             const number = try numberAsF64(value);
             if (!std.math.isFinite(number)) return error.InvalidEmbeddingNumber;
-            row[i] = @floatCast(number);
+            const narrowed: f32 = @floatCast(number);
+            // JSON numbers are parsed as f64. Values such as 1e100 are finite
+            // there but overflow to infinity in the f32 index representation.
+            if (!std.math.isFinite(narrowed)) return error.InvalidEmbeddingNumber;
+            row[i] = narrowed;
         }
     }
     return vectors;
@@ -552,10 +567,23 @@ fn cosine(a: []const std.json.Value, b: []const std.json.Value) !f32 {
         dot += x * y;
         norm_a += x * x;
         norm_b += y * y;
+        // Large-but-finite JSON scalars can overflow these f64 accumulators.
+        // Reject immediately rather than allowing NaN to be clamped into a
+        // plausible (and potentially perfect) retrieval score.
+        if (!std.math.isFinite(dot) or !std.math.isFinite(norm_a) or !std.math.isFinite(norm_b)) {
+            return error.InvalidEmbeddingNumber;
+        }
     }
     if (norm_a == 0 or norm_b == 0) return error.InvalidEmbeddingVector;
-    const raw = dot / @sqrt(norm_a * norm_b);
-    return @floatCast(@max(-1.0, @min(1.0, raw)));
+    const norm_product = norm_a * norm_b;
+    if (!std.math.isFinite(norm_product) or norm_product <= 0) return error.InvalidEmbeddingNumber;
+    const denominator = @sqrt(norm_product);
+    if (!std.math.isFinite(denominator) or denominator == 0) return error.InvalidEmbeddingNumber;
+    const raw = dot / denominator;
+    if (!std.math.isFinite(raw)) return error.InvalidEmbeddingNumber;
+    const narrowed: f32 = @floatCast(@max(-1.0, @min(1.0, raw)));
+    if (!std.math.isFinite(narrowed)) return error.InvalidEmbeddingNumber;
+    return narrowed;
 }
 
 /// Parse an OpenAI-compatible embeddings response and return cosine scores for

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -203,15 +203,34 @@ fn appendBoundedDocument(
     candidate: Candidate,
     remaining_batch_bytes: usize,
 ) ![]const u8 {
-    const path_cap = @min(candidate.path.len, 512);
+    const item_cap = @min(max_document_bytes, remaining_batch_bytes);
+    if (item_cap <= 1) return error.BatchTextLimit;
+    const path_cap = @min(candidate.path.len, @min(@as(usize, 512), item_cap - 1));
     const fixed = path_cap + 1;
-    if (remaining_batch_bytes <= fixed) return error.BatchTextLimit;
-    const text_cap = @min(candidate.text.len, @min(max_document_bytes, remaining_batch_bytes - fixed));
+    const text_cap = @min(candidate.text.len, item_cap - fixed);
     const start = out.items.len;
     try out.appendSlice(allocator, candidate.path[0..path_cap]);
     try out.append(allocator, '\n');
     try out.appendSlice(allocator, candidate.text[0..text_cap]);
     return out.items[start..];
+}
+
+test "semantic exact-fallback item cap includes path and separator" {
+    const testing = std.testing;
+    var long_path: [700]u8 = undefined;
+    @memset(&long_path, 'p');
+    var long_text: [max_document_bytes * 2]u8 = undefined;
+    @memset(&long_text, 'x');
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    const item = try appendBoundedDocument(
+        testing.allocator,
+        &out,
+        .{ .path = &long_path, .text = &long_text },
+        max_batch_text_bytes,
+    );
+    try testing.expectEqual(max_document_bytes, item.len);
+    try testing.expectEqual(@as(usize, 512), std.mem.indexOfScalar(u8, item, '\n').?);
 }
 
 const EmbeddingRequest = struct {

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -1,0 +1,658 @@
+//! Optional, privacy-bounded remote embeddings for codedb_context.
+//!
+//! The lexical/symbol pipeline always runs first. This module receives only
+//! the already-bounded candidate snippets selected by that local pipeline,
+//! sends them in one embedding batch, and returns advisory cosine scores.
+//! It never uploads a repository, writes vectors, or falls back to a local/CPU
+//! model. A network or provider failure is handled by the caller by keeping the
+//! local BM25 ordering.
+
+const std = @import("std");
+const cio = @import("cio.zig");
+const snapshot = @import("snapshot.zig");
+
+pub const default_url = "https://embeddings.wiki.codes/v1/codedb/embeddings";
+pub const default_model = "Qwen/Qwen3-Embedding-0.6B";
+pub const default_dimensions: u16 = 512;
+pub const default_timeout_ms: u32 = 15_000;
+pub const min_timeout_ms: u32 = 10;
+pub const max_timeout_ms: u32 = 120_000;
+pub const max_documents: usize = 24;
+// The free public codedb lane accepts at most 25 inputs per request. Indexing
+// may fill all 25 slots because, unlike query reranking, it does not prepend a
+// query vector to the batch.
+pub const max_index_documents: usize = 25;
+pub const max_document_bytes: usize = 2 * 1024;
+// Keep the serialized anonymous request below Caddy's 64 KiB raw-body cap even
+// when source punctuation/control bytes expand during JSON escaping.
+pub const max_batch_text_bytes: usize = 8 * 1024;
+pub const max_request_bytes: usize = 60 * 1024;
+pub const max_response_bytes: usize = 2 * 1024 * 1024;
+pub const max_index_batch_text_bytes: usize = 25 * 1024;
+pub const max_index_embedding_attempts: usize = 3;
+pub const index_embedding_retry_base_ms: u32 = 250;
+pub const default_rrf_k: f32 = 60;
+pub const default_semantic_weight: f32 = 0.05;
+pub const default_ann_semantic_weight: f32 = 1.0;
+pub const query_prefix_version = "qwen3-query-instruct-v1";
+pub const document_card_version = "codedb-code-chunk-v2";
+pub const calibration_text = "codedb vector-space calibration v1: deterministic code retrieval";
+pub const calibration_min_cosine: f32 = 0.9999;
+
+pub const Candidate = struct {
+    path: []const u8,
+    text: []const u8,
+};
+
+pub const Result = struct {
+    scores: []f32,
+    model: []const u8,
+    dimensions: u16,
+    documents_sent: usize,
+    text_bytes_sent: usize,
+    /// The hosted codedb endpoint is operated as transient inference with no
+    /// request-body/vector retention. Custom endpoints are deliberately marked
+    /// unverified: a local client cannot prove another operator's policy.
+    retention: enum { none_by_codedb_policy, custom_endpoint_unverified },
+};
+
+pub const EmbeddingBatchResult = struct {
+    /// Row-major `count * dimensions` f32 vectors.
+    vectors: []f32,
+    count: usize,
+    model: []const u8,
+    dimensions: u16,
+    text_bytes_sent: usize,
+    retention: enum { none_by_codedb_policy, custom_endpoint_unverified },
+};
+
+pub const Config = struct {
+    url: []const u8,
+    model: []const u8,
+    token: ?[]const u8,
+    dimensions: u16,
+    timeout_ms: u32,
+
+    pub fn fromEnv() Config {
+        const url = nonEmptyEnv("CODEDB_EMBEDDINGS_URL") orelse default_url;
+        const model = nonEmptyEnv("CODEDB_EMBEDDINGS_MODEL") orelse default_model;
+        const token = nonEmptyEnv("CODEDB_EMBEDDINGS_TOKEN");
+        const dimensions = if (nonEmptyEnv("CODEDB_EMBEDDINGS_DIMENSIONS")) |raw|
+            parseDimensions(raw) orelse 0
+        else
+            default_dimensions;
+        const timeout_ms = if (nonEmptyEnv("CODEDB_EMBEDDINGS_TIMEOUT_MS")) |raw|
+            parseTimeoutMs(raw) orelse 0
+        else
+            default_timeout_ms;
+        return .{
+            .url = url,
+            .model = model,
+            .token = token,
+            .dimensions = dimensions,
+            .timeout_ms = timeout_ms,
+        };
+    }
+
+    pub fn validate(self: Config) !void {
+        if (self.url.len > 2048 or self.model.len > 256) return error.InvalidEmbeddingConfig;
+        if (self.token) |token| if (token.len > 4096) return error.InvalidEmbeddingConfig;
+        if (self.dimensions < 64 or self.dimensions > 4096) return error.InvalidEmbeddingConfig;
+        if (self.timeout_ms < min_timeout_ms or self.timeout_ms > max_timeout_ms) return error.InvalidEmbeddingConfig;
+
+        const uri = std.Uri.parse(self.url) catch return error.InvalidEmbeddingConfig;
+        if (uri.user != null or uri.password != null or uri.fragment != null) return error.InvalidEmbeddingConfig;
+        var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
+        const host = (uri.getHost(&host_buf) catch return error.InvalidEmbeddingConfig).bytes;
+        if (host.len == 0) return error.InvalidEmbeddingConfig;
+        if (std.ascii.eqlIgnoreCase(uri.scheme, "https")) return;
+        if (std.ascii.eqlIgnoreCase(uri.scheme, "http") and
+            (std.ascii.eqlIgnoreCase(host, "localhost") or
+                std.mem.eql(u8, host, "127.0.0.1") or
+                std.mem.eql(u8, host, "[::1]"))) return;
+        return error.InsecureEmbeddingEndpoint;
+    }
+
+    pub fn isCodedbHosted(self: Config) bool {
+        const uri = std.Uri.parse(self.url) catch return false;
+        if (!std.ascii.eqlIgnoreCase(uri.scheme, "https") or uri.user != null or uri.password != null) return false;
+        var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
+        const host = (uri.getHost(&host_buf) catch return false).bytes;
+        return std.ascii.eqlIgnoreCase(host, "embeddings.wiki.codes");
+    }
+
+    /// Stable identity for all client-controlled parts of the vector space.
+    /// The stored calibration vector separately detects server-side weight or
+    /// quantization changes behind an otherwise identical endpoint/model.
+    pub fn vectorSpaceId(self: Config) u64 {
+        var hash = std.hash.Wyhash.init(0x4344_4256_5350_4143);
+        hash.update(self.url);
+        hash.update(&.{0});
+        hash.update(self.model);
+        hash.update(&.{0});
+        hash.update(std.mem.asBytes(&self.dimensions));
+        hash.update(query_prefix_version);
+        hash.update(&.{0});
+        hash.update(document_card_version);
+        return hash.final();
+    }
+};
+
+/// Final cloud-boundary guard. The watcher and snapshot loader already reject
+/// sensitive paths, but this check is deliberately repeated immediately before
+/// request construction so a stale, hand-built, or malformed in-memory index
+/// still cannot send `.env`, credential, private-key, traversal, or absolute
+/// paths to an embedding provider.
+pub fn isRemoteCandidatePathAllowed(path: []const u8) bool {
+    if (!snapshot.isSafeSnapshotPath(path)) return false;
+    const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
+    // The cloud boundary is intentionally stricter than the local indexer:
+    // block case variants, direnv files, and .envrc even on case-sensitive
+    // filesystems. Avoid broad `.env*` matching so `.envoy.json` and
+    // `.environment` remain ordinary source/config names.
+    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[0..4], ".env")) {
+        if (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_' or
+            std.ascii.eqlIgnoreCase(basename[4..], "rc")) return false;
+    }
+    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[basename.len - 4 ..], ".env")) return false;
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (std.ascii.eqlIgnoreCase(component, ".direnv")) return false;
+    }
+    return true;
+}
+
+fn nonEmptyEnv(name: []const u8) ?[]const u8 {
+    const value = cio.posixGetenv(name) orelse return null;
+    return if (value.len == 0) null else value;
+}
+
+fn parseDimensions(value: []const u8) ?u16 {
+    const parsed = std.fmt.parseInt(u16, value, 10) catch return null;
+    if (parsed < 64 or parsed > 4096) return null;
+    return parsed;
+}
+
+fn parseTimeoutMs(value: []const u8) ?u32 {
+    const parsed = std.fmt.parseInt(u32, value, 10) catch return null;
+    if (parsed < min_timeout_ms or parsed > max_timeout_ms) return null;
+    return parsed;
+}
+
+fn appendBoundedDocument(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    candidate: Candidate,
+    remaining_batch_bytes: usize,
+) ![]const u8 {
+    const path_cap = @min(candidate.path.len, 512);
+    const fixed = path_cap + 1;
+    if (remaining_batch_bytes <= fixed) return error.BatchTextLimit;
+    const text_cap = @min(candidate.text.len, @min(max_document_bytes, remaining_batch_bytes - fixed));
+    const start = out.items.len;
+    try out.appendSlice(allocator, candidate.path[0..path_cap]);
+    try out.append(allocator, '\n');
+    try out.appendSlice(allocator, candidate.text[0..text_cap]);
+    return out.items[start..];
+}
+
+const EmbeddingRequest = struct {
+    model: []const u8,
+    input: []const []const u8,
+    dimensions: u16,
+    encoding_format: []const u8 = "float",
+};
+
+fn fetchEmbeddingResponseOnce(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    config: Config,
+    body: []const u8,
+) ![]u8 {
+    if (body.len > max_request_bytes) return error.EmbeddingRequestTooLarge;
+    var headers: [2]std.http.Header = undefined;
+    var header_count: usize = 1;
+    headers[0] = .{ .name = "content-type", .value = "application/json" };
+    var auth_value: ?[]u8 = null;
+    defer if (auth_value) |value| allocator.free(value);
+    if (config.token) |token| {
+        const value = try std.fmt.allocPrint(allocator, "Bearer {s}", .{token});
+        auth_value = value;
+        headers[1] = .{ .name = "authorization", .value = value };
+        header_count = 2;
+    }
+
+    var client = std.http.Client{ .allocator = allocator, .io = io };
+    defer client.deinit();
+    const response_buffer = try allocator.alloc(u8, max_response_bytes);
+    defer allocator.free(response_buffer);
+    var response_writer = std.Io.Writer.fixed(response_buffer);
+    const fetch_result = try client.fetch(.{
+        .location = .{ .url = config.url },
+        .method = .POST,
+        .payload = body,
+        .extra_headers = headers[0..header_count],
+        .response_writer = &response_writer,
+    });
+    if (fetch_result.status != .ok) {
+        return switch (fetch_result.status) {
+            .too_many_requests => error.EmbeddingRateLimited,
+            .internal_server_error, .bad_gateway, .service_unavailable, .gateway_timeout => error.EmbeddingProviderUnavailable,
+            else => error.EmbeddingProviderRejected,
+        };
+    }
+    return try allocator.dupe(u8, response_writer.buffer[0..response_writer.end]);
+}
+
+fn waitForEmbeddingTimeout(io: std.Io, timeout_ms: u32) std.Io.Cancelable!void {
+    try io.sleep(.fromMilliseconds(timeout_ms), .awake);
+}
+
+const EmbeddingRace = union(enum) {
+    fetch: anyerror![]u8,
+    timeout: std.Io.Cancelable!void,
+};
+
+fn releaseRaceResult(allocator: std.mem.Allocator, result: EmbeddingRace) void {
+    switch (result) {
+        .fetch => |outcome| if (outcome) |response| allocator.free(response) else |_| {},
+        .timeout => {},
+    }
+}
+
+fn cancelAndDrainRace(allocator: std.mem.Allocator, select: *std.Io.Select(EmbeddingRace)) void {
+    while (select.cancel()) |result| releaseRaceResult(allocator, result);
+}
+
+fn fetchEmbeddingResponse(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    config: Config,
+    body: []const u8,
+) ![]u8 {
+    var completed: [2]EmbeddingRace = undefined;
+    var select = std.Io.Select(EmbeddingRace).init(io, &completed);
+    select.async(.fetch, fetchEmbeddingResponseOnce, .{ io, allocator, config, body });
+    select.async(.timeout, waitForEmbeddingTimeout, .{ io, config.timeout_ms });
+
+    const first = try select.await();
+    return switch (first) {
+        .fetch => |outcome| blk: {
+            // Cancel the timer. A second fetch result is impossible, but drain
+            // defensively so an allocated response can never be discarded.
+            cancelAndDrainRace(allocator, &select);
+            break :blk try outcome;
+        },
+        .timeout => |outcome| {
+            try outcome;
+            cancelAndDrainRace(allocator, &select);
+            return error.EmbeddingTimeout;
+        },
+    };
+}
+
+/// Embed an already-bounded batch. This is the primitive used by the local
+/// file-card ANN builder and query-only ANN lookup. It never writes vectors.
+pub fn embedRemoteTexts(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    inputs: []const []const u8,
+) !EmbeddingBatchResult {
+    const config = Config.fromEnv();
+    try config.validate();
+    if (inputs.len == 0 or inputs.len > max_index_documents) return error.InvalidEmbeddingBatch;
+    var text_bytes: usize = 0;
+    for (inputs) |input| {
+        if (input.len < 1 or input.len > max_document_bytes) return error.InvalidEmbeddingDocument;
+        text_bytes = std.math.add(usize, text_bytes, input.len) catch return error.EmbeddingRequestTooLarge;
+    }
+    if (text_bytes > max_index_batch_text_bytes) return error.EmbeddingRequestTooLarge;
+
+    const body = try std.json.Stringify.valueAlloc(allocator, EmbeddingRequest{
+        .model = config.model,
+        .input = inputs,
+        .dimensions = config.dimensions,
+    }, .{});
+    defer allocator.free(body);
+    const response = try fetchEmbeddingResponse(io, allocator, config, body);
+    defer allocator.free(response);
+    const vectors = try vectorsFromProviderResponse(allocator, response, inputs.len, config.dimensions, config.model);
+    return .{
+        .vectors = vectors,
+        .count = inputs.len,
+        .model = config.model,
+        .dimensions = config.dimensions,
+        .text_bytes_sent = text_bytes,
+        .retention = if (config.isCodedbHosted()) .none_by_codedb_policy else .custom_endpoint_unverified,
+    };
+}
+
+/// Index builds are explicit, long-running operations, so transient hosted
+/// lane pressure gets a small bounded retry budget. Interactive context calls
+/// intentionally use `embedRemoteTexts` directly and fail fast to lexical.
+pub fn embedIndexRemoteTexts(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    inputs: []const []const u8,
+) !EmbeddingBatchResult {
+    for (0..max_index_embedding_attempts) |attempt| {
+        return embedRemoteTexts(io, allocator, inputs) catch |err| {
+            const retryable = err == error.EmbeddingRateLimited or
+                err == error.EmbeddingProviderUnavailable or
+                err == error.EmbeddingTimeout;
+            if (!retryable or attempt + 1 == max_index_embedding_attempts) return err;
+            const delay_ms = index_embedding_retry_base_ms << @intCast(attempt);
+            io.sleep(.fromMilliseconds(delay_ms), .awake) catch {};
+            continue;
+        };
+    }
+    unreachable;
+}
+
+pub fn embedQueryRemote(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    task: []const u8,
+) !EmbeddingBatchResult {
+    if (task.len < 3 or task.len > 1024) return error.InvalidEmbeddingQuery;
+    const query = try std.fmt.allocPrint(
+        allocator,
+        "Instruct: Retrieve code relevant to the user request.\nQuery: {s}",
+        .{task},
+    );
+    defer allocator.free(query);
+    return embedRemoteTexts(io, allocator, &.{query});
+}
+
+/// Embed the private task and a fixed public canary in one bounded request.
+/// The canary vector is compared with the one stored at ANN build time, which
+/// detects server-side model/weight changes that reuse the same model string.
+pub fn embedQueryAndCalibrationRemote(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    task: []const u8,
+) !EmbeddingBatchResult {
+    if (task.len < 3 or task.len > 1024) return error.InvalidEmbeddingQuery;
+    const query = try std.fmt.allocPrint(
+        allocator,
+        "Instruct: Retrieve code relevant to the user request.\nQuery: {s}",
+        .{task},
+    );
+    defer allocator.free(query);
+    return embedRemoteTexts(io, allocator, &.{ query, calibration_text });
+}
+
+pub fn cosineF32(a: []const f32, b: []const f32) !f32 {
+    if (a.len == 0 or a.len != b.len) return error.InvalidEmbeddingDimensions;
+    var dot: f64 = 0;
+    var norm_a: f64 = 0;
+    var norm_b: f64 = 0;
+    for (a, b) |x32, y32| {
+        if (!std.math.isFinite(x32) or !std.math.isFinite(y32)) return error.InvalidEmbeddingNumber;
+        const x: f64 = x32;
+        const y: f64 = y32;
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    if (norm_a == 0 or norm_b == 0) return error.InvalidEmbeddingVector;
+    return @floatCast(@max(-1.0, @min(1.0, dot / @sqrt(norm_a * norm_b))));
+}
+
+/// Make one batched remote request. The returned scores use `allocator` and
+/// are aligned with `candidates[0..result.documents_sent]`.
+pub fn scoreRemote(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    task: []const u8,
+    candidates: []const Candidate,
+) !Result {
+    const config = Config.fromEnv();
+    try config.validate();
+    if (task.len < 3 or task.len > 1024) return error.InvalidEmbeddingQuery;
+    if (candidates.len == 0) return error.NoEmbeddingCandidates;
+
+    var text_storage: std.ArrayList(u8) = .empty;
+    defer text_storage.deinit(allocator);
+    // The ArrayList may move while documents are appended, so offsets are
+    // captured first and converted to slices only after the final append.
+    const offsets = try allocator.alloc(struct { start: usize, len: usize }, @min(candidates.len, max_documents));
+    defer allocator.free(offsets);
+
+    var text_bytes: usize = 0;
+    var actual_documents: usize = 0;
+    for (candidates) |candidate| {
+        if (actual_documents == max_documents) break;
+        if (!isRemoteCandidatePathAllowed(candidate.path)) continue;
+        if (text_bytes >= max_batch_text_bytes) break;
+        const start = text_storage.items.len;
+        _ = appendBoundedDocument(allocator, &text_storage, candidate, max_batch_text_bytes - text_bytes) catch |err| switch (err) {
+            error.BatchTextLimit => break,
+            else => return err,
+        };
+        const len = text_storage.items.len - start;
+        offsets[actual_documents] = .{ .start = start, .len = len };
+        text_bytes += len;
+        actual_documents += 1;
+    }
+    if (actual_documents == 0) return error.NoEmbeddingCandidates;
+
+    const instruction = "Instruct: Retrieve code relevant to the user request.\nQuery: ";
+    const query = try std.fmt.allocPrint(allocator, "{s}{s}", .{ instruction, task });
+    defer allocator.free(query);
+
+    const inputs = try allocator.alloc([]const u8, actual_documents + 1);
+    defer allocator.free(inputs);
+    inputs[0] = query;
+    for (offsets[0..actual_documents], 0..) |offset, i| {
+        inputs[i + 1] = text_storage.items[offset.start .. offset.start + offset.len];
+    }
+
+    const body = try std.json.Stringify.valueAlloc(allocator, EmbeddingRequest{
+        .model = config.model,
+        .input = inputs,
+        .dimensions = config.dimensions,
+    }, .{});
+    defer allocator.free(body);
+    if (body.len > max_request_bytes) return error.EmbeddingRequestTooLarge;
+
+    const response = try fetchEmbeddingResponse(io, allocator, config, body);
+    defer allocator.free(response);
+
+    const scores = try scoresFromProviderResponse(
+        allocator,
+        response,
+        actual_documents,
+        config.dimensions,
+        config.model,
+    );
+    return .{
+        .scores = scores,
+        .model = config.model,
+        .dimensions = config.dimensions,
+        .documents_sent = actual_documents,
+        .text_bytes_sent = text_bytes + query.len,
+        .retention = if (config.isCodedbHosted()) .none_by_codedb_policy else .custom_endpoint_unverified,
+    };
+}
+
+fn numberAsF64(value: std.json.Value) !f64 {
+    return switch (value) {
+        .float => |n| n,
+        .integer => |n| @floatFromInt(n),
+        else => error.InvalidEmbeddingNumber,
+    };
+}
+
+/// Parse an OpenAI-compatible response into a validated row-major f32 matrix.
+pub fn vectorsFromResponse(
+    allocator: std.mem.Allocator,
+    json_text: []const u8,
+    count: usize,
+    dimensions: u16,
+) ![]f32 {
+    return vectorsFromProviderResponse(allocator, json_text, count, dimensions, null);
+}
+
+fn validateProviderModel(root: std.json.Value, expected_model: ?[]const u8) !void {
+    const expected = expected_model orelse return;
+    if (root != .object) return error.InvalidEmbeddingResponse;
+    const model = root.object.get("model") orelse return error.InvalidEmbeddingModel;
+    if (model != .string or !std.mem.eql(u8, model.string, expected)) return error.EmbeddingModelMismatch;
+}
+
+fn vectorsFromProviderResponse(
+    allocator: std.mem.Allocator,
+    json_text: []const u8,
+    count: usize,
+    dimensions: u16,
+    expected_model: ?[]const u8,
+) ![]f32 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_text, .{});
+    defer parsed.deinit();
+    try validateProviderModel(parsed.value, expected_model);
+    if (parsed.value != .object) return error.InvalidEmbeddingResponse;
+    const data_value = parsed.value.object.get("data") orelse return error.InvalidEmbeddingResponse;
+    if (data_value != .array or data_value.array.items.len != count) return error.InvalidEmbeddingResponse;
+
+    const values_len = std.math.mul(usize, count, dimensions) catch return error.InvalidEmbeddingDimensions;
+    const vectors = try allocator.alloc(f32, values_len);
+    errdefer allocator.free(vectors);
+    const seen = try allocator.alloc(bool, count);
+    defer allocator.free(seen);
+    @memset(seen, false);
+    for (data_value.array.items) |item_value| {
+        if (item_value != .object) return error.InvalidEmbeddingResponse;
+        const index_value = item_value.object.get("index") orelse return error.InvalidEmbeddingResponse;
+        if (index_value != .integer or index_value.integer < 0) return error.InvalidEmbeddingResponse;
+        const index: usize = @intCast(index_value.integer);
+        if (index >= count or seen[index]) return error.InvalidEmbeddingResponse;
+        seen[index] = true;
+        const embedding_value = item_value.object.get("embedding") orelse return error.InvalidEmbeddingResponse;
+        if (embedding_value != .array or embedding_value.array.items.len != dimensions) return error.InvalidEmbeddingDimensions;
+        const row = vectors[index * dimensions ..][0..dimensions];
+        for (embedding_value.array.items, 0..) |value, i| {
+            const number = try numberAsF64(value);
+            if (!std.math.isFinite(number)) return error.InvalidEmbeddingNumber;
+            row[i] = @floatCast(number);
+        }
+    }
+    return vectors;
+}
+
+fn cosine(a: []const std.json.Value, b: []const std.json.Value) !f32 {
+    if (a.len == 0 or a.len != b.len) return error.InvalidEmbeddingDimensions;
+    var dot: f64 = 0;
+    var norm_a: f64 = 0;
+    var norm_b: f64 = 0;
+    for (a, b) |av, bv| {
+        const x = try numberAsF64(av);
+        const y = try numberAsF64(bv);
+        if (!std.math.isFinite(x) or !std.math.isFinite(y)) return error.InvalidEmbeddingNumber;
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    if (norm_a == 0 or norm_b == 0) return error.InvalidEmbeddingVector;
+    const raw = dot / @sqrt(norm_a * norm_b);
+    return @floatCast(@max(-1.0, @min(1.0, raw)));
+}
+
+/// Parse an OpenAI-compatible embeddings response and return cosine scores for
+/// document indices 1..N against query index 0. Items may arrive out of order.
+pub fn scoresFromResponse(
+    allocator: std.mem.Allocator,
+    json_text: []const u8,
+    document_count: usize,
+    dimensions: u16,
+) ![]f32 {
+    return scoresFromProviderResponse(allocator, json_text, document_count, dimensions, null);
+}
+
+fn scoresFromProviderResponse(
+    allocator: std.mem.Allocator,
+    json_text: []const u8,
+    document_count: usize,
+    dimensions: u16,
+    expected_model: ?[]const u8,
+) ![]f32 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_text, .{});
+    defer parsed.deinit();
+    try validateProviderModel(parsed.value, expected_model);
+    if (parsed.value != .object) return error.InvalidEmbeddingResponse;
+    const data_value = parsed.value.object.get("data") orelse return error.InvalidEmbeddingResponse;
+    if (data_value != .array or data_value.array.items.len != document_count + 1) return error.InvalidEmbeddingResponse;
+
+    const vectors = try allocator.alloc(?[]const std.json.Value, document_count + 1);
+    defer allocator.free(vectors);
+    @memset(vectors, null);
+    for (data_value.array.items) |item_value| {
+        if (item_value != .object) return error.InvalidEmbeddingResponse;
+        const index_value = item_value.object.get("index") orelse return error.InvalidEmbeddingResponse;
+        if (index_value != .integer or index_value.integer < 0) return error.InvalidEmbeddingResponse;
+        const index: usize = @intCast(index_value.integer);
+        if (index >= vectors.len or vectors[index] != null) return error.InvalidEmbeddingResponse;
+        const embedding_value = item_value.object.get("embedding") orelse return error.InvalidEmbeddingResponse;
+        if (embedding_value != .array or embedding_value.array.items.len != dimensions) return error.InvalidEmbeddingDimensions;
+        vectors[index] = embedding_value.array.items;
+    }
+    const query = vectors[0] orelse return error.InvalidEmbeddingResponse;
+    const scores = try allocator.alloc(f32, document_count);
+    errdefer allocator.free(scores);
+    for (scores, 0..) |*score, i| {
+        score.* = try cosine(query, vectors[i + 1] orelse return error.InvalidEmbeddingResponse);
+    }
+    return scores;
+}
+
+/// Lexical-authoritative reciprocal-rank fusion. The semantic vote is capped
+/// at 5% of the lexical vote: the top lexical result cannot be displaced by a
+/// lower candidate, while embeddings can still resolve weaker tail rankings.
+/// Exact definition files are kept in a separate leading group by the caller.
+pub fn advisoryRrfScore(lexical_rank: usize, semantic_rank: usize) f32 {
+    return advisoryRrfScoreWithPolicy(lexical_rank, semantic_rank, default_rrf_k, default_semantic_weight);
+}
+
+pub fn advisoryRrfScoreWithPolicy(lexical_rank: usize, semantic_rank: usize, rrf_k: f32, semantic_weight: f32) f32 {
+    const k = @max(1, rrf_k);
+    const weight = @max(0, @min(1, semantic_weight));
+    const lexical_vote = 1.0 / (k + @as(f32, @floatFromInt(lexical_rank + 1)));
+    const semantic_vote = weight / (k + @as(f32, @floatFromInt(semantic_rank + 1)));
+    return lexical_vote + semantic_vote;
+}
+
+pub fn annRrfScore(lexical_present: bool, lexical_rank: usize, semantic_present: bool, semantic_rank: usize) f32 {
+    const lexical_vote: f32 = if (lexical_present)
+        1.0 / (default_rrf_k + @as(f32, @floatFromInt(lexical_rank + 1)))
+    else
+        0;
+    const semantic_vote: f32 = if (semantic_present)
+        default_ann_semantic_weight / (default_rrf_k + @as(f32, @floatFromInt(semantic_rank + 1)))
+    else
+        0;
+    return lexical_vote + semantic_vote;
+}
+
+/// Conservative ANN ordering policy: the first three lexical results remain
+/// authoritative, then local ANN may reorder/extend the tail via RRF.
+pub fn annRankComesBefore(
+    a_lexical_present: bool,
+    a_lexical_rank: usize,
+    a_semantic_present: bool,
+    a_hybrid_score: f32,
+    a_path: []const u8,
+    b_lexical_present: bool,
+    b_lexical_rank: usize,
+    b_semantic_present: bool,
+    b_hybrid_score: f32,
+    b_path: []const u8,
+) bool {
+    const a_guard = a_lexical_present and a_lexical_rank < 3;
+    const b_guard = b_lexical_present and b_lexical_rank < 3;
+    if (a_guard != b_guard) return a_guard;
+    if (a_guard) return a_lexical_rank < b_lexical_rank;
+    if (a_hybrid_score != b_hybrid_score) return a_hybrid_score > b_hybrid_score;
+    if (a_semantic_present != b_semantic_present) return a_semantic_present;
+    if (a_lexical_rank != b_lexical_rank) return a_lexical_rank < b_lexical_rank;
+    return std.mem.lessThan(u8, a_path, b_path);
+}

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -103,7 +103,7 @@ pub const Config = struct {
         const uri = std.Uri.parse(self.url) catch return error.InvalidEmbeddingConfig;
         if (uri.user != null or uri.password != null or uri.fragment != null) return error.InvalidEmbeddingConfig;
         var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
-        const host = (uri.getHost(&host_buf) catch return error.InvalidEmbeddingConfig).bytes;
+        const host = uriHost(uri, &host_buf) catch return error.InvalidEmbeddingConfig;
         if (host.len == 0) return error.InvalidEmbeddingConfig;
         if (std.ascii.eqlIgnoreCase(uri.scheme, "https")) return;
         if (std.ascii.eqlIgnoreCase(uri.scheme, "http") and
@@ -117,7 +117,7 @@ pub const Config = struct {
         const uri = std.Uri.parse(self.url) catch return false;
         if (!std.ascii.eqlIgnoreCase(uri.scheme, "https") or uri.user != null or uri.password != null) return false;
         var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
-        const host = (uri.getHost(&host_buf) catch return false).bytes;
+        const host = uriHost(uri, &host_buf) catch return false;
         return std.ascii.eqlIgnoreCase(host, "embeddings.wiki.codes");
     }
 
@@ -137,6 +137,24 @@ pub const Config = struct {
         return hash.final();
     }
 };
+
+fn uriHost(uri: std.Uri, buffer: *[std.Io.net.HostName.max_len]u8) ![]const u8 {
+    const component = uri.host orelse return error.UriMissingHost;
+    const host = try component.toRaw(buffer);
+    if (host.len == 0) return error.InvalidHostName;
+
+    // HostName.fromUri deliberately accepts DNS names only on newer Zig
+    // toolchains, while URI hosts may also be bracketed IPv6 literals. Keep
+    // the authority validation strict without making loopback IPv6 unusable.
+    if (host[0] == '[') {
+        if (host.len < 3 or host[host.len - 1] != ']') return error.InvalidHostName;
+        _ = std.Io.net.Ip6Address.parse(host[1 .. host.len - 1], 0) catch
+            return error.InvalidHostName;
+    } else {
+        try std.Io.net.HostName.validate(host);
+    }
+    return host;
+}
 
 /// Final cloud-boundary guard. The watcher and snapshot loader already reject
 /// sensitive paths, but this check is deliberately repeated immediately before

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -81,6 +81,7 @@ pub const SearchOutput = struct {
     embed_ns: u64,
     search_ns: u64,
     mmap_backed: bool,
+    cache_hit: bool,
     vector_space_id: u64,
 };
 
@@ -123,6 +124,46 @@ const Loaded = struct {
         self.allocator.free(self.records);
         self.allocator.free(self.storage);
         self.* = undefined;
+    }
+};
+
+const FileIdentity = struct {
+    inode: std.Io.File.INode,
+    size: u64,
+    mtime_ns: i96,
+    ctime_ns: i96,
+
+    fn eql(a: FileIdentity, b: FileIdentity) bool {
+        return a.inode == b.inode and a.size == b.size and a.mtime_ns == b.mtime_ns and a.ctime_ns == b.ctime_ns;
+    }
+};
+
+const CachedLoaded = struct {
+    loaded: Loaded,
+    metadata_identity: FileIdentity,
+    slab_identity: FileIdentity,
+    store_seq: u64,
+};
+
+/// One validated immutable semantic sidecar generation per project. Warm
+/// searches take the shared lock, so concurrent users can embed and search in
+/// parallel. Replacement is transactional under the exclusive lock: a stale,
+/// malformed, or concurrently replaced sidecar never evicts the last valid
+/// generation and is never queried.
+pub const SearchCache = struct {
+    mu: cio.RwLock = .{},
+    allocator: std.mem.Allocator,
+    cached: ?CachedLoaded = null,
+
+    pub fn init(allocator: std.mem.Allocator) SearchCache {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *SearchCache) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        if (self.cached) |*cached| cached.loaded.deinit();
+        self.cached = null;
     }
 };
 
@@ -180,6 +221,19 @@ fn fileSize(io: std.Io, path: []const u8) !usize {
     defer file.close(io);
     const stat = try file.stat(io);
     return std.math.cast(usize, stat.size) orelse error.AnnSlabTooLarge;
+}
+
+fn fileIdentity(io: std.Io, path: []const u8) !FileIdentity {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .follow_symlinks = false });
+    defer file.close(io);
+    const stat = try file.stat(io);
+    if (stat.kind != .file) return error.InvalidAnnSidecar;
+    return .{
+        .inode = stat.inode,
+        .size = stat.size,
+        .mtime_ns = stat.mtime.nanoseconds,
+        .ctime_ns = stat.ctime.nanoseconds,
+    };
 }
 
 fn currentSlabName(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !?[]u8 {
@@ -852,35 +906,21 @@ fn validateRecordLineRanges(explorer: *Explorer, records: []const Record) !void 
     }
 }
 
-pub fn search(
-    io: std.Io,
-    allocator: std.mem.Allocator,
-    explorer: *Explorer,
-    store: *Store,
-    project_root: []const u8,
-    data_dir: []const u8,
-    task: []const u8,
-    k: usize,
-) !SearchOutput {
-    const config = semantic.Config.fromEnv();
-    try config.validate();
-    const load_started = cio.nanoTimestamp();
-    var loaded = try loadMetadata(io, allocator, data_dir);
-    defer loaded.deinit();
-
+fn validateLoadedConfig(config: *const semantic.Config, loaded: *const Loaded) !void {
     if (config.dimensions != loaded.dimensions) return error.AnnDimensionsMismatch;
     if (!std.mem.eql(u8, config.model, loaded.model)) return error.AnnModelMismatch;
     if (config.vectorSpaceId() != loaded.vector_space_id) return error.AnnVectorSpaceMismatch;
-    const current_head = try git_mod.getGitHead(project_root, allocator);
-    if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
-    if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
-    // Metadata is attacker-controlled local input. Validate the entire mapping
-    // while the index is still empty so a failure remains transactional and no
-    // forged line can reach rendering arithmetic.
-    try validateRecordLineRanges(explorer, loaded.records);
-    try loaded.loadGraph();
-    const load_ns = elapsedNs(load_started);
+}
 
+fn searchLoaded(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    loaded: *Loaded,
+    task: []const u8,
+    k: usize,
+    load_ns: u64,
+    cache_hit: bool,
+) !SearchOutput {
     const embed_started = cio.nanoTimestamp();
     const query = try semantic.embedQueryAndCalibrationRemote(io, allocator, task);
     defer allocator.free(query.vectors);
@@ -935,8 +975,153 @@ pub fn search(
         .embed_ns = embed_ns,
         .search_ns = search_ns,
         .mmap_backed = loaded.index.isMmapBacked(),
+        .cache_hit = cache_hit,
         .vector_space_id = loaded.vector_space_id,
     };
+}
+
+fn cachedGenerationCurrent(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cached: *const CachedLoaded,
+    config: *const semantic.Config,
+    store: *Store,
+    data_dir: []const u8,
+) !bool {
+    const metadata_path = try sidecarPath(allocator, data_dir);
+    defer allocator.free(metadata_path);
+    const metadata_identity = fileIdentity(io, metadata_path) catch return false;
+    if (!metadata_identity.eql(cached.metadata_identity)) return false;
+    const slab_identity = fileIdentity(io, cached.loaded.slab_path) catch return false;
+    if (!slab_identity.eql(cached.slab_identity)) return false;
+    try validateLoadedConfig(config, &cached.loaded);
+    // The cold/reload path validates Git HEAD, the exact repository content
+    // fingerprint, and every record range together. Warm reuse is then keyed
+    // by Store sequence: a checkout that changes indexed content advances the
+    // watcher sequence, while a commit-only HEAD update with identical content
+    // cannot invalidate the chunk mapping. This avoids a fork+exec on every
+    // query without weakening content freshness.
+    return store.currentSeq() == cached.store_seq;
+}
+
+fn loadValidatedGeneration(
+    io: std.Io,
+    persistent: std.mem.Allocator,
+    temporary: std.mem.Allocator,
+    config: *const semantic.Config,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+) !CachedLoaded {
+    const metadata_path = try sidecarPath(temporary, data_dir);
+    defer temporary.free(metadata_path);
+    const metadata_before = try fileIdentity(io, metadata_path);
+
+    var loaded = try loadMetadata(io, persistent, data_dir);
+    errdefer loaded.deinit();
+    try validateLoadedConfig(config, &loaded);
+    const head_before = try git_mod.getGitHead(project_root, temporary);
+    if (!headsEqual(head_before, loaded.git_head)) return error.StaleAnnGitHead;
+    const seq_before = store.currentSeq();
+    if (try repositoryFingerprint(explorer, store, temporary) != loaded.manifest) return error.StaleAnnManifest;
+    try validateRecordLineRanges(explorer, loaded.records);
+    if (store.currentSeq() != seq_before) return error.StaleAnnManifest;
+
+    const slab_before = try fileIdentity(io, loaded.slab_path);
+    try loaded.loadGraph();
+    const metadata_after = try fileIdentity(io, metadata_path);
+    const slab_after = try fileIdentity(io, loaded.slab_path);
+    if (!metadata_before.eql(metadata_after) or !slab_before.eql(slab_after)) return error.AnnSidecarChangedDuringLoad;
+    const head_after = try git_mod.getGitHead(project_root, temporary);
+    if (!headsEqual(head_before, head_after)) return error.StaleAnnGitHead;
+    const seq_after = store.currentSeq();
+    if (seq_after != seq_before) return error.StaleAnnManifest;
+
+    return .{
+        .loaded = loaded,
+        .metadata_identity = metadata_after,
+        .slab_identity = slab_after,
+        .store_seq = seq_after,
+    };
+}
+
+/// Reuse a fully validated mmap generation for warm MCP queries. The fast
+/// path still checks both sidecar file identities, repository sequence, model,
+/// dimensions, and vector-space identity before any remote query embedding is
+/// issued. Git HEAD, content fingerprint, and record ranges are revalidated
+/// transactionally whenever that warm identity changes.
+pub fn searchCached(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cache: *SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !SearchOutput {
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const load_started = cio.nanoTimestamp();
+
+    cache.mu.lockShared();
+    if (cache.cached) |*cached| {
+        const current = cachedGenerationCurrent(io, allocator, cached, &config, store, data_dir) catch |err| {
+            cache.mu.unlockShared();
+            return err;
+        };
+        if (current) {
+            defer cache.mu.unlockShared();
+            return searchLoaded(io, allocator, &cached.loaded, task, k, elapsedNs(load_started), true);
+        }
+    }
+    cache.mu.unlockShared();
+
+    cache.mu.lock();
+    defer cache.mu.unlock();
+    // Another concurrent cold request may have installed the generation while
+    // this request waited for the exclusive lock.
+    if (cache.cached) |*cached| {
+        if (try cachedGenerationCurrent(io, allocator, cached, &config, store, data_dir)) {
+            return searchLoaded(io, allocator, &cached.loaded, task, k, elapsedNs(load_started), true);
+        }
+    }
+
+    const replacement = try loadValidatedGeneration(io, cache.allocator, allocator, &config, explorer, store, project_root, data_dir);
+    if (cache.cached) |*old| old.loaded.deinit();
+    cache.cached = replacement;
+    return searchLoaded(io, allocator, &cache.cached.?.loaded, task, k, elapsedNs(load_started), false);
+}
+
+pub fn search(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !SearchOutput {
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const load_started = cio.nanoTimestamp();
+    var loaded = try loadMetadata(io, allocator, data_dir);
+    defer loaded.deinit();
+
+    try validateLoadedConfig(&config, &loaded);
+    const current_head = try git_mod.getGitHead(project_root, allocator);
+    if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
+    if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
+    // Metadata is attacker-controlled local input. Validate the entire mapping
+    // while the index is still empty so a failure remains transactional and no
+    // forged line can reach rendering arithmetic.
+    try validateRecordLineRanges(explorer, loaded.records);
+    try loaded.loadGraph();
+    const load_ns = elapsedNs(load_started);
+    return searchLoaded(io, allocator, &loaded, task, k, load_ns, false);
 }
 
 test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" {
@@ -1271,6 +1456,94 @@ test "semantic ANN rejects stale content before mmaping the graph" {
         error.StaleAnnManifest,
         search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find alpha implementation", 5),
     );
+}
+
+test "semantic ANN warm generation invalidates on repository sequence and sidecar identity" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    var source_file = try tmp.dir.createFile(io, "src/a.zig", .{});
+    const content = "pub fn alpha() void {}\n";
+    try source_file.writeStreamingAll(io, content);
+    source_file.close(io);
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.setRoot(io, dir_path);
+    try explorer.indexFile("src/a.zig", content);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = try store.recordSnapshot("src/a.zig", content.len, std.hash.Wyhash.hash(0, content));
+
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const calibration = try testing.allocator.alloc(f32, config.dimensions);
+    defer testing.allocator.free(calibration);
+    @memset(calibration, 0);
+    calibration[0] = 1;
+    var source = ann.Index.init(testing.allocator, config.dimensions, .{ .seed = 41 });
+    defer source.deinit();
+    _ = try source.insert(calibration);
+    const slab_name = "semantic-chunks-v3-ca-ce.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    try source.writeSlabs(slab_path);
+    const manifest = try repositoryFingerprint(&explorer, &store, testing.allocator);
+    const current_head = try git_mod.getGitHead(dir_path, testing.allocator);
+    _ = try writeMetadata(
+        io,
+        testing.allocator,
+        dir_path,
+        config.model,
+        config.dimensions,
+        manifest,
+        config.vectorSpaceId(),
+        calibration,
+        current_head,
+        slab_name,
+        &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }},
+    );
+
+    const cached = try loadValidatedGeneration(
+        io,
+        testing.allocator,
+        testing.allocator,
+        &config,
+        &explorer,
+        &store,
+        dir_path,
+        dir_path,
+    );
+    var cache = SearchCache.init(testing.allocator);
+    defer cache.deinit();
+    cache.cached = cached;
+    try testing.expect(try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+
+    // Even a content-equivalent Store update must force full freshness
+    // revalidation before this generation can be reused.
+    _ = try store.recordSnapshot("src/a.zig", content.len, std.hash.Wyhash.hash(0, content));
+    try testing.expect(!try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+
+    cache.cached.?.store_seq = store.currentSeq();
+    const metadata_path = try sidecarPath(testing.allocator, dir_path);
+    defer testing.allocator.free(metadata_path);
+    var metadata_file = try std.Io.Dir.cwd().openFile(io, metadata_path, .{ .mode = .read_write });
+    defer metadata_file.close(io);
+    try metadata_file.writePositionalAll(io, "X", 0);
+    try metadata_file.sync(io);
+    try testing.expect(!try cachedGenerationCurrent(io, testing.allocator, &cache.cached.?, &config, &store, dir_path));
+    try testing.expectError(
+        error.InvalidAnnSidecar,
+        searchCached(io, testing.allocator, &cache, &explorer, &store, dir_path, dir_path, "find alpha", 1),
+    );
+    // Failed replacement is transactional: the previously validated mapping
+    // remains owned and can be retired safely on cache destruction.
+    try testing.expect(cache.cached != null);
+    try testing.expect(cache.cached.?.loaded.index.isMmapBacked());
 }
 
 test "semantic build live fingerprint catches unreconciled repository edits" {

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -1,0 +1,1105 @@
+//! Persistent, local code-chunk ANN index for hybrid codedb retrieval.
+//!
+//! Building is explicit: `codedb <root> semantic-index`. Safe, bounded file
+//! chunks are embedded remotely in batches, while the vectors, HNSW graph, and
+//! record mapping are written only to codedb's per-project local data dir.
+//! Querying sends only the user's bounded query and searches OpenPuffer in
+//! process. A missing, stale, malformed, or incompatible sidecar is never an
+//! excuse for a CPU embedding fallback.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const cio = @import("cio.zig");
+const Explorer = @import("explore.zig").Explorer;
+const Store = @import("store.zig").Store;
+const ann = @import("ann.zig");
+const semantic = @import("semantic.zig");
+const git_mod = @import("git.zig");
+
+pub const sidecar_name = "semantic-chunks-v3.meta";
+pub const slab_file_prefix = "semantic-chunks-v3-";
+pub const slab_file_suffix = ".hmls";
+pub const max_chunk_card_bytes: usize = 1024;
+pub const chunk_source_bytes: usize = 832;
+pub const max_chunks_per_file: usize = 256;
+// Hosted-lane hill climb (256 chunks, 2026-08-26): c1=12.4s, c2=9.4s,
+// c4=6.1s, c8=16.7s. Four avoids queue/rate-limit contention while keeping
+// the explicit override available for differently provisioned endpoints.
+pub const default_parallel_batches: usize = 4;
+pub const max_parallel_batches: usize = 8;
+pub const default_search_results: usize = 24;
+pub const max_records: usize = 250_000;
+/// Metadata is copied into heap storage so record paths can borrow from one
+/// stable buffer. The HNSW payload itself is mmap-backed; keeping this cap well
+/// below the old 256 MiB limit prevents a crafted mapping table from recreating
+/// the 650-700 MiB query RSS profile that mmap is meant to avoid.
+pub const max_metadata_bytes: usize = 64 * 1024 * 1024;
+pub const max_slab_bytes: usize = 1024 * 1024 * 1024;
+
+const magic = [8]u8{ 'C', 'D', 'B', 'A', 'N', 'N', '0', '3' };
+const format_version: u16 = 3;
+const header_bytes: usize = 48;
+
+pub const BuildStats = struct {
+    records: usize,
+    files_indexed: usize,
+    dimensions: u16,
+    model: []const u8,
+    file_bytes: usize,
+    graph_bytes: usize,
+    metadata_bytes: usize,
+    vector_payload_bytes: usize,
+    text_bytes_sent: usize,
+    sensitive_paths_blocked: usize,
+    manifest: u64,
+    elapsed_ns: u64,
+    embedding_wall_ns: u64,
+    insertion_ns: u64,
+    parallel_batches: usize,
+    vector_space_id: u64,
+};
+
+pub const Hit = struct {
+    path: []const u8,
+    line_start: u32,
+    line_end: u32,
+    distance: f32,
+};
+
+pub const SearchOutput = struct {
+    hits: []Hit,
+    model: []const u8,
+    dimensions: u16,
+    records: usize,
+    index_bytes: usize,
+    text_bytes_sent: usize,
+    retention: enum { none_by_codedb_policy, custom_endpoint_unverified },
+    load_ns: u64,
+    embed_ns: u64,
+    search_ns: u64,
+    mmap_backed: bool,
+    vector_space_id: u64,
+};
+
+const Record = struct {
+    path: []const u8,
+    line_start: u32,
+    line_end: u32,
+};
+
+const Loaded = struct {
+    allocator: std.mem.Allocator,
+    storage: []u8,
+    records: []Record,
+    slab_path: []u8,
+    slab_bytes: usize,
+    model: []const u8,
+    dimensions: u16,
+    manifest: u64,
+    vector_space_id: u64,
+    calibration: []f32,
+    git_head: ?[40]u8,
+    index: ann.Index,
+
+    fn loadGraph(self: *Loaded) !void {
+        if (self.index.len() != 0 or self.index.isMmapBacked()) return error.AnnRecordMappingMismatch;
+        self.index.loadMmap(self.slab_path) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidAnnSidecar,
+        };
+        if (!self.index.isMmapBacked() or self.index.len() != self.records.len) return error.AnnRecordMappingMismatch;
+    }
+
+    fn deinit(self: *Loaded) void {
+        self.index.deinit();
+        self.allocator.free(self.calibration);
+        self.allocator.free(self.slab_path);
+        self.allocator.free(self.records);
+        self.allocator.free(self.storage);
+        self.* = undefined;
+    }
+};
+
+fn elapsedNs(since: i128) u64 {
+    const now = cio.nanoTimestamp();
+    return if (now > since) @intCast(now - since) else 0;
+}
+
+fn sidecarPath(allocator: std.mem.Allocator, data_dir: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ data_dir, sidecar_name });
+}
+
+fn privateFilePermissions() std.Io.File.Permissions {
+    if (comptime builtin.os.tag == .windows) return .default_file;
+    return .fromMode(0o600);
+}
+
+fn privateDirPermissions() std.Io.File.Permissions {
+    if (comptime builtin.os.tag == .windows) return .default_dir;
+    return .fromMode(0o700);
+}
+
+fn secureDataDir(io: std.Io, data_dir: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(io, data_dir);
+    var dir = try std.Io.Dir.cwd().openDir(io, data_dir, .{ .iterate = true });
+    defer dir.close(io);
+    try dir.setPermissions(io, privateDirPermissions());
+}
+
+fn syncDataDir(io: std.Io, data_dir: []const u8) !void {
+    if (comptime builtin.os.tag == .windows) return;
+    var dir = try std.Io.Dir.cwd().openDir(io, data_dir, .{});
+    defer dir.close(io);
+    switch (std.posix.errno(std.posix.system.fsync(dir.handle))) {
+        .SUCCESS => {},
+        else => return error.AnnDirectorySyncFailed,
+    }
+}
+
+fn isValidSlabName(name: []const u8) bool {
+    if (!std.mem.startsWith(u8, name, slab_file_prefix) or !std.mem.endsWith(u8, name, slab_file_suffix)) return false;
+    const middle = name[slab_file_prefix.len .. name.len - slab_file_suffix.len];
+    if (middle.len == 0 or middle.len > 80) return false;
+    for (middle) |byte| if (!std.ascii.isHex(byte) and byte != '-') return false;
+    return true;
+}
+
+fn slabPath(allocator: std.mem.Allocator, data_dir: []const u8, slab_name: []const u8) ![]u8 {
+    if (!isValidSlabName(slab_name)) return error.InvalidAnnSlabName;
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ data_dir, slab_name });
+}
+
+fn fileSize(io: std.Io, path: []const u8) !usize {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    return std.math.cast(usize, stat.size) orelse error.AnnSlabTooLarge;
+}
+
+fn currentSlabName(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !?[]u8 {
+    const path = try sidecarPath(allocator, data_dir);
+    defer allocator.free(path);
+    const storage = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_metadata_bytes)) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer allocator.free(storage);
+    if (storage.len < header_bytes or !std.mem.eql(u8, storage[0..8], &magic)) return error.InvalidAnnSidecar;
+    if (std.mem.readInt(u16, storage[8..10], .little) != format_version) return error.UnsupportedAnnSidecarVersion;
+    const model_len: usize = std.mem.readInt(u16, storage[32..34], .little);
+    const slab_name_len: usize = std.mem.readInt(u16, storage[34..36], .little);
+    const slab_start = std.math.add(usize, header_bytes, model_len) catch return error.InvalidAnnSidecar;
+    if (slab_name_len == 0 or slab_start > storage.len or slab_name_len > storage.len - slab_start) return error.TruncatedAnnSidecar;
+    const name = storage[slab_start .. slab_start + slab_name_len];
+    if (!isValidSlabName(name)) return error.InvalidAnnSlabName;
+    return try allocator.dupe(u8, name);
+}
+
+fn deleteReplacedSlab(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    data_dir: []const u8,
+    previous_name: ?[]const u8,
+    current_name: []const u8,
+) void {
+    const name = previous_name orelse return;
+    if (std.mem.eql(u8, name, current_name)) return;
+    const path = slabPath(allocator, data_dir, name) catch return;
+    defer allocator.free(path);
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+}
+
+fn updateScalar(hasher: *std.hash.Wyhash, value: anytype) void {
+    hasher.update(std.mem.asBytes(&value));
+}
+
+/// Stable, cheap advisory freshness signature. This intentionally hashes the
+/// parsed repository shape rather than every source byte so context queries do
+/// not turn into a full-repository read. Git HEAD is checked independently.
+pub fn manifestFingerprint(explorer: *Explorer, allocator: std.mem.Allocator) !u64 {
+    explorer.mu.lockShared();
+    defer explorer.mu.unlockShared();
+
+    var paths: std.ArrayList([]const u8) = .empty;
+    defer paths.deinit(allocator);
+    try paths.ensureTotalCapacity(allocator, explorer.outlines.count());
+    var it = explorer.outlines.keyIterator();
+    while (it.next()) |path| paths.appendAssumeCapacity(path.*);
+    std.mem.sort([]const u8, paths.items, {}, struct {
+        fn lt(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.order(u8, a, b) == .lt;
+        }
+    }.lt);
+
+    var hash = std.hash.Wyhash.init(0x4344_4241_4e4e_3031);
+    for (paths.items) |path| {
+        const outline = explorer.outlines.get(path) orelse continue;
+        hash.update(path);
+        hash.update(&.{0});
+        updateScalar(&hash, @intFromEnum(outline.language));
+        updateScalar(&hash, outline.line_count);
+        updateScalar(&hash, outline.byte_size);
+        for (outline.symbols.items) |symbol| {
+            updateScalar(&hash, @intFromEnum(symbol.kind));
+            updateScalar(&hash, symbol.line_start);
+            updateScalar(&hash, symbol.line_end);
+            hash.update(symbol.name);
+            hash.update(&.{0});
+        }
+    }
+    return hash.final();
+}
+
+fn repositoryFingerprint(explorer: *Explorer, store: *Store, allocator: std.mem.Allocator) !u64 {
+    const shape = try manifestFingerprint(explorer, allocator);
+    const content = try store.contentFingerprint(allocator);
+    var hash = std.hash.Wyhash.init(0x4344_4252_4550_4f33);
+    hash.update(std.mem.asBytes(&shape));
+    hash.update(std.mem.asBytes(&content));
+    return hash.final();
+}
+
+fn cloneSortedPaths(explorer: *Explorer, allocator: std.mem.Allocator) ![][]u8 {
+    explorer.mu.lockShared();
+    defer explorer.mu.unlockShared();
+    const paths = try allocator.alloc([]u8, explorer.outlines.count());
+    errdefer allocator.free(paths);
+    var filled: usize = 0;
+    errdefer for (paths[0..filled]) |path| allocator.free(path);
+    var it = explorer.outlines.keyIterator();
+    while (it.next()) |path| {
+        paths[filled] = try allocator.dupe(u8, path.*);
+        filled += 1;
+    }
+    std.mem.sort([]u8, paths, {}, struct {
+        fn lt(_: void, a: []u8, b: []u8) bool {
+            return std.mem.order(u8, a, b) == .lt;
+        }
+    }.lt);
+    return paths;
+}
+
+fn appendAsciiPreview(out: *std.ArrayList(u8), allocator: std.mem.Allocator, bytes: []const u8, limit: usize) !void {
+    const remaining = limit -| out.items.len;
+    for (bytes[0..@min(bytes.len, remaining)]) |byte| {
+        const safe = if (byte == '\n' or byte == '\t' or (byte >= 0x20 and byte < 0x7f)) byte else ' ';
+        try out.append(allocator, safe);
+    }
+}
+
+const Chunk = struct {
+    source: []const u8,
+    line_start: u32,
+    line_end: u32,
+};
+
+const ChunkCursor = struct {
+    content: []const u8,
+    offset: usize = 0,
+    line: u32 = 1,
+
+    fn next(self: *ChunkCursor) ?Chunk {
+        if (self.offset >= self.content.len) return null;
+        const start = self.offset;
+        const line_start = self.line;
+        var end = @min(start + chunk_source_bytes, self.content.len);
+        if (end < self.content.len) {
+            if (std.mem.lastIndexOfScalar(u8, self.content[start..end], '\n')) |relative| {
+                const line_end_offset = start + relative + 1;
+                if (line_end_offset > start + chunk_source_bytes / 3) end = line_end_offset;
+            }
+        }
+        if (end <= start) end = @min(start + 1, self.content.len);
+        const source = self.content[start..end];
+        var newlines: u32 = 0;
+        for (source) |byte| if (byte == '\n') {
+            newlines +|= 1;
+        };
+        const trailing_newline: u32 = if (source.len > 0 and source[source.len - 1] == '\n') 1 else 0;
+        const line_end = line_start +| newlines -| trailing_newline;
+        self.offset = end;
+        self.line +|= newlines;
+        return .{ .source = source, .line_start = line_start, .line_end = @max(line_start, line_end) };
+    }
+};
+
+fn makeChunkCard(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    language: []const u8,
+    chunk: Chunk,
+) ![]u8 {
+    var card: std.ArrayList(u8) = .empty;
+    errdefer card.deinit(allocator);
+    const writer = cio.listWriter(&card, allocator);
+    writer.print("Code snippet\nPath: {s}\nLanguage: {s}\nLines: {d}-{d}\n", .{
+        path,
+        language,
+        chunk.line_start,
+        chunk.line_end,
+    }) catch return error.OutOfMemory;
+    try appendAsciiPreview(&card, allocator, chunk.source, max_chunk_card_bytes);
+    if (card.items.len > max_chunk_card_bytes) card.items.len = max_chunk_card_bytes;
+    return try card.toOwnedSlice(allocator);
+}
+
+const FlushStats = struct {
+    text_bytes: usize,
+    records: usize,
+    embedding_wall_ns: u64,
+    insertion_ns: u64,
+};
+
+const BatchWorker = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    inputs: []const []const u8,
+    result: ?semantic.EmbeddingBatchResult = null,
+    failure: ?anyerror = null,
+
+    fn run(self: *BatchWorker) void {
+        self.result = semantic.embedIndexRemoteTexts(self.io, self.allocator, self.inputs) catch |err| {
+            self.failure = err;
+            return;
+        };
+    }
+};
+
+fn indexConcurrency() usize {
+    const raw = cio.posixGetenv("CODEDB_SEMANTIC_INDEX_CONCURRENCY") orelse return default_parallel_batches;
+    return @max(1, @min(max_parallel_batches, std.fmt.parseInt(usize, raw, 10) catch default_parallel_batches));
+}
+
+fn embeddingBatchCount(card_count: usize) usize {
+    return (card_count + semantic.max_index_documents - 1) / semantic.max_index_documents;
+}
+
+fn flushWave(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    index: *ann.Index,
+    config: semantic.Config,
+    cards: *std.ArrayList([]u8),
+    pending_records: *std.ArrayList(Record),
+    indexed_records: *std.ArrayList(Record),
+) !FlushStats {
+    if (cards.items.len == 0) return .{
+        .text_bytes = 0,
+        .records = 0,
+        .embedding_wall_ns = 0,
+        .insertion_ns = 0,
+    };
+    if (cards.items.len != pending_records.items.len) return error.AnnRecordMappingMismatch;
+    const batch_count = embeddingBatchCount(cards.items.len);
+    if (batch_count > max_parallel_batches) return error.TooManyEmbeddingBatches;
+    var input_storage: [max_parallel_batches][semantic.max_index_documents][]const u8 = undefined;
+    var workers: [max_parallel_batches]BatchWorker = undefined;
+    var threads: [max_parallel_batches]?std.Thread = @splat(null);
+    const embedding_started = cio.nanoTimestamp();
+    for (0..batch_count) |batch_index| {
+        const start = batch_index * semantic.max_index_documents;
+        const end = @min(cards.items.len, start + semantic.max_index_documents);
+        for (cards.items[start..end], 0..) |card, i| input_storage[batch_index][i] = card;
+        workers[batch_index] = .{
+            .io = io,
+            // Each request runs on its own OS thread. c_allocator is safe for
+            // concurrent allocations; callers may supply a non-thread-safe
+            // arena/GPA for the surrounding build state.
+            .allocator = std.heap.c_allocator,
+            .inputs = input_storage[batch_index][0 .. end - start],
+        };
+        threads[batch_index] = std.Thread.spawn(.{}, BatchWorker.run, .{&workers[batch_index]}) catch null;
+        if (threads[batch_index] == null) workers[batch_index].run();
+    }
+    for (threads[0..batch_count]) |maybe_thread| if (maybe_thread) |thread| thread.join();
+    const embedding_wall_ns = elapsedNs(embedding_started);
+    defer for (workers[0..batch_count]) |worker| if (worker.result) |embedded| worker.allocator.free(embedded.vectors);
+    for (workers[0..batch_count]) |worker| if (worker.failure) |err| return err;
+
+    var text_bytes: usize = 0;
+    const insertion_started = cio.nanoTimestamp();
+    for (workers[0..batch_count], 0..) |worker, batch_index| {
+        const embedded = worker.result orelse return error.MissingEmbeddingBatchResult;
+        if (embedded.dimensions != config.dimensions or !std.mem.eql(u8, embedded.model, config.model)) {
+            return error.EmbeddingConfigChangedDuringBuild;
+        }
+        text_bytes = try std.math.add(usize, text_bytes, embedded.text_bytes_sent);
+        const record_start = batch_index * semantic.max_index_documents;
+        for (0..embedded.count) |row_index| {
+            const vector_start = row_index * @as(usize, embedded.dimensions);
+            const row = embedded.vectors[vector_start..][0..embedded.dimensions];
+            const id = try index.insert(row);
+            if (id != indexed_records.items.len) return error.AnnRecordMappingMismatch;
+            try indexed_records.append(allocator, pending_records.items[record_start + row_index]);
+        }
+    }
+    const insertion_ns = elapsedNs(insertion_started);
+    const records = cards.items.len;
+    for (cards.items) |card| allocator.free(card);
+    cards.clearRetainingCapacity();
+    pending_records.clearRetainingCapacity();
+    return .{
+        .text_bytes = text_bytes,
+        .records = records,
+        .embedding_wall_ns = embedding_wall_ns,
+        .insertion_ns = insertion_ns,
+    };
+}
+
+fn writeMetadata(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    data_dir: []const u8,
+    model: []const u8,
+    dimensions: u16,
+    manifest: u64,
+    vector_space_id: u64,
+    calibration: []const f32,
+    git_head: ?[40]u8,
+    slab_name: []const u8,
+    records: []const Record,
+) !usize {
+    if (model.len == 0 or model.len > std.math.maxInt(u16)) return error.InvalidEmbeddingModel;
+    if (dimensions < 64 or dimensions > 4096 or calibration.len != dimensions) return error.InvalidEmbeddingDimensions;
+    if (records.len == 0 or records.len > max_records) return error.InvalidAnnRecordCount;
+    if (!isValidSlabName(slab_name) or slab_name.len > std.math.maxInt(u16)) return error.InvalidAnnSlabName;
+    for (calibration) |value| if (!std.math.isFinite(value)) return error.InvalidEmbeddingNumber;
+    for (records) |record| {
+        if (!semantic.isRemoteCandidatePathAllowed(record.path) or record.path.len > std.math.maxInt(u16) or
+            record.line_start == 0 or record.line_end < record.line_start) return error.InvalidAnnRecordPath;
+    }
+
+    var total = header_bytes;
+    total = try std.math.add(usize, total, model.len);
+    total = try std.math.add(usize, total, slab_name.len);
+    total = try std.math.add(usize, total, if (git_head == null) @as(usize, 0) else 40);
+    total = try std.math.add(usize, total, try std.math.mul(usize, calibration.len, @sizeOf(f32)));
+    for (records) |record| total = try std.math.add(usize, total, 10 + record.path.len);
+    if (total > max_metadata_bytes) return error.AnnMetadataTooLarge;
+
+    const final_path = try sidecarPath(allocator, data_dir);
+    defer allocator.free(final_path);
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ final_path, cio.randU64() });
+    defer allocator.free(tmp_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+
+    var file = try std.Io.Dir.cwd().createFile(io, tmp_path, .{ .permissions = privateFilePermissions() });
+    var file_open = true;
+    defer if (file_open) file.close(io);
+    var file_buffer: [256 * 1024]u8 = undefined;
+    var writer = file.writer(io, &file_buffer);
+
+    var header: [header_bytes]u8 = @splat(0);
+    @memcpy(header[0..8], &magic);
+    std.mem.writeInt(u16, header[8..10], format_version, .little);
+    std.mem.writeInt(u16, header[10..12], dimensions, .little);
+    std.mem.writeInt(u32, header[12..16], @intCast(records.len), .little);
+    std.mem.writeInt(u64, header[16..24], manifest, .little);
+    std.mem.writeInt(u64, header[24..32], vector_space_id, .little);
+    std.mem.writeInt(u16, header[32..34], @intCast(model.len), .little);
+    std.mem.writeInt(u16, header[34..36], @intCast(slab_name.len), .little);
+    header[36] = if (git_head == null) 0 else 40;
+    std.mem.writeInt(u32, header[40..44], @intCast(calibration.len), .little);
+    try writer.interface.writeAll(&header);
+    try writer.interface.writeAll(model);
+    try writer.interface.writeAll(slab_name);
+    if (git_head) |head| try writer.interface.writeAll(&head);
+    for (calibration) |value| {
+        var bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &bytes, @bitCast(value), .little);
+        try writer.interface.writeAll(&bytes);
+    }
+    for (records) |record| {
+        var length: [2]u8 = undefined;
+        std.mem.writeInt(u16, &length, @intCast(record.path.len), .little);
+        try writer.interface.writeAll(&length);
+        try writer.interface.writeAll(record.path);
+        var lines: [8]u8 = undefined;
+        std.mem.writeInt(u32, lines[0..4], record.line_start, .little);
+        std.mem.writeInt(u32, lines[4..8], record.line_end, .little);
+        try writer.interface.writeAll(&lines);
+    }
+    try writer.interface.flush();
+    try file.sync(io);
+    file.close(io);
+    file_open = false;
+    try std.Io.Dir.cwd().rename(tmp_path, std.Io.Dir.cwd(), final_path, io);
+    return total;
+}
+
+pub fn build(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+) !BuildStats {
+    const started = cio.nanoTimestamp();
+    try secureDataDir(io, data_dir);
+    const previous_slab_name = currentSlabName(io, allocator, data_dir) catch null;
+    defer if (previous_slab_name) |name| allocator.free(name);
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const vector_space_id = config.vectorSpaceId();
+    const manifest_before = try repositoryFingerprint(explorer, store, allocator);
+    const git_head_before = try git_mod.getGitHead(project_root, allocator);
+    const paths = try cloneSortedPaths(explorer, allocator);
+    defer {
+        for (paths) |path| allocator.free(path);
+        allocator.free(paths);
+    }
+
+    var index = ann.Index.init(allocator, config.dimensions, .{});
+    defer index.deinit();
+
+    const calibration_started = cio.nanoTimestamp();
+    const calibration_result = try semantic.embedRemoteTexts(io, allocator, &.{semantic.calibration_text});
+    defer allocator.free(calibration_result.vectors);
+    if (calibration_result.count != 1 or calibration_result.dimensions != config.dimensions or
+        !std.mem.eql(u8, calibration_result.model, config.model)) return error.InvalidEmbeddingCalibration;
+    const calibration = calibration_result.vectors[0..config.dimensions];
+    var cards: std.ArrayList([]u8) = .empty;
+    defer {
+        for (cards.items) |card| allocator.free(card);
+        cards.deinit(allocator);
+    }
+    var pending_records: std.ArrayList(Record) = .empty;
+    defer pending_records.deinit(allocator);
+    var indexed_records: std.ArrayList(Record) = .empty;
+    defer indexed_records.deinit(allocator);
+
+    const parallel_batches = indexConcurrency();
+    const wave_capacity = parallel_batches * semantic.max_index_documents;
+    var text_bytes_sent: usize = calibration_result.text_bytes_sent;
+    var embedding_wall_ns: u64 = elapsedNs(calibration_started);
+    var insertion_ns: u64 = 0;
+    var blocked: usize = 0;
+    var files_indexed: usize = 0;
+    for (paths) |path| {
+        if (!semantic.isRemoteCandidatePathAllowed(path)) {
+            blocked += 1;
+            continue;
+        }
+        const content = (explorer.getContent(path, allocator) catch null) orelse continue;
+        defer allocator.free(content);
+        if (content.len == 0) continue;
+        var outline = (explorer.getOutline(path, allocator) catch null) orelse continue;
+        defer outline.deinit();
+        var cursor = ChunkCursor{ .content = content };
+        var chunks_for_file: usize = 0;
+        while (chunks_for_file < max_chunks_per_file) : (chunks_for_file += 1) {
+            const chunk = cursor.next() orelse break;
+            if (indexed_records.items.len + pending_records.items.len >= max_records) return error.AnnRecordBudgetExceeded;
+            if (cards.items.len == wave_capacity) {
+                const stats = try flushWave(io, allocator, &index, config, &cards, &pending_records, &indexed_records);
+                text_bytes_sent = try std.math.add(usize, text_bytes_sent, stats.text_bytes);
+                embedding_wall_ns = try std.math.add(u64, embedding_wall_ns, stats.embedding_wall_ns);
+                insertion_ns = try std.math.add(u64, insertion_ns, stats.insertion_ns);
+                if (try index.slabImageSize() > max_slab_bytes) return error.AnnSlabTooLarge;
+            }
+            const card = try makeChunkCard(allocator, path, @tagName(outline.language), chunk);
+            try cards.append(allocator, card);
+            try pending_records.append(allocator, .{
+                .path = path,
+                .line_start = chunk.line_start,
+                .line_end = chunk.line_end,
+            });
+        }
+        if (chunks_for_file > 0) files_indexed += 1;
+    }
+    const final_stats = try flushWave(io, allocator, &index, config, &cards, &pending_records, &indexed_records);
+    text_bytes_sent = try std.math.add(usize, text_bytes_sent, final_stats.text_bytes);
+    embedding_wall_ns = try std.math.add(u64, embedding_wall_ns, final_stats.embedding_wall_ns);
+    insertion_ns = try std.math.add(u64, insertion_ns, final_stats.insertion_ns);
+    if (index.len() == 0) return error.NoSafeAnnRecords;
+    if (try index.slabImageSize() > max_slab_bytes) return error.AnnSlabTooLarge;
+
+    const manifest_after = try repositoryFingerprint(explorer, store, allocator);
+    if (manifest_after != manifest_before) return error.RepositoryChangedDuringAnnBuild;
+    const git_head_after = try git_mod.getGitHead(project_root, allocator);
+    if (!headsEqual(git_head_before, git_head_after)) return error.RepositoryChangedDuringAnnBuild;
+
+    const slab_name = try std.fmt.allocPrint(allocator, "{s}{x}-{x}-{x}{s}", .{
+        slab_file_prefix,
+        manifest_after,
+        vector_space_id,
+        cio.randU64(),
+        slab_file_suffix,
+    });
+    defer allocator.free(slab_name);
+    const slab_path = try slabPath(allocator, data_dir, slab_name);
+    defer allocator.free(slab_path);
+    var slab_referenced = false;
+    errdefer if (!slab_referenced) std.Io.Dir.cwd().deleteFile(io, slab_path) catch {};
+    try index.writeSlabs(slab_path);
+    const slab_bytes = try fileSize(io, slab_path);
+    if (slab_bytes > max_slab_bytes) return error.AnnSlabTooLarge;
+    var slab_file = try std.Io.Dir.cwd().openFile(io, slab_path, .{ .mode = .read_write });
+    defer slab_file.close(io);
+    try slab_file.setPermissions(io, privateFilePermissions());
+
+    const metadata_bytes = try writeMetadata(
+        io,
+        allocator,
+        data_dir,
+        config.model,
+        config.dimensions,
+        manifest_after,
+        vector_space_id,
+        calibration,
+        git_head_after,
+        slab_name,
+        indexed_records.items,
+    );
+    // The metadata rename now references this generation. Retain the slab even
+    // if the following directory fsync fails; deleting it would turn a durable
+    // rename with a transient sync error into a guaranteed broken sidecar.
+    slab_referenced = true;
+    try syncDataDir(io, data_dir);
+    // The metadata rename is the commit point. Only after it succeeds may the
+    // previously referenced slab be removed; existing POSIX mmaps stay valid,
+    // while platforms that refuse deletion simply retain a harmless cache file.
+    deleteReplacedSlab(io, allocator, data_dir, previous_slab_name, slab_name);
+    const file_bytes = try std.math.add(usize, metadata_bytes, slab_bytes);
+    return .{
+        .records = index.len(),
+        .files_indexed = files_indexed,
+        .dimensions = config.dimensions,
+        .model = config.model,
+        .file_bytes = file_bytes,
+        .graph_bytes = slab_bytes,
+        .metadata_bytes = metadata_bytes,
+        .vector_payload_bytes = try ann.vectorPayloadBytes(index.len(), config.dimensions),
+        .text_bytes_sent = text_bytes_sent,
+        .sensitive_paths_blocked = blocked,
+        .manifest = manifest_after,
+        .elapsed_ns = elapsedNs(started),
+        .embedding_wall_ns = embedding_wall_ns,
+        .insertion_ns = insertion_ns,
+        .parallel_batches = parallel_batches,
+        .vector_space_id = vector_space_id,
+    };
+}
+
+fn take(comptime T: type, data: []const u8, pos: *usize) !T {
+    const size = @sizeOf(T);
+    if (pos.* > data.len or size > data.len - pos.*) return error.TruncatedAnnSidecar;
+    const value = std.mem.readInt(T, data[pos.*..][0..size], .little);
+    pos.* += size;
+    return value;
+}
+
+fn loadMetadata(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !Loaded {
+    const path = try sidecarPath(allocator, data_dir);
+    defer allocator.free(path);
+    const storage = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(max_metadata_bytes)) catch |err| switch (err) {
+        error.FileNotFound => return error.AnnIndexMissing,
+        else => return err,
+    };
+    errdefer allocator.free(storage);
+    if (storage.len < header_bytes or !std.mem.eql(u8, storage[0..8], &magic)) return error.InvalidAnnSidecar;
+    var pos: usize = 8;
+    if (try take(u16, storage, &pos) != format_version) return error.UnsupportedAnnSidecarVersion;
+    const dimensions = try take(u16, storage, &pos);
+    const count = try take(u32, storage, &pos);
+    const manifest = try take(u64, storage, &pos);
+    const vector_space_id = try take(u64, storage, &pos);
+    const model_len = try take(u16, storage, &pos);
+    const slab_name_len = try take(u16, storage, &pos);
+    if (pos > storage.len or 4 > storage.len - pos) return error.TruncatedAnnSidecar;
+    const head_len = storage[pos];
+    pos += 4; // head_len + three reserved bytes
+    const calibration_count = try take(u32, storage, &pos);
+    _ = try take(u32, storage, &pos); // reserved
+    if (dimensions < 64 or dimensions > 4096 or count == 0 or count > max_records or
+        model_len == 0 or model_len > 256 or calibration_count != dimensions or
+        (head_len != 0 and head_len != 40)) return error.InvalidAnnSidecar;
+    const fixed_payload = std.math.add(usize, model_len, slab_name_len) catch return error.InvalidAnnSidecar;
+    const with_head = std.math.add(usize, fixed_payload, head_len) catch return error.InvalidAnnSidecar;
+    const calibration_bytes = std.math.mul(usize, calibration_count, @sizeOf(f32)) catch return error.InvalidAnnSidecar;
+    const required = std.math.add(usize, with_head, calibration_bytes) catch return error.InvalidAnnSidecar;
+    if (pos > storage.len or required > storage.len - pos) return error.TruncatedAnnSidecar;
+    const model = storage[pos .. pos + model_len];
+    pos += model_len;
+    const slab_name = storage[pos .. pos + slab_name_len];
+    if (!isValidSlabName(slab_name)) return error.InvalidAnnSlabName;
+    pos += slab_name_len;
+    var git_head: ?[40]u8 = null;
+    if (head_len == 40) {
+        var head: [40]u8 = undefined;
+        @memcpy(&head, storage[pos .. pos + 40]);
+        git_head = head;
+        pos += 40;
+    }
+    const calibration = try allocator.alloc(f32, calibration_count);
+    errdefer allocator.free(calibration);
+    for (calibration) |*value| {
+        const bits = try take(u32, storage, &pos);
+        value.* = @bitCast(bits);
+        if (!std.math.isFinite(value.*)) return error.InvalidEmbeddingNumber;
+    }
+    const minimum_record_bytes: usize = 11; // u16 length + >=1 path + two u32 lines
+    if (count > (storage.len - pos) / minimum_record_bytes) return error.TruncatedAnnSidecar;
+    const records = try allocator.alloc(Record, count);
+    errdefer allocator.free(records);
+    for (records) |*record| {
+        const path_len = try take(u16, storage, &pos);
+        const record_bytes = std.math.add(usize, path_len, 8) catch return error.InvalidAnnSidecar;
+        if (path_len == 0 or pos > storage.len or record_bytes > storage.len - pos) return error.TruncatedAnnSidecar;
+        const record_path = storage[pos .. pos + path_len];
+        if (!semantic.isRemoteCandidatePathAllowed(record_path)) return error.InvalidAnnRecordPath;
+        pos += path_len;
+        const line_start = try take(u32, storage, &pos);
+        const line_end = try take(u32, storage, &pos);
+        if (line_start == 0 or line_end < line_start) return error.InvalidAnnRecordPath;
+        record.* = .{ .path = record_path, .line_start = line_start, .line_end = line_end };
+    }
+    if (pos != storage.len) return error.InvalidAnnSidecar;
+
+    const slab_path = try slabPath(allocator, data_dir, slab_name);
+    errdefer allocator.free(slab_path);
+    const slab_bytes = try fileSize(io, slab_path);
+    if (slab_bytes == 0 or slab_bytes > max_slab_bytes) return error.AnnSlabTooLarge;
+    var index = ann.Index.init(allocator, dimensions, .{});
+    errdefer index.deinit();
+    return .{
+        .allocator = allocator,
+        .storage = storage,
+        .records = records,
+        .slab_path = slab_path,
+        .slab_bytes = slab_bytes,
+        .model = model,
+        .dimensions = dimensions,
+        .manifest = manifest,
+        .vector_space_id = vector_space_id,
+        .calibration = calibration,
+        .git_head = git_head,
+        .index = index,
+    };
+}
+
+fn load(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !Loaded {
+    var loaded = try loadMetadata(io, allocator, data_dir);
+    errdefer loaded.deinit();
+    try loaded.loadGraph();
+    return loaded;
+}
+
+/// Validate and mmap a persisted sidecar without issuing an embedding request.
+/// Used by release smoke/RSS tooling and intentionally returns no record paths.
+pub fn validateSidecar(io: std.Io, allocator: std.mem.Allocator, data_dir: []const u8) !void {
+    var loaded = try load(io, allocator, data_dir);
+    defer loaded.deinit();
+}
+
+fn headsEqual(a: ?[40]u8, b: ?[40]u8) bool {
+    if (a == null or b == null) return a == null and b == null;
+    return std.mem.eql(u8, &a.?, &b.?);
+}
+
+pub fn search(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+    task: []const u8,
+    k: usize,
+) !SearchOutput {
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const load_started = cio.nanoTimestamp();
+    var loaded = try loadMetadata(io, allocator, data_dir);
+    defer loaded.deinit();
+
+    if (config.dimensions != loaded.dimensions) return error.AnnDimensionsMismatch;
+    if (!std.mem.eql(u8, config.model, loaded.model)) return error.AnnModelMismatch;
+    if (config.vectorSpaceId() != loaded.vector_space_id) return error.AnnVectorSpaceMismatch;
+    const current_head = try git_mod.getGitHead(project_root, allocator);
+    if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
+    if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
+    try loaded.loadGraph();
+    const load_ns = elapsedNs(load_started);
+
+    const embed_started = cio.nanoTimestamp();
+    const query = try semantic.embedQueryAndCalibrationRemote(io, allocator, task);
+    defer allocator.free(query.vectors);
+    const embed_ns = elapsedNs(embed_started);
+    if (query.count != 2 or query.dimensions != loaded.dimensions or !std.mem.eql(u8, query.model, loaded.model)) {
+        return error.AnnQueryEmbeddingMismatch;
+    }
+    const query_vector = query.vectors[0..loaded.dimensions];
+    const calibration_vector = query.vectors[loaded.dimensions..][0..loaded.dimensions];
+    if (try semantic.cosineF32(calibration_vector, loaded.calibration) < semantic.calibration_min_cosine) {
+        return error.AnnVectorSpaceCalibrationMismatch;
+    }
+
+    const search_started = cio.nanoTimestamp();
+    const expanded_k = std.math.mul(usize, k, 4) catch k;
+    const raw = try loaded.index.search(query_vector, @min(@max(k, expanded_k), loaded.records.len), allocator);
+    defer allocator.free(raw);
+    const search_ns = elapsedNs(search_started);
+    var hits: std.ArrayList(Hit) = .empty;
+    var seen_paths = std.StringHashMap(void).init(allocator);
+    defer seen_paths.deinit();
+    errdefer {
+        for (hits.items) |hit| allocator.free(hit.path);
+        hits.deinit(allocator);
+    }
+    for (raw) |result| {
+        if (result.id >= loaded.records.len) return error.AnnRecordMappingMismatch;
+        const record = loaded.records[result.id];
+        if (!semantic.isRemoteCandidatePathAllowed(record.path)) continue;
+        if (seen_paths.contains(record.path)) continue;
+        var outline = (try explorer.getOutline(record.path, allocator)) orelse continue;
+        outline.deinit();
+        try seen_paths.put(record.path, {});
+        try hits.append(allocator, .{
+            .path = try allocator.dupe(u8, record.path),
+            .line_start = record.line_start,
+            .line_end = record.line_end,
+            .distance = result.distance,
+        });
+        if (hits.items.len == k) break;
+    }
+    return .{
+        .hits = try hits.toOwnedSlice(allocator),
+        .model = try allocator.dupe(u8, loaded.model),
+        .dimensions = loaded.dimensions,
+        .records = loaded.records.len,
+        .index_bytes = try std.math.add(usize, loaded.storage.len, loaded.slab_bytes),
+        .text_bytes_sent = query.text_bytes_sent,
+        .retention = switch (query.retention) {
+            .none_by_codedb_policy => .none_by_codedb_policy,
+            .custom_endpoint_unverified => .custom_endpoint_unverified,
+        },
+        .load_ns = load_ns,
+        .embed_ns = embed_ns,
+        .search_ns = search_ns,
+        .mmap_backed = loaded.index.isMmapBacked(),
+        .vector_space_id = loaded.vector_space_id,
+    };
+}
+
+test "semantic ANN sidecar round-trips record mapping and graph" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 19 });
+    defer source.deinit();
+    var a: [64]f32 = @splat(0);
+    var b: [64]f32 = @splat(0);
+    a[0] = 1;
+    b[1] = 1;
+    _ = try source.insert(&a);
+    _ = try source.insert(&b);
+    const slab_name = "semantic-chunks-v3-a-b-c.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    try source.writeSlabs(slab_path);
+    var calibration: [64]f32 = @splat(0);
+    calibration[3] = 1;
+    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 1234, 5678, &calibration, null, slab_name, &.{
+        .{ .path = "src/a.zig", .line_start = 1, .line_end = 2 },
+        .{ .path = "src/b.zig", .line_start = 8, .line_end = 12 },
+    });
+
+    var restored = try load(io, testing.allocator, dir_path);
+    defer restored.deinit();
+    try testing.expect(restored.index.isMmapBacked());
+    try testing.expectEqual(@as(usize, 2), restored.records.len);
+    try testing.expectEqualStrings("src/b.zig", restored.records[1].path);
+    try testing.expectEqual(@as(u32, 8), restored.records[1].line_start);
+    try testing.expectEqual(@as(u64, 1234), restored.manifest);
+    try testing.expectEqual(@as(u64, 5678), restored.vector_space_id);
+    try testing.expectEqualSlices(f32, &calibration, restored.calibration);
+    const results = try restored.index.search(&b, 1, testing.allocator);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(u32, 1), results[0].id);
+}
+
+test "semantic ANN sidecar refuses sensitive record mappings" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    var source = ann.Index.init(testing.allocator, 64, .{});
+    defer source.deinit();
+    var vector: [64]f32 = @splat(0);
+    vector[0] = 1;
+    _ = try source.insert(&vector);
+    var calibration: [64]f32 = @splat(0);
+    calibration[0] = 1;
+    try testing.expectError(
+        error.InvalidAnnRecordPath,
+        writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, "semantic-chunks-v3-a.hmls", &.{.{ .path = ".env", .line_start = 1, .line_end = 1 }}),
+    );
+    try testing.expectError(
+        error.InvalidAnnRecordPath,
+        writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, "semantic-chunks-v3-a.hmls", &.{.{ .path = "PRIVATE_KEY.PEM", .line_start = 1, .line_end = 1 }}),
+    );
+}
+
+test "semantic ANN metadata rejects traversal and oversized record counts before allocation" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    var calibration: [64]f32 = @splat(0);
+    calibration[0] = 1;
+    try testing.expectError(
+        error.InvalidAnnSlabName,
+        writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, "../outside.hmls", &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }}),
+    );
+
+    var index = ann.Index.init(testing.allocator, 64, .{});
+    defer index.deinit();
+    _ = try index.insert(&calibration);
+    const slab_name = "semantic-chunks-v3-c0a7-9aa4d.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    try index.writeSlabs(slab_path);
+    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, slab_name, &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }});
+
+    const metadata_path = try sidecarPath(testing.allocator, dir_path);
+    defer testing.allocator.free(metadata_path);
+    var metadata_file = try std.Io.Dir.cwd().openFile(io, metadata_path, .{ .mode = .read_write });
+    defer metadata_file.close(io);
+    var forged_count: [4]u8 = undefined;
+    std.mem.writeInt(u32, &forged_count, max_records, .little);
+    try metadata_file.writePositionalAll(io, &forged_count, 12);
+    try metadata_file.sync(io);
+    try testing.expectError(error.TruncatedAnnSidecar, load(io, testing.allocator, dir_path));
+}
+
+test "semantic ANN metadata and data directory use private permissions" {
+    if (builtin.os.tag == .windows) return;
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    try secureDataDir(io, dir_path);
+    var calibration: [64]f32 = @splat(0);
+    calibration[0] = 1;
+    const slab_name = "semantic-chunks-v3-fee1-dead.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    var source = ann.Index.init(testing.allocator, 64, .{});
+    defer source.deinit();
+    _ = try source.insert(&calibration);
+    try source.writeSlabs(slab_path);
+    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, slab_name, &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }});
+    const metadata_path = try sidecarPath(testing.allocator, dir_path);
+    defer testing.allocator.free(metadata_path);
+    var metadata_file = try std.Io.Dir.cwd().openFile(io, metadata_path, .{});
+    defer metadata_file.close(io);
+    const metadata_stat = try metadata_file.stat(io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o600), metadata_stat.permissions.toMode() & 0o777);
+    var slab_file = try std.Io.Dir.cwd().openFile(io, slab_path, .{});
+    defer slab_file.close(io);
+    const slab_stat = try slab_file.stat(io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o600), slab_stat.permissions.toMode() & 0o777);
+    var data_dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true });
+    defer data_dir.close(io);
+    const dir_stat = try data_dir.stat(io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o700), dir_stat.permissions.toMode() & 0o777);
+}
+
+test "semantic ANN replacement removes only the previously referenced slab" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const old_name = "semantic-chunks-v3-aaa-bbb.hmls";
+    const new_name = "semantic-chunks-v3-ccc-ddd.hmls";
+    const old_path = try slabPath(testing.allocator, dir_path, old_name);
+    defer testing.allocator.free(old_path);
+    const new_path = try slabPath(testing.allocator, dir_path, new_name);
+    defer testing.allocator.free(new_path);
+    var old_file = try std.Io.Dir.cwd().createFile(io, old_path, .{});
+    old_file.close(io);
+    var new_file = try std.Io.Dir.cwd().createFile(io, new_path, .{});
+    new_file.close(io);
+    var calibration: [64]f32 = @splat(0);
+    calibration[0] = 1;
+    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, old_name, &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }});
+    const previous = (try currentSlabName(io, testing.allocator, dir_path)).?;
+    defer testing.allocator.free(previous);
+    try testing.expectEqualStrings(old_name, previous);
+    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 0, 1, &calibration, null, new_name, &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }});
+    deleteReplacedSlab(io, testing.allocator, dir_path, previous, new_name);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, old_path, .{}));
+    try std.Io.Dir.cwd().access(io, new_path, .{});
+}
+
+test "semantic ANN wave uses the public 25-item batch boundary" {
+    try std.testing.expectEqual(@as(usize, 1), embeddingBatchCount(semantic.max_index_documents));
+    try std.testing.expectEqual(@as(usize, 2), embeddingBatchCount(semantic.max_index_documents + 1));
+    try std.testing.expectEqual(
+        max_parallel_batches,
+        embeddingBatchCount(max_parallel_batches * semantic.max_index_documents),
+    );
+}
+
+test "semantic ANN rejects stale content before mmaping the graph" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const calibration = try testing.allocator.alloc(f32, config.dimensions);
+    defer testing.allocator.free(calibration);
+    @memset(calibration, 0);
+    calibration[0] = 1;
+    const slab_name = "semantic-chunks-v3-dead-bad.hmls";
+    const bad_slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(bad_slab_path);
+    var bad_slab = try std.Io.Dir.cwd().createFile(io, bad_slab_path, .{ .permissions = privateFilePermissions() });
+    try bad_slab.writeStreamingAll(io, "x");
+    try bad_slab.sync(io);
+    bad_slab.close(io);
+    const current_head = try git_mod.getGitHead(dir_path, testing.allocator);
+    _ = try writeMetadata(
+        io,
+        testing.allocator,
+        dir_path,
+        config.model,
+        config.dimensions,
+        std.math.maxInt(u64),
+        config.vectorSpaceId(),
+        calibration,
+        current_head,
+        slab_name,
+        &.{.{ .path = "src/a.zig", .line_start = 1, .line_end = 1 }},
+    );
+
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    const content = "pub fn alpha() void {}\n";
+    try explorer.indexFile("src/a.zig", content);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = try store.recordSnapshot("src/a.zig", content.len, std.hash.Wyhash.hash(0, content));
+    try testing.expectError(
+        error.StaleAnnManifest,
+        search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find alpha implementation", 5),
+    );
+}

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -15,6 +15,8 @@ const Store = @import("store.zig").Store;
 const ann = @import("ann.zig");
 const semantic = @import("semantic.zig");
 const git_mod = @import("git.zig");
+const snapshot_mod = @import("snapshot.zig");
+const watcher = @import("watcher.zig");
 
 pub const sidecar_name = "semantic-chunks-v3.meta";
 pub const slab_file_prefix = "semantic-chunks-v3-";
@@ -252,7 +254,12 @@ pub fn manifestFingerprint(explorer: *Explorer, allocator: std.mem.Allocator) !u
 
 fn repositoryFingerprint(explorer: *Explorer, store: *Store, allocator: std.mem.Allocator) !u64 {
     const shape = try manifestFingerprint(explorer, allocator);
-    const content = try store.contentFingerprint(allocator);
+    const paths = try cloneSortedPaths(explorer, allocator);
+    defer {
+        for (paths) |path| allocator.free(path);
+        allocator.free(paths);
+    }
+    const content = try store.contentFingerprintForPaths(paths);
     var hash = std.hash.Wyhash.init(0x4344_4252_4550_4f33);
     hash.update(std.mem.asBytes(&shape));
     hash.update(std.mem.asBytes(&content));
@@ -798,6 +805,27 @@ fn headsEqual(a: ?[40]u8, b: ?[40]u8) bool {
     return std.mem.eql(u8, &a.?, &b.?);
 }
 
+/// Validate every untrusted metadata range against the current live outline
+/// before mmaping or searching the graph. Records produced by the builder are
+/// grouped by path, so retaining the previous count avoids repeated locks on
+/// the common multi-chunk-per-file path without allocating attacker-sized
+/// validation state.
+fn validateRecordLineRanges(explorer: *Explorer, records: []const Record) !void {
+    var previous_path: []const u8 = "";
+    var previous_line_count: u32 = 0;
+    for (records) |record| {
+        if (!std.mem.eql(u8, record.path, previous_path)) {
+            previous_line_count = explorer.outlineLineCount(record.path) orelse return error.InvalidAnnRecordPath;
+            previous_path = record.path;
+        }
+        if (record.line_start == 0 or record.line_start > previous_line_count or
+            record.line_end < record.line_start or record.line_end > previous_line_count)
+        {
+            return error.InvalidAnnRecordPath;
+        }
+    }
+}
+
 pub fn search(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -820,6 +848,10 @@ pub fn search(
     const current_head = try git_mod.getGitHead(project_root, allocator);
     if (!headsEqual(current_head, loaded.git_head)) return error.StaleAnnGitHead;
     if (try repositoryFingerprint(explorer, store, allocator) != loaded.manifest) return error.StaleAnnManifest;
+    // Metadata is attacker-controlled local input. Validate the entire mapping
+    // while the index is still empty so a failure remains transactional and no
+    // forged line can reach rendering arithmetic.
+    try validateRecordLineRanges(explorer, loaded.records);
     try loaded.loadGraph();
     const load_ns = elapsedNs(load_started);
 
@@ -853,8 +885,6 @@ pub fn search(
         const record = loaded.records[result.id];
         if (!semantic.isRemoteCandidatePathAllowed(record.path)) continue;
         if (seen_paths.contains(record.path)) continue;
-        var outline = (try explorer.getOutline(record.path, allocator)) orelse continue;
-        outline.deinit();
         try seen_paths.put(record.path, {});
         try hits.append(allocator, .{
             .path = try allocator.dupe(u8, record.path),
@@ -924,6 +954,41 @@ test "semantic ANN sidecar round-trips record mapping and graph" {
     try testing.expectEqual(@as(u32, 1), results[0].id);
 }
 
+test "semantic repository fingerprint survives cold scan snapshot reload" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    var source = try tmp.dir.createFile(io, "src/live.zig", .{});
+    try source.writeStreamingAll(io, "pub fn live() void {}\n");
+    source.close(io);
+    // Stat-only/non-indexed Store entries must not perturb a manifest of the
+    // live parsed outline set.
+    var empty = try tmp.dir.createFile(io, "empty.bin", .{});
+    empty.close(io);
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPathFile(io, ".", &root_buf)];
+    var first_explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer first_explorer.deinit();
+    var first_store = Store.init(testing.allocator);
+    defer first_store.deinit();
+    try watcher.initialScan(io, &first_store, &first_explorer, root, testing.allocator, true);
+    const before = try repositoryFingerprint(&first_explorer, &first_store, testing.allocator);
+
+    const snapshot_path = try std.fmt.allocPrint(testing.allocator, "{s}/roundtrip.snapshot", .{root});
+    defer testing.allocator.free(snapshot_path);
+    try snapshot_mod.writeSnapshot(io, &first_explorer, root, snapshot_path, testing.allocator);
+
+    var restored_explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer restored_explorer.deinit();
+    var restored_store = Store.init(testing.allocator);
+    defer restored_store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snapshot_path, &restored_explorer, &restored_store, testing.allocator));
+    try testing.expectEqual(before, try repositoryFingerprint(&restored_explorer, &restored_store, testing.allocator));
+}
+
 test "semantic ANN sidecar refuses sensitive record mappings" {
     const testing = std.testing;
     const io = testing.io;
@@ -980,6 +1045,82 @@ test "semantic ANN metadata rejects traversal and oversized record counts before
     try metadata_file.writePositionalAll(io, &forged_count, 12);
     try metadata_file.sync(io);
     try testing.expectError(error.TruncatedAnnSidecar, load(io, testing.allocator, dir_path));
+}
+
+test "semantic ANN rejects forged overflow line ranges before mmap or hits" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+
+    const source_path = "src/overflow.zig";
+    const content = "pub fn bounded() void {}\n";
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.indexFile(source_path, content);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    _ = try store.recordSnapshot(source_path, content.len, std.hash.Wyhash.hash(0, content));
+
+    const config = semantic.Config.fromEnv();
+    try config.validate();
+    const calibration = try testing.allocator.alloc(f32, config.dimensions);
+    defer testing.allocator.free(calibration);
+    @memset(calibration, 0);
+    calibration[0] = 1;
+
+    var index = ann.Index.init(testing.allocator, config.dimensions, .{});
+    defer index.deinit();
+    _ = try index.insert(calibration);
+    const slab_name = "semantic-chunks-v3-dead-beef.hmls";
+    const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
+    defer testing.allocator.free(slab_path);
+    try index.writeSlabs(slab_path);
+    const manifest = try repositoryFingerprint(&explorer, &store, testing.allocator);
+    const current_head = try git_mod.getGitHead(dir_path, testing.allocator);
+    _ = try writeMetadata(
+        io,
+        testing.allocator,
+        dir_path,
+        config.model,
+        config.dimensions,
+        manifest,
+        config.vectorSpaceId(),
+        calibration,
+        current_head,
+        slab_name,
+        &.{.{ .path = source_path, .line_start = 1, .line_end = 1 }},
+    );
+
+    const metadata_path = try sidecarPath(testing.allocator, dir_path);
+    defer testing.allocator.free(metadata_path);
+    const metadata = try std.Io.Dir.cwd().readFileAlloc(io, metadata_path, testing.allocator, .limited(max_metadata_bytes));
+    defer testing.allocator.free(metadata);
+    const record_path_offset = std.mem.indexOf(u8, metadata, source_path) orelse return error.MissingFixtureRecord;
+    const line_offset = record_path_offset + source_path.len;
+    var forged_lines: [8]u8 = undefined;
+    std.mem.writeInt(u32, forged_lines[0..4], std.math.maxInt(u32), .little);
+    std.mem.writeInt(u32, forged_lines[4..8], std.math.maxInt(u32), .little);
+    var metadata_file = try std.Io.Dir.cwd().openFile(io, metadata_path, .{ .mode = .read_write });
+    try metadata_file.writePositionalAll(io, &forged_lines, line_offset);
+    try metadata_file.sync(io);
+    metadata_file.close(io);
+
+    // Loading the raw metadata succeeds because the range is structurally
+    // ordered. Live-outline validation must reject it while the graph remains
+    // unattached, so neither safe nor ReleaseFast can reach line+2 wrapping.
+    var loaded = try loadMetadata(io, testing.allocator, dir_path);
+    defer loaded.deinit();
+    try testing.expectError(error.InvalidAnnRecordPath, validateRecordLineRanges(&explorer, loaded.records));
+    try testing.expect(!loaded.index.isMmapBacked());
+    try testing.expectEqual(@as(usize, 0), loaded.index.len());
+
+    try testing.expectError(
+        error.InvalidAnnRecordPath,
+        search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find bounded implementation", 5),
+    );
 }
 
 test "semantic ANN metadata and data directory use private permissions" {

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -433,13 +433,12 @@ fn flushWave(
         if (embedded.dimensions != config.dimensions or !std.mem.eql(u8, embedded.model, config.model)) {
             return error.EmbeddingConfigChangedDuringBuild;
         }
+        if (embedded.count != worker.inputs.len) return error.InvalidEmbeddingBatchShape;
         text_bytes = try std.math.add(usize, text_bytes, embedded.text_bytes_sent);
         const record_start = batch_index * semantic.max_index_documents;
+        const first_id = try index.insertEmbeddingBatch(embedded.vectors, embedded.count, embedded.dimensions);
+        if (first_id != indexed_records.items.len) return error.AnnRecordMappingMismatch;
         for (0..embedded.count) |row_index| {
-            const vector_start = row_index * @as(usize, embedded.dimensions);
-            const row = embedded.vectors[vector_start..][0..embedded.dimensions];
-            const id = try index.insert(row);
-            if (id != indexed_records.items.len) return error.AnnRecordMappingMismatch;
             try indexed_records.append(allocator, pending_records.items[record_start + row_index]);
         }
     }
@@ -916,7 +915,7 @@ pub fn search(
     };
 }
 
-test "semantic ANN sidecar round-trips record mapping and graph" {
+test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" {
     const testing = std.testing;
     const io = testing.io;
     var tmp = testing.tmpDir(.{});
@@ -924,10 +923,10 @@ test "semantic ANN sidecar round-trips record mapping and graph" {
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
 
-    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 19 });
+    var source = ann.Index.init(testing.allocator, ann.default_dimensions, .{ .seed = 19 });
     defer source.deinit();
-    var a: [64]f32 = @splat(0);
-    var b: [64]f32 = @splat(0);
+    var a: [ann.default_dimensions]f32 = @splat(0);
+    var b: [ann.default_dimensions]f32 = @splat(0);
     a[0] = 1;
     b[1] = 1;
     _ = try source.insert(&a);
@@ -936,9 +935,9 @@ test "semantic ANN sidecar round-trips record mapping and graph" {
     const slab_path = try slabPath(testing.allocator, dir_path, slab_name);
     defer testing.allocator.free(slab_path);
     try source.writeSlabs(slab_path);
-    var calibration: [64]f32 = @splat(0);
+    var calibration: [ann.default_dimensions]f32 = @splat(0);
     calibration[3] = 1;
-    _ = try writeMetadata(io, testing.allocator, dir_path, "test-model", 64, 1234, 5678, &calibration, null, slab_name, &.{
+    _ = try writeMetadata(io, testing.allocator, dir_path, semantic.default_model, ann.default_dimensions, 1234, 5678, &calibration, null, slab_name, &.{
         .{ .path = "src/a.zig", .line_start = 1, .line_end = 2 },
         .{ .path = "src/b.zig", .line_start = 8, .line_end = 12 },
     });
@@ -951,6 +950,8 @@ test "semantic ANN sidecar round-trips record mapping and graph" {
     try testing.expectEqual(@as(u32, 8), restored.records[1].line_start);
     try testing.expectEqual(@as(u64, 1234), restored.manifest);
     try testing.expectEqual(@as(u64, 5678), restored.vector_space_id);
+    try testing.expectEqual(ann.default_dimensions, restored.dimensions);
+    try testing.expectEqualStrings(semantic.default_model, restored.model);
     try testing.expectEqualSlices(f32, &calibration, restored.calibration);
     const results = try restored.index.search(&b, 1, testing.allocator);
     defer testing.allocator.free(results);

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -57,6 +57,7 @@ pub const BuildStats = struct {
     elapsed_ns: u64,
     embedding_wall_ns: u64,
     insertion_ns: u64,
+    source_validation_ns: u64,
     parallel_batches: usize,
     vector_space_id: u64,
 };
@@ -558,6 +559,14 @@ pub fn build(
         for (paths) |path| allocator.free(path);
         allocator.free(paths);
     }
+    var remote_paths: std.ArrayList([]const u8) = .empty;
+    defer remote_paths.deinit(allocator);
+    try remote_paths.ensureTotalCapacity(allocator, paths.len);
+    for (paths) |path| {
+        if (semantic.isRemoteCandidatePathAllowed(path)) remote_paths.appendAssumeCapacity(path);
+    }
+    const source_content_before = try store.semanticContentFingerprintForPaths(remote_paths.items);
+    var embedded_content = Store.semanticContentHasher();
 
     var index = ann.Index.init(allocator, config.dimensions, .{});
     defer index.deinit();
@@ -590,10 +599,16 @@ pub fn build(
             blocked += 1;
             continue;
         }
-        const content = (explorer.getContent(path, allocator) catch null) orelse continue;
+        const content = (try explorer.getContent(path, allocator)) orelse return error.RepositoryChangedDuringAnnBuild;
         defer allocator.free(content);
+        Store.updateSemanticContentFingerprint(
+            &embedded_content,
+            path,
+            std.hash.Wyhash.hash(0, content),
+            @intCast(content.len),
+        );
         if (content.len == 0) continue;
-        var outline = (explorer.getOutline(path, allocator) catch null) orelse continue;
+        var outline = (try explorer.getOutline(path, allocator)) orelse return error.RepositoryChangedDuringAnnBuild;
         defer outline.deinit();
         var cursor = ChunkCursor{ .content = content };
         var chunks_for_file: usize = 0;
@@ -624,10 +639,18 @@ pub fn build(
     if (index.len() == 0) return error.NoSafeAnnRecords;
     if (try index.slabImageSize() > max_slab_bytes) return error.AnnSlabTooLarge;
 
+    const validation_started = cio.nanoTimestamp();
+    if (embedded_content.final() != source_content_before) return error.RepositoryChangedDuringAnnBuild;
+    const source_root = explorer.root_dir orelse return error.InvalidProjectRoot;
+    if (try watcher.liveIndexedContentFingerprint(io, source_root, allocator) != source_content_before) {
+        return error.RepositoryChangedDuringAnnBuild;
+    }
+
     const manifest_after = try repositoryFingerprint(explorer, store, allocator);
     if (manifest_after != manifest_before) return error.RepositoryChangedDuringAnnBuild;
     const git_head_after = try git_mod.getGitHead(project_root, allocator);
     if (!headsEqual(git_head_before, git_head_after)) return error.RepositoryChangedDuringAnnBuild;
+    const source_validation_ns = elapsedNs(validation_started);
 
     const slab_name = try std.fmt.allocPrint(allocator, "{s}{x}-{x}-{x}{s}", .{
         slab_file_prefix,
@@ -686,6 +709,7 @@ pub fn build(
         .elapsed_ns = elapsedNs(started),
         .embedding_wall_ns = embedding_wall_ns,
         .insertion_ns = insertion_ns,
+        .source_validation_ns = source_validation_ns,
         .parallel_batches = parallel_batches,
         .vector_space_id = vector_space_id,
     };
@@ -1247,4 +1271,45 @@ test "semantic ANN rejects stale content before mmaping the graph" {
         error.StaleAnnManifest,
         search(io, testing.allocator, &explorer, &store, dir_path, dir_path, "find alpha implementation", 5),
     );
+}
+
+test "semantic build live fingerprint catches unreconciled repository edits" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    var source = try tmp.dir.createFile(io, "src/live.zig", .{});
+    try source.writeStreamingAll(io, "pub fn before() void {}\n");
+    source.close(io);
+    var ignored = try tmp.dir.createFile(io, ".env", .{});
+    try ignored.writeStreamingAll(io, "TEST_ONLY_NOT_A_SECRET=1\n");
+    ignored.close(io);
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try tmp.dir.realPathFile(io, ".", &root_buf)];
+    var explorer = Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.setRoot(io, root);
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    try watcher.initialScan(io, &store, &explorer, root, testing.allocator, true);
+
+    const paths = try cloneSortedPaths(&explorer, testing.allocator);
+    defer {
+        for (paths) |path| testing.allocator.free(path);
+        testing.allocator.free(paths);
+    }
+    const indexed = try store.semanticContentFingerprintForPaths(paths);
+    try testing.expectEqual(indexed, try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
+
+    var ignored_changed = try tmp.dir.createFile(io, ".env", .{ .truncate = true });
+    try ignored_changed.writeStreamingAll(io, "TEST_ONLY_NOT_A_SECRET=2\n");
+    ignored_changed.close(io);
+    try testing.expectEqual(indexed, try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
+
+    var changed = try tmp.dir.createFile(io, "src/live.zig", .{ .truncate = true });
+    try changed.writeStreamingAll(io, "pub fn after() void {}\n");
+    changed.close(io);
+    try testing.expect(indexed != try watcher.liveIndexedContentFingerprint(io, explorer.root_dir.?, testing.allocator));
 }

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -104,6 +104,9 @@ const Loaded = struct {
     index: ann.Index,
 
     fn loadGraph(self: *Loaded) !void {
+        // No copy-in fallback: native Windows mmap is tracked upstream as
+        // justrach/openpuffer#25.
+        if (comptime builtin.os.tag == .windows) return error.UnsupportedPlatform;
         if (self.index.len() != 0 or self.index.isMmapBacked()) return error.AnnRecordMappingMismatch;
         self.index.loadMmap(self.slab_path) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,

--- a/src/server.zig
+++ b/src/server.zig
@@ -14,6 +14,8 @@ const AgentRegistry = @import("agent.zig").AgentRegistry;
 const Explorer = @import("explore.zig").Explorer;
 const snapshot_json = @import("snapshot_json.zig");
 const watcher = @import("watcher.zig");
+const project_file = @import("project_file.zig");
+const project_path = @import("project_path.zig");
 
 pub fn serve(
     io: std.Io,
@@ -275,17 +277,23 @@ fn handleConnection(
             respondJson(&conn, "403 Forbidden", "{\"error\":\"path traversal not allowed\"}");
             return;
         }
+        if (watcher.isSensitivePath(path)) {
+            respondJson(&conn, "403 Forbidden", "{\"error\":\"access to sensitive file blocked\"}");
+            return;
+        }
         const root_dir = explorer.root_dir orelse {
             respondJson(&conn, "500 Internal Server Error", "{\"error\":\"root not configured\"}");
             return;
         };
-        const content = root_dir.readFileAlloc(io, path, allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
+        const content = project_file.readAllocNoFollow(io, root_dir, path, allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
             error.FileNotFound => {
                 respondJson(&conn, "404 Not Found", "{\"error\":\"file not found\"}");
                 return;
             },
             else => {
-                respondJson(&conn, "500 Internal Server Error", "{\"error\":\"read failed\"}");
+                // File symlinks and other disallowed resolutions are a
+                // controlled policy rejection, never a content-bearing read.
+                respondJson(&conn, "403 Forbidden", "{\"error\":\"file read not allowed\"}");
                 return;
             },
         };
@@ -606,18 +614,7 @@ fn readSome(io: std.Io, stream: std.Io.net.Stream, dest: []u8) !usize {
 // ── Response helpers ────────────────────────────────────────────
 
 fn isPathSafe(path: []const u8) bool {
-    if (path.len == 0) return false;
-    if (path[0] == '/') return false;
-    // Block null bytes (path truncation attack).
-    if (std.mem.indexOfScalar(u8, path, 0) != null) return false;
-    // Block backslash separators so Windows-style `..\..\x` can't bypass the
-    // forward-slash `..` check below. Matches mcp.isPathSafe.
-    if (std.mem.indexOfScalar(u8, path, '\\') != null) return false;
-    var it = std.mem.splitScalar(u8, path, '/');
-    while (it.next()) |component| {
-        if (std.mem.eql(u8, component, "..")) return false;
-    }
-    return true;
+    return project_path.isNormalizedRelative(path);
 }
 
 fn respondJson(conn: *Conn, status: []const u8, body: []const u8) void {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -419,7 +419,10 @@ pub fn writeSnapshot(
     try fw.writeAll(&ver_buf);
     try fw.writeAll(&[2]u8{ 0, 0 }); // flags
 
-    const git_head = git_mod.getGitHead(stable_root_path, allocator) catch null;
+    const git_head = if (explorer.root_dir) |root_dir|
+        git_mod.getGitHeadDir(io, root_dir, allocator) catch null
+    else
+        git_mod.getGitHead(stable_root_path, allocator) catch null;
     if (git_head) |head| {
         try fw.writeAll(&head);
     } else {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -66,6 +66,27 @@ const SectionEntry = struct {
     length: u64,
 };
 
+const OutputPathStyle = enum { posix, windows };
+
+fn splitOutputPath(path: []const u8, style: OutputPathStyle) struct { parent: []const u8, name: []const u8 } {
+    const parent = switch (style) {
+        .posix => std.fs.path.dirnamePosix(path),
+        .windows => std.fs.path.dirnameWindows(path),
+    } orelse ".";
+    const name = switch (style) {
+        .posix => std.fs.path.basenamePosix(path),
+        .windows => std.fs.path.basenameWindows(path),
+    };
+    return .{ .parent = parent, .name = name };
+}
+
+fn nativeOutputPathStyle() OutputPathStyle {
+    return switch (builtin.os.tag) {
+        .windows, .uefi => .windows,
+        else => .posix,
+    };
+}
+
 /// Write a portable `.codedb` snapshot file.
 pub fn writeSnapshot(
     io: std.Io,
@@ -89,9 +110,9 @@ pub fn writeSnapshot(
     };
     defer if (owned_source_root) |dir| dir.close(io);
 
-    const sep = std.mem.lastIndexOfScalar(u8, output_path, '/');
-    const output_parent_path = if (sep) |s| if (s == 0) "/" else output_path[0..s] else ".";
-    const output_name = if (sep) |s| output_path[s + 1 ..] else output_path;
+    const output_parts = splitOutputPath(output_path, nativeOutputPathStyle());
+    const output_parent_path = output_parts.parent;
+    const output_name = output_parts.name;
     if (output_name.len == 0) return error.BadPathName;
     const root_snapshot = isRootSnapshot(output_path, root_path);
     var owned_output_dir: ?std.Io.Dir = null;
@@ -463,6 +484,16 @@ pub fn writeSnapshot(
     if (root_snapshot) {
         ensureGitIgnoresSnapshotAtRoot(io, source_root, allocator);
     }
+}
+
+test "snapshot output path split handles POSIX and Windows absolute paths" {
+    const testing = std.testing;
+    const posix = splitOutputPath("/var/cache/codedb.snapshot", .posix);
+    try testing.expectEqualStrings("/var/cache", posix.parent);
+    try testing.expectEqualStrings("codedb.snapshot", posix.name);
+    const windows = splitOutputPath("C:\\cache\\codedb.snapshot", .windows);
+    try testing.expectEqualStrings("C:\\cache", windows.parent);
+    try testing.expectEqualStrings("codedb.snapshot", windows.name);
 }
 
 /// True when `output_path` is the in-tree project-root snapshot

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1473,28 +1473,44 @@ fn resolveSafeSnapshotPath(io: std.Io, root_dir: std.Io.Dir, canonical_root: []c
 /// snapshot or live-indexed. Single implementation of this security filter;
 /// `watcher.isSensitivePath` delegates here (parity-tested in test_snapshot.zig
 /// "issue-528: isSensitivePath parity").
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    if (value.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}
+
+fn hasSensitiveExtension(basename: []const u8) bool {
+    const extensions = [_][]const u8{ ".env", ".pem", ".key", ".p12", ".pfx", ".jks" };
+    for (extensions) |extension| {
+        if (endsWithIgnoreCase(basename, extension)) return true;
+    }
+    return false;
+}
+
+fn hasSensitiveDirectory(path: []const u8) bool {
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |component| {
+        if (std.ascii.eqlIgnoreCase(component, ".ssh") or
+            std.ascii.eqlIgnoreCase(component, ".gnupg") or
+            std.ascii.eqlIgnoreCase(component, ".aws")) return true;
+    }
+    return false;
+}
+
 pub fn isSensitivePath(path: []const u8) bool {
     const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
     // Fast path: most source files have extensions like .zig, .ts, .py — none start with '.'
     // or match sensitive patterns. Skip the full check for common cases.
     if (basename.len == 0) return false;
-    const first = basename[0];
+    const first = std.ascii.toLower(basename[0]);
     // Only check sensitive names if basename starts with '.', 'c', 's', 'i' or has key/cert extension
     if (first != '.' and first != 'c' and first != 's' and first != 'i') {
         // Still need to check extensions and directory patterns
-        if (std.mem.endsWith(u8, basename, ".env") or
-            std.mem.endsWith(u8, basename, ".pem") or
-            std.mem.endsWith(u8, basename, ".key") or
-            std.mem.endsWith(u8, basename, ".p12") or
-            std.mem.endsWith(u8, basename, ".pfx") or
-            std.mem.endsWith(u8, basename, ".jks")) return true;
-        if (std.mem.indexOf(u8, path, ".ssh/") != null or
-            std.mem.indexOf(u8, path, ".gnupg/") != null or
-            std.mem.indexOf(u8, path, ".aws/") != null) return true;
+        if (hasSensitiveExtension(basename)) return true;
+        if (hasSensitiveDirectory(path)) return true;
         return false;
     }
     // .env, .env.<token>; do NOT match .envoy, .envrc, .environment, etc.
-    if (basename.len >= 4 and std.mem.eql(u8, basename[0..4], ".env") and
+    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[0..4], ".env") and
         (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
     // Exact matches
     const sensitive_names = [_][]const u8{
@@ -1504,17 +1520,10 @@ pub fn isSensitivePath(path: []const u8) bool {
         "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
     };
     for (sensitive_names) |name| {
-        if (std.mem.eql(u8, basename, name)) return true;
+        if (std.ascii.eqlIgnoreCase(basename, name)) return true;
     }
-    if (std.mem.endsWith(u8, basename, ".env") or
-        std.mem.endsWith(u8, basename, ".pem") or
-        std.mem.endsWith(u8, basename, ".key") or
-        std.mem.endsWith(u8, basename, ".p12") or
-        std.mem.endsWith(u8, basename, ".pfx") or
-        std.mem.endsWith(u8, basename, ".jks")) return true;
-    if (std.mem.indexOf(u8, path, ".ssh/") != null or
-        std.mem.indexOf(u8, path, ".gnupg/") != null or
-        std.mem.indexOf(u8, path, ".aws/") != null) return true;
+    if (hasSensitiveExtension(basename)) return true;
+    if (hasSensitiveDirectory(path)) return true;
     return false;
 }
 fn endsWith(s: []const u8, suffix: []const u8) bool {

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -34,9 +34,14 @@ const DocumentLink = explore_mod.DocumentLink;
 const DocumentLinkKind = explore_mod.DocumentLinkKind;
 const Store = @import("store.zig").Store;
 const git_mod = @import("git.zig");
+const project_file = @import("project_file.zig");
+const project_path = @import("project_path.zig");
 
 const MAGIC = [4]u8{ 'C', 'D', 'B', 0x01 };
-const FORMAT_VERSION: u16 = 3;
+// v4 snapshots guarantee that every content record was read from a validated
+// no-follow project handle. Older v3 files may contain bytes captured through
+// a safe-looking alias and are deliberately invalidated on upgrade.
+const FORMAT_VERSION: u16 = 4;
 
 pub const SectionId = enum(u32) {
     tree = 1,
@@ -68,6 +73,10 @@ pub fn writeSnapshot(
     defer allocator.free(tmp_path);
 
     var file = try std.Io.Dir.cwd().createFile(io, tmp_path, .{});
+    errdefer {
+        file.close(io);
+        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+    }
 
     var sections: std.ArrayList(SectionEntry) = .empty;
     defer sections.deinit(allocator);
@@ -84,6 +93,22 @@ pub fn writeSnapshot(
 
     explorer.mu.lockShared();
     defer explorer.mu.unlockShared();
+
+    var source_root = try std.Io.Dir.cwd().openDir(io, root_path, .{});
+    defer source_root.close(io);
+    // A production explorer always owns a rooted I/O capability. Revalidate every
+    // cached record against that live capability before persisting it so a file
+    // that was swapped to a symlink after indexing cannot poison the snapshot.
+    // Synthetic unit-test explorers intentionally have no root capability and may
+    // contain in-memory-only records; cache misses below still require a validated
+    // live file in both modes.
+    if (explorer.io != null and explorer.root_dir != null) {
+        var validate_iter = explorer.outlines.keyIterator();
+        while (validate_iter.next()) |path| {
+            if (!isSafeSnapshotPath(path.*)) continue;
+            _ = project_file.statNoFollow(io, source_root, path.*) catch return error.InvalidSnapshotSource;
+        }
+    }
 
     // ── Section: META ──
     {
@@ -263,9 +288,6 @@ pub fn writeSnapshot(
     defer content_hashes.deinit(allocator);
     {
         const offset = file_writer.logicalPos();
-        var root_dir = std.Io.Dir.cwd().openDir(io, root_path, .{}) catch null;
-        defer if (root_dir) |*dir| dir.close(io);
-
         var path_iter = explorer.outlines.keyIterator();
         while (path_iter.next()) |path_ptr| {
             const path = path_ptr.*;
@@ -282,8 +304,8 @@ pub fn writeSnapshot(
                 try fw.writeAll(&cl_buf);
                 try fw.writeAll(content);
                 try content_hashes.append(allocator, std.hash.Wyhash.hash(0, content));
-            } else if (root_dir) |*dir| {
-                const disk_content = dir.readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch continue;
+            } else {
+                const disk_content = try project_file.readAllocNoFollow(io, source_root, path, allocator, .limited(64 * 1024 * 1024));
                 errdefer allocator.free(disk_content);
 
                 var pl_buf: [2]u8 = undefined;
@@ -430,7 +452,7 @@ pub fn ensureGitIgnoresSnapshot(io: std.Io, root_path: []const u8, allocator: st
     defer info_dir.close(io);
 
     const needle = "codedb.snapshot";
-    const existing: ?[]u8 = info_dir.readFileAlloc(io, "exclude", allocator, .limited(1024 * 1024)) catch null;
+    const existing: ?[]u8 = project_file.readAllocNoFollow(io, info_dir, "exclude", allocator, .limited(1024 * 1024)) catch null;
     defer if (existing) |e| allocator.free(e);
 
     if (existing) |content| {
@@ -460,6 +482,14 @@ fn readSectionsFromFile(io: std.Io, file: std.Io.File, allocator: std.mem.Alloca
     var magic_buf: [4]u8 = undefined;
     const n = file.readPositionalAll(io, &magic_buf, 0) catch return null;
     if (n != 4 or !std.mem.eql(u8, &magic_buf, &MAGIC)) return null;
+
+    // v4 is the first format whose writer and loader both enforce repository-
+    // rooted, no-follow source reads. Older snapshots may already contain bytes
+    // captured through a benign-looking symlink, so they are not safe inputs to
+    // search or remote semantic indexing after an upgrade.
+    var version_buf: [2]u8 = undefined;
+    const vn = file.readPositionalAll(io, &version_buf, 4) catch return null;
+    if (vn != version_buf.len or std.mem.readInt(u16, &version_buf, .little) != FORMAT_VERSION) return null;
 
     // offset 4 + 44 = 48: skip version + flags + git_head
     var sc_buf: [4]u8 = undefined;
@@ -683,13 +713,12 @@ pub fn loadSnapshotValidated(
 
         // Re-index from disk if file was modified after the snapshot
         var disk_content: ?[]u8 = null;
-        if (snap_mtime > 0 and disk_root != null and canonical_root != null) blk: {
-            var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const resolved = resolveSafeSnapshotPath(io, disk_root.?, canonical_root.?, path_buf, &resolved_buf) orelse break :blk;
-            const ds = std.Io.Dir.cwd().statFile(io, resolved, .{}) catch break :blk;
+        if (disk_root) |root| blk: {
+            const ds = project_file.statNoFollow(io, root, path_buf) catch return false;
+            if (snap_mtime <= 0) break :blk;
             const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
             if (ds_mtime <= snap_mtime) break :blk;
-            disk_content = std.Io.Dir.cwd().readFileAlloc(io, resolved, allocator, .limited(16 * 1024 * 1024)) catch break :blk;
+            disk_content = project_file.readAllocNoFollow(io, root, path_buf, allocator, .limited(16 * 1024 * 1024)) catch return false;
         }
         defer if (disk_content) |dc| allocator.free(dc);
         const effective = if (disk_content) |dc| dc else content;
@@ -1014,6 +1043,7 @@ const LoadRecord = struct {
 // pure and trivially thread-safe; the insert pass reads fresh content (sequentially,
 // one file at a time) for the rare stale ones.
 const LoadFreshness = struct {
+    valid: bool = false,
     stale: bool = false,
 };
 
@@ -1021,11 +1051,10 @@ const LoadFreshness = struct {
 // open/close) and flag it stale when its mtime is newer than the snapshot. Pure
 // read-only and allocation-free, so workers run this over disjoint chunks
 // concurrently; each writes only its own slice of `out`.
-fn freshnessScan(io: std.Io, root_dir: std.Io.Dir, canonical_root: []const u8, snap_mtime: i128, recs: []const LoadRecord, out: []LoadFreshness) void {
+fn freshnessScan(io: std.Io, root_dir: std.Io.Dir, snap_mtime: i128, recs: []const LoadRecord, out: []LoadFreshness) void {
     for (recs, out) |record, *fr| {
-        var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const resolved = resolveSafeSnapshotPath(io, root_dir, canonical_root, record.path, &resolved_buf) orelse continue;
-        const ds = std.Io.Dir.cwd().statFile(io, resolved, .{}) catch continue;
+        const ds = project_file.statNoFollow(io, root_dir, record.path) catch continue;
+        fr.valid = true;
         const ds_mtime: i128 = @intCast(ds.mtime.nanoseconds);
         if (ds_mtime > snap_mtime) fr.stale = true;
     }
@@ -1185,10 +1214,10 @@ fn loadSnapshotFast(
     // for the flagged files and mutates Explorer/Store single-threaded.
     const fresh_results = allocator.alloc(LoadFreshness, records.items.len) catch return false;
     defer allocator.free(fresh_results);
-    for (fresh_results) |*fr| fr.* = .{};
+    for (fresh_results) |*fr| fr.* = .{ .valid = disk_root == null };
 
     const t_fresh0: i128 = if (prof) cio.nanoTimestamp() else 0;
-    if (snap_mtime > 0 and records.items.len > 0 and disk_root != null and canonical_root != null) {
+    if (records.items.len > 0 and disk_root != null and canonical_root != null) {
         const want_workers = blk: {
             if (cio.posixGetenv("CODEDB_LOAD_WORKERS")) |raw| {
                 const parsed = std.fmt.parseInt(usize, raw, 10) catch 0;
@@ -1200,7 +1229,7 @@ fn loadSnapshotFast(
         };
         const n_workers = @max(@as(usize, 1), @min(want_workers, records.items.len));
         if (n_workers <= 1) {
-            freshnessScan(io, disk_root.?, canonical_root.?, snap_mtime, records.items, fresh_results);
+            freshnessScan(io, disk_root.?, snap_mtime, records.items, fresh_results);
         } else if (allocator.alloc(std.Thread, n_workers)) |threads| {
             defer allocator.free(threads);
             const chunk = records.items.len / n_workers;
@@ -1215,24 +1244,25 @@ fn loadSnapshotFast(
                 const recs = records.items[start..off];
                 const out = fresh_results[start..off];
                 if (spawn_failed) {
-                    freshnessScan(io, disk_root.?, canonical_root.?, snap_mtime, recs, out);
+                    freshnessScan(io, disk_root.?, snap_mtime, recs, out);
                     continue;
                 }
-                if (std.Thread.spawn(.{}, freshnessScan, .{ io, disk_root.?, canonical_root.?, snap_mtime, recs, out })) |t| {
+                if (std.Thread.spawn(.{}, freshnessScan, .{ io, disk_root.?, snap_mtime, recs, out })) |t| {
                     threads[spawned] = t;
                     spawned += 1;
                 } else |_| {
                     // Out of threads: scan this chunk (and any remaining) inline.
-                    freshnessScan(io, disk_root.?, canonical_root.?, snap_mtime, recs, out);
+                    freshnessScan(io, disk_root.?, snap_mtime, recs, out);
                     spawn_failed = true;
                 }
             }
             for (threads[0..spawned]) |t| t.join();
         } else |_| {
-            freshnessScan(io, disk_root.?, canonical_root.?, snap_mtime, records.items, fresh_results);
+            freshnessScan(io, disk_root.?, snap_mtime, records.items, fresh_results);
         }
     }
     if (prof) fresh_ns += cio.nanoTimestamp() - t_fresh0;
+    for (fresh_results) |fr| if (!fr.valid) return false;
     const rss_fresh: u64 = if (prof) loadMaxRssBytes() else 0;
     // ── Pass C: insert restored / changed / outline-only files (sequential). ──
     // #564: defer the global symbol index — Pass C's per-file rebuilds become
@@ -1250,10 +1280,7 @@ fn loadSnapshotFast(
         // peak memory is one file's content, not every changed file's at once.
         var disk_content: ?[]u8 = null;
         if (fr.stale and disk_root != null and canonical_root != null) {
-            var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
-            if (resolveSafeSnapshotPath(io, disk_root.?, canonical_root.?, path, &resolved_buf)) |resolved| {
-                disk_content = std.Io.Dir.cwd().readFileAlloc(io, resolved, allocator, .limited(16 * 1024 * 1024)) catch null;
-            }
+            disk_content = project_file.readAllocNoFollow(io, disk_root.?, path, allocator, .limited(16 * 1024 * 1024)) catch return false;
         }
         defer if (disk_content) |dc| allocator.free(dc);
 
@@ -1442,17 +1469,7 @@ fn parseJsonU64(json: []const u8, key: []const u8) ?u64 {
 /// Snapshot records are untrusted input. Only canonical project-relative paths
 /// may be persisted, indexed, or used for freshness reads.
 pub fn isSafeSnapshotPath(path: []const u8) bool {
-    if (path.len == 0 or path.len > 4096 or std.fs.path.isAbsolute(path)) return false;
-    if (std.mem.indexOfScalar(u8, path, 0) != null or
-        std.mem.indexOfScalar(u8, path, '\\') != null or
-        std.mem.indexOfScalar(u8, path, ':') != null or
-        isSensitivePath(path)) return false;
-
-    var components = std.mem.splitScalar(u8, path, '/');
-    while (components.next()) |component| {
-        if (component.len == 0 or std.mem.eql(u8, component, ".") or std.mem.eql(u8, component, "..")) return false;
-    }
-    return true;
+    return project_path.isReadable(path);
 }
 
 fn isWithinCanonicalRoot(root: []const u8, candidate: []const u8) bool {
@@ -1469,62 +1486,11 @@ fn resolveSafeSnapshotPath(io: std.Io, root_dir: std.Io.Dir, canonical_root: []c
     return resolved;
 }
 
-/// Returns true for secret/credential paths that must never be persisted to a
-/// snapshot or live-indexed. Single implementation of this security filter;
-/// `watcher.isSensitivePath` delegates here (parity-tested in test_snapshot.zig
-/// "issue-528: isSensitivePath parity").
-fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
-    if (value.len < suffix.len) return false;
-    return std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
-}
-
-fn hasSensitiveExtension(basename: []const u8) bool {
-    const extensions = [_][]const u8{ ".env", ".pem", ".key", ".p12", ".pfx", ".jks" };
-    for (extensions) |extension| {
-        if (endsWithIgnoreCase(basename, extension)) return true;
-    }
-    return false;
-}
-
-fn hasSensitiveDirectory(path: []const u8) bool {
-    var components = std.mem.splitScalar(u8, path, '/');
-    while (components.next()) |component| {
-        if (std.ascii.eqlIgnoreCase(component, ".ssh") or
-            std.ascii.eqlIgnoreCase(component, ".gnupg") or
-            std.ascii.eqlIgnoreCase(component, ".aws")) return true;
-    }
-    return false;
-}
-
+/// Compatibility export for callers that historically used snapshot.zig as
+/// the sensitive-path policy boundary. The implementation now lives in the
+/// shared project-path module used by every repository read surface.
 pub fn isSensitivePath(path: []const u8) bool {
-    const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep| path[sep + 1 ..] else path;
-    // Fast path: most source files have extensions like .zig, .ts, .py — none start with '.'
-    // or match sensitive patterns. Skip the full check for common cases.
-    if (basename.len == 0) return false;
-    const first = std.ascii.toLower(basename[0]);
-    // Only check sensitive names if basename starts with '.', 'c', 's', 'i' or has key/cert extension
-    if (first != '.' and first != 'c' and first != 's' and first != 'i') {
-        // Still need to check extensions and directory patterns
-        if (hasSensitiveExtension(basename)) return true;
-        if (hasSensitiveDirectory(path)) return true;
-        return false;
-    }
-    // .env, .env.<token>; do NOT match .envoy, .envrc, .environment, etc.
-    if (basename.len >= 4 and std.ascii.eqlIgnoreCase(basename[0..4], ".env") and
-        (basename.len == 4 or basename[4] == '.' or basename[4] == '-' or basename[4] == '_')) return true;
-    // Exact matches
-    const sensitive_names = [_][]const u8{
-        ".dev.vars",        ".npmrc",               ".pypirc",      ".netrc",
-        "credentials.json", "service-account.json", "secrets.json", "secrets.yaml",
-        "secrets.yml",      "id_rsa",               "id_ed25519",   ".git-credentials",
-        "id_ecdsa",         "id_dsa",               "id_ecdsa_sk",  "id_ed25519_sk",
-    };
-    for (sensitive_names) |name| {
-        if (std.ascii.eqlIgnoreCase(basename, name)) return true;
-    }
-    if (hasSensitiveExtension(basename)) return true;
-    if (hasSensitiveDirectory(path)) return true;
-    return false;
+    return project_path.isSensitive(path);
 }
 fn endsWith(s: []const u8, suffix: []const u8) bool {
     if (s.len < suffix.len) return false;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -108,11 +108,14 @@ pub fn writeSnapshot(
     const tmp_name = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ output_name, rand_suffix });
     defer allocator.free(tmp_name);
 
-    var file = try output_dir.createFile(io, tmp_name, .{ .permissions = privateFilePermissions() });
-    errdefer {
-        file.close(io);
-        output_dir.deleteFile(io, tmp_name) catch {};
-    }
+    var file = try output_dir.createFile(io, tmp_name, .{
+        .exclusive = true,
+        .permissions = privateFilePermissions(),
+        .resolve_beneath = true,
+    });
+    var file_open = true;
+    defer if (file_open) file.close(io);
+    errdefer output_dir.deleteFile(io, tmp_name) catch {};
 
     var sections: std.ArrayList(SectionEntry) = .empty;
     defer sections.deinit(allocator);
@@ -448,7 +451,7 @@ pub fn writeSnapshot(
     try fw.flush();
     try file.sync(io);
     file.close(io);
-    file = undefined;
+    file_open = false;
     output_dir.rename(tmp_name, output_dir, output_name, io) catch |err| {
         // If rename fails (e.g. output_path is a directory), clean up tmp
         output_dir.deleteFile(io, tmp_name) catch {};
@@ -1616,25 +1619,114 @@ pub fn writeSnapshotDual(
     // keep the secondary crash-safe. Sharing one indexed_at/git_head between
     // the two copies is more correct than the old double-serialize, which
     // could capture different values.
-    copyToProjectCache(io, explorer, root_path, output_path, allocator) catch {};
+    try copyToProjectCache(io, explorer, root_path, output_path, allocator);
+}
+
+fn writePrivateFileAtomic(io: std.Io, dir: std.Io.Dir, name: []const u8, data: []const u8, allocator: std.mem.Allocator) !void {
+    const tmp = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ name, cio.randU64() });
+    defer allocator.free(tmp);
+    errdefer dir.deleteFile(io, tmp) catch {};
+
+    var file = try dir.createFile(io, tmp, .{
+        .exclusive = true,
+        .permissions = privateFilePermissions(),
+        .resolve_beneath = true,
+    });
+    var file_open = true;
+    defer if (file_open) file.close(io);
+    try file.writeStreamingAll(io, data);
+    try file.sync(io);
+    file.close(io);
+    file_open = false;
+    try dir.rename(tmp, dir, name, io);
+}
+
+fn copyOpenFileAtomic(io: std.Io, source: std.Io.File, dest_dir: std.Io.Dir, dest_name: []const u8, allocator: std.mem.Allocator) !void {
+    const tmp = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ dest_name, cio.randU64() });
+    defer allocator.free(tmp);
+    errdefer dest_dir.deleteFile(io, tmp) catch {};
+
+    var dest = try dest_dir.createFile(io, tmp, .{
+        .exclusive = true,
+        .permissions = privateFilePermissions(),
+        .resolve_beneath = true,
+    });
+    var dest_open = true;
+    defer if (dest_open) dest.close(io);
+
+    var offset: u64 = 0;
+    var buffer: [64 * 1024]u8 = undefined;
+    while (true) {
+        const count = try source.readPositionalAll(io, &buffer, offset);
+        if (count == 0) break;
+        try dest.writeStreamingAll(io, buffer[0..count]);
+        offset += count;
+        if (count < buffer.len) break;
+    }
+    try dest.sync(io);
+    dest.close(io);
+    dest_open = false;
+    try dest_dir.rename(tmp, dest_dir, dest_name, io);
+}
+
+fn openRegularFileNoFollow(io: std.Io, dir: std.Io.Dir, name: []const u8) !std.Io.File {
+    const source = try dir.openFile(io, name, .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    errdefer source.close(io);
+    const source_stat = try source.stat(io);
+    if (source_stat.kind != .file) return error.InvalidSnapshotSource;
+    return source;
+}
+
+test "snapshot cache source does not follow symlinks" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const testing = std.testing;
+    const test_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(test_io, .{ .sub_path = "snapshot", .data = "snapshot bytes" });
+    try tmp.dir.symLink(test_io, "snapshot", "snapshot-link", .{});
+
+    if (openRegularFileNoFollow(test_io, tmp.dir, "snapshot-link")) |file| {
+        file.close(test_io);
+        return error.TestExpectedError;
+    } else |_| {}
+}
+
+test "snapshot cache copy stays pinned to the opened source inode" {
+    const testing = std.testing;
+    const test_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(test_io, .{ .sub_path = "snapshot", .data = "first generation" });
+
+    const source = try openRegularFileNoFollow(test_io, tmp.dir, "snapshot");
+    defer source.close(test_io);
+    try tmp.dir.rename("snapshot", tmp.dir, "snapshot.old", test_io);
+    try tmp.dir.writeFile(test_io, .{ .sub_path = "snapshot", .data = "replacement generation" });
+
+    try copyOpenFileAtomic(test_io, source, tmp.dir, "copied", testing.allocator);
+    const copied = try tmp.dir.readFileAlloc(test_io, "copied", testing.allocator, .limited(1024));
+    defer testing.allocator.free(copied);
+    try testing.expectEqualStrings("first generation", copied);
 }
 
 fn copyToProjectCache(io: std.Io, explorer: *Explorer, root_path: []const u8, primary_path: []const u8, allocator: std.mem.Allocator) !void {
     const canonical_root = explorer.root_path orelse root_path;
     const hash = std.hash.Wyhash.hash(0, canonical_root);
-    const home_raw = cio.homeDir() orelse return;
-    const home = allocator.dupe(u8, home_raw) catch return;
+    const home_raw = cio.homeDir() orelse return error.HomeDirectoryUnavailable;
+    const home = try allocator.dupe(u8, home_raw);
     defer allocator.free(home);
-    const dir_path = std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash }) catch return;
+    const dir_path = try std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash });
     defer allocator.free(dir_path);
-    std.Io.Dir.cwd().createDirPath(io, dir_path) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, dir_path);
     var central_dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .follow_symlinks = false });
     defer central_dir.close(io);
 
-    var f = try central_dir.createFile(io, "project.txt", .{ .truncate = true, .permissions = privateFilePermissions() });
-    f.writeStreamingAll(io, canonical_root) catch {};
-    f.sync(io) catch {};
-    f.close(io);
+    try writePrivateFileAtomic(io, central_dir, "project.txt", canonical_root, allocator);
 
     const sep = std.mem.lastIndexOfScalar(u8, primary_path, '/');
     const source_parent = if (sep) |s| if (s == 0) "/" else primary_path[0..s] else ".";
@@ -1649,14 +1741,9 @@ fn copyToProjectCache(io: std.Io, explorer: *Explorer, root_path: []const u8, pr
     };
     defer if (owned_source_dir) |dir| dir.close(io);
 
-    const tmp = try std.fmt.allocPrint(allocator, "codedb.snapshot.{x}.tmp", .{cio.randU64()});
-    defer allocator.free(tmp);
-    errdefer central_dir.deleteFile(io, tmp) catch {};
-    try std.Io.Dir.copyFile(source_dir, source_name, central_dir, tmp, io, .{});
-    const copied = try central_dir.openFile(io, tmp, .{ .mode = .read_write, .follow_symlinks = false });
-    copied.sync(io) catch {};
-    copied.close(io);
-    try central_dir.rename(tmp, central_dir, "codedb.snapshot", io);
+    const source = try openRegularFileNoFollow(io, source_dir, source_name);
+    defer source.close(io);
+    try copyOpenFileAtomic(io, source, central_dir, "codedb.snapshot", allocator);
 }
 
 pub fn writeProjectCacheSnapshot(
@@ -1666,21 +1753,18 @@ pub fn writeProjectCacheSnapshot(
     allocator: std.mem.Allocator,
 ) !void {
     const hash = std.hash.Wyhash.hash(0, root_path);
-    const home_raw = cio.homeDir() orelse return;
-    const home = allocator.dupe(u8, home_raw) catch return;
+    const home_raw = cio.homeDir() orelse return error.HomeDirectoryUnavailable;
+    const home = try allocator.dupe(u8, home_raw);
     defer allocator.free(home);
-    const secondary = std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}/codedb.snapshot", .{ home, hash }) catch return;
+    const secondary = try std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}/codedb.snapshot", .{ home, hash });
     defer allocator.free(secondary);
 
-    const dir_path = std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash }) catch return;
+    const dir_path = try std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash });
     defer allocator.free(dir_path);
-    std.Io.Dir.cwd().createDirPath(io, dir_path) catch {};
-
-    const proj_txt = std.fmt.allocPrint(allocator, "{s}/project.txt", .{dir_path}) catch return;
-    defer allocator.free(proj_txt);
-    var f = try std.Io.Dir.cwd().createFile(io, proj_txt, .{ .truncate = true });
-    f.writeStreamingAll(io, root_path) catch {};
-    f.close(io);
+    try std.Io.Dir.cwd().createDirPath(io, dir_path);
+    var central_dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .follow_symlinks = false });
+    defer central_dir.close(io);
+    try writePrivateFileAtomic(io, central_dir, "project.txt", root_path, allocator);
 
     try writeSnapshot(io, explorer, root_path, secondary, allocator);
 }

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -23,6 +23,7 @@
 //     OUTLINE_STATE (7): binary per-file outline/import metadata for fast warm restore
 
 const std = @import("std");
+const builtin = @import("builtin");
 const cio = @import("cio.zig");
 const explore_mod = @import("explore.zig");
 const Explorer = explore_mod.Explorer;
@@ -42,6 +43,11 @@ const MAGIC = [4]u8{ 'C', 'D', 'B', 0x01 };
 // no-follow project handle. Older v3 files may contain bytes captured through
 // a safe-looking alias and are deliberately invalidated on upgrade.
 const FORMAT_VERSION: u16 = 4;
+
+fn privateFilePermissions() std.Io.File.Permissions {
+    if (comptime builtin.os.tag == .windows) return .default_file;
+    return .fromMode(0o600);
+}
 
 pub const SectionId = enum(u32) {
     tree = 1,
@@ -68,14 +74,44 @@ pub fn writeSnapshot(
     output_path: []const u8,
     allocator: std.mem.Allocator,
 ) !void {
-    const rand_suffix = cio.randU64();
-    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ output_path, rand_suffix });
-    defer allocator.free(tmp_path);
+    const stable_root_path = explorer.root_path orelse root_path;
+    var owned_source_root: ?std.Io.Dir = null;
+    const source_root = if (explorer.root_dir) |dir| blk: {
+        if (!project_file.rootMatchesPath(io, dir, root_path)) return error.InvalidSnapshotSource;
+        break :blk dir;
+    } else blk: {
+        // Synthetic tests may build an in-memory Explorer without a root
+        // capability (and macOS spells /tmp through a directory symlink).
+        // Production explorers are always rooted by setRoot above.
+        const dir = try std.Io.Dir.cwd().openDir(io, root_path, .{});
+        owned_source_root = dir;
+        break :blk dir;
+    };
+    defer if (owned_source_root) |dir| dir.close(io);
 
-    var file = try std.Io.Dir.cwd().createFile(io, tmp_path, .{});
+    const sep = std.mem.lastIndexOfScalar(u8, output_path, '/');
+    const output_parent_path = if (sep) |s| if (s == 0) "/" else output_path[0..s] else ".";
+    const output_name = if (sep) |s| output_path[s + 1 ..] else output_path;
+    if (output_name.len == 0) return error.BadPathName;
+    const root_snapshot = isRootSnapshot(output_path, root_path);
+    var owned_output_dir: ?std.Io.Dir = null;
+    const output_dir = if (root_snapshot) blk: {
+        break :blk explorer.root_dir orelse return error.InvalidSnapshotSource;
+    } else blk: {
+        const dir = try std.Io.Dir.cwd().openDir(io, output_parent_path, .{ .follow_symlinks = false });
+        owned_output_dir = dir;
+        break :blk dir;
+    };
+    defer if (owned_output_dir) |dir| dir.close(io);
+
+    const rand_suffix = cio.randU64();
+    const tmp_name = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ output_name, rand_suffix });
+    defer allocator.free(tmp_name);
+
+    var file = try output_dir.createFile(io, tmp_name, .{ .permissions = privateFilePermissions() });
     errdefer {
         file.close(io);
-        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        output_dir.deleteFile(io, tmp_name) catch {};
     }
 
     var sections: std.ArrayList(SectionEntry) = .empty;
@@ -94,22 +130,6 @@ pub fn writeSnapshot(
     explorer.mu.lockShared();
     defer explorer.mu.unlockShared();
 
-    var source_root = try std.Io.Dir.cwd().openDir(io, root_path, .{});
-    defer source_root.close(io);
-    // A production explorer always owns a rooted I/O capability. Revalidate every
-    // cached record against that live capability before persisting it so a file
-    // that was swapped to a symlink after indexing cannot poison the snapshot.
-    // Synthetic unit-test explorers intentionally have no root capability and may
-    // contain in-memory-only records; cache misses below still require a validated
-    // live file in both modes.
-    if (explorer.io != null and explorer.root_dir != null) {
-        var validate_iter = explorer.outlines.keyIterator();
-        while (validate_iter.next()) |path| {
-            if (!isSafeSnapshotPath(path.*)) continue;
-            _ = project_file.statNoFollow(io, source_root, path.*) catch return error.InvalidSnapshotSource;
-        }
-    }
-
     // ── Section: META ──
     {
         const offset = file_writer.logicalPos();
@@ -127,7 +147,7 @@ pub fn writeSnapshot(
             if (isSafeSnapshotPath(k.*)) file_count_meta += 1;
         }
 
-        const root_hash = std.hash.Wyhash.hash(0, root_path);
+        const root_hash = std.hash.Wyhash.hash(0, stable_root_path);
         try writer.print(
             \\{{"file_count":{d},"total_bytes":{d},"indexed_at":{d},"format_version":{d},"root_hash":{d}}}
         , .{
@@ -295,6 +315,9 @@ pub fn writeSnapshot(
             if (!isSafeSnapshotPath(path)) continue;
             const cached_content = explorer.contents.get(path);
             if (cached_content) |content| {
+                if (explorer.root_dir != null) {
+                    _ = project_file.statNoFollowAtRoot(io, source_root, stable_root_path, path) catch return error.InvalidSnapshotSource;
+                }
                 var pl_buf: [2]u8 = undefined;
                 std.mem.writeInt(u16, &pl_buf, @intCast(path.len), .little);
                 try fw.writeAll(&pl_buf);
@@ -305,7 +328,10 @@ pub fn writeSnapshot(
                 try fw.writeAll(content);
                 try content_hashes.append(allocator, std.hash.Wyhash.hash(0, content));
             } else {
-                const disk_content = try project_file.readAllocNoFollow(io, source_root, path, allocator, .limited(64 * 1024 * 1024));
+                const disk_content = if (explorer.root_dir != null)
+                    project_file.readAllocNoFollowAtRoot(io, source_root, stable_root_path, path, allocator, .limited(64 * 1024 * 1024)) catch return error.InvalidSnapshotSource
+                else
+                    project_file.readAllocNoFollow(io, source_root, path, allocator, .limited(64 * 1024 * 1024)) catch return error.InvalidSnapshotSource;
                 errdefer allocator.free(disk_content);
 
                 var pl_buf: [2]u8 = undefined;
@@ -393,7 +419,7 @@ pub fn writeSnapshot(
     try fw.writeAll(&ver_buf);
     try fw.writeAll(&[2]u8{ 0, 0 }); // flags
 
-    const git_head = git_mod.getGitHead(root_path, allocator) catch null;
+    const git_head = git_mod.getGitHead(stable_root_path, allocator) catch null;
     if (git_head) |head| {
         try fw.writeAll(&head);
     } else {
@@ -417,18 +443,19 @@ pub fn writeSnapshot(
     }
 
     try fw.flush();
+    try file.sync(io);
     file.close(io);
     file = undefined;
-    std.Io.Dir.cwd().rename(tmp_path, std.Io.Dir.cwd(), output_path, io) catch |err| {
+    output_dir.rename(tmp_name, output_dir, output_name, io) catch |err| {
         // If rename fails (e.g. output_path is a directory), clean up tmp
-        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        output_dir.deleteFile(io, tmp_name) catch {};
         return err;
     };
 
     // #625: the snapshot lives inside the project tree — make sure git ignores
     // it so it never pollutes `git status` or gets committed by accident.
-    if (isRootSnapshot(output_path, root_path)) {
-        ensureGitIgnoresSnapshot(io, root_path, allocator);
+    if (root_snapshot) {
+        ensureGitIgnoresSnapshotAtRoot(io, source_root, allocator);
     }
 }
 
@@ -446,9 +473,15 @@ pub fn isRootSnapshot(output_path: []const u8, root_path: []const u8) bool {
 /// worktree where `.git` is a file, permissions, or any I/O error is silently
 /// skipped. Indexing must never fail because of this. Idempotent.
 pub fn ensureGitIgnoresSnapshot(io: std.Io, root_path: []const u8, allocator: std.mem.Allocator) void {
-    var info_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const info_path = std.fmt.bufPrint(&info_buf, "{s}/.git/info", .{root_path}) catch return;
-    var info_dir = std.Io.Dir.cwd().openDir(io, info_path, .{}) catch return;
+    var root_dir = std.Io.Dir.cwd().openDir(io, root_path, .{ .follow_symlinks = false }) catch return;
+    defer root_dir.close(io);
+    ensureGitIgnoresSnapshotAtRoot(io, root_dir, allocator);
+}
+
+fn ensureGitIgnoresSnapshotAtRoot(io: std.Io, root_dir: std.Io.Dir, allocator: std.mem.Allocator) void {
+    var git_dir = root_dir.openDir(io, ".git", .{ .follow_symlinks = false }) catch return;
+    defer git_dir.close(io);
+    var info_dir = git_dir.openDir(io, "info", .{ .follow_symlinks = false }) catch return;
     defer info_dir.close(io);
 
     const needle = "codedb.snapshot";
@@ -529,6 +562,10 @@ pub fn readSectionBytes(io: std.Io, path: []const u8, section_id: SectionId, all
     const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return null;
     defer file.close(io);
 
+    return readSectionBytesFromFile(io, file, section_id, allocator);
+}
+
+fn readSectionBytesFromFile(io: std.Io, file: std.Io.File, section_id: SectionId, allocator: std.mem.Allocator) !?[]u8 {
     var sections = try readSectionsFromFile(io, file, allocator) orelse return null;
     defer sections.deinit();
 
@@ -555,6 +592,10 @@ pub fn readSnapshotGitHead(io: std.Io, path: []const u8) ?[40]u8 {
     const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return null;
     defer file.close(io);
 
+    return readSnapshotGitHeadFromFile(io, file);
+}
+
+pub fn readSnapshotGitHeadFromFile(io: std.Io, file: std.Io.File) ?[40]u8 {
     var magic_buf: [4]u8 = undefined;
     const mn = file.readPositionalAll(io, &magic_buf, 0) catch return null;
     if (mn != 4) return null;
@@ -602,6 +643,35 @@ pub fn loadSnapshotValidated(
     const file = std.Io.Dir.cwd().openFile(io, snapshot_path, .{}) catch return false;
     defer file.close(io);
 
+    return loadSnapshotValidatedFromFile(io, file, expected_root, explorer, store, allocator);
+}
+
+pub fn loadSnapshotValidatedFromRoot(
+    io: std.Io,
+    root_dir: std.Io.Dir,
+    expected_root: []const u8,
+    explorer: *Explorer,
+    store: *Store,
+    allocator: std.mem.Allocator,
+) bool {
+    const file = root_dir.openFile(io, "codedb.snapshot", .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch return false;
+    defer file.close(io);
+    return loadSnapshotValidatedFromFile(io, file, expected_root, explorer, store, allocator);
+}
+
+pub fn loadSnapshotValidatedFromFile(
+    io: std.Io,
+    file: std.Io.File,
+    expected_root: ?[]const u8,
+    explorer: *Explorer,
+    store: *Store,
+    allocator: std.mem.Allocator,
+) bool {
+
     // Read section table (validates magic internally) — reuse already-open file (#253)
     var sections = (readSectionsFromFile(io, file, allocator) catch return false) orelse return false;
     defer sections.deinit();
@@ -626,7 +696,8 @@ pub fn loadSnapshotValidated(
 
     // Validate repo identity if requested (issue-41)
     if (expected_root) |root| {
-        const expected_hash = std.hash.Wyhash.hash(0, root);
+        const identity_root = explorer.root_path orelse root;
+        const expected_hash = std.hash.Wyhash.hash(0, identity_root);
         if (meta_root_hash) |stored_hash| {
             if (stored_hash != expected_hash) return false;
         } else {
@@ -641,17 +712,22 @@ pub fn loadSnapshotValidated(
     // snapshot-provided path is used for disk I/O.
     var disk_root: ?std.Io.Dir = null;
     var close_disk_root = false;
-    if (expected_root) |root| {
-        disk_root = std.Io.Dir.cwd().openDir(io, root, .{}) catch return false;
-        close_disk_root = true;
-    } else if (explorer.root_dir) |dir| {
+    if (explorer.root_dir) |dir| {
+        if (expected_root) |root| {
+            if (!project_file.rootMatchesPath(io, dir, root)) return false;
+        }
         disk_root = dir;
+    } else if (expected_root) |root| {
+        disk_root = std.Io.Dir.cwd().openDir(io, root, .{ .follow_symlinks = false }) catch return false;
+        close_disk_root = true;
     }
     defer if (close_disk_root) if (disk_root) |*dir| dir.close(io);
 
     var canonical_root_buf: [std.fs.max_path_bytes]u8 = undefined;
     var canonical_root: ?[]const u8 = null;
-    if (disk_root) |dir| root_blk: {
+    if (explorer.root_path) |path| {
+        canonical_root = path;
+    } else if (disk_root) |dir| root_blk: {
         const len = dir.realPathFile(io, ".", &canonical_root_buf) catch {
             if (expected_root != null) return false;
             disk_root = null;
@@ -661,7 +737,7 @@ pub fn loadSnapshotValidated(
     }
 
     if (sections.get(@intFromEnum(SectionId.outline_state)) != null) {
-        return loadSnapshotFast(io, snapshot_path, expected_file_count, disk_root, canonical_root, explorer, store, allocator) catch false;
+        return loadSnapshotFast(io, file, expected_file_count, disk_root, canonical_root, explorer, store, allocator) catch false;
     }
 
     // Load CONTENT section — this is the core data
@@ -819,15 +895,13 @@ fn readSectionStringBorrowed(buf: []const u8, cursor: *usize, max_len: usize) ![
 /// allocator), NOT `allocator` (the per-load allocator): it is retained by the
 /// Explorer and must share its lifetime/allocator. Everything else (the map,
 /// keys/paths) uses `allocator` exactly as before.
-fn loadOutlineStateMap(io: std.Io, snapshot_path: []const u8, allocator: std.mem.Allocator, backing_allocator: std.mem.Allocator, expected: ?u32, backing_out: *?[]const u8) !std.StringHashMap(FileOutline) {
+fn loadOutlineStateMap(io: std.Io, snapshot_file: std.Io.File, allocator: std.mem.Allocator, backing_allocator: std.mem.Allocator, expected: ?u32, backing_out: *?[]const u8) !std.StringHashMap(FileOutline) {
     backing_out.* = null;
-    const bytes = (try readSectionBytes(io, snapshot_path, .outline_state, backing_allocator)) orelse return error.InvalidData;
+    const bytes = (try readSectionBytesFromFile(io, snapshot_file, .outline_state, backing_allocator)) orelse return error.InvalidData;
     // Kept alive on success (handed to backing_out); freed here on any error.
     var release_bytes = true;
     defer if (release_bytes) backing_allocator.free(bytes);
 
-    const snapshot_file = try std.Io.Dir.cwd().openFile(io, snapshot_path, .{});
-    defer snapshot_file.close(io);
     var version_buf: [2]u8 = undefined;
     if (try snapshot_file.readPositionalAll(io, &version_buf, 4) != version_buf.len) return error.InvalidData;
     const format_version = std.mem.readInt(u16, &version_buf, .little);
@@ -1062,7 +1136,7 @@ fn freshnessScan(io: std.Io, root_dir: std.Io.Dir, snap_mtime: i128, recs: []con
 
 fn loadSnapshotFast(
     io: std.Io,
-    snapshot_path: []const u8,
+    snapshot_file: std.Io.File,
     expected_file_count: ?u32,
     disk_root: ?std.Io.Dir,
     canonical_root: ?[]const u8,
@@ -1086,7 +1160,7 @@ fn loadSnapshotFast(
     // the Explorer (outline_section_bufs) and freed via explorer.allocator, so it
     // must be allocated from the same allocator (matters when the per-load
     // allocator differs from the Explorer's, e.g. arena-backed Explorers).
-    var outline_states = loadOutlineStateMap(io, snapshot_path, allocator, explorer.allocator, expected_file_count, &section_backing) catch std.StringHashMap(FileOutline).init(allocator);
+    var outline_states = loadOutlineStateMap(io, snapshot_file, allocator, explorer.allocator, expected_file_count, &section_backing) catch std.StringHashMap(FileOutline).init(allocator);
     defer deinitOutlineStateMap(&outline_states, allocator);
 
     // Restored outlines borrow their import/symbol strings as slices into this
@@ -1110,12 +1184,11 @@ fn loadSnapshotFast(
 
     const rss_outline: u64 = if (prof) loadMaxRssBytes() else 0;
     const t_outline: i128 = if (prof) cio.nanoTimestamp() else 0;
-    var sections = (try readSections(io, snapshot_path, allocator)) orelse return false;
+    var sections = (try readSectionsFromFile(io, snapshot_file, allocator)) orelse return false;
     defer sections.deinit();
 
     const content_entry = sections.get(@intFromEnum(SectionId.content)) orelse return false;
-    const content_file = std.Io.Dir.cwd().openFile(io, snapshot_path, .{}) catch return false;
-    defer content_file.close(io);
+    const content_file = snapshot_file;
 
     const file_stat = content_file.stat(io) catch return false;
     if (content_entry.offset + content_entry.length > file_stat.size) return false;
@@ -1127,7 +1200,7 @@ fn loadSnapshotFast(
     // Precomputed per-record content hashes (CONTENT_HASHES section), in content
     // order. Lets the restored branch record Store baselines without re-hashing
     // (which would also fault in all content pages). Absent => recompute.
-    const content_hashes_buf: ?[]u8 = readSectionBytes(io, snapshot_path, .content_hashes, allocator) catch null;
+    const content_hashes_buf: ?[]u8 = readSectionBytesFromFile(io, snapshot_file, .content_hashes, allocator) catch null;
     defer if (content_hashes_buf) |b| allocator.free(b);
 
     // Read the content section as one block, then parse records from memory.
@@ -1332,10 +1405,8 @@ fn loadSnapshotFast(
         if (freq_entry.length == 256 * 256 * 2) {
             const index_mod = @import("index.zig");
             const ft = allocator.create([256][256]u16) catch return file_count > 0;
-            const freq_file = std.Io.Dir.cwd().openFile(io, snapshot_path, .{}) catch return file_count > 0;
-            defer freq_file.close(io);
             var bulk_buf: [256 * 256 * 2]u8 = undefined;
-            const nr = freq_file.readPositionalAll(io, &bulk_buf, freq_entry.offset) catch {
+            const nr = snapshot_file.readPositionalAll(io, &bulk_buf, freq_entry.offset) catch {
                 allocator.destroy(ft);
                 return file_count > 0;
             };
@@ -1357,7 +1428,7 @@ fn loadSnapshotFast(
     // search skips the lazy rebuild (ensureCallCentrality's null-check returns
     // early once this is set). Best-effort: any failure just leaves it unbuilt.
     if (sections.get(@intFromEnum(SectionId.call_centrality))) |cc_entry| {
-        restoreCallCentrality(io, snapshot_path, cc_entry, explorer, allocator) catch {};
+        restoreCallCentrality(io, snapshot_file, cc_entry, explorer, allocator) catch {};
     }
 
     if (prof) {
@@ -1399,7 +1470,7 @@ fn loadSnapshotFast(
 /// outlines (changed/removed since the snapshot) are simply skipped.
 fn restoreCallCentrality(
     io: std.Io,
-    snapshot_path: []const u8,
+    snapshot_file: std.Io.File,
     entry: SectionEntry,
     explorer: *Explorer,
     allocator: std.mem.Allocator,
@@ -1407,9 +1478,7 @@ fn restoreCallCentrality(
     if (entry.length < 4 or entry.length > 256 * 1024 * 1024) return;
     const bytes = try allocator.alloc(u8, entry.length);
     defer allocator.free(bytes);
-    const f = try std.Io.Dir.cwd().openFile(io, snapshot_path, .{});
-    defer f.close(io);
-    if ((try f.readPositionalAll(io, bytes, entry.offset)) != entry.length) return;
+    if ((try snapshot_file.readPositionalAll(io, bytes, entry.offset)) != entry.length) return;
 
     var cursor: usize = 0;
     if (cursor + 4 > bytes.len) return;
@@ -1544,31 +1613,47 @@ pub fn writeSnapshotDual(
     // keep the secondary crash-safe. Sharing one indexed_at/git_head between
     // the two copies is more correct than the old double-serialize, which
     // could capture different values.
-    copyToProjectCache(io, root_path, output_path, allocator) catch {};
+    copyToProjectCache(io, explorer, root_path, output_path, allocator) catch {};
 }
 
-fn copyToProjectCache(io: std.Io, root_path: []const u8, primary_path: []const u8, allocator: std.mem.Allocator) !void {
-    const hash = std.hash.Wyhash.hash(0, root_path);
+fn copyToProjectCache(io: std.Io, explorer: *Explorer, root_path: []const u8, primary_path: []const u8, allocator: std.mem.Allocator) !void {
+    const canonical_root = explorer.root_path orelse root_path;
+    const hash = std.hash.Wyhash.hash(0, canonical_root);
     const home_raw = cio.homeDir() orelse return;
     const home = allocator.dupe(u8, home_raw) catch return;
     defer allocator.free(home);
     const dir_path = std.fmt.allocPrint(allocator, "{s}/.codedb/projects/{x}", .{ home, hash }) catch return;
     defer allocator.free(dir_path);
     std.Io.Dir.cwd().createDirPath(io, dir_path) catch {};
+    var central_dir = try std.Io.Dir.cwd().openDir(io, dir_path, .{ .follow_symlinks = false });
+    defer central_dir.close(io);
 
-    const proj_txt = std.fmt.allocPrint(allocator, "{s}/project.txt", .{dir_path}) catch return;
-    defer allocator.free(proj_txt);
-    var f = try std.Io.Dir.cwd().createFile(io, proj_txt, .{ .truncate = true });
-    f.writeStreamingAll(io, root_path) catch {};
+    var f = try central_dir.createFile(io, "project.txt", .{ .truncate = true, .permissions = privateFilePermissions() });
+    f.writeStreamingAll(io, canonical_root) catch {};
+    f.sync(io) catch {};
     f.close(io);
 
-    const tmp = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot.{x}.tmp", .{ dir_path, cio.randU64() }) catch return;
+    const sep = std.mem.lastIndexOfScalar(u8, primary_path, '/');
+    const source_parent = if (sep) |s| if (s == 0) "/" else primary_path[0..s] else ".";
+    const source_name = if (sep) |s| primary_path[s + 1 ..] else primary_path;
+    var owned_source_dir: ?std.Io.Dir = null;
+    const source_dir = if (isRootSnapshot(primary_path, root_path)) blk: {
+        break :blk explorer.root_dir orelse return error.InvalidSnapshotSource;
+    } else blk: {
+        const dir = try std.Io.Dir.cwd().openDir(io, source_parent, .{ .follow_symlinks = false });
+        owned_source_dir = dir;
+        break :blk dir;
+    };
+    defer if (owned_source_dir) |dir| dir.close(io);
+
+    const tmp = try std.fmt.allocPrint(allocator, "codedb.snapshot.{x}.tmp", .{cio.randU64()});
     defer allocator.free(tmp);
-    const secondary = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{dir_path}) catch return;
-    defer allocator.free(secondary);
-    errdefer std.Io.Dir.cwd().deleteFile(io, tmp) catch {};
-    try std.Io.Dir.copyFile(std.Io.Dir.cwd(), primary_path, std.Io.Dir.cwd(), tmp, io, .{});
-    try std.Io.Dir.cwd().rename(tmp, std.Io.Dir.cwd(), secondary, io);
+    errdefer central_dir.deleteFile(io, tmp) catch {};
+    try std.Io.Dir.copyFile(source_dir, source_name, central_dir, tmp, io, .{});
+    const copied = try central_dir.openFile(io, tmp, .{ .mode = .read_write, .follow_symlinks = false });
+    copied.sync(io) catch {};
+    copied.close(io);
+    try central_dir.rename(tmp, central_dir, "codedb.snapshot", io);
 }
 
 pub fn writeProjectCacheSnapshot(

--- a/src/store.zig
+++ b/src/store.zig
@@ -392,6 +392,41 @@ pub const Store = struct {
         return hash.final();
     }
 
+    /// Content-only identity used to compare the indexed Store with a fresh
+    /// capability-relative filesystem walk. Unlike the persisted semantic
+    /// manifest above, this intentionally excludes the process-local Version
+    /// operation: identical repository bytes must compare equal whether they
+    /// came from a cold snapshot, a watcher refresh, or a restored snapshot.
+    pub fn semanticContentFingerprintForPaths(self: *Store, sorted_paths: anytype) !u64 {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        var hash = semanticContentHasher();
+        for (sorted_paths) |path| {
+            const versions = self.files.get(path) orelse return error.MissingContentIdentity;
+            const latest = versions.latest() orelse return error.MissingContentIdentity;
+            if (latest.op == .tombstone or latest.hash == 0) return error.MissingContentIdentity;
+            updateSemanticContentFingerprint(&hash, path, latest.hash, latest.size);
+        }
+        return hash.final();
+    }
+
+    pub fn semanticContentHasher() std.hash.Wyhash {
+        return std.hash.Wyhash.init(0x4344_4253_454d_3031);
+    }
+
+    pub fn updateSemanticContentFingerprint(
+        hash: *std.hash.Wyhash,
+        path: []const u8,
+        content_hash: u64,
+        size: u64,
+    ) void {
+        hash.update(path);
+        hash.update(&.{0});
+        hash.update(std.mem.asBytes(&content_hash));
+        hash.update(std.mem.asBytes(&size));
+    }
+
     pub fn listFiles(self: *Store) ![][]const u8 {
         self.mu.lock();
         defer self.mu.unlock();

--- a/src/store.zig
+++ b/src/store.zig
@@ -315,6 +315,44 @@ pub const Store = struct {
         return self.seq;
     }
 
+    /// Deterministic repository-content identity from the latest watcher/
+    /// snapshot hashes. Unlike `seq`, this survives process restarts and
+    /// detects same-size uncommitted edits without re-reading every source
+    /// file during each semantic query.
+    pub fn contentFingerprint(self: *Store, allocator: std.mem.Allocator) !u64 {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        var paths: std.ArrayList([]const u8) = .empty;
+        defer paths.deinit(allocator);
+        try paths.ensureTotalCapacity(allocator, self.files.count());
+        var iter = self.files.keyIterator();
+        while (iter.next()) |path| paths.appendAssumeCapacity(path.*);
+        std.mem.sort([]const u8, paths.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+
+        var hash = std.hash.Wyhash.init(0x4344_4253_544f_5245);
+        for (paths.items) |path| {
+            const versions = self.files.get(path) orelse continue;
+            const latest = versions.latest() orelse continue;
+            // Fingerprint the live repository state, not its edit history.
+            // Explorer shape already drops deleted files, and retaining a
+            // tombstone here would make create-then-delete permanently stale
+            // an otherwise identical semantic sidecar.
+            if (latest.op == .tombstone) continue;
+            hash.update(path);
+            hash.update(&.{0});
+            hash.update(std.mem.asBytes(&latest.hash));
+            hash.update(std.mem.asBytes(&latest.size));
+            const op: u8 = @intFromEnum(latest.op);
+            hash.update(&.{op});
+        }
+        return hash.final();
+    }
+
     pub fn listFiles(self: *Store) ![][]const u8 {
         self.mu.lock();
         defer self.mu.unlock();

--- a/src/store.zig
+++ b/src/store.zig
@@ -75,6 +75,22 @@ pub const Store = struct {
         return self.appendVersion(path, 0, .snapshot, hash, size, null);
     }
 
+    /// Replace the placeholder identity recorded by the cold stat pass once
+    /// the parser worker has read the file. This is deliberately not a new
+    /// version/event: initial discovery already advanced `seq`, and consumers
+    /// must observe one stable snapshot whose content hash survives reload.
+    pub fn refineLatestSnapshotHash(self: *Store, path: []const u8, size: u64, hash: u64) bool {
+        if (hash == 0) return false;
+        self.mu.lock();
+        defer self.mu.unlock();
+        const versions = self.files.getPtr(path) orelse return false;
+        if (versions.versions.items.len == 0) return false;
+        const latest = &versions.versions.items[versions.versions.items.len - 1];
+        if (latest.op != .snapshot or latest.size != size or latest.hash != 0) return false;
+        latest.hash = hash;
+        return true;
+    }
+
     pub fn recordEdit(self: *Store, path: []const u8, agent: AgentId, op: Op, hash: u64, size: u64, diff: ?[]const u8) !u64 {
         return self.appendVersion(path, agent, op, hash, size, diff);
     }
@@ -343,6 +359,29 @@ pub const Store = struct {
             // tombstone here would make create-then-delete permanently stale
             // an otherwise identical semantic sidecar.
             if (latest.op == .tombstone) continue;
+            hash.update(path);
+            hash.update(&.{0});
+            hash.update(std.mem.asBytes(&latest.hash));
+            hash.update(std.mem.asBytes(&latest.size));
+            const op: u8 = @intFromEnum(latest.op);
+            hash.update(&.{op});
+        }
+        return hash.final();
+    }
+
+    /// Deterministic content identity for an already sorted live path set.
+    /// The Store may contain stat-only/skipped records that Explorer never
+    /// indexed; semantic freshness must compare exactly the files represented
+    /// by its parsed manifest across cold-scan and snapshot-load processes.
+    pub fn contentFingerprintForPaths(self: *Store, sorted_paths: anytype) !u64 {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        var hash = std.hash.Wyhash.init(0x4344_4253_544f_5245);
+        for (sorted_paths) |path| {
+            const versions = self.files.get(path) orelse return error.MissingContentIdentity;
+            const latest = versions.latest() orelse return error.MissingContentIdentity;
+            if (latest.op == .tombstone) return error.MissingContentIdentity;
             hash.update(path);
             hash.update(&.{0});
             hash.update(std.mem.asBytes(&latest.hash));

--- a/src/test_ann.zig
+++ b/src/test_ann.zig
@@ -22,6 +22,86 @@ test "ann: OpenPuffer wrapper finds the exact nearest vector" {
     try testing.expect(results[0].distance < results[1].distance);
 }
 
+test "ann: CodeDB 512D row-major embeddings keep stable ids through mmap" {
+    if (@import("builtin").os.tag == .windows) return;
+    const dimensions: u16 = 512;
+    const count: usize = 3;
+    var vectors: [count * dimensions]f32 = @splat(0);
+    vectors[0 * dimensions + 3] = 1;
+    vectors[1 * dimensions + 17] = 1;
+    vectors[2 * dimensions + 29] = 1;
+    vectors[2 * dimensions + 31] = 0.25;
+
+    var source = ann.Index.init(testing.allocator, dimensions, .{ .seed = 107 });
+    defer source.deinit();
+    try testing.expectEqual(@as(u32, 0), try source.insertEmbeddingBatch(&vectors, count, dimensions));
+    try testing.expectEqual(count, source.len());
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(testing.io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/codedb-512d.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+    try source.writeSlabs(path);
+
+    var wrong_dimensions = ann.Index.init(testing.allocator, dimensions - 1, .{});
+    defer wrong_dimensions.deinit();
+    try testing.expectError(error.DimensionMismatch, wrong_dimensions.loadMmap(path));
+
+    const slab_bytes = try std.Io.Dir.cwd().readFileAlloc(testing.io, path, testing.allocator, .limited(1024 * 1024));
+    defer testing.allocator.free(slab_bytes);
+    const truncated_path = try std.fmt.allocPrint(testing.allocator, "{s}/codedb-512d-truncated.hmls", .{dir_path});
+    defer testing.allocator.free(truncated_path);
+    var truncated = try std.Io.Dir.cwd().createFile(testing.io, truncated_path, .{});
+    try truncated.writeStreamingAll(testing.io, slab_bytes[0 .. slab_bytes.len - 1]);
+    truncated.close(testing.io);
+    var truncated_index = ann.Index.init(testing.allocator, dimensions, .{});
+    defer truncated_index.deinit();
+    try testing.expectError(error.Truncated, truncated_index.loadMmap(truncated_path));
+
+    const qscale_offset: usize = @intCast(std.mem.readInt(u64, slab_bytes[64..72], .little));
+    std.mem.writeInt(u32, slab_bytes[qscale_offset..][0..4], @bitCast(std.math.nan(f32)), .little);
+    const nan_path = try std.fmt.allocPrint(testing.allocator, "{s}/codedb-512d-nan-scale.hmls", .{dir_path});
+    defer testing.allocator.free(nan_path);
+    var nan_file = try std.Io.Dir.cwd().createFile(testing.io, nan_path, .{});
+    try nan_file.writeStreamingAll(testing.io, slab_bytes);
+    nan_file.close(testing.io);
+    var nan_index = ann.Index.init(testing.allocator, dimensions, .{});
+    defer nan_index.deinit();
+    try testing.expectError(error.InvalidVectorValue, nan_index.loadMmap(nan_path));
+
+    var loaded = ann.Index.init(testing.allocator, dimensions, .{});
+    defer loaded.deinit();
+    try loaded.loadMmap(path);
+    try testing.expect(loaded.isMmapBacked());
+    try testing.expectEqual(count, loaded.len());
+    const query = vectors[2 * dimensions ..][0..dimensions];
+    const results = try loaded.search(query, 2, testing.allocator);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(u32, 2), results[0].id);
+}
+
+test "ann: CodeDB embedding batch rejects malformed shape and invalid rows" {
+    const dimensions: u16 = 512;
+    var index = ann.Index.init(testing.allocator, dimensions, .{ .seed = 109 });
+    defer index.deinit();
+    var row: [dimensions]f32 = @splat(0);
+    row[0] = 1;
+
+    try testing.expectError(error.InvalidEmbeddingBatch, index.insertEmbeddingBatch(&row, 0, dimensions));
+    try testing.expectError(error.DimensionMismatch, index.insertEmbeddingBatch(&row, 1, dimensions - 1));
+    try testing.expectError(error.InvalidEmbeddingBatchShape, index.insertEmbeddingBatch(row[0 .. row.len - 1], 1, dimensions));
+    try testing.expectError(error.InvalidEmbeddingBatchShape, index.insertEmbeddingBatch(&row, 2, dimensions));
+    row[7] = std.math.nan(f32);
+    try testing.expectError(error.InvalidVectorValue, index.insertEmbeddingBatch(&row, 1, dimensions));
+    row[7] = std.math.inf(f32);
+    try testing.expectError(error.InvalidVectorValue, index.insertEmbeddingBatch(&row, 1, dimensions));
+    @memset(&row, 0);
+    try testing.expectError(error.ZeroNormVector, index.insertEmbeddingBatch(&row, 1, dimensions));
+    try testing.expectEqual(@as(usize, 0), index.len());
+}
+
 test "ann: serialized index round-trips without changing the best result" {
     var source = ann.Index.init(testing.allocator, 3, .{ .seed = 11 });
     defer source.deinit();

--- a/src/test_ann.zig
+++ b/src/test_ann.zig
@@ -109,6 +109,94 @@ test "ann: mmap loader rejects out-of-range neighbor ids" {
     try testing.expectEqual(@as(u32, 0), copy_recovered[0].id);
 }
 
+test "ann: mmap loader rejects a high-layer edge to a node without that layer" {
+    if (@import("builtin").os.tag == .windows) return;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/bad-neighbor-layer.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 43 });
+    defer source.deinit();
+    for (0..128) |i| {
+        var vector: [64]f32 = @splat(0);
+        vector[i % vector.len] = 1;
+        vector[(i * 11 + 7) % vector.len] += 0.2;
+        _ = try source.insert(&vector);
+    }
+    try source.writeSlabs(path);
+
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
+    defer file.close(io);
+    var header: [136]u8 = undefined;
+    try testing.expectEqual(header.len, try file.readPositionalAll(io, &header, 0));
+    const count: usize = @intCast(std.mem.readInt(u64, header[16..24], .little));
+    const m: usize = std.mem.readInt(u32, header[32..36], .little);
+    const hi_slots: usize = @intCast(std.mem.readInt(u64, header[48..56], .little));
+    const levels_offset = std.mem.readInt(u64, header[56..64], .little);
+    const hi_start_offset = std.mem.readInt(u64, header[104..112], .little);
+    const hi_degree_offset = std.mem.readInt(u64, header[112..120], .little);
+    const hi_neighbors_offset = std.mem.readInt(u64, header[120..128], .little);
+
+    const levels = try testing.allocator.alloc(u32, count);
+    defer testing.allocator.free(levels);
+    try testing.expectEqual(std.mem.sliceAsBytes(levels).len, try file.readPositionalAll(io, std.mem.sliceAsBytes(levels), levels_offset));
+    const hi_starts = try testing.allocator.alloc(u32, count);
+    defer testing.allocator.free(hi_starts);
+    try testing.expectEqual(std.mem.sliceAsBytes(hi_starts).len, try file.readPositionalAll(io, std.mem.sliceAsBytes(hi_starts), hi_start_offset));
+    const hi_degrees = try testing.allocator.alloc(u16, hi_slots);
+    defer testing.allocator.free(hi_degrees);
+    try testing.expectEqual(std.mem.sliceAsBytes(hi_degrees).len, try file.readPositionalAll(io, std.mem.sliceAsBytes(hi_degrees), hi_degree_offset));
+
+    var level_zero_id: ?u32 = null;
+    for (levels, 0..) |level, id| {
+        if (level == 0) {
+            level_zero_id = @intCast(id);
+            break;
+        }
+    }
+    try testing.expect(level_zero_id != null);
+
+    const hi_stride = m + 1;
+    var corrupt_offset: ?u64 = null;
+    for (levels, 0..) |level, id| {
+        if (level == 0) continue;
+        const start: usize = hi_starts[id];
+        for (0..level) |slot_offset| {
+            const slot = start + slot_offset;
+            if (hi_degrees[slot] == 0) continue;
+            const neighbor_index = slot * hi_stride;
+            corrupt_offset = hi_neighbors_offset + @as(u64, @intCast(neighbor_index * @sizeOf(u32)));
+            break;
+        }
+        if (corrupt_offset != null) break;
+    }
+    try testing.expect(corrupt_offset != null);
+
+    var forged_neighbor: [4]u8 = undefined;
+    std.mem.writeInt(u32, &forged_neighbor, level_zero_id.?, .little);
+    try file.writePositionalAll(io, &forged_neighbor, corrupt_offset.?);
+    try file.sync(io);
+
+    var loaded = ann.Index.init(testing.allocator, 64, .{});
+    defer loaded.deinit();
+    try testing.expectError(error.InvalidNeighborLayer, loaded.loadMmap(path));
+    try testing.expect(!loaded.isMmapBacked());
+    try testing.expectEqual(@as(usize, 0), loaded.len());
+
+    // A rejected sidecar leaves a reusable empty index instead of a partially
+    // attached mapping, and the following search proves there was no panic.
+    var recovery: [64]f32 = @splat(0);
+    recovery[3] = 1;
+    _ = try loaded.insert(&recovery);
+    const recovered = try loaded.search(&recovery, 1, testing.allocator);
+    defer testing.allocator.free(recovered);
+    try testing.expectEqual(@as(u32, 0), recovered[0].id);
+}
+
 test "ann: legacy loader bounds record and layer allocations before use" {
     var source = ann.Index.init(testing.allocator, 3, .{ .seed = 59 });
     defer source.deinit();

--- a/src/test_ann.zig
+++ b/src/test_ann.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const testing = std.testing;
+const ann = @import("ann.zig");
+const semantic_index = @import("semantic_index.zig");
+
+test "ann: codedb uses the recall-gated 512D search profile" {
+    try testing.expectEqual(@as(u32, 48), ann.default_ef_search);
+    try testing.expectEqual(@as(usize, 2), ann.default_rerank_multiplier);
+}
+
+test "ann: OpenPuffer wrapper finds the exact nearest vector" {
+    var index = ann.Index.init(testing.allocator, 4, .{ .seed = 7 });
+    defer index.deinit();
+    _ = try index.insert(&.{ 1, 0, 0, 0 });
+    _ = try index.insert(&.{ 0, 1, 0, 0 });
+    _ = try index.insert(&.{ 0, 0, 1, 0 });
+
+    const results = try index.search(&.{ 0.99, 0.01, 0, 0 }, 2, testing.allocator);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(usize, 2), results.len);
+    try testing.expectEqual(@as(u32, 0), results[0].id);
+    try testing.expect(results[0].distance < results[1].distance);
+}
+
+test "ann: serialized index round-trips without changing the best result" {
+    var source = ann.Index.init(testing.allocator, 3, .{ .seed = 11 });
+    defer source.deinit();
+    _ = try source.insert(&.{ 1, 0, 0 });
+    _ = try source.insert(&.{ 0, 1, 0 });
+    const bytes = try source.serialize(testing.allocator);
+    defer testing.allocator.free(bytes);
+    try testing.expectEqual(bytes.len, source.serializedSize());
+
+    var loaded = ann.Index.init(testing.allocator, 3, .{ .seed = 11 });
+    defer loaded.deinit();
+    try loaded.load(bytes);
+    const results = try loaded.search(&.{ 0, 0.9, 0.1 }, 1, testing.allocator);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(u32, 1), results[0].id);
+}
+
+test "ann: payload accounting is checked and dimension aware" {
+    try testing.expectEqual(@as(usize, 20_000 * 512 * 5), try ann.vectorPayloadBytes(20_000, 512));
+    try testing.expectEqual(@as(usize, 20_000 * 512), try ann.vectorPayloadBytesWithMode(20_000, 512, false));
+    try testing.expectError(error.Overflow, ann.vectorPayloadBytes(std.math.maxInt(usize), 512));
+}
+
+test "ann: official int8-only library mode omits f32 and remains searchable" {
+    var index = ann.Index.init(testing.allocator, 4, .{ .seed = 23, .store_f32 = false });
+    defer index.deinit();
+    _ = try index.insert(&.{ 1, 0, 0, 0 });
+    _ = try index.insert(&.{ 0, 1, 0, 0 });
+    try testing.expect(!index.hasStoredF32());
+    try testing.expectEqual(@as(usize, 0), index.vectorConst(0).len);
+    const results = try index.search(&.{ 0.99, 0.01, 0, 0 }, 1, testing.allocator);
+    defer testing.allocator.free(results);
+    try testing.expectEqual(@as(u32, 0), results[0].id);
+}
+
+test "ann: mmap loader rejects out-of-range neighbor ids" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/corrupt-neighbor.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 41 });
+    defer source.deinit();
+    var a: [64]f32 = @splat(0);
+    var b: [64]f32 = @splat(0);
+    a[0] = 1;
+    b[1] = 1;
+    _ = try source.insert(&a);
+    _ = try source.insert(&b);
+    try source.writeSlabs(path);
+
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
+    defer file.close(io);
+    var header: [136]u8 = undefined;
+    try testing.expectEqual(header.len, try file.readPositionalAll(io, &header, 0));
+    const l0_degree_offset = std.mem.readInt(u64, header[88..96], .little);
+    const l0_neighbors_offset = std.mem.readInt(u64, header[96..104], .little);
+    var degree_bytes: [2]u8 = undefined;
+    try testing.expectEqual(degree_bytes.len, try file.readPositionalAll(io, &degree_bytes, l0_degree_offset));
+    try testing.expect(std.mem.readInt(u16, &degree_bytes, .little) > 0);
+    var invalid_neighbor: [4]u8 = undefined;
+    std.mem.writeInt(u32, &invalid_neighbor, std.math.maxInt(u32), .little);
+    try file.writePositionalAll(io, &invalid_neighbor, l0_neighbors_offset);
+    try file.sync(io);
+
+    var loaded = ann.Index.init(testing.allocator, 64, .{});
+    defer loaded.deinit();
+    try testing.expectError(error.InvalidNeighborId, loaded.loadMmap(path));
+    _ = try loaded.insert(&a);
+    const recovered = try loaded.search(&a, 1, testing.allocator);
+    defer testing.allocator.free(recovered);
+    try testing.expectEqual(@as(u32, 0), recovered[0].id);
+
+    const corrupt = try std.Io.Dir.cwd().readFileAlloc(io, path, testing.allocator, .limited(1024 * 1024));
+    defer testing.allocator.free(corrupt);
+    var copied = ann.Index.init(testing.allocator, 64, .{});
+    defer copied.deinit();
+    try testing.expectError(error.InvalidNeighborId, copied.loadSlabsCopy(corrupt));
+    _ = try copied.insert(&b);
+    const copy_recovered = try copied.search(&b, 1, testing.allocator);
+    defer testing.allocator.free(copy_recovered);
+    try testing.expectEqual(@as(u32, 0), copy_recovered[0].id);
+}
+
+test "ann: legacy loader bounds record and layer allocations before use" {
+    var source = ann.Index.init(testing.allocator, 3, .{ .seed = 59 });
+    defer source.deinit();
+    _ = try source.insert(&.{ 1, 0, 0 });
+    const valid = try source.serialize(testing.allocator);
+    defer testing.allocator.free(valid);
+
+    const huge_count = try testing.allocator.dupe(u8, valid);
+    defer testing.allocator.free(huge_count);
+    std.mem.writeInt(u64, huge_count[16..24], std.math.maxInt(u64), .little);
+    var count_loaded = ann.Index.init(testing.allocator, 3, .{});
+    defer count_loaded.deinit();
+    try testing.expectError(error.InvalidSlabLayout, count_loaded.load(huge_count));
+
+    const excessive_layers = try testing.allocator.dupe(u8, valid);
+    defer testing.allocator.free(excessive_layers);
+    const layer_count_offset = 48 + 4 + 4 + 3 * @sizeOf(f32) + 3;
+    std.mem.writeInt(u32, excessive_layers[layer_count_offset..][0..4], 66, .little);
+    var layer_loaded = ann.Index.init(testing.allocator, 3, .{});
+    defer layer_loaded.deinit();
+    try testing.expectError(error.InvalidSlabLayout, layer_loaded.load(excessive_layers));
+}
+
+test "ann: mmap loader rejects graph layouts above the validation RSS budget" {
+    if (@import("builtin").os.tag == .windows) return;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(testing.io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/graph-budget.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 47 });
+    defer source.deinit();
+    var vector: [64]f32 = @splat(0);
+    vector[0] = 1;
+    _ = try source.insert(&vector);
+    try source.writeSlabs(path);
+
+    var file = try std.Io.Dir.cwd().openFile(testing.io, path, .{ .mode = .read_write });
+    defer file.close(testing.io);
+    var forged: [8]u8 = undefined;
+    const records: u64 = 100_000;
+    std.mem.writeInt(u64, &forged, records, .little);
+    try file.writePositionalAll(testing.io, &forged, 16);
+    std.mem.writeInt(u64, &forged, records * 64, .little);
+    try file.writePositionalAll(testing.io, &forged, 48);
+    var option: [4]u8 = undefined;
+    std.mem.writeInt(u32, &option, 1024, .little);
+    try file.writePositionalAll(testing.io, &option, 32);
+    std.mem.writeInt(u32, &option, 16, .little);
+    try file.writePositionalAll(testing.io, &option, 36);
+    try file.sync(testing.io);
+
+    var loaded = ann.Index.init(testing.allocator, 64, .{});
+    defer loaded.deinit();
+    try testing.expectError(error.GraphValidationBudgetExceeded, loaded.loadMmap(path));
+}
+
+test "ann: mmap loader rejects a max layer not owned by the entry point" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/bad-entry-level.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 61 });
+    defer source.deinit();
+    var vector: [64]f32 = @splat(0);
+    vector[0] = 1;
+    _ = try source.insert(&vector);
+    try source.writeSlabs(path);
+
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_write });
+    defer file.close(io);
+    var forged: [4]u8 = undefined;
+    std.mem.writeInt(u32, &forged, 1, .little);
+    try file.writePositionalAll(io, &forged, 28);
+    try file.sync(io);
+
+    var loaded = ann.Index.init(testing.allocator, 64, .{});
+    defer loaded.deinit();
+    try testing.expectError(error.InvalidSlabLayout, loaded.loadMmap(path));
+}
+
+test "ann: mmap layout round-trips after neighbor slabs cross a page boundary" {
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = path_buf[0..try tmp.dir.realPathFile(io, ".", &path_buf)];
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/multi-page.hmls", .{dir_path});
+    defer testing.allocator.free(path);
+
+    var source = ann.Index.init(testing.allocator, 64, .{ .seed = 53 });
+    defer source.deinit();
+    for (0..600) |i| {
+        var vector: [64]f32 = @splat(0);
+        vector[i % vector.len] = 1;
+        vector[(i * 7 + 3) % vector.len] += 0.25;
+        _ = try source.insert(&vector);
+    }
+    try source.writeSlabs(path);
+
+    var loaded = ann.Index.init(testing.allocator, 64, .{});
+    defer loaded.deinit();
+    try loaded.loadMmap(path);
+    try testing.expect(loaded.isMmapBacked());
+    try testing.expectEqual(@as(usize, 600), loaded.len());
+}
+
+test "ann: an indexed repository-shape manifest is deterministic and sensitive" {
+    var explorer = @import("explore.zig").Explorer.init(testing.allocator, 1024 * 1024);
+    defer explorer.deinit();
+    try explorer.indexFile("src/a.zig", "pub fn alpha() void {}\n");
+    try explorer.indexFile("src/b.zig", "pub fn beta() void {}\n");
+    const before = try semantic_index.manifestFingerprint(&explorer, testing.allocator);
+    try testing.expectEqual(before, try semantic_index.manifestFingerprint(&explorer, testing.allocator));
+    try explorer.indexFile("src/b.zig", "pub fn betaChanged() void {}\n");
+    try testing.expect(before != try semantic_index.manifestFingerprint(&explorer, testing.allocator));
+}

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -3,6 +3,7 @@ const cio = @import("cio.zig");
 const testing = std.testing;
 const io = std.testing.io;
 const Store = @import("store.zig").Store;
+const bootstrap = @import("bootstrap.zig");
 const ChangeEntry = @import("store.zig").ChangeEntry;
 const AgentRegistry = @import("agent.zig").AgentRegistry;
 const Config = @import("config.zig").Config;
@@ -21,6 +22,40 @@ test "store: record and retrieve snapshots" {
     try testing.expect(seq1 == 1);
     try testing.expect(seq2 == 2);
     try testing.expect(store.currentSeq() == 2);
+}
+
+test "store: content fingerprint is deterministic and detects same-size edits" {
+    var first = Store.init(testing.allocator);
+    defer first.deinit();
+    _ = try first.recordSnapshot("src/b.zig", 12, 0xBBBB);
+    _ = try first.recordSnapshot("src/a.zig", 12, 0xAAAA);
+    const before = try first.contentFingerprint(testing.allocator);
+
+    // Insertion order and process-local sequence numbers are deliberately not
+    // part of the identity, so a freshly loaded store produces the same value.
+    var reordered = Store.init(testing.allocator);
+    defer reordered.deinit();
+    _ = try reordered.recordSnapshot("src/a.zig", 12, 0xAAAA);
+    _ = try reordered.recordSnapshot("src/b.zig", 12, 0xBBBB);
+    try testing.expectEqual(before, try reordered.contentFingerprint(testing.allocator));
+
+    // The size stays constant but the watcher hash changes, which must stale a
+    // semantic sidecar built from the old source bytes.
+    _ = try first.recordSnapshot("src/a.zig", 12, 0xCCCC);
+    try testing.expect(before != try first.contentFingerprint(testing.allocator));
+
+    // A transient file that is created and then removed must not change the
+    // identity of the final live tree.
+    _ = try reordered.recordSnapshot("src/transient.zig", 8, 0xDDDD);
+    _ = try reordered.recordDelete("src/transient.zig", 0);
+    try testing.expectEqual(before, try reordered.contentFingerprint(testing.allocator));
+}
+
+test "semantic-index always forces a live filesystem rescan" {
+    try testing.expect(bootstrap.commandForcesRescan("semantic-index"));
+    try testing.expect(bootstrap.commandForcesRescan("snapshot"));
+    try testing.expect(bootstrap.commandForcesRescan("index"));
+    try testing.expect(!bootstrap.commandForcesRescan("context"));
 }
 
 test "store: getLatest returns most recent version" {

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -51,6 +51,41 @@ test "store: content fingerprint is deterministic and detects same-size edits" {
     try testing.expectEqual(before, try reordered.contentFingerprint(testing.allocator));
 }
 
+test "store: cold scan refines placeholder hash without publishing an edit" {
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+
+    _ = try store.recordSnapshot("src/live.zig", 12, 0);
+    const sequence = store.currentSeq();
+    const placeholder = try store.contentFingerprint(testing.allocator);
+    try testing.expect(store.refineLatestSnapshotHash("src/live.zig", 12, 0xCAFE));
+    try testing.expectEqual(sequence, store.currentSeq());
+    try testing.expect(placeholder != try store.contentFingerprint(testing.allocator));
+    try testing.expectEqual(@as(u64, 0xCAFE), store.getLatest("src/live.zig").?.hash);
+
+    // Refuse to overwrite an already authoritative identity or a mismatched
+    // stat record; a concurrent watcher update therefore wins safely.
+    try testing.expect(!store.refineLatestSnapshotHash("src/live.zig", 12, 0xBEEF));
+    _ = try store.recordSnapshot("src/changed.zig", 8, 0);
+    try testing.expect(!store.refineLatestSnapshotHash("src/changed.zig", 9, 0xABCD));
+}
+
+test "store: path-scoped content identity excludes stat-only records" {
+    var with_extra = Store.init(testing.allocator);
+    defer with_extra.deinit();
+    _ = try with_extra.recordSnapshot("src/a.zig", 12, 0xAAAA);
+    _ = try with_extra.recordSnapshot("ignored.bin", 900, 0);
+
+    var parsed_only = Store.init(testing.allocator);
+    defer parsed_only.deinit();
+    _ = try parsed_only.recordSnapshot("src/a.zig", 12, 0xAAAA);
+    const paths = [_][]const u8{"src/a.zig"};
+    try testing.expectEqual(
+        try parsed_only.contentFingerprintForPaths(&paths),
+        try with_extra.contentFingerprintForPaths(&paths),
+    );
+}
+
 test "semantic-index always forces a live filesystem rescan" {
     try testing.expect(bootstrap.commandForcesRescan("semantic-index"));
     try testing.expect(bootstrap.commandForcesRescan("snapshot"));

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -11,6 +11,59 @@ const explore = @import("explore.zig");
 const Explorer = explore.Explorer;
 const ContentCache = @import("hot_cache.zig").ContentCache;
 const git = @import("git.zig");
+const builtin = @import("builtin");
+const project_file = @import("project_file.zig");
+
+test "project file reads reject final-component symlinks without hiding regular files" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var outside = testing.tmpDir(.{});
+    defer outside.cleanup();
+    try outside.dir.writeFile(io, .{ .sub_path = "outside.txt", .data = "OUTSIDE_READ_CANARY\n" });
+    var outside_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const outside_path = outside_buf[0..try outside.dir.realPathFile(io, "outside.txt", &outside_buf)];
+
+    var project = testing.tmpDir(.{});
+    defer project.cleanup();
+    try project.dir.createDirPath(io, "src");
+    try project.dir.createDirPath(io, "real_dir");
+    try project.dir.createDirPath(io, ".ssh");
+    try project.dir.writeFile(io, .{ .sub_path = "src/ordinary.txt", .data = "ORDINARY_READ_CANARY\n" });
+    try project.dir.writeFile(io, .{ .sub_path = "real_dir/inside.txt", .data = "IN_ROOT_DIRECTORY_ALIAS_CANARY\n" });
+    try project.dir.writeFile(io, .{ .sub_path = ".ssh/config", .data = "SENSITIVE_DIRECTORY_ALIAS_CANARY\n" });
+    try project.dir.writeFile(io, .{ .sub_path = ".env", .data = "SENSITIVE_READ_CANARY\n" });
+    var src = try project.dir.openDir(io, "src", .{});
+    defer src.close(io);
+    src.symLink(io, outside_path, "outside_alias.txt", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    try src.symLink(io, "../.env", "sensitive_alias.txt", .{});
+    try project.dir.symLink(io, "real_dir", "dir_alias", .{});
+    try project.dir.symLink(io, ".ssh", "sensitive_dir_alias", .{});
+
+    const ordinary = try project_file.readAllocNoFollow(io, project.dir, "src/ordinary.txt", testing.allocator, .limited(1024));
+    defer testing.allocator.free(ordinary);
+    try testing.expectEqualStrings("ORDINARY_READ_CANARY\n", ordinary);
+
+    const through_safe_dir = try project_file.readAllocNoFollow(io, project.dir, "dir_alias/inside.txt", testing.allocator, .limited(1024));
+    defer testing.allocator.free(through_safe_dir);
+    try testing.expectEqualStrings("IN_ROOT_DIRECTORY_ALIAS_CANARY\n", through_safe_dir);
+
+    for ([_][]const u8{ "src/outside_alias.txt", "src/sensitive_alias.txt", "sensitive_dir_alias/config", ".env", "../outside.txt", "src//ordinary.txt" }) |path| {
+        if (project_file.readAllocNoFollow(io, project.dir, path, testing.allocator, .limited(1024))) |unexpected| {
+            testing.allocator.free(unexpected);
+            return error.TestExpectedError;
+        } else |_| {}
+    }
+
+    // The policy is applied before cache lookup too: a forged/restored cache
+    // entry cannot make a direct or semantic caller recover sensitive bytes.
+    var guarded = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer guarded.deinit();
+    try guarded.indexFile(".env", "CACHED_SENSITIVE_CANARY\n");
+    try testing.expect((try guarded.getContent(".env", testing.allocator)) == null);
+}
 
 test "store: record and retrieve snapshots" {
     var store = Store.init(testing.allocator);

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -138,6 +138,7 @@ const SymbolLocation = explore.SymbolLocation;
 const watcher = @import("watcher.zig");
 const git_mod = @import("git.zig");
 const snapshot_mod = @import("snapshot.zig");
+const bootstrap_mod = @import("bootstrap.zig");
 
 test "word tokenizer" {
     var tok = WordTokenizer{ .buf = "pub fn main() !void {" };
@@ -1886,7 +1887,7 @@ test "integration: Tier 0.5 prefix expansion finds partial identifier" {
     try testing.expect(results.len >= 1);
 }
 
-test "issue-389: FilteredWalker yields symlinked source files" {
+test "issue-389: FilteredWalker skips file symlinks without hiding their targets" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
@@ -1914,21 +1915,212 @@ test "issue-389: FilteredWalker yields symlinked source files" {
     explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
-    // Both the real file and the symlinked alias must be indexed. The bug at
-    // src/watcher.zig:319 drops every entry whose kind != .file, silently
-    // skipping symlinks even when they point at in-workspace source files.
+    // The canonical source remains indexed, but the file alias is intentionally
+    // skipped. Following the alias would create a check/retarget/open race at
+    // the root and sensitive-file boundaries.
     try testing.expect(explorer.contents.contains("src/target.zig"));
-    try testing.expect(explorer.contents.contains("src/alias.zig"));
+    try testing.expect(!explorer.contents.contains("src/alias.zig"));
+}
+
+test "file symlink aliases cannot expose outside-root or sensitive targets" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var outside = testing.tmpDir(.{});
+    defer outside.cleanup();
+    try outside.dir.writeFile(io, .{ .sub_path = "outside.zig", .data = "pub const OUTSIDE_ALIAS_CANARY = 1;\n" });
+    var outside_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const outside_path = outside_buf[0..try outside.dir.realPathFile(io, "outside.zig", &outside_buf)];
+
+    var project = testing.tmpDir(.{});
+    defer project.cleanup();
+    try project.dir.createDirPath(io, "src");
+    try project.dir.writeFile(io, .{ .sub_path = "src/target.zig", .data = "pub const SAFE_ALIAS_CANARY = 1;\n" });
+    try project.dir.writeFile(io, .{ .sub_path = ".env", .data = "pub const SENSITIVE_ALIAS_CANARY = 1;\n" });
+    var src = try project.dir.openDir(io, "src", .{ .iterate = true });
+    defer src.close(io);
+    src.symLink(io, "target.zig", "safe_alias.zig", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    try src.symLink(io, outside_path, "outside_alias.zig", .{});
+    try src.symLink(io, "../.env", "sensitive_alias.zig", .{});
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try project.dir.realPathFile(io, ".", &root_buf)];
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
+
+    // File aliases are skipped uniformly; the real safe source remains visible,
+    // while neither unsafe alias nor its sensitive canonical target is indexed.
+    try testing.expect(explorer.contents.contains("src/target.zig"));
+    try testing.expect(!explorer.contents.contains("src/safe_alias.zig"));
+    try testing.expect(!explorer.contents.contains("src/outside_alias.zig"));
+    try testing.expect(!explorer.contents.contains("src/sensitive_alias.zig"));
+    try testing.expect(!explorer.contents.contains(".env"));
+    try testing.expect(store.getLatest("src/outside_alias.zig") == null);
+    try testing.expect(store.getLatest("src/sensitive_alias.zig") == null);
+
+    for ([_][]const u8{ "OUTSIDE_ALIAS_CANARY", "SENSITIVE_ALIAS_CANARY" }) |canary| {
+        const hits = try explorer.searchContent(canary, testing.allocator, 10);
+        defer {
+            for (hits) |hit| {
+                testing.allocator.free(hit.path);
+                testing.allocator.free(hit.line_text);
+            }
+            testing.allocator.free(hits);
+        }
+        try testing.expectEqual(@as(usize, 0), hits.len);
+    }
+
+    // Exercise the incremental walker separately with aliases created after
+    // the cold scan.
+    try src.symLink(io, "target.zig", "incremental_safe.zig", .{});
+    try src.symLink(io, outside_path, "incremental_outside.zig", .{});
+    try src.symLink(io, "../.env", "incremental_sensitive.zig", .{});
+    try watcher.refreshIndex(io, &store, &explorer, root, testing.allocator);
+    try testing.expect(!explorer.contents.contains("src/incremental_safe.zig"));
+    try testing.expect(!explorer.contents.contains("src/incremental_outside.zig"));
+    try testing.expect(!explorer.contents.contains("src/incremental_sensitive.zig"));
+    try testing.expect(store.getLatest("src/incremental_outside.zig") == null);
+    try testing.expect(store.getLatest("src/incremental_sensitive.zig") == null);
+
+    // Snapshot creation can only persist the filtered live set, and a fresh
+    // process must not resurrect either alias.
+    const snapshot_path = try std.fmt.allocPrint(testing.allocator, "{s}/symlink.snapshot", .{root});
+    defer testing.allocator.free(snapshot_path);
+    try snapshot_mod.writeSnapshot(io, &explorer, root, snapshot_path, testing.allocator);
+    var restored = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer restored.deinit();
+    var restored_store = Store.init(testing.allocator);
+    defer restored_store.deinit();
+    try testing.expect(snapshot_mod.loadSnapshot(io, snapshot_path, &restored, &restored_store, testing.allocator));
+    try testing.expect(!restored.contents.contains("src/outside_alias.zig"));
+    try testing.expect(!restored.contents.contains("src/sensitive_alias.zig"));
+    try testing.expect(!restored.contents.contains("src/incremental_outside.zig"));
+    try testing.expect(!restored.contents.contains("src/incremental_sensitive.zig"));
+}
+
+test "regular file retargeted to symlink stays unreadable after content release" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var project = testing.tmpDir(.{});
+    defer project.cleanup();
+    try project.dir.createDirPath(io, "src");
+    try project.dir.createDirPath(io, "data");
+    try project.dir.writeFile(io, .{ .sub_path = "src/swap.zig", .data = "pub const safe_swap_token = 1;\n" });
+    try project.dir.writeFile(io, .{ .sub_path = "src/ordinary.zig", .data = "pub const ordinarytoken = 1;\n" });
+    try project.dir.writeFile(io, .{ .sub_path = ".env", .data = "pub const sensitive_swap_token = 1;\n" });
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try project.dir.realPathFile(io, ".", &root_buf)];
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try explorer.indexFile("src/swap.zig", "pub const safe_swap_token = 1;\n");
+    try explorer.indexFile("src/ordinary.zig", "pub const ordinarytoken = 1;\n");
+
+    const snapshot_path = try std.fmt.allocPrint(testing.allocator, "{s}/before-swap.snapshot", .{root});
+    defer testing.allocator.free(snapshot_path);
+    try snapshot_mod.writeSnapshot(io, &explorer, root, snapshot_path, testing.allocator);
+
+    explorer.releaseContents();
+    try project.dir.deleteFile(io, "src/swap.zig");
+    var src = try project.dir.openDir(io, "src", .{});
+    defer src.close(io);
+    src.symLink(io, "../.env", "swap.zig", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    try testing.expect((try explorer.getContent("src/swap.zig", testing.allocator)) == null);
+    const literal_hits = try explorer.searchContent("sensitive_swap_token", testing.allocator, 20);
+    defer {
+        for (literal_hits) |hit| {
+            testing.allocator.free(hit.path);
+            testing.allocator.free(hit.line_text);
+        }
+        testing.allocator.free(literal_hits);
+    }
+    try testing.expectEqual(@as(usize, 0), literal_hits.len);
+    const regex_hits = try explorer.searchContentRegex(".*", testing.allocator, 20);
+    defer {
+        for (regex_hits) |hit| {
+            testing.allocator.free(hit.path);
+            testing.allocator.free(hit.line_text);
+        }
+        testing.allocator.free(regex_hits);
+    }
+    for (regex_hits) |hit| try testing.expect(std.mem.indexOf(u8, hit.line_text, "sensitive_swap_token") == null);
+
+    const after_swap_snapshot = try std.fmt.allocPrint(testing.allocator, "{s}/after-swap.snapshot", .{root});
+    defer testing.allocator.free(after_swap_snapshot);
+    try testing.expectError(
+        error.InvalidSnapshotSource,
+        snapshot_mod.writeSnapshot(io, &explorer, root, after_swap_snapshot, testing.allocator),
+    );
+    try testing.expectError(error.FileNotFound, std.Io.Dir.cwd().statFile(io, after_swap_snapshot, .{}));
+
+    // Snapshot freshness invalidates the artifact rather than retaining bytes
+    // that a vulnerable older writer may have captured through this alias.
+    var restored = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer restored.deinit();
+    var restored_store = Store.init(testing.allocator);
+    defer restored_store.deinit();
+    try testing.expect(!snapshot_mod.loadSnapshotValidated(io, snapshot_path, root, &restored, &restored_store, testing.allocator));
+    try testing.expect((try restored.getContent("src/swap.zig", testing.allocator)) == null);
+
+    // The cache-miss word-index persistence path uses the same reader and can
+    // still persist ordinary files without admitting the alias target.
+    const data_dir = try std.fmt.allocPrint(testing.allocator, "{s}/data", .{root});
+    defer testing.allocator.free(data_dir);
+    try bootstrap_mod.persistWordIndexFromSource(io, &explorer, root, data_dir, null, testing.allocator);
+    var loaded_words = WordIndex.readFromDisk(io, data_dir, testing.allocator) orelse return error.TestExpectedEqual;
+    defer loaded_words.deinit();
+    try testing.expectEqual(@as(usize, 0), loaded_words.search("sensitive_swap_token").len);
+    try testing.expect(loaded_words.search("ordinarytoken").len > 0);
+}
+
+test "symlinked ignore files are not read as policy input" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var outside = testing.tmpDir(.{});
+    defer outside.cleanup();
+    try outside.dir.writeFile(io, .{ .sub_path = "ignore", .data = "src/ordinary.zig\n" });
+    var outside_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const outside_path = outside_buf[0..try outside.dir.realPathFile(io, "ignore", &outside_buf)];
+
+    var project = testing.tmpDir(.{});
+    defer project.cleanup();
+    try project.dir.createDirPath(io, "src");
+    try project.dir.writeFile(io, .{ .sub_path = "src/ordinary.zig", .data = "pub const ignore_symlink_canary = 1;\n" });
+    project.dir.symLink(io, outside_path, ".gitignore", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    try project.dir.symLink(io, outside_path, ".codedbignore", .{});
+
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = root_buf[0..try project.dir.realPathFile(io, ".", &root_buf)];
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
+    try testing.expect(explorer.contents.contains("src/ordinary.zig"));
 }
 
 test "issue-405: FilteredWalker walks directory symlinks safely (cycle + escape)" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    // Follow-up to #389. The current FilteredWalker.next() (src/watcher.zig:319-323)
-    // treats sym_link entries as files when statFile reports .file, but silently
-    // drops sym_link entries whose target is a directory. Real repos rely on
-    // directory symlinks (monorepo package links, vendored deps, dotfile configs),
-    // so the indexer must walk them — but only safely. This test pins three things:
+    // Directory links have a deliberately narrower policy than file links:
+    // their opened target may be walked only when its canonical directory stays
+    // inside the project and cycle detection accepts it. Real repos rely on
+    // directory symlinks (monorepo package links and vendored deps), so this test
+    // pins three things:
     //   1. A file inside a symlinked subdirectory is indexed.
     //   2. A symlink that introduces a cycle does not hang or duplicate entries.
     //   3. (Implicit) The walker terminates in bounded time on the fixture.
@@ -1969,8 +2161,7 @@ test "issue-405: FilteredWalker walks directory symlinks safely (cycle + escape)
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // 1. The in-target file must appear under the symlinked path. This is the
-    //    behaviour gap left by #389 — directory symlinks are currently ignored,
-    //    so this assertion fails on main.
+    //    separate directory-link behavior without re-enabling file aliases.
     try testing.expect(explorer.contents.contains("app/linked_pkg/inside.zig"));
 
     // 2. The real path must also be indexed exactly once.

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -1912,7 +1912,7 @@ test "issue-389: FilteredWalker skips file symlinks without hiding their targets
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // The canonical source remains indexed, but the file alias is intentionally
@@ -1951,7 +1951,7 @@ test "file symlink aliases cannot expose outside-root or sensitive targets" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // File aliases are skipped uniformly; the real safe source remains visible,
@@ -2019,7 +2019,7 @@ test "regular file retargeted to symlink stays unreadable after content release"
     const root = root_buf[0..try project.dir.realPathFile(io, ".", &root_buf)];
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try explorer.indexFile("src/swap.zig", "pub const safe_swap_token = 1;\n");
     try explorer.indexFile("src/ordinary.zig", "pub const ordinarytoken = 1;\n");
 
@@ -2108,7 +2108,7 @@ test "symlinked ignore files are not read as policy input" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
     try testing.expect(explorer.contents.contains("src/ordinary.zig"));
 }
@@ -2157,7 +2157,7 @@ test "issue-405: FilteredWalker walks directory symlinks safely (cycle + escape)
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // 1. The in-target file must appear under the symlinked path. This is the
@@ -2210,7 +2210,7 @@ test "walker: generated tool-output dirs are not indexed" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // Real source is still indexed.
@@ -2261,7 +2261,7 @@ test "issue-692: .devenv and .jj are not indexed" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     try testing.expect(explorer.contents.contains("src/app.py"));
@@ -3112,7 +3112,7 @@ test "disk-backed line ranges do not reuse offsets for changed content" {
     const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
     var ex = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer ex.deinit();
-    ex.setRoot(io, root_buf[0..root_len]);
+    try ex.setRoot(io, root_buf[0..root_len]);
 
     var first: std.ArrayList(u8) = .empty;
     defer first.deinit(testing.allocator);

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3737,11 +3737,12 @@ test "issue-693: unchanged-dir prune must not rescan the whole known map" {
         dirs.deinit();
     }
 
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expectEqual(dir_count * files_per_dir, known.count());
 
@@ -3749,7 +3750,7 @@ test "issue-693: unchanged-dir prune must not rescan the whole known map" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expectEqual(dir_count * files_per_dir, known.count());
     try testing.expectEqual(@as(usize, 0), watcher.debug_unchanged_full_scans);
@@ -3787,11 +3788,12 @@ test "issue-694: dirty-set skips stats on unchanged dirs but reindexes dirty fil
         dirs.deinit();
     }
 
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expectEqual(@as(u32, 3), known.count());
 
@@ -3802,7 +3804,7 @@ test "issue-694: dirty-set skips stats on unchanged dirs but reindexes dirty fil
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffDirty(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
     }
     try testing.expectEqual(@as(u32, 3), known.count());
     try testing.expectEqual(@as(usize, 0), watcher.debug_unchanged_file_stats);
@@ -3814,13 +3816,205 @@ test "issue-694: dirty-set skips stats on unchanged dirs but reindexes dirty fil
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffDirty(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
     }
     try testing.expectEqual(@as(usize, 1), watcher.debug_unchanged_file_stats);
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
     try testing.expect(try explorer.renderOutline("src/a.py", testing.allocator, &out, false));
     try testing.expect(std.mem.indexOf(u8, out.items, "a_changed") != null);
+}
+
+test "watcher directory event defeats stale mtime probe for atomic rename" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "keep.py", .data = "def old_value():\n    return 1\n" });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    var known = watcher.FileMap.init(testing.allocator);
+    defer {
+        var iter = known.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    var dirs = watcher.DirMap.init(testing.allocator);
+    defer {
+        var iter = dirs.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
+    }
+    try tmp.dir.writeFile(io, .{ .sub_path = "keep.py.tmp", .data = "def new_value():\n    return 9\n" });
+    try tmp.dir.rename("keep.py.tmp", tmp.dir, "keep.py", io);
+    const root_dir = explorer.root_dir orelse return error.TestUnexpectedResult;
+    const stat = try root_dir.statFile(io, ".", .{});
+    (dirs.getPtr("") orelse return error.TestUnexpectedResult).* = .{
+        .mtime_ns = stat.mtime.nanoseconds,
+        .ctime_ns = stat.ctime.nanoseconds,
+        .inode = stat.inode,
+    };
+    const file_stat = try root_dir.statFile(io, "keep.py", .{ .follow_symlinks = false });
+    const stale_file = known.getPtr("keep.py") orelse return error.TestUnexpectedResult;
+    stale_file.mtime = @intCast(@divTrunc(file_stat.mtime.nanoseconds, std.time.ns_per_ms));
+    stale_file.mtime_ns = file_stat.mtime.nanoseconds;
+    stale_file.ctime_ns = file_stat.ctime.nanoseconds;
+    stale_file.inode = file_stat.inode;
+    stale_file.size = file_stat.size;
+    var dirty = watcher.DirtySet.init(testing.allocator);
+    defer dirty.deinit();
+    try dirty.put("", {});
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+    }
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try testing.expect(try explorer.renderOutline("keep.py", testing.allocator, &out, false));
+    try testing.expect(std.mem.indexOf(u8, out.items, "new_value") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "old_value") == null);
+}
+
+test "unknown dirty child forces parent listing without admitting sensitive files" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/base.py", .data = "def base():\n    return 1\n" });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    var known = watcher.FileMap.init(testing.allocator);
+    defer {
+        var iter = known.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    var dirs = watcher.DirMap.init(testing.allocator);
+    defer {
+        var iter = dirs.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
+    }
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/new.py", .data = "def newly_visible():\n    return 2\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".env", .data = "WATCHER_SECRET_CANARY=never-index\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "PRIVATE_KEY.PEM", .data = "WATCHER_PRIVATE_CANARY\n" });
+    const root_dir = explorer.root_dir orelse return error.TestUnexpectedResult;
+    const root_stat = try root_dir.statFile(io, ".", .{});
+    const src_stat = try root_dir.statFile(io, "src", .{});
+    (dirs.getPtr("") orelse return error.TestUnexpectedResult).* = .{
+        .mtime_ns = root_stat.mtime.nanoseconds,
+        .ctime_ns = root_stat.ctime.nanoseconds,
+        .inode = root_stat.inode,
+    };
+    (dirs.getPtr("src") orelse return error.TestUnexpectedResult).* = .{
+        .mtime_ns = src_stat.mtime.nanoseconds,
+        .ctime_ns = src_stat.ctime.nanoseconds,
+        .inode = src_stat.inode,
+    };
+    var dirty = watcher.DirtySet.init(testing.allocator);
+    defer dirty.deinit();
+    try dirty.put("src/new.py", {});
+    try dirty.put(".env", {});
+    try dirty.put("PRIVATE_KEY.PEM", {});
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+    }
+    try testing.expect(known.contains("src/new.py"));
+    try testing.expect(!known.contains(".env"));
+    try testing.expect(!known.contains("PRIVATE_KEY.PEM"));
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try testing.expect(try explorer.renderOutline("src/new.py", testing.allocator, &out, false));
+    try testing.expect(std.mem.indexOf(u8, out.items, "newly_visible") != null);
+    const secret_hits = try explorer.searchContent("WATCHER_SECRET_CANARY", testing.allocator, 10);
+    defer testing.allocator.free(secret_hits);
+    try testing.expectEqual(@as(usize, 0), secret_hits.len);
+    const private_hits = try explorer.searchContent("WATCHER_PRIVATE_CANARY", testing.allocator, 10);
+    defer testing.allocator.free(private_hits);
+    try testing.expectEqual(@as(usize, 0), private_hits.len);
+}
+
+test "inactive watcher discovers unknown child when exact directory identity changes" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/old.py", .data = "OLD_CHILD = 1\n" });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    var known = watcher.FileMap.init(testing.allocator);
+    defer {
+        var iter = known.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    var dirs = watcher.DirMap.init(testing.allocator);
+    defer {
+        var iter = dirs.keyIterator();
+        while (iter.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
+    }
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/new.py", .data = "EXACT_DIR_CHILD = 2\n" });
+    const stable_root = explorer.root_dir orelse return error.TestUnexpectedResult;
+    const src_stat = try stable_root.statFile(io, "src", .{ .follow_symlinks = false });
+    (dirs.getPtr("src") orelse return error.TestUnexpectedResult).* = .{
+        .mtime_ns = src_stat.mtime.nanoseconds,
+        .ctime_ns = src_stat.ctime.nanoseconds - 1,
+        .inode = src_stat.inode,
+    };
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
+    }
+    try testing.expect(known.contains("src/new.py"));
+    const hits = try explorer.searchContent("EXACT_DIR_CHILD", testing.allocator, 10);
+    defer {
+        for (hits) |hit| {
+            testing.allocator.free(hit.line_text);
+            testing.allocator.free(hit.path);
+        }
+        testing.allocator.free(hits);
+    }
+    try testing.expectEqual(@as(usize, 1), hits.len);
 }
 
 test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
@@ -3867,12 +4061,13 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
         dirs.deinit();
     }
 
-    var queue = watcher.EventQueue{};
+    const queue = try heapEventQueue();
+    defer testing.allocator.destroy(queue);
     var timer = try cio.Timer.start();
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     const first_ms = timer.lap() / 1_000_000;
     const file_count = dir_count * files_per_dir;
@@ -3885,7 +4080,7 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffDirty(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
     }
     const quiet_ms = timer.lap() / 1_000_000;
     const quiet_stats = watcher.debug_unchanged_file_stats;
@@ -3895,7 +4090,7 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try watcher.incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     const fallback_ms = timer.lap() / 1_000_000;
     const fallback_stats = watcher.debug_unchanged_file_stats;
@@ -3909,7 +4104,7 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffDirty(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
     }
     const edit_ms = timer.lap() / 1_000_000;
     try testing.expectEqual(@as(usize, 1), watcher.debug_unchanged_file_stats);
@@ -3926,7 +4121,7 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try watcher.incrementalDiffDirty(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
+        try watcher.incrementalDiffDirty(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator(), &dirty);
     }
     const sibling_ms = timer.lap() / 1_000_000;
     try testing.expectEqual(file_count + 1, known.count());

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -612,7 +612,7 @@ test "watcher: parallel initial scan matches sequential results" {
     defer store_seq.deinit();
     var explorer_seq = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_seq.deinit();
-    explorer_seq.setRoot(io, root);
+    try explorer_seq.setRoot(io, root);
     cio.posixSetenv("CODEDB_LOAD_WORKERS", "1");
     try watcher.initialScanWithWorkerCount(io, &store_seq, &explorer_seq, root, testing.allocator, false, 1);
 
@@ -620,7 +620,7 @@ test "watcher: parallel initial scan matches sequential results" {
     defer store_par.deinit();
     var explorer_par = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_par.deinit();
-    explorer_par.setRoot(io, root);
+    try explorer_par.setRoot(io, root);
     cio.posixSetenv("CODEDB_LOAD_WORKERS", "4");
     try watcher.initialScanWithWorkerCount(io, &store_par, &explorer_par, root, testing.allocator, false, 4);
 
@@ -786,7 +786,7 @@ test "watcher: parallel word-index shards match sequential (skip_file_words)" {
     var explorer_seq = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_seq.deinit();
     explorer_seq.word_index.skip_file_words = true;
-    explorer_seq.setRoot(io, root);
+    try explorer_seq.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store_seq, &explorer_seq, root, testing.allocator, false, 1);
 
     var store_par = Store.init(testing.allocator);
@@ -794,7 +794,7 @@ test "watcher: parallel word-index shards match sequential (skip_file_words)" {
     var explorer_par = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_par.deinit();
     explorer_par.word_index.skip_file_words = true;
-    explorer_par.setRoot(io, root);
+    try explorer_par.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store_par, &explorer_par, root, testing.allocator, false, 4);
 
     // Word-index structural parity.
@@ -3515,7 +3515,7 @@ test "issue-635: files between 512KB and 1MB are silently dropped from the index
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
 
     // control: the small file is indexed and searchable
@@ -3542,7 +3542,7 @@ test "issue-690: refreshIndex skips unchanged files but re-indexes changed ones"
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, true, 1);
 
     // First refresh records real content hashes for entries the initial scan
@@ -3576,7 +3576,7 @@ test "issue-690: refreshIndex adds new files and drops deleted ones" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, true, 1);
 
     try tmp.dir.writeFile(io, .{ .sub_path = "added.py", .data = "def added():\n    return 1\n" });
@@ -3610,7 +3610,7 @@ test "refreshIndex second pass skips unread files once mtimes are cached" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, true, 1);
 
     try watcher.refreshIndex(io, &store, &explorer, root, testing.allocator);
@@ -3634,7 +3634,7 @@ test "indexMissingFile indexes a new file without a full refresh" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try explorer.indexFile("keep.py", "def keep():\n    return 1\n");
 
     try testing.expect(watcher.indexMissingFile(io, &store, &explorer, "added.py"));
@@ -3658,7 +3658,7 @@ test "issue-690: incrementalLoop startup indexes files missing from the snapshot
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try watcher.initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, true, 1);
 
     // File exists on disk before the daemon starts, but is absent from the
@@ -3722,7 +3722,7 @@ test "issue-693: unchanged-dir prune must not rescan the whole known map" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
 
     var known = watcher.FileMap.init(testing.allocator);
     defer {
@@ -3773,7 +3773,7 @@ test "issue-694: dirty-set skips stats on unchanged dirs but reindexes dirty fil
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
 
     var known = watcher.FileMap.init(testing.allocator);
     defer {
@@ -4046,7 +4046,7 @@ test "experiment-694: quiet dirty cycle is cheaper than stat-all" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
 
     var known = watcher.FileMap.init(testing.allocator);
     defer {

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3836,7 +3836,7 @@ test "watcher directory event defeats stale mtime probe for atomic rename" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     var known = watcher.FileMap.init(testing.allocator);
     defer {
         var iter = known.keyIterator();
@@ -3899,7 +3899,7 @@ test "unknown dirty child forces parent listing without admitting sensitive file
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     var known = watcher.FileMap.init(testing.allocator);
     defer {
         var iter = known.keyIterator();
@@ -3972,7 +3972,7 @@ test "inactive watcher discovers unknown child when exact directory identity cha
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     var known = watcher.FileMap.init(testing.allocator);
     defer {
         var iter = known.keyIterator();

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2570,9 +2570,13 @@ test "issue-688: codedb_context json exposes typed provenance and preserves mark
 
     const structured = try std.json.parseFromSlice(std.json.Value, testing.allocator, json_out.items, .{});
     defer structured.deinit();
-    try testing.expectEqual(@as(i64, 1), structured.value.object.get("schema_version").?.integer);
+    try testing.expectEqual(@as(i64, 2), structured.value.object.get("schema_version").?.integer);
     try testing.expectEqualStrings("codedb_context", structured.value.object.get("format").?.string);
     try testing.expect(structured.value.object.get("reader").?.object.contains("validation"));
+    const retrieval = structured.value.object.get("retrieval").?.object;
+    try testing.expectEqualStrings("local_bm25_and_symbols", retrieval.get("initial").?.string);
+    try testing.expectEqualStrings("not_requested", retrieval.get("semantic").?.string);
+    try testing.expectEqualStrings("keep_local_bm25_no_cpu_embedding_fallback", retrieval.get("failure_policy").?.string);
     try testing.expect(structured.value.object.get("omissions").? == .array);
 
     var found_parsed = false;
@@ -2614,6 +2618,60 @@ test "issue-688: codedb_context json exposes typed provenance and preserves mark
     bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &default_args.value.object, &default_out, &store, &explorer, &agents);
     bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &markdown_args.value.object, &markdown_out, &store, &explorer, &agents);
     try testing.expectEqualStrings(default_out.items, markdown_out.items);
+}
+
+test "codedb_context hybrid is explicit and keeps local results when provider is unavailable" {
+    const url_guard = EnvVarGuard.save("CODEDB_EMBEDDINGS_URL");
+    defer url_guard.restore();
+    cio.posixSetenv("CODEDB_EMBEDDINGS_URL", "http://example.com/v1/embeddings");
+
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile(
+        "src/privacy.zig",
+        "pub fn retentionPolicy() void { keepLocalBm25(); }\npub fn keepLocalBm25() void {}\n",
+    );
+    // indexFile intentionally bypasses the watcher. This simulates a stale or
+    // hand-built index containing a secret and proves the send-time guard is
+    // independent of normal indexing exclusions.
+    try explorer.indexFile(
+        ".env.production",
+        "KEEP_LOCAL_BM25_SECRET=retentionPolicy\n",
+    );
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args = try std.json.parseFromSlice(std.json.Value, testing.allocator,
+        \\{"task":"trace retentionPolicy and keepLocalBm25","format":"json","semantic":"hybrid"}
+    , .{});
+    defer args.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &args.value.object, &out, &store, &explorer, &agents);
+
+    const structured = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.items, .{});
+    defer structured.deinit();
+    const retrieval = structured.value.object.get("retrieval").?.object;
+    try testing.expectEqualStrings("local_bm25_and_symbols", retrieval.get("initial").?.string);
+    try testing.expectEqualStrings("unavailable", retrieval.get("semantic").?.string);
+    try testing.expectEqualStrings("InsecureEmbeddingEndpoint", retrieval.get("detail").?.string);
+    try testing.expectEqual(@as(i64, 0), retrieval.get("documents_sent").?.integer);
+    try testing.expectEqual(@as(i64, 1), retrieval.get("sensitive_paths_blocked").?.integer);
+
+    var found_local_file = false;
+    for (structured.value.object.get("sections").?.array.items) |section_value| {
+        const section = section_value.object;
+        if (!std.mem.eql(u8, section.get("id").?.string, "most_relevant_files")) continue;
+        for (section.get("items").?.array.items) |item| {
+            if (std.mem.eql(u8, item.object.get("path").?.string, "src/privacy.zig")) found_local_file = true;
+        }
+    }
+    try testing.expect(found_local_file);
 }
 
 test "issue-688: structured no-candidate response retains reader evidence" {
@@ -2722,6 +2780,8 @@ test "issue-685: codedb_deps exposes bounded typed document edges" {
     try testing.expect(found_document_graph);
     try testing.expect(std.mem.indexOf(u8, mcp_mod.tools_list, "\"edge_type\":{\"type\":\"string\",\"enum\":[\"imports\",\"documents\"]") != null);
     try testing.expect(std.mem.indexOf(u8, mcp_mod.tools_list, "\"document_hops\":{\"type\":\"integer\"") != null);
+    try testing.expect(std.mem.indexOf(u8, mcp_mod.tools_list, "\"semantic\":{\"type\":\"string\",\"enum\":[\"local\",\"hybrid\"]") != null);
+    try testing.expect(std.mem.indexOf(u8, mcp_mod.tools_list, "stores neither the repository, request body, candidate paths, nor vectors") != null);
 }
 
 test "issue-690: codedb_index description says it refreshes a live daemon" {
@@ -3959,11 +4019,11 @@ test "mcp: read-only tools advertise readOnlyHint on every profile" {
     // mode refuses any tool without it and never consults the allow list, so an
     // unannotated read-only tool prompts on every single call.
     const read_only = [_][]const u8{
-        "codedb_tree",     "codedb_outline", "codedb_symbol",  "codedb_search",
-        "codedb_word",     "codedb_callers", "codedb_callpath", "codedb_context",
-        "codedb_hot",      "codedb_deps",    "codedb_read",    "codedb_changes",
+        "codedb_tree",     "codedb_outline",  "codedb_symbol",   "codedb_search",
+        "codedb_word",     "codedb_callers",  "codedb_callpath", "codedb_context",
+        "codedb_hot",      "codedb_deps",     "codedb_read",     "codedb_changes",
         "codedb_status",   "codedb_snapshot", "codedb_projects", "codedb_find",
-        "codedb_explain",  "codedb_query",   "codedb_glob",     "codedb_ls",
+        "codedb_explain",  "codedb_query",    "codedb_glob",     "codedb_ls",
         "codedb_list_dir",
     };
 

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -34,6 +34,12 @@ comptime {
     _ = @import("config.zig");
 }
 
+fn setTestProjectRoot(explorer: *Explorer) !void {
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try std.Io.Dir.cwd().realPathFile(io, ".", &root_buf);
+    try explorer.setRoot(io, root_buf[0..root_len]);
+}
+
 test "mcp json: line reader preserves newline and EOF framing" {
     var reader: std.Io.Reader = .fixed("first\nlast");
 
@@ -1245,7 +1251,7 @@ test "issue-bug5: codedb_read returns binary stub instead of dumping bytes" {
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, dir_path);
+    try explorer.setRoot(io, dir_path);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
@@ -1287,7 +1293,7 @@ test "issue-bug6: codedb_read errors when line_start > line_end" {
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, dir_path);
+    try explorer.setRoot(io, dir_path);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
@@ -2513,6 +2519,7 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     // plain words instead of erroring.
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
     try explorer.indexFile("src/ranking.zig", "pub fn rankingBoost() void {}\n");
 
     var store = Store.init(testing.allocator);
@@ -2521,7 +2528,7 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     defer agents.deinit();
     _ = try agents.register("__filesystem__");
 
-    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
     const args_json =
@@ -2543,6 +2550,7 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
 test "issue-688: codedb_context json exposes typed provenance and preserves markdown default" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
     try explorer.indexFile(
         "src/ranking.zig",
         "pub fn rankingBoost() void { helper(); }\npub fn helper() void {}\n",
@@ -2553,7 +2561,7 @@ test "issue-688: codedb_context json exposes typed provenance and preserves mark
     var agents = AgentRegistry.init(testing.allocator);
     defer agents.deinit();
     _ = try agents.register("__filesystem__");
-    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
     const json_args = try std.json.parseFromSlice(
@@ -2627,6 +2635,7 @@ test "codedb_context hybrid is explicit and keeps local results when provider is
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
     try explorer.indexFile(
         "src/privacy.zig",
         "pub fn retentionPolicy() void { keepLocalBm25(); }\npub fn keepLocalBm25() void {}\n",
@@ -2643,7 +2652,7 @@ test "codedb_context hybrid is explicit and keeps local results when provider is
     var agents = AgentRegistry.init(testing.allocator);
     defer agents.deinit();
     _ = try agents.register("__filesystem__");
-    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
     const args = try std.json.parseFromSlice(std.json.Value, testing.allocator,
@@ -2679,6 +2688,7 @@ test "issue-688: structured no-candidate response retains reader evidence" {
     defer tmp.cleanup();
     try tmp.dir.createDirPath(io, ".codedb");
     try tmp.dir.writeFile(io, .{ .sub_path = "source.zig", .data = "pub fn source() void {}\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "build.zig", .data = "const std = @import(\"std\");\n" });
     try tmp.dir.writeFile(io, .{
         .sub_path = ".codedb/reader.md",
         .data = "---\nsource_hash: blake2b:00000000000000000000000000000000\nsource_files:\n  - source.zig\n---\nreader body\n",
@@ -2688,6 +2698,7 @@ test "issue-688: structured no-candidate response retains reader evidence" {
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try explorer.setRoot(io, root_buf[0..root_len]);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
@@ -2721,6 +2732,7 @@ test "issue-688: structured no-candidate response retains reader evidence" {
 test "issue-685: codedb_deps exposes bounded typed document edges" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
     try explorer.indexFile("docs/c.md", "# Gamma\n[A](a.md)\n");
     try explorer.indexFile("docs/b.md", "# Beta\n[C](c.md)\n");
     try explorer.indexFile("docs/a.md", "# Alpha\n[B](b.md)\n");
@@ -2729,7 +2741,7 @@ test "issue-685: codedb_deps exposes bounded typed document edges" {
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
     defer agents.deinit();
-    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
     const args = try std.json.parseFromSlice(
@@ -2803,7 +2815,7 @@ test "live outline indexes a missing on-disk file instead of hinting codedb_inde
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try explorer.indexFile("keep.py", "def keep():\n    return 1\n");
 
     var store = Store.init(testing.allocator);
@@ -2836,7 +2848,7 @@ test "live read indexes a missing on-disk file so later search can find it" {
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try explorer.indexFile("keep.py", "def keep():\n    return 1\n");
 
     var store = Store.init(testing.allocator);
@@ -3158,6 +3170,7 @@ test "cli-mcp-parity: runCliTool bridges navigation commands to MCP handlers" {
 test "issue-531: codedb_context max_tokens packs sections by value under the budget" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
 
     // A defined symbol with a fat body (inlined when unbudgeted) plus several
     // mention files so the snippets section is large too.
@@ -3206,7 +3219,7 @@ test "issue-531: codedb_context max_tokens packs sections by value under the bud
     defer agents.deinit();
     _ = try agents.register("__filesystem__");
 
-    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer bench_ctx.deinit();
 
     const args_full =
@@ -3438,7 +3451,7 @@ test "issue-632: codedb_read raw mode returns byte-exact range without line-numb
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, dir_path);
+    try explorer.setRoot(io, dir_path);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);
@@ -3508,7 +3521,7 @@ test "issue-632: codedb_read raw mode coverage — full-file byte-exact, default
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, dir_path);
+    try explorer.setRoot(io, dir_path);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     var agents = AgentRegistry.init(testing.allocator);

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2492,23 +2492,21 @@ test "issue-528: finishCli maps error-prefixed handler output to exit 1" {
     try testing.expectEqual(@as(u8, 0), mcp_mod.finishCli(&empty_out, 0));
 }
 
-test "issue-538: temp roots are indexable only when CODEDB_ALLOW_TEMP opts in" {
+test "issue-538: temp roots are indexable only when explicitly opted in" {
     // Default (footgun guard, #80/#346): temp roots are refused so codedb never
     // indexes a scratch dir by accident.
-    try testing.expect(!root_policy.isIndexableRoot("/tmp/cdbtest"));
-    try testing.expect(!root_policy.isIndexableRoot("/private/tmp/cdbtest"));
+    try testing.expect(!root_policy.isIndexableRootWithTempOpt("/tmp/cdbtest", false));
+    try testing.expect(!root_policy.isIndexableRootWithTempOpt("/private/tmp/cdbtest", false));
 
     // Opt-in escape hatch for SWE-bench / CI harnesses that clone throwaway
     // checkouts under /tmp (issue #538).
-    cio.posixSetenv("CODEDB_ALLOW_TEMP", "1");
-    defer cio.posixUnsetenv("CODEDB_ALLOW_TEMP");
-    try testing.expect(root_policy.isIndexableRoot("/tmp/cdbtest"));
-    try testing.expect(root_policy.isIndexableRoot("/private/tmp/cdbtest/src"));
+    try testing.expect(root_policy.isIndexableRootWithTempOpt("/tmp/cdbtest", true));
+    try testing.expect(root_policy.isIndexableRootWithTempOpt("/private/tmp/cdbtest/src", true));
 
     // The opt-in must NOT widen the guard to real system roots.
-    try testing.expect(!root_policy.isIndexableRoot("/etc"));
-    try testing.expect(!root_policy.isIndexableRoot("/usr/local/bin"));
-    try testing.expect(!root_policy.isIndexableRoot("/"));
+    try testing.expect(!root_policy.isIndexableRootWithTempOpt("/etc", true));
+    try testing.expect(!root_policy.isIndexableRootWithTempOpt("/usr/local/bin", true));
+    try testing.expect(!root_policy.isIndexableRootWithTempOpt("/", true));
 }
 
 test "issue-570: codedb_context falls back to plain words for all-lowercase tasks" {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -361,6 +361,11 @@ test "issue-93: isSensitivePath blocks .env and credentials" {
     try testing.expect(watcher.isSensitivePath("keystore.jks"));
     try testing.expect(watcher.isSensitivePath("identity.pfx"));
     try testing.expect(watcher.isSensitivePath(".ssh/known_hosts"));
+    try testing.expect(watcher.isSensitivePath("CERT.PEM"));
+    try testing.expect(watcher.isSensitivePath("server.KeY"));
+    try testing.expect(watcher.isSensitivePath("KEYSTORE.JKS"));
+    try testing.expect(watcher.isSensitivePath("Credentials.JSON"));
+    try testing.expect(watcher.isSensitivePath(".SSH/known_hosts"));
     // Normal files should NOT be blocked
     try testing.expect(!watcher.isSensitivePath("main.zig"));
     try testing.expect(!watcher.isSensitivePath("src/server.zig"));

--- a/src/test_query.zig
+++ b/src/test_query.zig
@@ -1074,7 +1074,7 @@ test "issue-356-p3: codedb_read appends fuzzy suggestions when path is unreadabl
 
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(tmp_io, project_path);
+    try explorer.setRoot(tmp_io, project_path);
     try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
     try explorer.indexFile("src/lib.zig", "pub fn helper() void {}\n");
 
@@ -1102,6 +1102,50 @@ test "issue-356-p3: codedb_read appends fuzzy suggestions when path is unreadabl
     try testing.expect(std.mem.indexOf(u8, out.items, "failed to read file") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "did you mean") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "src/main.zig") != null);
+}
+
+test "codedb_read returns configured-root content and denies an unrooted explorer" {
+    const tmp_io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(tmp_io, "src");
+    const canary = "pub const CONFIGURED_ROOT_READ_CANARY = true;\n";
+    try tmp.dir.writeFile(tmp_io, .{ .sub_path = "src/main.zig", .data = canary });
+    var project_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_path_len = try tmp.dir.realPathFile(tmp_io, ".", &project_path_buf);
+    const project_path = project_path_buf[0..project_path_len];
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, project_path, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator,
+        \\{"path":"src/main.zig","line_start":1,"line_end":20}
+    , .{});
+    defer parsed.deinit();
+
+    var rooted = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer rooted.deinit();
+    try rooted.setRoot(tmp_io, project_path);
+    try rooted.indexFile("src/main.zig", canary);
+    var rooted_out: std.ArrayList(u8) = .empty;
+    defer rooted_out.deinit(testing.allocator);
+    bench_ctx.runDispatch(tmp_io, testing.allocator, .codedb_read, &parsed.value.object, &rooted_out, &store, &rooted, &agents);
+    try testing.expect(std.mem.indexOf(u8, rooted_out.items, "CONFIGURED_ROOT_READ_CANARY") != null);
+    try testing.expect(!std.mem.startsWith(u8, rooted_out.items, "error:"));
+
+    var unrooted = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer unrooted.deinit();
+    try unrooted.indexFile("src/main.zig", canary);
+    var unrooted_out: std.ArrayList(u8) = .empty;
+    defer unrooted_out.deinit(testing.allocator);
+    bench_ctx.runDispatch(tmp_io, testing.allocator, .codedb_read, &parsed.value.object, &unrooted_out, &store, &unrooted, &agents);
+    try testing.expectEqualStrings("error: project root is not configured", unrooted_out.items);
+    try testing.expect(std.mem.indexOf(u8, unrooted_out.items, "CONFIGURED_ROOT_READ_CANARY") == null);
 }
 
 test "issue-558: codedb_query filter must filter (or error) — never silently pass every file" {

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2047,7 +2047,7 @@ test "audit: searchContent loses a word-indexed file >512KB evicted from the con
 
     var explorer = Explorer.init(testing.allocator, 1); // capacity 1 forces eviction
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
 
     try explorer.indexFile("big.zig", big.items);
     try explorer.indexFile("filler.zig", "fn g() void {}\n");

--- a/src/test_semantic.zig
+++ b/src/test_semantic.zig
@@ -119,7 +119,13 @@ const RetryEmbeddingServer = struct {
     }
 };
 
-fn makeMockEmbeddingResponse(allocator: std.mem.Allocator, model: []const u8, count: usize, dimensions: usize) ![]u8 {
+fn makeMockEmbeddingResponseWithScalar(
+    allocator: std.mem.Allocator,
+    model: []const u8,
+    count: usize,
+    dimensions: usize,
+    nonzero_scalar: []const u8,
+) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
     const writer = cio.listWriter(&out, allocator);
@@ -129,12 +135,16 @@ fn makeMockEmbeddingResponse(allocator: std.mem.Allocator, model: []const u8, co
         try writer.print("{{\"index\":{d},\"embedding\":[", .{row});
         for (0..dimensions) |column| {
             if (column > 0) try writer.writeByte(',');
-            try writer.writeAll(if (column == row % dimensions) "1" else "0");
+            try writer.writeAll(if (column == row % dimensions) nonzero_scalar else "0");
         }
         try writer.writeAll("]}");
     }
     try writer.writeAll("]}");
     return out.toOwnedSlice(allocator);
+}
+
+fn makeMockEmbeddingResponse(allocator: std.mem.Allocator, model: []const u8, count: usize, dimensions: usize) ![]u8 {
+    return makeMockEmbeddingResponseWithScalar(allocator, model, count, dimensions, "1");
 }
 
 fn configureMockEndpoint(server: *const std.Io.net.Server, model: []const u8, timeout_ms: u32) !void {
@@ -376,6 +386,55 @@ test "semantic: provider model mismatch fails closed" {
     thread.join();
     if (mock.failure) |err| return err;
     try testing.expectError(error.EmbeddingModelMismatch, outcome);
+}
+
+test "semantic: provider f64 values that overflow f32 fail closed" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    // 1e100 is finite as the JSON parser's f64, but not representable as the
+    // f32 vectors consumed by the local ANN index.
+    const response = try makeMockEmbeddingResponseWithScalar(testing.allocator, "mock-model", 1, 64, "1e100");
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", 2_000);
+
+    var mock = MockEmbeddingServer{ .server = &server, .response = response };
+    const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+    const outcome = semantic.embedRemoteTexts(io, testing.allocator, &.{"code"});
+    if (outcome) |result| testing.allocator.free(result.vectors) else |_| {}
+    thread.join();
+    if (mock.failure) |err| return err;
+    try testing.expectError(error.InvalidEmbeddingNumber, outcome);
+}
+
+test "semantic: no-sidecar exact fallback rejects overflowing cosine from mock provider" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    // The exact fallback embeds one query and one bounded candidate. Each
+    // scalar is finite f64, while its square overflows the cosine accumulator.
+    const response = try makeMockEmbeddingResponseWithScalar(testing.allocator, "mock-model", 2, 64, "1e200");
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", 2_000);
+
+    var mock = MockEmbeddingServer{ .server = &server, .response = response };
+    const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+    const outcome = semantic.scoreRemote(
+        io,
+        testing.allocator,
+        "find bounded implementation",
+        &.{.{ .path = "src/bounded.zig", .text = "L1: pub fn bounded() void {}" }},
+    );
+    if (outcome) |result| testing.allocator.free(result.scores) else |_| {}
+    thread.join();
+    if (mock.failure) |err| return err;
+    try testing.expectError(error.InvalidEmbeddingNumber, outcome);
 }
 
 test "semantic: request deadline cancels a stalled local provider" {

--- a/src/test_semantic.zig
+++ b/src/test_semantic.zig
@@ -1,0 +1,472 @@
+const std = @import("std");
+const testing = std.testing;
+const semantic = @import("semantic.zig");
+const cio = @import("cio.zig");
+const io = std.testing.io;
+
+const EnvVarGuard = struct {
+    name: []const u8,
+    had_prev: bool,
+    prev_len: usize,
+    prev: [4096]u8,
+
+    fn save(name: []const u8) EnvVarGuard {
+        var guard = EnvVarGuard{ .name = name, .had_prev = false, .prev_len = 0, .prev = undefined };
+        if (cio.posixGetenv(name)) |value| {
+            if (value.len <= guard.prev.len) {
+                @memcpy(guard.prev[0..value.len], value);
+                guard.prev_len = value.len;
+                guard.had_prev = true;
+            }
+        }
+        return guard;
+    }
+
+    fn restore(self: *const EnvVarGuard) void {
+        if (self.had_prev) cio.posixSetenv(self.name, self.prev[0..self.prev_len]) else cio.posixUnsetenv(self.name);
+    }
+};
+
+const EmbeddingEnvGuards = struct {
+    guards: [5]EnvVarGuard,
+
+    fn init() EmbeddingEnvGuards {
+        const names = [_][]const u8{
+            "CODEDB_EMBEDDINGS_URL",
+            "CODEDB_EMBEDDINGS_MODEL",
+            "CODEDB_EMBEDDINGS_TOKEN",
+            "CODEDB_EMBEDDINGS_DIMENSIONS",
+            "CODEDB_EMBEDDINGS_TIMEOUT_MS",
+        };
+        var self: EmbeddingEnvGuards = undefined;
+        for (names, 0..) |name, i| self.guards[i] = EnvVarGuard.save(name);
+        return self;
+    }
+
+    fn deinit(self: *const EmbeddingEnvGuards) void {
+        for (&self.guards) |*guard| guard.restore();
+    }
+};
+
+const MockEmbeddingServer = struct {
+    server: *std.Io.net.Server,
+    response: []const u8,
+    status: []const u8 = "200 OK",
+    delay_ms: u32 = 0,
+    request: [65536]u8 = undefined,
+    request_len: usize = 0,
+    failure: ?anyerror = null,
+
+    fn contentLength(headers: []const u8) !usize {
+        var lines = std.mem.splitSequence(u8, headers, "\r\n");
+        while (lines.next()) |line| {
+            const prefix = "content-length:";
+            if (line.len >= prefix.len and std.ascii.eqlIgnoreCase(line[0..prefix.len], prefix)) {
+                return std.fmt.parseInt(usize, std.mem.trim(u8, line[prefix.len..], " \t"), 10);
+            }
+        }
+        return error.MissingContentLength;
+    }
+
+    fn run(self: *MockEmbeddingServer) void {
+        const stream = self.server.accept(io) catch |err| {
+            self.failure = err;
+            return;
+        };
+        defer stream.close(io);
+
+        while (self.request_len < self.request.len) {
+            var iov = [1][]u8{self.request[self.request_len..]};
+            const n = stream.read(io, &iov) catch |err| {
+                self.failure = err;
+                return;
+            };
+            if (n == 0) break;
+            self.request_len += n;
+            const header_end = std.mem.indexOf(u8, self.request[0..self.request_len], "\r\n\r\n") orelse continue;
+            const content_len = contentLength(self.request[0..header_end]) catch |err| {
+                self.failure = err;
+                return;
+            };
+            if (self.request_len >= header_end + 4 + content_len) break;
+        }
+
+        if (self.delay_ms > 0) io.sleep(.fromMilliseconds(self.delay_ms), .awake) catch {};
+        var writer_buf: [4096]u8 = undefined;
+        var writer = stream.writer(io, &writer_buf);
+        var header_buf: [256]u8 = undefined;
+        const header = std.fmt.bufPrint(&header_buf, "HTTP/1.1 {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{ self.status, self.response.len }) catch return;
+        writer.interface.writeAll(header) catch return;
+        writer.interface.writeAll(self.response) catch return;
+        writer.interface.flush() catch return;
+    }
+};
+
+const RetryEmbeddingServer = struct {
+    server: *std.Io.net.Server,
+    response: []const u8,
+    failure: ?anyerror = null,
+
+    fn run(self: *RetryEmbeddingServer) void {
+        for ([_][]const u8{ "429 Too Many Requests", "503 Service Unavailable", "200 OK" }) |status| {
+            var one = MockEmbeddingServer{ .server = self.server, .response = self.response, .status = status };
+            one.run();
+            if (one.failure) |err| {
+                self.failure = err;
+                return;
+            }
+        }
+    }
+};
+
+fn makeMockEmbeddingResponse(allocator: std.mem.Allocator, model: []const u8, count: usize, dimensions: usize) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const writer = cio.listWriter(&out, allocator);
+    try writer.print("{{\"model\":\"{s}\",\"data\":[", .{model});
+    for (0..count) |row| {
+        if (row > 0) try writer.writeByte(',');
+        try writer.print("{{\"index\":{d},\"embedding\":[", .{row});
+        for (0..dimensions) |column| {
+            if (column > 0) try writer.writeByte(',');
+            try writer.writeAll(if (column == row % dimensions) "1" else "0");
+        }
+        try writer.writeAll("]}");
+    }
+    try writer.writeAll("]}");
+    return out.toOwnedSlice(allocator);
+}
+
+fn configureMockEndpoint(server: *const std.Io.net.Server, model: []const u8, timeout_ms: u32) !void {
+    var url_buf: [128]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/custom/embeddings", .{server.socket.address.getPort()});
+    cio.posixSetenv("CODEDB_EMBEDDINGS_URL", url);
+    cio.posixSetenv("CODEDB_EMBEDDINGS_MODEL", model);
+    cio.posixSetenv("CODEDB_EMBEDDINGS_TOKEN", "mock-secret-token");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_DIMENSIONS", "64");
+    var timeout_buf: [16]u8 = undefined;
+    const timeout = try std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_ms});
+    cio.posixSetenv("CODEDB_EMBEDDINGS_TIMEOUT_MS", timeout);
+}
+
+test "semantic: parses out-of-order OpenAI embeddings and computes cosine" {
+    const response =
+        \\{"data":[
+        \\  {"index":2,"embedding":[0,1,0]},
+        \\  {"index":0,"embedding":[1,0,0]},
+        \\  {"index":1,"embedding":[1,0,0]}
+        \\]}
+    ;
+    const scores = try semantic.scoresFromResponse(testing.allocator, response, 2, 3);
+    defer testing.allocator.free(scores);
+    try testing.expectApproxEqAbs(@as(f32, 1), scores[0], 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0), scores[1], 0.0001);
+}
+
+test "semantic: rejects wrong dimensions and duplicate indices" {
+    try testing.expectError(error.InvalidEmbeddingDimensions, semantic.scoresFromResponse(
+        testing.allocator,
+        \\{"data":[{"index":0,"embedding":[1,0]},{"index":1,"embedding":[1,0]}]}
+    ,
+        1,
+        3,
+    ));
+    try testing.expectError(error.InvalidEmbeddingResponse, semantic.scoresFromResponse(
+        testing.allocator,
+        \\{"data":[{"index":0,"embedding":[1,0,0]},{"index":0,"embedding":[1,0,0]}]}
+    ,
+        1,
+        3,
+    ));
+}
+
+test "semantic: parses raw vectors in response index order" {
+    const vectors = try semantic.vectorsFromResponse(
+        testing.allocator,
+        \\{"data":[{"index":1,"embedding":[0,1]},{"index":0,"embedding":[1,0]}]}
+    ,
+        2,
+        2,
+    );
+    defer testing.allocator.free(vectors);
+    try testing.expectEqualSlices(f32, &.{ 1, 0, 0, 1 }, vectors);
+}
+
+test "semantic: advisory fusion keeps lexical channel dominant" {
+    const best_lexical_worst_semantic = semantic.advisoryRrfScore(0, 23);
+    const second_lexical_best_semantic = semantic.advisoryRrfScore(1, 0);
+    try testing.expect(best_lexical_worst_semantic > second_lexical_best_semantic);
+}
+
+test "semantic: ANN fusion preserves the top-three lexical guard" {
+    const guarded_score = semantic.annRrfScore(true, 2, false, 99);
+    const semantic_only_score = semantic.annRrfScore(false, 3, true, 0);
+    try testing.expect(semantic_only_score > guarded_score);
+    try testing.expect(semantic.annRankComesBefore(
+        true,
+        2,
+        false,
+        guarded_score,
+        "src/lexical.zig",
+        false,
+        3,
+        true,
+        semantic_only_score,
+        "src/semantic.zig",
+    ));
+    try testing.expect(!semantic.annRankComesBefore(
+        false,
+        3,
+        true,
+        semantic_only_score,
+        "src/semantic.zig",
+        true,
+        2,
+        false,
+        guarded_score,
+        "src/lexical.zig",
+    ));
+}
+
+test "semantic: endpoint validation parses the authority instead of trusting a prefix" {
+    const base = semantic.Config{
+        .url = "https://example.com/v1/embeddings",
+        .model = "test-model",
+        .token = null,
+        .dimensions = 512,
+        .timeout_ms = semantic.default_timeout_ms,
+    };
+    try base.validate();
+    var config = base;
+    config.url = "http://127.0.0.1:8765/v1/embeddings";
+    try config.validate();
+    config.url = "http://localhost:8765/v1/embeddings";
+    try config.validate();
+    config.url = "http://[::1]:8765/v1/embeddings";
+    try config.validate();
+
+    const rejected = [_]struct { url: []const u8, expected: anyerror }{
+        .{ .url = "http://example.com/v1/embeddings", .expected = error.InsecureEmbeddingEndpoint },
+        .{ .url = "http://localhost:80@evil.example/v1/embeddings", .expected = error.InvalidEmbeddingConfig },
+        .{ .url = "http://127.0.0.1:80@evil.example/v1/embeddings", .expected = error.InvalidEmbeddingConfig },
+        .{ .url = "https://user@example.com/v1/embeddings", .expected = error.InvalidEmbeddingConfig },
+        .{ .url = "https://example.com/v1/embeddings#fragment", .expected = error.InvalidEmbeddingConfig },
+        .{ .url = "file:///tmp/embeddings", .expected = error.InvalidEmbeddingConfig },
+    };
+    for (rejected) |case| {
+        config.url = case.url;
+        try testing.expectError(case.expected, config.validate());
+    }
+}
+
+test "semantic: environment overrides are explicit and invalid values fail closed" {
+    const names = [_][]const u8{
+        "CODEDB_EMBEDDINGS_URL",
+        "CODEDB_EMBEDDINGS_MODEL",
+        "CODEDB_EMBEDDINGS_TOKEN",
+        "CODEDB_EMBEDDINGS_DIMENSIONS",
+        "CODEDB_EMBEDDINGS_TIMEOUT_MS",
+    };
+    var guards: [names.len]EnvVarGuard = undefined;
+    for (names, 0..) |name, i| guards[i] = EnvVarGuard.save(name);
+    defer for (&guards) |*guard| guard.restore();
+
+    cio.posixSetenv("CODEDB_EMBEDDINGS_URL", "http://127.0.0.1:9876/v1/embeddings");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_MODEL", "override-model");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_TOKEN", "test-token-not-from-dotenv");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_DIMENSIONS", "256");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_TIMEOUT_MS", "3210");
+    const configured = semantic.Config.fromEnv();
+    try configured.validate();
+    try testing.expectEqualStrings("http://127.0.0.1:9876/v1/embeddings", configured.url);
+    try testing.expectEqualStrings("override-model", configured.model);
+    try testing.expectEqualStrings("test-token-not-from-dotenv", configured.token.?);
+    try testing.expectEqual(@as(u16, 256), configured.dimensions);
+    try testing.expectEqual(@as(u32, 3210), configured.timeout_ms);
+
+    cio.posixSetenv("CODEDB_EMBEDDINGS_DIMENSIONS", "not-a-number");
+    try testing.expectError(error.InvalidEmbeddingConfig, semantic.Config.fromEnv().validate());
+    cio.posixSetenv("CODEDB_EMBEDDINGS_DIMENSIONS", "256");
+    cio.posixSetenv("CODEDB_EMBEDDINGS_TIMEOUT_MS", "0");
+    try testing.expectError(error.InvalidEmbeddingConfig, semantic.Config.fromEnv().validate());
+}
+
+test "semantic: calibration cosine detects a changed vector space" {
+    try testing.expectApproxEqAbs(@as(f32, 1), try semantic.cosineF32(&.{ 1, 0, 0 }, &.{ 1, 0, 0 }), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0), try semantic.cosineF32(&.{ 1, 0, 0 }, &.{ 0, 1, 0 }), 0.0001);
+}
+
+test "semantic: cloud-boundary path guard rejects env secrets and unsafe paths" {
+    const rejected = [_][]const u8{
+        ".env",
+        ".env.local",
+        ".ENV",
+        ".Env.local",
+        ".envrc",
+        ".direnv/cache.envrc",
+        "config/.env.production",
+        "frontend.env",
+        "keys/private.pem",
+        "keys/PRIVATE_KEY.PEM",
+        "keys/service.KeY",
+        "credentials.json",
+        "config/Credentials.JSON",
+        "deep/.ssh/id_ed25519",
+        "deep/.SSH/id_ed25519",
+        "../outside.zig",
+        "/etc/passwd",
+    };
+    for (rejected) |path| try testing.expect(!semantic.isRemoteCandidatePathAllowed(path));
+
+    try testing.expect(semantic.isRemoteCandidatePathAllowed("src/main.zig"));
+    try testing.expect(semantic.isRemoteCandidatePathAllowed("config/.envoy.json"));
+}
+
+test "semantic: endpoint override batches 25 inputs with auth and validates provider model" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    const response = try makeMockEmbeddingResponse(testing.allocator, "mock-model", 25, 64);
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", 2_000);
+
+    var mock = MockEmbeddingServer{ .server = &server, .response = response };
+    const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+    var inputs: [25][]const u8 = undefined;
+    for (&inputs, 0..) |*input, i| input.* = if (i == 0) "first" else "code";
+    const result = semantic.embedRemoteTexts(io, testing.allocator, &inputs) catch |err| {
+        thread.join();
+        return err;
+    };
+    defer testing.allocator.free(result.vectors);
+    thread.join();
+    if (mock.failure) |err| return err;
+
+    try testing.expectEqual(@as(usize, 25), result.count);
+    try testing.expectEqual(@as(usize, 25 * 64), result.vectors.len);
+    const request = mock.request[0..mock.request_len];
+    try testing.expect(std.mem.indexOf(u8, request, "POST /custom/embeddings HTTP/1.1") != null);
+    try testing.expect(std.mem.indexOf(u8, request, "authorization: Bearer mock-secret-token") != null or
+        std.mem.indexOf(u8, request, "Authorization: Bearer mock-secret-token") != null);
+    const header_end = std.mem.indexOf(u8, request, "\r\n\r\n") orelse return error.InvalidMockRequest;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, request[header_end + 4 ..], .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("mock-model", parsed.value.object.get("model").?.string);
+    try testing.expectEqual(@as(usize, 25), parsed.value.object.get("input").?.array.items.len);
+}
+
+test "semantic: provider model mismatch fails closed" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    const response = try makeMockEmbeddingResponse(testing.allocator, "different-model", 1, 64);
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", 2_000);
+
+    var mock = MockEmbeddingServer{ .server = &server, .response = response };
+    const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+    const outcome = semantic.embedRemoteTexts(io, testing.allocator, &.{"code"});
+    if (outcome) |result| testing.allocator.free(result.vectors) else |_| {}
+    thread.join();
+    if (mock.failure) |err| return err;
+    try testing.expectError(error.EmbeddingModelMismatch, outcome);
+}
+
+test "semantic: request deadline cancels a stalled local provider" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    const response = try makeMockEmbeddingResponse(testing.allocator, "mock-model", 1, 64);
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", semantic.min_timeout_ms);
+
+    var mock = MockEmbeddingServer{ .server = &server, .response = response, .delay_ms = 100 };
+    const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+    const outcome = semantic.embedRemoteTexts(io, testing.allocator, &.{"code"});
+    if (outcome) |result| testing.allocator.free(result.vectors) else |_| {}
+    thread.join();
+    // A canceled client may close before the delayed server write. That is the
+    // expected deadline path, so only read/accept failures are recorded above.
+    try testing.expectError(error.EmbeddingTimeout, outcome);
+}
+
+test "semantic: provider 4xx and 5xx responses fail closed with retryable classes" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    for ([_]struct { status: []const u8, expected: anyerror }{
+        .{ .status = "429 Too Many Requests", .expected = error.EmbeddingRateLimited },
+        .{ .status = "500 Internal Server Error", .expected = error.EmbeddingProviderUnavailable },
+    }) |case| {
+        const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+        var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+        defer server.deinit(io);
+        try configureMockEndpoint(&server, "mock-model", 2_000);
+        var mock = MockEmbeddingServer{ .server = &server, .response = "{\"error\":\"mock\"}", .status = case.status };
+        const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+        const outcome = semantic.embedRemoteTexts(io, testing.allocator, &.{"code"});
+        if (outcome) |result| testing.allocator.free(result.vectors) else |_| {}
+        thread.join();
+        if (mock.failure) |err| return err;
+        try testing.expectError(case.expected, outcome);
+    }
+}
+
+test "semantic: explicit index batches retry bounded 429 and 5xx responses" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    const response = try makeMockEmbeddingResponse(testing.allocator, "mock-model", 1, 64);
+    defer testing.allocator.free(response);
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+    defer server.deinit(io);
+    try configureMockEndpoint(&server, "mock-model", 2_000);
+
+    var mock = RetryEmbeddingServer{ .server = &server, .response = response };
+    const thread = try std.Thread.spawn(.{}, RetryEmbeddingServer.run, .{&mock});
+    const result = semantic.embedIndexRemoteTexts(io, testing.allocator, &.{"code"}) catch |err| {
+        thread.join();
+        return err;
+    };
+    defer testing.allocator.free(result.vectors);
+    thread.join();
+    if (mock.failure) |err| return err;
+    try testing.expectEqual(@as(usize, 1), result.count);
+}
+
+test "semantic: truncated and oversized provider bodies fail closed" {
+    var guards = EmbeddingEnvGuards.init();
+    defer guards.deinit();
+
+    const oversized = try testing.allocator.alloc(u8, semantic.max_response_bytes + 1);
+    defer testing.allocator.free(oversized);
+    @memset(oversized, 'x');
+    for ([_][]const u8{ "{\"model\":\"mock-model\",\"data\":[", oversized }) |response| {
+        const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+        var server = try addr.listen(io, .{ .reuse_address = true, .mode = .stream, .protocol = .tcp });
+        defer server.deinit(io);
+        try configureMockEndpoint(&server, "mock-model", 2_000);
+        var mock = MockEmbeddingServer{ .server = &server, .response = response };
+        const thread = try std.Thread.spawn(.{}, MockEmbeddingServer.run, .{&mock});
+        const outcome = semantic.embedRemoteTexts(io, testing.allocator, &.{"code"});
+        if (outcome) |result| {
+            testing.allocator.free(result.vectors);
+            thread.join();
+            return error.ExpectedEmbeddingFailure;
+        } else |_| {}
+        thread.join();
+        // The oversized case commonly closes the client while the mock is
+        // writing, which is expected and deliberately not treated as a server
+        // failure here.
+    }
+}

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -242,23 +242,23 @@ test "issue-685: snapshot round trip preserves typed document links and graph" {
     try testing.expectEqual(@as(usize, 1), deps.len);
     try testing.expectEqualStrings("issue-685-fixture/b.md", deps[0]);
 
-    // A pre-document-graph snapshot remains usable: only its old outline-state
-    // fast path is rejected, forcing a safe reparse of the retained CONTENT.
+    // Security boundary: v3 and older writers could follow file aliases and
+    // persist outside-root or sensitive bytes under a safe-looking path. The
+    // whole legacy snapshot must be rejected, not merely its outline fast path.
     {
         const file = try std.Io.Dir.cwd().openFile(io, snap_path, .{ .mode = .read_write });
         defer file.close(io);
         var version_buf: [2]u8 = undefined;
-        std.mem.writeInt(u16, &version_buf, 2, .little);
+        std.mem.writeInt(u16, &version_buf, 3, .little);
         try file.writePositionalAll(io, &version_buf, 4);
     }
     var legacy = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer legacy.deinit();
     var legacy_store = Store.init(testing.allocator);
     defer legacy_store.deinit();
-    try testing.expect(snapshot_mod.loadSnapshot(io, snap_path, &legacy, &legacy_store, testing.allocator));
-    const legacy_deps = legacy.document_graph.getForwardDeps("issue-685-fixture/a.md") orelse return error.TestUnexpectedResult;
-    try testing.expectEqual(@as(usize, 1), legacy_deps.len);
-    try testing.expectEqualStrings("issue-685-fixture/b.md", legacy_deps[0]);
+    try testing.expect(!snapshot_mod.loadSnapshot(io, snap_path, &legacy, &legacy_store, testing.allocator));
+    try testing.expectEqual(@as(usize, 0), legacy.outlines.count());
+    try testing.expect((try legacy.getContent("issue-685-fixture/a.md", testing.allocator)) == null);
 }
 
 // Restored FileOutlines borrow their import/symbol/document-link strings as slices into a

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -1049,11 +1049,19 @@ test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
         "cert.pem",                     "keystore.jks",       "identity.pfx",
         "bundle.p12",                   "config/.env.local",  "a/b/secrets.yaml",
         "deep/nested/.ssh/known_hosts", ".gnupg/secring.gpg", "x/.aws/credentials",
+        // case variants must not bypass the canonical filter
+        ".ENV",                         ".Env.Production",    "CONFIG.ENV",
+        "CERT.PEM",                     "server.KeY",         "bundle.P12",
+        "identity.PfX",                 "keystore.JKS",       "Credentials.JSON",
+        "Service-Account.JSON",         "SECRETS.YAML",       "ID_RSA",
+        "deep/.SSH/id_ed25519",         "x/.GnUpG/private",   "config/.AWS/credentials",
         // non-secrets — both copies must allow (esp. the .env-prefix edge cases)
         ".envoy.json",                  ".environment",       ".envrc",
+        ".EnVoY.json",                  ".ENVIRONMENT",       ".EnVrC",
         ".envconfig.yaml",              "main.zig",           "src/server.zig",
         "README.md",                    "package.json",       "id_rsa.pub",
         "envvars.ts",                   "Makefile",           "Dockerfile",
+        "src/PUBLIC.PEM.txt",
     };
     for (cases) |p| {
         try testing.expectEqual(watcher.isSensitivePath(p), snapshot_mod.isSensitivePath(p));
@@ -1064,7 +1072,13 @@ test "issue-528: isSensitivePath parity between snapshot.zig and watcher.zig" {
     try testing.expect(snapshot_mod.isSensitivePath("credentials.json"));
     try testing.expect(snapshot_mod.isSensitivePath("deep/.ssh/id_rsa"));
     try testing.expect(snapshot_mod.isSensitivePath("keystore.jks")); // fast-path ext
+    try testing.expect(snapshot_mod.isSensitivePath("CERT.PEM"));
+    try testing.expect(snapshot_mod.isSensitivePath("server.KeY"));
+    try testing.expect(snapshot_mod.isSensitivePath("Credentials.JSON"));
+    try testing.expect(!snapshot_mod.isSafeSnapshotPath("keys/PRIVATE_KEY.PEM"));
+    try testing.expect(!snapshot_mod.isSafeSnapshotPath("config/.Env.Local"));
     try testing.expect(!snapshot_mod.isSensitivePath(".envoy.json")); // issue-409
+    try testing.expect(!snapshot_mod.isSensitivePath(".EnVoY.json"));
     try testing.expect(!snapshot_mod.isSensitivePath(".environment"));
     try testing.expect(!snapshot_mod.isSensitivePath("main.zig"));
 }

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -114,7 +114,7 @@ test "issue-44: snapshot stale after working tree changes cause stale query resu
     var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena2.deinit();
     var exp2 = Explorer.init(arena2.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
-    exp2.setRoot(io, dir_path);
+    try exp2.setRoot(io, dir_path);
     var store2 = Store.init(testing.allocator);
     defer store2.deinit();
 
@@ -204,7 +204,7 @@ test "issue-685: unsafe snapshot records are rejected before indexing" {
 
     var restored = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer restored.deinit();
-    restored.setRoot(io, root);
+    try restored.setRoot(io, root);
     var store = Store.init(testing.allocator);
     defer store.deinit();
     try testing.expect(!snapshot_mod.loadSnapshot(io, snap_path, &restored, &store, testing.allocator));
@@ -553,7 +553,7 @@ test "snapshot: parallel freshness load re-indexes changed files, restores the r
     var arena2 = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena2.deinit();
     var exp2 = Explorer.init(arena2.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
-    exp2.setRoot(io, dir_path);
+    try exp2.setRoot(io, dir_path);
     var store = Store.init(testing.allocator);
     defer store.deinit();
 
@@ -627,7 +627,7 @@ test "snapshot: writer streams uncached file contents for large repos" {
     try testing.expectEqual(@as(usize, 1), hits_no_root.len);
 
     var loaded = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
-    loaded.setRoot(io, dir_path);
+    try loaded.setRoot(io, dir_path);
     defer loaded.deinit();
     var store = Store.init(testing.allocator);
     defer store.deinit();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -76,13 +76,21 @@ pub const EventQueue = struct {
 
 const FileState = struct {
     mtime: i64, // milliseconds since epoch — cheap stat check
+    mtime_ns: i128 = 0, // exact in-process discriminator for rapid rewrites
+    ctime_ns: i128 = 0, // catches same-size writes that preserve mtime
+    inode: std.posix.ino_t = 0, // catches rename-over-save replacement
     size: u64, // cheap change discriminator before hashing
     hash: u64, // wyhash of content — confirms actual change
     seen: bool, // set during current poll cycle for deletion detection
 };
 
 pub const FileMap = std.StringHashMap(FileState);
-pub const DirMap = std.StringHashMap(i64);
+pub const DirState = struct {
+    mtime_ns: i128,
+    ctime_ns: i128,
+    inode: std.posix.ino_t,
+};
+pub const DirMap = std.StringHashMap(DirState);
 pub const DirtySet = std.StringHashMap(void);
 pub var debug_unchanged_full_scans: usize = 0;
 pub var debug_unchanged_file_stats: usize = 0;
@@ -91,24 +99,27 @@ fn parentRel(path: []const u8) []const u8 {
     return if (std.mem.lastIndexOfScalar(u8, path, '/')) |i| path[0..i] else "";
 }
 
-
 fn joinRel(tmp: std.mem.Allocator, prefix: []const u8, name: []const u8) ![]const u8 {
     if (prefix.len == 0) return name;
     return std.fmt.allocPrint(tmp, "{s}/{s}", .{ prefix, name });
 }
 
-fn dirMtimeMs(io: std.Io, dir: std.Io.Dir, rel: []const u8) ?i64 {
+fn dirState(io: std.Io, dir: std.Io.Dir, rel: []const u8) ?DirState {
     const st = dir.statFile(io, if (rel.len == 0) "." else rel, .{}) catch return null;
-    return @intCast(@divTrunc(st.mtime.nanoseconds, std.time.ns_per_ms));
+    return .{
+        .mtime_ns = st.mtime.nanoseconds,
+        .ctime_ns = st.ctime.nanoseconds,
+        .inode = st.inode,
+    };
 }
 
-fn rememberDirMtime(dirs: *DirMap, persistent: std.mem.Allocator, rel: []const u8, mtime: i64) void {
+fn rememberDirState(dirs: *DirMap, persistent: std.mem.Allocator, rel: []const u8, state: DirState) void {
     if (dirs.getPtr(rel)) |slot| {
-        slot.* = mtime;
+        slot.* = state;
         return;
     }
     const key = persistent.dupe(u8, rel) catch return;
-    dirs.put(key, mtime) catch persistent.free(key);
+    dirs.put(key, state) catch persistent.free(key);
 }
 
 const InitialScanEntry = struct {
@@ -1268,17 +1279,21 @@ const FileChangeWatch = struct {
     alloc: std.mem.Allocator,
     active: bool = false,
     armed_files: u32 = 0,
+    armed_dirs: u32 = 0,
     kq: i32 = -1,
     inotify_fd: i32 = -1,
     files: std.ArrayList(std.posix.fd_t) = .empty,
     unwatched: std.ArrayList([]u8) = .empty,
+    unwatched_dirs: std.ArrayList([]u8) = .empty,
     ident_to_path: std.AutoHashMap(usize, []u8),
+    ident_to_dir: std.AutoHashMap(usize, []u8),
     wd_to_dir: std.AutoHashMap(i32, []u8),
 
     fn init(alloc: std.mem.Allocator) FileChangeWatch {
         return .{
             .alloc = alloc,
             .ident_to_path = .init(alloc),
+            .ident_to_dir = .init(alloc),
             .wd_to_dir = .init(alloc),
         };
     }
@@ -1286,9 +1301,11 @@ const FileChangeWatch = struct {
     fn deinit(self: *FileChangeWatch, io: std.Io) void {
         self.reset(io);
         self.ident_to_path.deinit();
+        self.ident_to_dir.deinit();
         self.wd_to_dir.deinit();
         self.files.deinit(self.alloc);
         self.unwatched.deinit(self.alloc);
+        self.unwatched_dirs.deinit(self.alloc);
     }
 
     fn reset(self: *FileChangeWatch, io: std.Io) void {
@@ -1296,6 +1313,9 @@ const FileChangeWatch = struct {
         var pit = self.ident_to_path.iterator();
         while (pit.next()) |kv| self.alloc.free(kv.value_ptr.*);
         self.ident_to_path.clearRetainingCapacity();
+        var pdit = self.ident_to_dir.iterator();
+        while (pdit.next()) |kv| self.alloc.free(kv.value_ptr.*);
+        self.ident_to_dir.clearRetainingCapacity();
         var dit = self.wd_to_dir.iterator();
         while (dit.next()) |kv| self.alloc.free(kv.value_ptr.*);
         self.wd_to_dir.clearRetainingCapacity();
@@ -1305,6 +1325,8 @@ const FileChangeWatch = struct {
         self.files.clearRetainingCapacity();
         for (self.unwatched.items) |p| self.alloc.free(p);
         self.unwatched.clearRetainingCapacity();
+        for (self.unwatched_dirs.items) |p| self.alloc.free(p);
+        self.unwatched_dirs.clearRetainingCapacity();
         if (self.kq >= 0) {
             cio.closeFd(self.kq);
             self.kq = -1;
@@ -1317,47 +1339,65 @@ const FileChangeWatch = struct {
     }
 
     fn rememberUnwatched(self: *FileChangeWatch, path: []const u8) void {
+        for (self.unwatched.items) |existing| if (std.mem.eql(u8, existing, path)) return;
         const duped = self.alloc.dupe(u8, path) catch return;
         self.unwatched.append(self.alloc, duped) catch self.alloc.free(duped);
+    }
+
+    fn rememberUnwatchedDir(self: *FileChangeWatch, path: []const u8) void {
+        for (self.unwatched_dirs.items) |existing| if (std.mem.eql(u8, existing, path)) return;
+        const duped = self.alloc.dupe(u8, path) catch return;
+        self.unwatched_dirs.append(self.alloc, duped) catch self.alloc.free(duped);
+    }
+
+    fn forgetUnwatchedDir(self: *FileChangeWatch, path: []const u8) void {
+        var i: usize = 0;
+        while (i < self.unwatched_dirs.items.len) : (i += 1) {
+            if (!std.mem.eql(u8, self.unwatched_dirs.items[i], path)) continue;
+            self.alloc.free(self.unwatched_dirs.swapRemove(i));
+            return;
+        }
     }
 
     fn addUnwatched(self: *const FileChangeWatch, dirty: *DirtySet) void {
         for (self.unwatched.items) |path| {
             dirty.put(path, {}) catch {};
         }
+        for (self.unwatched_dirs.items) |path| dirty.put(path, {}) catch {};
     }
 
-    fn arm(self: *FileChangeWatch, io: std.Io, root: []const u8, known: *const FileMap, dirs: *const DirMap) void {
+    fn arm(self: *FileChangeWatch, io: std.Io, root_dir: std.Io.Dir, known: *const FileMap, dirs: *const DirMap) void {
         self.reset(io);
         self.armed_files = @intCast(known.count());
+        self.armed_dirs = @intCast(dirs.count());
         if (comptime watch_kqueue) {
-            self.armKqueue(io, root, known, dirs);
+            self.armKqueue(root_dir, known, dirs);
         } else if (comptime watch_inotify) {
-            self.armInotify(root, dirs);
+            self.armInotify(io, root_dir, dirs);
         }
     }
 
-    fn armKqueue(self: *FileChangeWatch, io: std.Io, root: []const u8, known: *const FileMap, dirs: *const DirMap) void {
+    fn armKqueue(self: *FileChangeWatch, root_dir: std.Io.Dir, known: *const FileMap, dirs: *const DirMap) void {
         if (comptime !watch_kqueue) return;
         if (known.count() > 32768) return;
         raiseNofileLimit();
         const kq = std.c.kqueue();
         if (kq < 0) return;
         self.kq = kq;
-        const root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch return;
-        defer root_dir.close(io);
         const vnode_flags = std.c.NOTE.WRITE | std.c.NOTE.DELETE | std.c.NOTE.RENAME | std.c.NOTE.EXTEND;
-        var it = known.iterator();
-        while (it.next()) |kv| {
-            const path = kv.key_ptr.*;
-            self.watchKqueueFile(root_dir.handle, path, vnode_flags);
-        }
-        self.watchKqueueDir(root_dir.handle, ".", vnode_flags);
+        // Directories cover the scan-to-arm gap and provide replacement
+        // identity before the more numerous per-file watches are installed.
+        self.watchKqueueDir(root_dir.handle, "", vnode_flags);
         var dit = dirs.iterator();
         while (dit.next()) |kv| {
             const rel = kv.key_ptr.*;
             if (rel.len == 0) continue;
             self.watchKqueueDir(root_dir.handle, rel, vnode_flags);
+        }
+        var it = known.iterator();
+        while (it.next()) |kv| {
+            const path = kv.key_ptr.*;
+            self.watchKqueueFile(root_dir.handle, path, vnode_flags);
         }
         if (std.posix.openat(std.posix.AT.FDCWD, "/tmp/codedb-notify", .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true }, 0)) |nfd| {
             if (self.addVnode(nfd, std.c.NOTE.WRITE | std.c.NOTE.EXTEND)) {
@@ -1366,52 +1406,72 @@ const FileChangeWatch = struct {
                 cio.closeFd(nfd);
             }
         } else |_| {}
-        self.active = self.ident_to_path.count() > 0 or self.unwatched.items.len > 0;
+        self.active = self.ident_to_path.count() > 0 or self.ident_to_dir.count() > 0 or self.unwatched.items.len > 0 or self.unwatched_dirs.items.len > 0;
     }
 
-    fn watchKqueueFile(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) void {
-        if (comptime !watch_kqueue) return;
+    fn addKqueueFileWatch(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) ?std.posix.fd_t {
+        if (comptime !watch_kqueue) return null;
         const fd = std.posix.openat(root_fd, path, .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true }, 0) catch {
             self.rememberUnwatched(path);
-            return;
+            return null;
         };
         if (!self.addVnode(fd, fflags)) {
             cio.closeFd(fd);
             self.rememberUnwatched(path);
-            return;
+            return null;
         }
         const duped = self.alloc.dupe(u8, path) catch {
             cio.closeFd(fd);
-            return;
+            return null;
         };
         self.ident_to_path.put(@intCast(fd), duped) catch {
             self.alloc.free(duped);
             cio.closeFd(fd);
-            return;
+            return null;
         };
-        self.files.append(self.alloc, fd) catch cio.closeFd(fd);
+        self.files.append(self.alloc, fd) catch {
+            if (self.ident_to_path.fetchRemove(@intCast(fd))) |entry| self.alloc.free(entry.value);
+            cio.closeFd(fd);
+            self.rememberUnwatched(path);
+            return null;
+        };
+        return fd;
     }
 
-    fn hasWatch(self: *const FileChangeWatch, path: []const u8) bool {
+    fn watchKqueueFile(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) void {
+        _ = self.addKqueueFileWatch(root_fd, path, fflags);
+    }
+
+    fn findKqueueFile(self: *const FileChangeWatch, path: []const u8) ?std.posix.fd_t {
         var it = self.ident_to_path.iterator();
         while (it.next()) |kv| {
-            if (std.mem.eql(u8, kv.value_ptr.*, path)) return true;
+            if (std.mem.eql(u8, kv.value_ptr.*, path)) return @intCast(kv.key_ptr.*);
         }
-        return false;
+        return null;
     }
 
-    fn dropWatchedPath(self: *FileChangeWatch, path: []const u8) void {
+    fn dropKqueueFile(self: *FileChangeWatch, fd: std.posix.fd_t) void {
         if (comptime !watch_kqueue) return;
-        var found: ?std.posix.fd_t = null;
-        var it = self.ident_to_path.iterator();
-        while (it.next()) |kv| {
-            if (std.mem.eql(u8, kv.value_ptr.*, path)) {
-                found = @intCast(kv.key_ptr.*);
-                break;
-            }
-        }
-        const fd = found orelse return;
         if (self.ident_to_path.fetchRemove(@intCast(fd))) |kv| self.alloc.free(kv.value);
+        self.dropKqueueFd(fd);
+    }
+
+    fn findKqueueDir(self: *const FileChangeWatch, path: []const u8) ?std.posix.fd_t {
+        var it = self.ident_to_dir.iterator();
+        while (it.next()) |kv| {
+            if (std.mem.eql(u8, kv.value_ptr.*, path)) return @intCast(kv.key_ptr.*);
+        }
+        return null;
+    }
+
+    fn dropKqueueDir(self: *FileChangeWatch, fd: std.posix.fd_t) void {
+        if (comptime !watch_kqueue) return;
+        if (self.ident_to_dir.fetchRemove(@intCast(fd))) |kv| self.alloc.free(kv.value);
+        self.dropKqueueFd(fd);
+    }
+
+    fn dropKqueueFd(self: *FileChangeWatch, fd: std.posix.fd_t) void {
+        if (comptime !watch_kqueue) return;
         var i: usize = 0;
         while (i < self.files.items.len) {
             if (self.files.items[i] == fd) {
@@ -1423,22 +1483,69 @@ const FileChangeWatch = struct {
         cio.closeFd(fd);
     }
 
-    fn rearmDirty(self: *FileChangeWatch, io: std.Io, root: []const u8, dirty: *const DirtySet) void {
-        if (comptime !watch_kqueue) return;
+    fn hasWatchedDir(self: *const FileChangeWatch, path: []const u8) bool {
+        if (comptime watch_kqueue) return self.findKqueueDir(path) != null;
+        if (comptime watch_inotify) return self.findInotifyDir(path) != null;
+        return false;
+    }
+
+    fn pathWithinNonRootDir(path: []const u8, dir: []const u8) bool {
+        return dir.len > 0 and path.len > dir.len and path[dir.len] == '/' and std.mem.startsWith(u8, path, dir);
+    }
+
+    fn affectedByDirtyDirectory(self: *const FileChangeWatch, dirty: *const DirtySet, path: []const u8) bool {
+        var it = dirty.keyIterator();
+        while (it.next()) |dirty_path| {
+            if (!self.hasWatchedDir(dirty_path.*)) continue;
+            if (std.mem.eql(u8, path, dirty_path.*) or pathWithinNonRootDir(path, dirty_path.*)) return true;
+        }
+        return false;
+    }
+
+    fn rememberRearmPath(paths: *std.StringHashMap(void), path: []const u8) void {
+        if (paths.contains(path)) return;
+        const copy = paths.allocator.dupe(u8, path) catch return;
+        paths.put(copy, {}) catch {};
+    }
+
+    fn rearmDirty(self: *FileChangeWatch, io: std.Io, root_dir: std.Io.Dir, dirty: *const DirtySet) void {
+        if (comptime !watch_kqueue and !watch_inotify) return;
         if (dirty.count() == 0) return;
-        const root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch return;
-        defer root_dir.close(io);
-        const vnode_flags = std.c.NOTE.WRITE | std.c.NOTE.DELETE | std.c.NOTE.RENAME | std.c.NOTE.EXTEND;
-        var dit = dirty.keyIterator();
-        while (dit.next()) |path_ptr| {
-            const path = path_ptr.*;
-            var owned: [std.fs.max_path_bytes]u8 = undefined;
-            if (path.len > owned.len) continue;
-            @memcpy(owned[0..path.len], path);
-            const rel = owned[0..path.len];
-            if (!self.hasWatch(rel)) continue;
-            self.dropWatchedPath(rel);
-            self.watchKqueueFile(root_dir.handle, rel, vnode_flags);
+
+        var dirs_to_rearm = std.StringHashMap(void).init(dirty.allocator);
+        defer dirs_to_rearm.deinit();
+        if (comptime watch_kqueue) {
+            var it = self.ident_to_dir.iterator();
+            while (it.next()) |entry| {
+                if (self.affectedByDirtyDirectory(dirty, entry.value_ptr.*)) rememberRearmPath(&dirs_to_rearm, entry.value_ptr.*);
+            }
+        } else if (comptime watch_inotify) {
+            var it = self.wd_to_dir.iterator();
+            while (it.next()) |entry| {
+                if (self.affectedByDirtyDirectory(dirty, entry.value_ptr.*)) rememberRearmPath(&dirs_to_rearm, entry.value_ptr.*);
+            }
+        }
+        for (self.unwatched_dirs.items) |path| {
+            if (dirty.contains(path)) rememberRearmPath(&dirs_to_rearm, path);
+        }
+
+        if (comptime watch_kqueue) {
+            var files_to_rearm = std.StringHashMap(void).init(dirty.allocator);
+            defer files_to_rearm.deinit();
+            var files = self.ident_to_path.iterator();
+            while (files.next()) |entry| {
+                const path = entry.value_ptr.*;
+                if (dirty.contains(path) or self.affectedByDirtyDirectory(dirty, path)) rememberRearmPath(&files_to_rearm, path);
+            }
+            const flags = std.c.NOTE.WRITE | std.c.NOTE.DELETE | std.c.NOTE.RENAME | std.c.NOTE.EXTEND;
+            var dirs_it = dirs_to_rearm.keyIterator();
+            while (dirs_it.next()) |path| self.rearmKqueueDir(root_dir.handle, path.*, flags);
+            var files_it = files_to_rearm.keyIterator();
+            while (files_it.next()) |path| self.rearmKqueueFile(root_dir.handle, path.*, flags);
+        } else if (comptime watch_inotify) {
+            const mask = inotifyDirectoryMask();
+            var dirs_it = dirs_to_rearm.keyIterator();
+            while (dirs_it.next()) |path| self.rearmInotifyDir(io, root_dir, path.*, mask);
         }
     }
 
@@ -1453,49 +1560,165 @@ const FileChangeWatch = struct {
         return rc >= 0;
     }
 
-    fn watchKqueueDir(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) void {
-        if (comptime !watch_kqueue) return;
-        const fd = std.posix.openat(root_fd, rel, .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true, .DIRECTORY = true }, 0) catch return;
+    fn addKqueueDirWatch(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) ?std.posix.fd_t {
+        if (comptime !watch_kqueue) return null;
+        const open_rel = if (rel.len == 0) "." else rel;
+        const fd = std.posix.openat(root_fd, open_rel, .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true, .DIRECTORY = true }, 0) catch {
+            self.rememberUnwatchedDir(rel);
+            return null;
+        };
         if (!self.addVnode(fd, fflags)) {
             cio.closeFd(fd);
-            return;
+            self.rememberUnwatchedDir(rel);
+            return null;
         }
-        self.files.append(self.alloc, fd) catch cio.closeFd(fd);
+        const duped = self.alloc.dupe(u8, rel) catch {
+            cio.closeFd(fd);
+            self.rememberUnwatchedDir(rel);
+            return null;
+        };
+        self.ident_to_dir.put(@intCast(fd), duped) catch {
+            self.alloc.free(duped);
+            cio.closeFd(fd);
+            self.rememberUnwatchedDir(rel);
+            return null;
+        };
+        self.files.append(self.alloc, fd) catch {
+            if (self.ident_to_dir.fetchRemove(@intCast(fd))) |entry| self.alloc.free(entry.value);
+            cio.closeFd(fd);
+            self.rememberUnwatchedDir(rel);
+            return null;
+        };
+        self.forgetUnwatchedDir(rel);
+        return fd;
     }
 
-    fn armInotify(self: *FileChangeWatch, root: []const u8, dirs: *const DirMap) void {
+    fn watchKqueueDir(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) void {
+        _ = self.addKqueueDirWatch(root_fd, rel, fflags);
+    }
+
+    fn rearmKqueueDir(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) void {
+        if (comptime !watch_kqueue) return;
+        const old_fd = self.findKqueueDir(rel);
+        if (self.addKqueueDirWatch(root_fd, rel, fflags) == null) return;
+        if (old_fd) |fd| self.dropKqueueDir(fd);
+    }
+
+    fn rearmKqueueFile(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) void {
+        if (comptime !watch_kqueue) return;
+        const old_fd = self.findKqueueFile(path);
+        if (self.addKqueueFileWatch(root_fd, path, fflags) == null) return;
+        if (old_fd) |fd| self.dropKqueueFile(fd);
+    }
+
+    fn inotifyDirectoryMask() u32 {
+        return std.os.linux.IN.MODIFY | std.os.linux.IN.CREATE | std.os.linux.IN.DELETE |
+            std.os.linux.IN.MOVED_FROM | std.os.linux.IN.MOVED_TO | std.os.linux.IN.ATTRIB |
+            std.os.linux.IN.DELETE_SELF | std.os.linux.IN.MOVE_SELF;
+    }
+
+    fn armInotify(self: *FileChangeWatch, io: std.Io, root_dir: std.Io.Dir, dirs: *const DirMap) void {
         if (comptime !watch_inotify) return;
         const rc = std.os.linux.inotify_init1(std.os.linux.IN.CLOEXEC);
-        if (std.posix.errno(rc) != .SUCCESS) return;
+        if (std.os.linux.errno(rc) != .SUCCESS) return;
         self.inotify_fd = @intCast(rc);
-        const mask = std.os.linux.IN.MODIFY | std.os.linux.IN.CREATE | std.os.linux.IN.DELETE |
-            std.os.linux.IN.MOVED_FROM | std.os.linux.IN.MOVED_TO | std.os.linux.IN.ATTRIB;
-        self.addInotifyWatch(root, "", mask);
+        const mask = inotifyDirectoryMask();
+        self.addInotifyWatchDir(root_dir, "", mask);
         var dit = dirs.iterator();
         while (dit.next()) |kv| {
             const rel = kv.key_ptr.*;
             if (rel.len == 0) continue;
-            var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const full = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ root, rel }) catch continue;
-            self.addInotifyWatch(full, rel, mask);
+            const child = root_dir.openDir(io, rel, .{ .follow_symlinks = false }) catch {
+                self.rememberUnwatchedDir(rel);
+                continue;
+            };
+            self.addInotifyWatchDir(child, rel, mask);
+            child.close(io);
         }
-        self.addInotifyWatch("/tmp/codedb-notify", null, std.os.linux.IN.MODIFY | std.os.linux.IN.CLOSE_WRITE);
-        self.active = self.wd_to_dir.count() > 0;
+        _ = self.addInotifyWatch("/tmp/codedb-notify", null, std.os.linux.IN.MODIFY | std.os.linux.IN.CLOSE_WRITE);
+        self.active = self.wd_to_dir.count() > 0 or self.unwatched_dirs.items.len > 0;
     }
 
-    fn addInotifyWatch(self: *FileChangeWatch, path: []const u8, rel: ?[]const u8, mask: u32) void {
-        if (comptime !watch_inotify) return;
+    fn addInotifyWatchDir(self: *FileChangeWatch, dir: std.Io.Dir, rel: []const u8, mask: u32) void {
+        var path_buf: [64]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "/proc/self/fd/{d}", .{dir.handle}) catch return;
+        if (self.addInotifyWatch(path, rel, mask)) self.forgetUnwatchedDir(rel) else self.rememberUnwatchedDir(rel);
+    }
+
+    fn addInotifyWatch(self: *FileChangeWatch, path: []const u8, rel: ?[]const u8, mask: u32) bool {
+        if (comptime !watch_inotify) return false;
+        const wd = self.rawAddInotifyWatch(path, mask) orelse return false;
+        if (rel) |dir_rel| {
+            if (!self.rememberInotifyWatch(wd, dir_rel)) {
+                self.removeInotifyWatch(wd);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fn rawAddInotifyWatch(self: *FileChangeWatch, path: []const u8, mask: u32) ?i32 {
+        if (comptime !watch_inotify) return null;
         var zbuf: [std.fs.max_path_bytes]u8 = undefined;
-        if (path.len >= zbuf.len) return;
+        if (path.len >= zbuf.len) return null;
         @memcpy(zbuf[0..path.len], path);
         zbuf[path.len] = 0;
         const wd_rc = std.os.linux.inotify_add_watch(self.inotify_fd, @ptrCast(&zbuf), mask);
-        if (std.posix.errno(wd_rc) != .SUCCESS) return;
-        const wd: i32 = @intCast(wd_rc);
-        if (rel) |dir_rel| {
-            const duped = self.alloc.dupe(u8, dir_rel) catch return;
-            self.wd_to_dir.put(wd, duped) catch self.alloc.free(duped);
+        if (std.os.linux.errno(wd_rc) != .SUCCESS) return null;
+        return @intCast(wd_rc);
+    }
+
+    fn rememberInotifyWatch(self: *FileChangeWatch, wd: i32, rel: []const u8) bool {
+        if (comptime !watch_inotify) return false;
+        const duped = self.alloc.dupe(u8, rel) catch return false;
+        const slot = self.wd_to_dir.getOrPut(wd) catch {
+            self.alloc.free(duped);
+            return false;
+        };
+        if (slot.found_existing) self.alloc.free(slot.value_ptr.*);
+        slot.value_ptr.* = duped;
+        return true;
+    }
+
+    fn findInotifyDir(self: *const FileChangeWatch, rel: []const u8) ?i32 {
+        var it = self.wd_to_dir.iterator();
+        while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.value_ptr.*, rel)) return entry.key_ptr.*;
         }
+        return null;
+    }
+
+    fn removeInotifyWatch(self: *FileChangeWatch, wd: i32) void {
+        if (comptime !watch_inotify) return;
+        if (self.wd_to_dir.fetchRemove(wd)) |entry| self.alloc.free(entry.value);
+        _ = std.os.linux.inotify_rm_watch(self.inotify_fd, wd);
+    }
+
+    fn rearmInotifyDir(self: *FileChangeWatch, io: std.Io, root_dir: std.Io.Dir, rel: []const u8, mask: u32) void {
+        if (comptime !watch_inotify) return;
+        const old_wd = self.findInotifyDir(rel);
+        const dir = if (rel.len == 0) root_dir else root_dir.openDir(io, rel, .{ .follow_symlinks = false }) catch {
+            self.rememberUnwatchedDir(rel);
+            return;
+        };
+        defer if (rel.len != 0) dir.close(io);
+        var path_buf: [64]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "/proc/self/fd/{d}", .{dir.handle}) catch return;
+        const new_wd = self.rawAddInotifyWatch(path, mask) orelse {
+            self.rememberUnwatchedDir(rel);
+            return;
+        };
+        if (old_wd != null and new_wd == old_wd.?) {
+            self.forgetUnwatchedDir(rel);
+            return;
+        }
+        if (!self.rememberInotifyWatch(new_wd, rel)) {
+            _ = std.os.linux.inotify_rm_watch(self.inotify_fd, new_wd);
+            self.rememberUnwatchedDir(rel);
+            return;
+        }
+        if (old_wd) |wd| self.removeInotifyWatch(wd);
+        self.forgetUnwatchedDir(rel);
     }
 
     fn poll(self: *FileChangeWatch, dirty: *DirtySet, timeout_ms: i32) void {
@@ -1528,7 +1751,28 @@ const FileChangeWatch = struct {
         var i: usize = 0;
         while (i < @as(usize, @intCast(n))) : (i += 1) {
             if (self.ident_to_path.get(events[i].ident)) |path| {
-                dirty.put(path, {}) catch {};
+                const copy = dirty.allocator.dupe(u8, path) catch continue;
+                dirty.put(copy, {}) catch {};
+            }
+            if (self.ident_to_dir.get(events[i].ident)) |path| {
+                const copy = dirty.allocator.dupe(u8, path) catch continue;
+                dirty.put(copy, {}) catch {};
+            }
+        }
+    }
+
+    fn markAllWatchedDirsDirty(self: *const FileChangeWatch, dirty: *DirtySet) void {
+        if (comptime watch_kqueue) {
+            var it = self.ident_to_dir.iterator();
+            while (it.next()) |entry| {
+                const copy = dirty.allocator.dupe(u8, entry.value_ptr.*) catch continue;
+                dirty.put(copy, {}) catch {};
+            }
+        } else if (comptime watch_inotify) {
+            var it = self.wd_to_dir.iterator();
+            while (it.next()) |entry| {
+                const copy = dirty.allocator.dupe(u8, entry.value_ptr.*) catch continue;
+                dirty.put(copy, {}) catch {};
             }
         }
     }
@@ -1553,7 +1797,19 @@ const FileChangeWatch = struct {
             const ev: *const std.os.linux.inotify_event = @ptrCast(@alignCast(buf[offset..].ptr));
             const ev_size = @sizeOf(std.os.linux.inotify_event) + ev.len;
             if (offset + ev_size > n) break;
+            if (ev.mask & std.os.linux.IN.Q_OVERFLOW != 0) {
+                self.markAllWatchedDirsDirty(dirty);
+                offset += ev_size;
+                continue;
+            }
             if (self.wd_to_dir.get(ev.wd)) |dir_rel| {
+                if (ev.mask & (std.os.linux.IN.DELETE_SELF | std.os.linux.IN.MOVE_SELF | std.os.linux.IN.IGNORED) != 0) {
+                    const copy = dirty.allocator.dupe(u8, dir_rel) catch {
+                        offset += ev_size;
+                        continue;
+                    };
+                    dirty.put(copy, {}) catch {};
+                }
                 if (ev.getName()) |name| {
                     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
                     const rel = if (dir_rel.len == 0) name else std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dir_rel, name }) catch {
@@ -1572,6 +1828,233 @@ const FileChangeWatch = struct {
     }
 };
 
+fn armAndCloseGap(
+    io: std.Io,
+    watch: *FileChangeWatch,
+    root_dir: std.Io.Dir,
+    store: *Store,
+    explorer: *Explorer,
+    queue: *EventQueue,
+    known: *FileMap,
+    dirs: *DirMap,
+    root: []const u8,
+    persistent: std.mem.Allocator,
+) void {
+    var pass: usize = 0;
+    while (pass < 2) : (pass += 1) {
+        watch.arm(io, root_dir, known, dirs);
+        var arena = std.heap.ArenaAllocator.init(persistent);
+        defer arena.deinit();
+        incrementalDiffInner(io, store, explorer, queue, known, dirs, root, persistent, arena.allocator()) catch |err| {
+            std.log.err("watcher: post-arm reconcile failed: {}", .{err});
+            return;
+        };
+        if (known.count() == watch.armed_files and dirs.count() == watch.armed_dirs) return;
+    }
+    watch.arm(io, root_dir, known, dirs);
+}
+
+test "file watcher remains pinned to opened root after pathname retarget" {
+    if (!(comptime watch_kqueue or watch_inotify)) return;
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "live");
+    try tmp.dir.createDirPath(io, "decoy");
+    try tmp.dir.writeFile(io, .{ .sub_path = "live/keep.py", .data = "def original():\n    return 1\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "decoy/keep.py", .data = "def decoy():\n    return 1\n" });
+    var live_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const live_len = try tmp.dir.realPathFile(io, "live", &live_buf);
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, live_buf[0..live_len]);
+    const root_dir = explorer.root_dir orelse return error.TestUnexpectedResult;
+    var known = FileMap.init(testing.allocator);
+    defer {
+        var it = known.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    const known_key = try testing.allocator.dupe(u8, "keep.py");
+    try known.put(known_key, .{ .mtime = 0, .size = 0, .hash = 0, .seen = false });
+    var dirs = DirMap.init(testing.allocator);
+    defer {
+        var it = dirs.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    const root_key = try testing.allocator.dupe(u8, "");
+    try dirs.put(root_key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
+    var watch = FileChangeWatch.init(testing.allocator);
+    defer watch.deinit(io);
+    watch.arm(io, root_dir, &known, &dirs);
+    try testing.expect(watch.active);
+    try tmp.dir.rename("live", tmp.dir, "moved", io);
+    try tmp.dir.rename("decoy", tmp.dir, "live", io);
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var dirty = DirtySet.init(arena.allocator());
+        defer dirty.deinit();
+        watch.poll(&dirty, 100);
+    }
+    try tmp.dir.writeFile(io, .{ .sub_path = "live/keep.py", .data = "def decoy_changed():\n    return 2\n" });
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var dirty = DirtySet.init(arena.allocator());
+        defer dirty.deinit();
+        watch.poll(&dirty, 100);
+        try testing.expectEqual(@as(u32, 0), dirty.count());
+    }
+    try tmp.dir.writeFile(io, .{ .sub_path = "moved/keep.py", .data = "def original_changed():\n    return 3\n" });
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var dirty = DirtySet.init(arena.allocator());
+        defer dirty.deinit();
+        watch.poll(&dirty, 1000);
+        try testing.expect(dirty.contains("keep.py") or dirty.contains(""));
+    }
+}
+
+test "directory watches follow repeated equal-count subtree replacements" {
+    if (!(comptime watch_kqueue or watch_inotify)) return;
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "project/src/nested");
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/src/nested/keep.py", .data = "VALUE = 'initial'\n" });
+    var stage_generation: usize = 0;
+    while (stage_generation < 30) : (stage_generation += 1) {
+        var stage_dir_buf: [48]u8 = undefined;
+        const stage_dir = try std.fmt.bufPrint(&stage_dir_buf, "stage-{d}/nested", .{stage_generation});
+        try tmp.dir.createDirPath(io, stage_dir);
+        var stage_file_buf: [64]u8 = undefined;
+        const stage_file = try std.fmt.bufPrint(&stage_file_buf, "stage-{d}/nested/keep.py", .{stage_generation});
+        var stage_content_buf: [64]u8 = undefined;
+        const stage_content = try std.fmt.bufPrint(&stage_content_buf, "VALUE = 'stage-{d}'\n", .{stage_generation});
+        try tmp.dir.writeFile(io, .{ .sub_path = stage_file, .data = stage_content });
+    }
+    const root_dir = try tmp.dir.openDir(io, "project", .{ .iterate = true, .follow_symlinks = false });
+    defer root_dir.close(io);
+    var known = FileMap.init(testing.allocator);
+    defer {
+        var it = known.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    const known_key = try testing.allocator.dupe(u8, "src/nested/keep.py");
+    try known.put(known_key, .{ .mtime = 0, .size = 0, .hash = 0, .seen = false });
+    var dirs = DirMap.init(testing.allocator);
+    defer {
+        var it = dirs.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    for ([_][]const u8{ "", "src", "src/nested" }) |path| {
+        const key = try testing.allocator.dupe(u8, path);
+        try dirs.put(key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
+    }
+    var watch = FileChangeWatch.init(testing.allocator);
+    defer watch.deinit(io);
+    watch.arm(io, root_dir, &known, &dirs);
+    try testing.expect(watch.active);
+    const Poll = struct {
+        fn untilAny(w: *FileChangeWatch, dirty: *DirtySet, first: []const u8, second: []const u8) !void {
+            var attempt: usize = 0;
+            while (attempt < 20) : (attempt += 1) {
+                w.poll(dirty, 100);
+                if (dirty.contains(first) or dirty.contains(second)) return;
+            }
+            return error.TestExpectedEqual;
+        }
+    };
+    var generation: usize = 0;
+    while (generation < 30) : (generation += 1) {
+        var stage_buf: [32]u8 = undefined;
+        const stage = try std.fmt.bufPrint(&stage_buf, "stage-{d}", .{generation});
+        var retired_buf: [32]u8 = undefined;
+        const retired = try std.fmt.bufPrint(&retired_buf, "retired-{d}", .{generation});
+        try tmp.dir.rename("project/src", tmp.dir, retired, io);
+        try tmp.dir.rename(stage, tmp.dir, "project/src", io);
+        {
+            var arena = std.heap.ArenaAllocator.init(testing.allocator);
+            defer arena.deinit();
+            var dirty = DirtySet.init(arena.allocator());
+            defer dirty.deinit();
+            try Poll.untilAny(&watch, &dirty, "src", "src");
+            watch.rearmDirty(io, root_dir, &dirty);
+        }
+        var content_buf: [64]u8 = undefined;
+        const content = try std.fmt.bufPrint(&content_buf, "VALUE = 'edited-{d}'\n", .{generation});
+        try root_dir.writeFile(io, .{ .sub_path = "src/nested/keep.py", .data = content });
+        {
+            var arena = std.heap.ArenaAllocator.init(testing.allocator);
+            defer arena.deinit();
+            var dirty = DirtySet.init(arena.allocator());
+            defer dirty.deinit();
+            try Poll.untilAny(&watch, &dirty, "src/nested/keep.py", "src/nested");
+            watch.rearmDirty(io, root_dir, &dirty);
+        }
+    }
+    var save: usize = 0;
+    while (save < 100) : (save += 1) {
+        var content_buf: [64]u8 = undefined;
+        const content = try std.fmt.bufPrint(&content_buf, "VALUE = 'save-{d}'\n", .{save});
+        try root_dir.writeFile(io, .{ .sub_path = "src/nested/keep.py", .data = content });
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var dirty = DirtySet.init(arena.allocator());
+        defer dirty.deinit();
+        try Poll.untilAny(&watch, &dirty, "src/nested/keep.py", "src/nested");
+        watch.rearmDirty(io, root_dir, &dirty);
+    }
+}
+
+test "failed directory watch admission retries through dirty reconciliation" {
+    if (!(comptime watch_kqueue or watch_inotify)) return;
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer root_dir.close(io);
+    var known = FileMap.init(testing.allocator);
+    defer known.deinit();
+    var dirs = DirMap.init(testing.allocator);
+    defer {
+        var it = dirs.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    for ([_][]const u8{ "", "late" }) |path| {
+        const key = try testing.allocator.dupe(u8, path);
+        try dirs.put(key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
+    }
+    var watch = FileChangeWatch.init(testing.allocator);
+    defer watch.deinit(io);
+    watch.arm(io, root_dir, &known, &dirs);
+    try testing.expect(watch.active);
+    try testing.expectEqual(@as(usize, 1), watch.unwatched_dirs.items.len);
+    try testing.expect(!watch.hasWatchedDir("late"));
+    try tmp.dir.createDirPath(io, "late");
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var dirty = DirtySet.init(arena.allocator());
+    defer dirty.deinit();
+    watch.addUnwatched(&dirty);
+    try testing.expect(dirty.contains("late"));
+    watch.rearmDirty(io, root_dir, &dirty);
+    try testing.expect(watch.hasWatchedDir("late"));
+    try testing.expectEqual(@as(usize, 0), watch.unwatched_dirs.items.len);
+    watch.markAllWatchedDirsDirty(&dirty);
+    try testing.expect(dirty.contains(""));
+    try testing.expect(dirty.contains("late"));
+}
+
 /// Background thread: polls for incremental FS changes.
 pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, root: []const u8, shutdown: *std.atomic.Value(bool), scan_done: *std.atomic.Value(bool)) void {
     var gpa = std.heap.DebugAllocator(.{}).init;
@@ -1585,6 +2068,7 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
         if (shutdown.load(.acquire)) return;
         cio.sleepMs(100);
     }
+    const stable_root = explorer.root_dir orelse return;
 
     var known = FileMap.init(backing);
     defer {
@@ -1618,16 +2102,14 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
 
     var watch = FileChangeWatch.init(backing);
     defer watch.deinit(io);
-    watch.arm(io, root, &known, &dirs);
+    armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
 
     // Track current git HEAD to detect branch switches (#116)
-    var last_git_head: ?[40]u8 = git_mod.getGitHead(root, backing) catch null;
+    var last_git_head: ?[40]u8 = git_mod.getGitHeadDir(io, stable_root, backing) catch null;
 
     // Cache .git/HEAD mtime so we only fork git rev-parse when the file changes (#254)
     var git_head_mtime: i128 = blk: {
-        const root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch break :blk -1;
-        defer root_dir.close(io);
-        const st = root_dir.statFile(io, ".git/HEAD", .{}) catch break :blk -1;
+        const st = stable_root.statFile(io, ".git/HEAD", .{}) catch break :blk -1;
         break :blk @intCast(st.mtime.nanoseconds);
     };
 
@@ -1642,20 +2124,18 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
             cio.sleepMs(2 * std.time.ns_per_s / 1_000_000);
         }
 
-        drainNotifyFile(io, store, explorer, queue, &known, root, backing);
+        drainNotifyFile(io, store, explorer, queue, &known, backing);
 
         // Check if git HEAD changed — stat .git/HEAD mtime first to skip fork+exec (#254)
         var current_head: ?[40]u8 = last_git_head;
         const head_changed = blk: {
             {
-                const root_dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch break :blk false;
-                defer root_dir.close(io);
-                const st = root_dir.statFile(io, ".git/HEAD", .{}) catch break :blk false;
+                const st = stable_root.statFile(io, ".git/HEAD", .{}) catch break :blk false;
                 const st_mtime: i128 = @intCast(st.mtime.nanoseconds);
                 if (st_mtime == git_head_mtime) break :blk false;
                 git_head_mtime = st_mtime;
             }
-            current_head = git_mod.getGitHead(root, backing) catch null;
+            current_head = git_mod.getGitHeadDir(io, stable_root, backing) catch null;
             if (last_git_head == null and current_head == null) break :blk false;
             if (last_git_head == null or current_head == null) break :blk true;
             break :blk !std.mem.eql(u8, &last_git_head.?, &current_head.?);
@@ -1688,7 +2168,7 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
             var rescan_arena = std.heap.ArenaAllocator.init(backing);
             defer rescan_arena.deinit();
             const tmp = rescan_arena.allocator();
-            const dir = std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true }) catch continue;
+            const dir = stable_root.openDir(io, ".", .{ .iterate = true, .follow_symlinks = false }) catch continue;
             defer dir.close(io);
             var walker = FilteredWalker.init(io, dir, tmp) catch continue;
             defer walker.deinit();
@@ -1704,7 +2184,7 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
                 const duped = backing.dupe(u8, entry.path) catch continue;
                 known.put(duped, .{ .mtime = mtime, .size = stat.size, .hash = 0, .seen = false }) catch backing.free(duped);
             }
-            watch.arm(io, root, &known, &dirs);
+            armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
             continue;
         }
 
@@ -1717,17 +2197,17 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
             incrementalDiffDirty(io, store, explorer, queue, &known, &dirs, root, backing, cycle_arena.allocator(), &dirty) catch |err| {
                 std.log.err("watcher: diff failed: {}", .{err});
             };
-            if (known.count() != watch.armed_files) {
-                watch.arm(io, root, &known, &dirs);
+            if (known.count() != watch.armed_files or dirs.count() != watch.armed_dirs) {
+                armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
             } else if (had_events) {
-                watch.rearmDirty(io, root, &dirty);
+                watch.rearmDirty(io, stable_root, &dirty);
             }
         } else {
             incrementalDiffInner(io, store, explorer, queue, &known, &dirs, root, backing, cycle_arena.allocator()) catch |err| {
                 std.log.err("watcher: diff failed: {}", .{err});
             };
-            if (known.count() != watch.armed_files) {
-                watch.arm(io, root, &known, &dirs);
+            if (known.count() != watch.armed_files or dirs.count() != watch.armed_dirs) {
+                armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
             }
         }
     }
@@ -1803,7 +2283,9 @@ pub fn incrementalDiffDirty(
     tmp: std.mem.Allocator,
     dirty: ?*const DirtySet,
 ) !void {
-    const dir = try std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true });
+    _ = root;
+    const root_dir = explorer.root_dir orelse return error.ProjectRootUnavailable;
+    const dir = try root_dir.openDir(io, ".", .{ .iterate = true, .follow_symlinks = false });
     defer dir.close(io);
 
     // Mark all known files unseen for this cycle.
@@ -1847,12 +2329,21 @@ fn applyKnownFile(
     dir: std.Io.Dir,
     path: []const u8,
     stat: std.Io.Dir.Stat,
+    force_read: bool,
 ) !void {
     const known_entry = known.getEntry(path) orelse return;
     const old = known_entry.value_ptr;
     old.seen = true;
     const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
-    if (old.mtime == mtime and old.size == stat.size) {
+    const exact_metadata_matches = old.mtime_ns != 0 and old.mtime_ns == stat.mtime.nanoseconds and old.ctime_ns == stat.ctime.nanoseconds and old.inode == stat.inode and old.size == stat.size;
+    if (!force_read and exact_metadata_matches) {
+        store.noteMtime(path, mtime);
+        return;
+    }
+    if (!force_read and old.mtime_ns == 0 and old.mtime == mtime and old.size == stat.size) {
+        old.mtime_ns = stat.mtime.nanoseconds;
+        old.ctime_ns = stat.ctime.nanoseconds;
+        old.inode = stat.inode;
         store.noteMtime(path, mtime);
         return;
     }
@@ -1873,6 +2364,9 @@ fn applyKnownFile(
 
     if (old.size == stat.size and hash != 0 and old.hash != 0 and hash == old.hash) {
         old.mtime = mtime;
+        old.mtime_ns = stat.mtime.nanoseconds;
+        old.ctime_ns = stat.ctime.nanoseconds;
+        old.inode = stat.inode;
         old.size = stat.size;
         store.noteMtime(path, mtime);
         return;
@@ -1880,6 +2374,9 @@ fn applyKnownFile(
 
     const seq = try store.recordSnapshot(path, stat.size, hash);
     old.mtime = mtime;
+    old.mtime_ns = stat.mtime.nanoseconds;
+    old.ctime_ns = stat.ctime.nanoseconds;
+    old.inode = stat.inode;
     old.size = stat.size;
     old.hash = hash;
     store.noteMtime(path, mtime);
@@ -1920,6 +2417,22 @@ fn buildParentIndex(known: *const FileMap, tmp: std.mem.Allocator) !ParentIndex 
     return .{ .files = files, .child_dirs = child_dirs };
 }
 
+fn dirtyForcesDirectoryScan(dirty: ?*const DirtySet, known: *const FileMap, prefix: []const u8) bool {
+    const set = dirty orelse return false;
+    if (set.get(prefix) != null) return true;
+    var it = set.keyIterator();
+    while (it.next()) |path| {
+        if (path.len == 0 or known.get(path.*) != null) continue;
+        if (std.mem.eql(u8, parentRel(path.*), prefix)) return true;
+    }
+    return false;
+}
+
+fn dirtyForcesFileRead(dirty: ?*const DirtySet, prefix: []const u8, path: []const u8) bool {
+    const set = dirty orelse return false;
+    return set.get(prefix) != null or set.get(path) != null;
+}
+
 fn walkRel(
     io: std.Io,
     store: *Store,
@@ -1935,9 +2448,10 @@ fn walkRel(
     parents: *const ParentIndex,
     dirty: ?*const DirtySet,
 ) !void {
-    const current_mtime = dirMtimeMs(io, dir, prefix);
-    const cached_mtime = if (dirs) |d| d.get(prefix) else null;
-    const dir_unchanged = current_mtime != null and cached_mtime != null and current_mtime.? == cached_mtime.?;
+    const current_dir_state = dirState(io, dir, prefix);
+    const cached_dir_state = if (dirs) |d| d.get(prefix) else null;
+    const force_scan = dirtyForcesDirectoryScan(dirty, known, prefix);
+    const dir_unchanged = !force_scan and current_dir_state != null and cached_dir_state != null and std.meta.eql(current_dir_state.?, cached_dir_state.?);
 
     if (dir_unchanged) {
         if (parents.files.get(prefix)) |file_list| {
@@ -1950,7 +2464,7 @@ fn walkRel(
                 }
                 debug_unchanged_file_stats += 1;
                 const stat = dir.statFile(io, path, .{}) catch continue;
-                try applyKnownFile(io, store, explorer, queue, known, dir, path, stat);
+                try applyKnownFile(io, store, explorer, queue, known, dir, path, stat, dirtyForcesFileRead(dirty, prefix, path));
             }
         }
         if (parents.child_dirs.get(prefix)) |children| {
@@ -1991,9 +2505,10 @@ fn walkRel(
 
         const rel = try joinRel(tmp, prefix, entry.name);
         if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, rel)) continue;
+        if (shouldSkipFile(rel)) continue;
         const stat = dir.statFile(io, rel, .{}) catch continue;
         if (known.getEntry(rel)) |known_entry| {
-            try applyKnownFile(io, store, explorer, queue, known, dir, known_entry.key_ptr.*, stat);
+            try applyKnownFile(io, store, explorer, queue, known, dir, known_entry.key_ptr.*, stat, dirtyForcesFileRead(dirty, prefix, rel));
         } else {
             const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
             const duped = try persistent.dupe(u8, rel);
@@ -2007,7 +2522,7 @@ fn walkRel(
     }
 
     if (dirs) |dir_map| {
-        if (current_mtime) |mt| rememberDirMtime(dir_map, persistent, prefix, mt);
+        if (current_dir_state) |state| rememberDirState(dir_map, persistent, prefix, state);
     }
 }
 
@@ -2125,10 +2640,22 @@ fn indexFileContent(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []co
 // We drain this file on every poll cycle and re-index the listed files
 // immediately, eliminating the 2s polling delay for muonry-sourced edits.
 
-fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, known: *FileMap, root: []const u8, alloc: std.mem.Allocator) void {
-    // Atomically read + truncate
-    const notify_path = "/tmp/codedb-notify";
-    const file = std.Io.Dir.cwd().openFile(io, notify_path, .{ .mode = .read_write }) catch return;
+fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, known: *FileMap, alloc: std.mem.Allocator) void {
+    drainNotifyFileFrom(io, store, explorer, queue, known, alloc, std.Io.Dir.cwd(), "/tmp/codedb-notify");
+}
+
+fn drainNotifyFileFrom(
+    io: std.Io,
+    store: *Store,
+    explorer: *Explorer,
+    queue: *EventQueue,
+    known: *FileMap,
+    alloc: std.mem.Allocator,
+    notify_dir: std.Io.Dir,
+    notify_path: []const u8,
+) void {
+    // Atomically read + truncate.
+    const file = notify_dir.openFile(io, notify_path, .{ .mode = .read_write }) catch return;
     defer file.close(io);
 
     const file_len = file.length(io) catch return;
@@ -2145,8 +2672,10 @@ fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *Event
     file.setLength(io, 0) catch return;
 
     // Re-index each notified path
-    const dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch return;
-    defer dir.close(io);
+    const dir = explorer.root_dir orelse return;
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = dir.realPathFile(io, ".", &root_buf) catch return;
+    const root = root_buf[0..root_len];
 
     var lines = std.mem.splitScalar(u8, data_slice, '\n');
     while (lines.next()) |line| {
@@ -2154,16 +2683,18 @@ fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *Event
         if (path.len == 0) continue;
 
         // Make path relative to root if it's absolute
-        const rel = if (std.mem.startsWith(u8, path, root))
-            std.mem.trimStart(u8, path[root.len..], "/")
-        else
-            path;
+        const rel = if (std.fs.path.isAbsolute(path)) blk: {
+            if (!std.mem.startsWith(u8, path, root) or path.len <= root.len or path[root.len] != '/') continue;
+            break :blk std.mem.trimStart(u8, path[root.len..], "/");
+        } else path;
+        if (shouldSkipFile(rel)) continue;
 
         // Skip re-indexing if file hasn't changed since last known state (#228)
-        const stat = dir.statFile(io, rel, .{}) catch continue;
+        const stat = dir.statFile(io, rel, .{ .follow_symlinks = false }) catch continue;
+        if (stat.kind != .file) continue;
         const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
         if (known.getPtr(rel)) |existing| {
-            if (existing.mtime == mtime and existing.size == stat.size) continue;
+            if (existing.mtime_ns != 0 and existing.mtime_ns == stat.mtime.nanoseconds and existing.ctime_ns == stat.ctime.nanoseconds and existing.inode == stat.inode and existing.size == stat.size) continue;
         }
 
         // Read once: index + hash from the same buffer (previously two separate
@@ -2174,8 +2705,12 @@ fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *Event
         // Update known-file state so incrementalDiff doesn't double-process
         if (known.getPtr(rel)) |existing| {
             existing.mtime = mtime;
+            existing.mtime_ns = stat.mtime.nanoseconds;
+            existing.ctime_ns = stat.ctime.nanoseconds;
+            existing.inode = stat.inode;
             existing.size = stat.size;
             existing.hash = hash;
+            existing.seen = true;
         }
         store.noteMtime(rel, mtime);
 
@@ -2184,6 +2719,81 @@ fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *Event
             _ = queue.push(ev);
         }
     }
+}
+
+test "notify drain uses exact metadata and refreshes the live fingerprint" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const old_content = "OLD_VALUE = 111\n";
+    const new_content = "NEW_VALUE = 222\n";
+    try testing.expectEqual(old_content.len, new_content.len);
+    try tmp.dir.writeFile(io, .{ .sub_path = "keep.py", .data = old_content });
+    try tmp.dir.writeFile(io, .{ .sub_path = "notify", .data = "" });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root = root_buf[0..root_len];
+    const store = try testing.allocator.create(Store);
+    defer testing.allocator.destroy(store);
+    store.* = Store.init(testing.allocator);
+    defer store.deinit();
+    const explorer = try testing.allocator.create(Explorer);
+    defer testing.allocator.destroy(explorer);
+    explorer.* = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    explorer.setRoot(io, root);
+    const stable_root = explorer.root_dir orelse return error.TestUnexpectedResult;
+    try indexFileContent(io, explorer, stable_root, "keep.py", testing.allocator, false);
+    const old_stat = try stable_root.statFile(io, "keep.py", .{ .follow_symlinks = false });
+    var known = FileMap.init(testing.allocator);
+    defer {
+        var it = known.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    const key = try testing.allocator.dupe(u8, "keep.py");
+    try known.put(key, .{
+        .mtime = @intCast(@divTrunc(old_stat.mtime.nanoseconds, std.time.ns_per_ms)),
+        .mtime_ns = old_stat.mtime.nanoseconds,
+        .ctime_ns = old_stat.ctime.nanoseconds,
+        .inode = old_stat.inode,
+        .size = old_stat.size,
+        .hash = std.hash.Wyhash.hash(0, old_content),
+        .seen = true,
+    });
+    try tmp.dir.writeFile(io, .{ .sub_path = "keep.py", .data = new_content });
+    const new_stat = try stable_root.statFile(io, "keep.py", .{ .follow_symlinks = false });
+    (known.getPtr("keep.py") orelse return error.TestUnexpectedResult).mtime =
+        @intCast(@divTrunc(new_stat.mtime.nanoseconds, std.time.ns_per_ms));
+    try tmp.dir.writeFile(io, .{ .sub_path = "notify", .data = "keep.py\n" });
+    const queue = try testing.allocator.create(EventQueue);
+    defer testing.allocator.destroy(queue);
+    queue.* = .{};
+    drainNotifyFileFrom(io, store, explorer, queue, &known, testing.allocator, tmp.dir, "notify");
+    const refreshed = known.getPtr("keep.py") orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(new_stat.mtime.nanoseconds, refreshed.mtime_ns);
+    try testing.expectEqual(new_stat.ctime.nanoseconds, refreshed.ctime_ns);
+    try testing.expectEqual(new_stat.inode, refreshed.inode);
+    try testing.expectEqual(std.hash.Wyhash.hash(0, new_content), refreshed.hash);
+    const new_hits = try explorer.searchContent("NEW_VALUE", testing.allocator, 10);
+    defer {
+        for (new_hits) |hit| {
+            testing.allocator.free(hit.line_text);
+            testing.allocator.free(hit.path);
+        }
+        testing.allocator.free(new_hits);
+    }
+    try testing.expectEqual(@as(usize, 1), new_hits.len);
+    const old_hits = try explorer.searchContent("OLD_VALUE", testing.allocator, 10);
+    defer {
+        for (old_hits) |hit| {
+            testing.allocator.free(hit.line_text);
+            testing.allocator.free(hit.path);
+        }
+        testing.allocator.free(old_hits);
+    }
+    try testing.expectEqual(@as(usize, 0), old_hits.len);
 }
 
 test "issue-685: watcher diff updates document edges for modify add and delete" {
@@ -2234,10 +2844,12 @@ test "issue-685: watcher diff updates document edges for modify add and delete" 
     try tmp.dir.writeFile(io, .{ .sub_path = "docs/c.md", .data = "# C\n" });
     try tmp.dir.deleteFile(io, "docs/b.md");
 
-    var queue = EventQueue{};
+    const queue = try testing.allocator.create(EventQueue);
+    defer testing.allocator.destroy(queue);
+    queue.* = .{};
     var cycle_arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer cycle_arena.deinit();
-    try incrementalDiff(io, &store, &explorer, &queue, &known, root, testing.allocator, cycle_arena.allocator());
+    try incrementalDiff(io, &store, &explorer, queue, &known, root, testing.allocator, cycle_arena.allocator());
 
     try testing.expect(!explorer.outlines.contains("docs/b.md"));
     try testing.expect(explorer.outlines.contains("docs/c.md"));
@@ -2279,11 +2891,13 @@ test "dir-mtime prune still stats known files and notices new siblings" {
         dirs.deinit();
     }
 
-    var queue = EventQueue{};
+    const queue = try testing.allocator.create(EventQueue);
+    defer testing.allocator.destroy(queue);
+    queue.* = .{};
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expect(explorer.outlines.contains("src/a.py"));
     try testing.expect(explorer.outlines.contains("src/b.py"));
@@ -2292,7 +2906,7 @@ test "dir-mtime prune still stats known files and notices new siblings" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expectEqual(first_seq, store.currentSeq());
 
@@ -2301,7 +2915,7 @@ test "dir-mtime prune still stats known files and notices new siblings" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
@@ -2313,7 +2927,7 @@ test "dir-mtime prune still stats known files and notices new siblings" {
     {
         var arena = std.heap.ArenaAllocator.init(testing.allocator);
         defer arena.deinit();
-        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root, testing.allocator, arena.allocator());
+        try incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expect(explorer.outlines.contains("src/c.py"));
 }

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1923,7 +1923,7 @@ test "file watcher remains pinned to opened root after pathname retarget" {
     const live_len = try tmp.dir.realPathFile(io, "live", &live_buf);
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, live_buf[0..live_len]);
+    try explorer.setRoot(io, live_buf[0..live_len]);
     const root_dir = explorer.root_dir orelse return error.TestUnexpectedResult;
     var known = FileMap.init(testing.allocator);
     defer {
@@ -2831,7 +2831,7 @@ test "notify drain uses exact metadata and refreshes the live fingerprint" {
     defer testing.allocator.destroy(explorer);
     explorer.* = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     const stable_root = explorer.root_dir orelse return error.TestUnexpectedResult;
     try indexFileContent(io, explorer, stable_root, "keep.py", testing.allocator, false);
     const old_stat = try stable_root.statFile(io, "keep.py", .{ .follow_symlinks = false });

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -779,7 +779,9 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
                 defer arena.deinit();
                 const parsed = try parseInitialScanEntry(io, dir, entry, arena.allocator(), arena.allocator());
                 if (parsed) |file| {
+                    const content_hash = std.hash.Wyhash.hash(0, file.content);
                     try explorer.commitParsedFileOwnedOutline(file.path, file.content, file.outline, true, file.skip_trigram);
+                    _ = store.refineLatestSnapshotHash(file.path, file.content.len, content_hash);
                 }
             }
         }
@@ -851,7 +853,9 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
     for (workers) |*worker| {
         for (0..worker.items.len) |item_index| {
             if (worker.takeReady(io, item_index)) |file| {
+                const content_hash = std.hash.Wyhash.hash(0, file.content);
                 try explorer.commitParsedFileAdoptOutline(file.path, file.content, file.outline, true, file.skip_trigram);
+                _ = store.refineLatestSnapshotHash(file.path, file.content.len, content_hash);
             }
         }
     }

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -8,6 +8,8 @@ const TrigramIndex = @import("index.zig").TrigramIndex;
 const WordIndex = @import("index.zig").WordIndex;
 const explore_mod = @import("explore.zig");
 const git_mod = @import("git.zig");
+const project_file = @import("project_file.zig");
+const project_path = @import("project_path.zig");
 
 fn nsToMs(ns: i128) f64 {
     return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
@@ -227,7 +229,7 @@ fn readIndexableFile(
             std.log.warn("codedb: not indexing {s} ({d} bytes > {d} cap) — reachable only via codedb_read", .{ path, size, max_indexed_file_bytes });
         return null;
     }
-    const content = try dir.readFileAlloc(io, path, alloc, .limited(max_indexed_file_bytes));
+    const content = try project_file.readAllocNoFollow(io, dir, path, alloc, .limited(max_indexed_file_bytes));
     // Skip binary content (null byte within the first 512 bytes).
     const check_len = @min(content.len, 512);
     if (std.mem.indexOfScalar(u8, content[0..check_len], 0) != null) {
@@ -236,6 +238,7 @@ fn readIndexableFile(
     }
     return content;
 }
+
 const skip_dirs = [_][]const u8{
     ".git",
     ".jj",
@@ -316,6 +319,40 @@ fn shouldSkipDir(name: []const u8) bool {
     return false;
 }
 
+fn isWithinCanonicalRoot(root: []const u8, candidate: []const u8) bool {
+    if (!std.mem.startsWith(u8, candidate, root)) return false;
+    if (candidate.len == root.len) return true;
+    return root.len > 0 and (std.fs.path.isSep(root[root.len - 1]) or std.fs.path.isSep(candidate[root.len]));
+}
+
+fn canonicalTargetRelative(root: []const u8, target: []const u8) ?[]const u8 {
+    if (!isWithinCanonicalRoot(root, target) or target.len == root.len) return null;
+    var start = root.len;
+    while (start < target.len and std.fs.path.isSep(target[start])) start += 1;
+    if (start == target.len) return null;
+    return target[start..];
+}
+
+/// Resolve every candidate under the canonical root and require both its
+/// visible path and canonical repo-relative target to satisfy the indexing
+/// filters. File symlinks themselves are skipped; this additionally protects
+/// regular files reached through an allowed directory symlink.
+fn resolvedFileTargetAllowed(io: std.Io, root_dir: std.Io.Dir, canonical_root: []const u8, alias_path: []const u8) bool {
+    if (canonical_root.len == 0 or shouldSkip(alias_path) or shouldSkipFile(alias_path)) return false;
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_len = root_dir.realPathFile(io, alias_path, &target_buf) catch return false;
+    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len]) orelse return false;
+    return !shouldSkip(target_rel) and !shouldSkipFile(target_rel);
+}
+
+fn resolvedDirectoryTargetAllowed(io: std.Io, root_dir: std.Io.Dir, canonical_root: []const u8, alias_path: []const u8) bool {
+    if (alias_path.len == 0) return canonical_root.len > 0;
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_len = root_dir.realPathFile(io, alias_path, &target_buf) catch return false;
+    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len]) orelse return false;
+    return !shouldSkip(target_rel) and !shouldSkipFile(target_rel);
+}
+
 /// Recursive directory walker that prunes skip_dirs before descending.
 /// Unlike std.Io.Dir.walk(), this never enters .git, node_modules, etc.,
 /// avoiding the CPU cost of traversing potentially huge directory trees.
@@ -323,6 +360,7 @@ pub const FilteredWalker = struct {
     const StackItem = struct {
         dir_handle: std.Io.Dir,
         iter: std.Io.Dir.Iterator,
+        through_symlink: bool,
     };
 
     stack: std.ArrayList(StackItem),
@@ -348,6 +386,7 @@ pub const FilteredWalker = struct {
         try self.stack.append(allocator, .{
             .dir_handle = root,
             .iter = root.iterate(),
+            .through_symlink = false,
         });
 
         var rr_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -359,7 +398,7 @@ pub const FilteredWalker = struct {
         } else |_| {}
 
         // Load .codedbignore if it exists
-        if (root.readFileAlloc(io, ".codedbignore", allocator, .limited(64 * 1024))) |content| {
+        if (project_file.readAllocNoFollow(io, root, ".codedbignore", allocator, .limited(64 * 1024))) |content| {
             defer allocator.free(content);
             var lines = std.mem.splitScalar(u8, content, '\n');
             while (lines.next()) |line| {
@@ -371,7 +410,7 @@ pub const FilteredWalker = struct {
         } else |_| {}
 
         // Also load .gitignore patterns (respect git's ignore rules)
-        if (root.readFileAlloc(io, ".gitignore", allocator, .limited(64 * 1024))) |content| {
+        if (project_file.readAllocNoFollow(io, root, ".gitignore", allocator, .limited(64 * 1024))) |content| {
             defer allocator.free(content);
             var lines = std.mem.splitScalar(u8, content, '\n');
             while (lines.next()) |line| {
@@ -430,6 +469,23 @@ pub const FilteredWalker = struct {
         return false;
     }
 
+    fn claimOpenedSymlinkDirectory(self: *FilteredWalker, dir: std.Io.Dir) bool {
+        if (self.real_root.len == 0) return false;
+        var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const target_len = dir.realPathFile(self.io, ".", &target_buf) catch return false;
+        const real_target = target_buf[0..target_len];
+        const target_rel = canonicalTargetRelative(self.real_root, real_target) orelse return false;
+        if (shouldSkip(target_rel) or shouldSkipFile(target_rel)) return false;
+        const gop = self.visited_real_paths.getOrPut(self.allocator, real_target) catch return false;
+        if (gop.found_existing) return false;
+        const dup = self.allocator.dupe(u8, real_target) catch {
+            _ = self.visited_real_paths.remove(real_target);
+            return false;
+        };
+        gop.key_ptr.* = dup;
+        return true;
+    }
+
     pub fn next(self: *FilteredWalker) !?Entry {
         // Trim any filename appended by the previous yield
         self.name_buffer.shrinkRetainingCapacity(self.dir_prefix_len);
@@ -463,52 +519,50 @@ pub const FilteredWalker = struct {
                     try self.stack.append(self.allocator, .{
                         .dir_handle = sub,
                         .iter = sub.iterate(),
+                        .through_symlink = top.through_symlink,
                     });
                     continue;
                 }
 
                 if (entry.kind != .file) {
                     if (entry.kind != .sym_link) continue;
-                    const target_stat = top.dir_handle.statFile(self.io, entry.name, .{}) catch continue;
-                    if (target_stat.kind == .directory) {
-                        if (shouldSkipDir(entry.name)) continue;
-                        if (self.ignore_patterns.items.len > 0) {
-                            var check_buf: [std.fs.max_path_bytes]u8 = undefined;
-                            const check_path = if (self.dir_prefix_len > 0)
-                                std.fmt.bufPrint(&check_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch entry.name
-                            else
-                                entry.name;
-                            if (self.isIgnored(entry.name, check_path)) continue;
-                        }
-                        var rt_buf: [std.fs.max_path_bytes]u8 = undefined;
-                        const rt_len = top.dir_handle.realPathFile(self.io, entry.name, &rt_buf) catch continue;
-                        const real_target = rt_buf[0..rt_len];
-                        if (self.real_root.len == 0) continue;
-                        if (!std.mem.startsWith(u8, real_target, self.real_root)) continue;
-                        if (real_target.len != self.real_root.len and real_target[self.real_root.len] != '/') continue;
-                        const gop = self.visited_real_paths.getOrPut(self.allocator, real_target) catch continue;
-                        if (gop.found_existing) continue;
-                        const dup = self.allocator.dupe(u8, real_target) catch {
-                            _ = self.visited_real_paths.remove(real_target);
-                            continue;
-                        };
-                        gop.key_ptr.* = dup;
-                        const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
-                        errdefer sub.close(self.io);
-                        const saved_len_sym = self.name_buffer.items.len;
-                        errdefer self.name_buffer.shrinkRetainingCapacity(saved_len_sym);
-                        if (self.name_buffer.items.len > 0)
-                            try self.name_buffer.append(self.allocator, '/');
-                        try self.name_buffer.appendSlice(self.allocator, entry.name);
-                        self.dir_prefix_len = self.name_buffer.items.len;
-                        try self.stack.append(self.allocator, .{
-                            .dir_handle = sub,
-                            .iter = sub.iterate(),
-                        });
+                    if (shouldSkipDir(entry.name)) continue;
+                    if (self.ignore_patterns.items.len > 0) {
+                        var check_buf: [std.fs.max_path_bytes]u8 = undefined;
+                        const check_path = if (self.dir_prefix_len > 0)
+                            std.fmt.bufPrint(&check_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch entry.name
+                        else
+                            entry.name;
+                        if (self.isIgnored(entry.name, check_path)) continue;
+                    }
+                    // Opening as a directory is also the file-symlink gate:
+                    // regular-file targets fail with NotDir and are skipped.
+                    // Validate the already-open directory handle so retargeting
+                    // the link cannot change the object that will be walked.
+                    const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
+                    if (!self.claimOpenedSymlinkDirectory(sub)) {
+                        sub.close(self.io);
                         continue;
                     }
-                    if (target_stat.kind != .file) continue;
+                    errdefer sub.close(self.io);
+                    const saved_len_sym = self.name_buffer.items.len;
+                    errdefer self.name_buffer.shrinkRetainingCapacity(saved_len_sym);
+                    if (self.name_buffer.items.len > 0)
+                        try self.name_buffer.append(self.allocator, '/');
+                    try self.name_buffer.appendSlice(self.allocator, entry.name);
+                    self.dir_prefix_len = self.name_buffer.items.len;
+                    try self.stack.append(self.allocator, .{
+                        .dir_handle = sub,
+                        .iter = sub.iterate(),
+                        .through_symlink = true,
+                    });
+                    continue;
                 }
+
+                // This also checks ordinary files reached through an allowed
+                // directory symlink, so a safe directory alias cannot expose a
+                // sensitive canonical target nested below it.
+                if (top.through_symlink and !resolvedFileTargetAllowed(self.io, top.dir_handle, self.real_root, entry.name)) continue;
 
                 // Build full relative path by appending filename
                 if (self.dir_prefix_len > 0)
@@ -559,7 +613,8 @@ pub fn trigramFileCap() usize {
 // keeps sequence assignment deterministic and avoids shared worker error state.
 fn statScanForInitial(io: std.Io, dir: std.Io.Dir, recs: []InitialScanEntry) void {
     for (recs) |*record| {
-        const ds = dir.statFile(io, record.path, .{}) catch continue;
+        const ds = dir.statFile(io, record.path, .{ .follow_symlinks = false }) catch continue;
+        if (ds.kind != .file) continue;
         record.size = ds.size;
         record.stat_succeeded = true;
     }
@@ -1258,7 +1313,8 @@ pub fn initialScan(io: std.Io, store: *Store, explorer: *Explorer, root: []const
 /// Fast index: parse symbols/outline only, skip expensive word+trigram indexes.
 fn indexFileOutline(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []const u8, allocator: std.mem.Allocator) !void {
     if (shouldSkipFile(path)) return;
-    const stat = try dir.statFile(io, path, .{});
+    const stat = try dir.statFile(io, path, .{ .follow_symlinks = false });
+    if (stat.kind != .file) return;
     const content = (try readIndexableFile(io, dir, path, allocator, stat.size, false)) orelse return;
     defer allocator.free(content);
     try explorer.indexFileOutlineOnly(path, content);
@@ -2179,7 +2235,8 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
             const max_trigram_files = trigramFileCap();
             var file_count: usize = 0;
             while (walker.next() catch null) |entry| {
-                const stat = dir.statFile(io, entry.path, .{}) catch continue;
+                const stat = dir.statFile(io, entry.path, .{ .follow_symlinks = false }) catch continue;
+                if (stat.kind != .file) continue;
                 _ = store.recordSnapshot(entry.path, stat.size, 0) catch {};
                 file_count += 1;
                 const effective_skip = file_count > max_trigram_files;
@@ -2246,7 +2303,7 @@ fn hashAndIndexFile(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []co
     if (size > max_indexed_file_bytes) return 0;
     var content_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer content_arena.deinit();
-    const content = dir.readFileAlloc(io, path, content_arena.allocator(), .limited(max_indexed_file_bytes)) catch return std.math.maxInt(u64);
+    const content = project_file.readAllocNoFollow(io, dir, path, content_arena.allocator(), .limited(max_indexed_file_bytes)) catch return std.math.maxInt(u64);
     const hash = std.hash.Wyhash.hash(0, content);
     indexContentBuffer(explorer, path, content, false) catch {};
     return hash;
@@ -2301,7 +2358,7 @@ pub fn incrementalDiffDirty(
     var ignore = try FilteredWalker.init(io, dir, tmp);
     defer ignore.deinit();
     const parents = try buildParentIndex(known, tmp);
-    try walkRel(io, store, explorer, queue, known, dirs, &ignore, dir, "", persistent, tmp, &parents, dirty);
+    try walkRel(io, store, explorer, queue, known, dirs, &ignore, dir, "", persistent, tmp, &parents, dirty, false);
 
     // Detect deleted files
     var to_remove: std.ArrayList([]const u8) = .empty;
@@ -2358,7 +2415,7 @@ fn applyKnownFile(
     var content_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer content_arena.deinit();
     if (!shouldSkipFile(path) and stat.size <= max_indexed_file_bytes) {
-        if (dir.readFileAlloc(io, path, content_arena.allocator(), .limited(max_indexed_file_bytes))) |buf| {
+        if (project_file.readAllocNoFollow(io, dir, path, content_arena.allocator(), .limited(max_indexed_file_bytes))) |buf| {
             content = buf;
             hash = std.hash.Wyhash.hash(0, buf);
         } else |_| {
@@ -2451,7 +2508,12 @@ fn walkRel(
     tmp: std.mem.Allocator,
     parents: *const ParentIndex,
     dirty: ?*const DirtySet,
+    through_symlink: bool,
 ) !void {
+    // Incremental walks recurse independently of FilteredWalker.next(). Apply
+    // the same canonical boundary before statting or opening a symlinked
+    // prefix, then retain the watcher identity checks used for atomic saves.
+    if (through_symlink and !resolvedDirectoryTargetAllowed(io, dir, ignore.real_root, prefix)) return;
     const current_dir_state = dirState(io, dir, prefix);
     const cached_dir_state = if (dirs) |d| d.get(prefix) else null;
     const force_scan = dirtyForcesDirectoryScan(dirty, known, prefix);
@@ -2467,7 +2529,9 @@ fn walkRel(
                     }
                 }
                 debug_unchanged_file_stats += 1;
-                const stat = dir.statFile(io, path, .{}) catch continue;
+                if (through_symlink and !resolvedFileTargetAllowed(io, dir, ignore.real_root, path)) continue;
+                const stat = dir.statFile(io, path, .{ .follow_symlinks = false }) catch continue;
+                if (stat.kind != .file) continue;
                 try applyKnownFile(io, store, explorer, queue, known, dir, path, stat, dirtyForcesFileRead(dirty, prefix, path));
             }
         }
@@ -2477,7 +2541,10 @@ fn walkRel(
                 if (shouldSkipDir(name.*)) continue;
                 const child = try joinRel(tmp, prefix, name.*);
                 if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(name.*, child)) continue;
-                try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty);
+                const child_stat = dir.statFile(io, child, .{ .follow_symlinks = false }) catch continue;
+                if (child_stat.kind != .directory and child_stat.kind != .sym_link) continue;
+                const child_through_symlink = through_symlink or child_stat.kind == .sym_link;
+                try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty, child_through_symlink);
             }
         }
         return;
@@ -2490,27 +2557,24 @@ fn walkRel(
     defer if (prefix.len != 0) listing.close(io);
     var it = listing.iterate();
     while (try it.next(io)) |entry| {
-        if (entry.kind == .directory or (entry.kind == .sym_link and blk: {
-            const st = listing.statFile(io, entry.name, .{}) catch break :blk false;
-            break :blk st.kind == .directory;
-        })) {
+        if (entry.kind == .directory or entry.kind == .sym_link) {
+            const child_through_symlink = through_symlink or entry.kind == .sym_link;
+            if (entry.kind == .sym_link and !resolvedDirectoryTargetAllowed(io, listing, ignore.real_root, entry.name)) continue;
             if (shouldSkipDir(entry.name)) continue;
             const child = try joinRel(tmp, prefix, entry.name);
             if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, child)) continue;
-            try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty);
+            try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty, child_through_symlink);
             continue;
         }
 
-        if (entry.kind != .file) {
-            if (entry.kind != .sym_link) continue;
-            const st = listing.statFile(io, entry.name, .{}) catch continue;
-            if (st.kind != .file) continue;
-        }
+        if (entry.kind != .file) continue;
 
         const rel = try joinRel(tmp, prefix, entry.name);
         if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, rel)) continue;
         if (shouldSkipFile(rel)) continue;
-        const stat = dir.statFile(io, rel, .{}) catch continue;
+        if (through_symlink and !resolvedFileTargetAllowed(io, dir, ignore.real_root, rel)) continue;
+        const stat = dir.statFile(io, rel, .{ .follow_symlinks = false }) catch continue;
+        if (stat.kind != .file) continue;
         if (known.getEntry(rel)) |known_entry| {
             try applyKnownFile(io, store, explorer, queue, known, dir, known_entry.key_ptr.*, stat, dirtyForcesFileRead(dirty, prefix, rel));
         } else {
@@ -2569,7 +2633,11 @@ pub fn indexMissingFile(io: std.Io, store: ?*Store, explorer: *Explorer, path: [
     }
     if (shouldSkipFile(path)) return false;
     const root_dir = explorer.root_dir orelse return false;
-    const stat = root_dir.statFile(io, path, .{}) catch return false;
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = root_dir.realPathFile(io, ".", &root_buf) catch return false;
+    if (!resolvedFileTargetAllowed(io, root_dir, root_buf[0..root_len], path)) return false;
+    const stat = root_dir.statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    if (stat.kind != .file) return false;
     if (stat.size > max_indexed_file_bytes) return false;
     indexFileContent(io, explorer, root_dir, path, explorer.allocator, false) catch return false;
     const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
@@ -2623,13 +2691,14 @@ fn shouldSkipFile(path: []const u8) bool {
 /// Delegates to snapshot.zig so live indexing and snapshots apply the same
 /// exclusion rules from a single implementation.
 pub fn isSensitivePath(path: []const u8) bool {
-    return @import("snapshot.zig").isSensitivePath(path);
+    return project_path.isSensitive(path);
 }
 
 fn indexFileContent(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []const u8, allocator: std.mem.Allocator, skip_trigram: bool) !void {
     _ = allocator;
     if (shouldSkipFile(path)) return;
-    const stat = try dir.statFile(io, path, .{});
+    const stat = try dir.statFile(io, path, .{ .follow_symlinks = false });
+    if (stat.kind != .file) return;
     // Use page_allocator arena for content — pages returned to OS immediately
     // via munmap on deinit, eliminating GPA page retention from content churn.
     var content_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -2688,10 +2757,11 @@ fn drainNotifyFileFrom(
 
         // Make path relative to root if it's absolute
         const rel = if (std.fs.path.isAbsolute(path)) blk: {
-            if (!std.mem.startsWith(u8, path, root) or path.len <= root.len or path[root.len] != '/') continue;
+            if (!isWithinCanonicalRoot(root, path) or path.len == root.len) continue;
             break :blk std.mem.trimStart(u8, path[root.len..], "/");
         } else path;
         if (shouldSkipFile(rel)) continue;
+        if (!resolvedFileTargetAllowed(io, dir, root, rel)) continue;
 
         // Skip re-indexing if file hasn't changed since last known state (#228)
         const stat = dir.statFile(io, rel, .{ .follow_symlinks = false }) catch continue;

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -374,6 +374,7 @@ pub const FilteredWalker = struct {
 
     pub const Entry = struct {
         path: []const u8, // relative path — valid until next call to next()
+        size: u64,
     };
 
     pub fn init(io: std.Io, root: std.Io.Dir, allocator: std.mem.Allocator) !FilteredWalker {
@@ -469,18 +470,30 @@ pub const FilteredWalker = struct {
         return false;
     }
 
-    fn claimOpenedSymlinkDirectory(self: *FilteredWalker, dir: std.Io.Dir) bool {
-        if (self.real_root.len == 0) return false;
+    /// Validate the directory object that was actually opened, regardless of
+    /// the iterator's pre-open kind. Returns whether its canonical target
+    /// differs from the visible path. Claiming every handle closes the race
+    /// where a `.directory` entry is replaced by an outside symlink between
+    /// iteration and open, and also supplies cycle prevention for all aliases.
+    fn claimOpenedDirectory(self: *FilteredWalker, dir: std.Io.Dir, visible_path: []const u8) ?bool {
+        if (self.real_root.len == 0) return null;
         var target_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const target_len = dir.realPathFile(self.io, ".", &target_buf) catch return false;
+        const target_len = dir.realPathFile(self.io, ".", &target_buf) catch return null;
         const real_target = target_buf[0..target_len];
-        const target_rel = canonicalTargetRelative(self.real_root, real_target) orelse return false;
-        if (shouldSkip(target_rel) or shouldSkipFile(target_rel)) return false;
-        const gop = self.visited_real_paths.getOrPut(self.allocator, real_target) catch return false;
-        if (gop.found_existing) return false;
+        const target_rel = canonicalTargetRelative(self.real_root, real_target) orelse return null;
+        if (shouldSkip(target_rel) or shouldSkipFile(target_rel)) return null;
+        const opened_as_alias = !std.mem.eql(u8, target_rel, visible_path);
+        // Ordinary directories may also be reachable through a deliberate
+        // in-root alias.  Only alias edges participate in cycle suppression;
+        // recording every ordinary directory would make whichever spelling is
+        // visited first hide the other one.  The root itself is pre-claimed,
+        // so an alias back to it is still rejected.
+        if (!opened_as_alias) return false;
+        const gop = self.visited_real_paths.getOrPut(self.allocator, real_target) catch return null;
+        if (gop.found_existing) return null;
         const dup = self.allocator.dupe(u8, real_target) catch {
             _ = self.visited_real_paths.remove(real_target);
-            return false;
+            return null;
         };
         gop.key_ptr.* = dup;
         return true;
@@ -495,17 +508,20 @@ pub const FilteredWalker = struct {
             if (try top.iter.next(self.io)) |entry| {
                 if (entry.kind == .directory) {
                     if (shouldSkipDir(entry.name)) continue;
+                    var visible_buf: [std.fs.max_path_bytes]u8 = undefined;
+                    const visible_path = if (self.dir_prefix_len > 0)
+                        std.fmt.bufPrint(&visible_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch continue
+                    else
+                        entry.name;
                     // Check .codedbignore patterns
                     if (self.ignore_patterns.items.len > 0) {
-                        // Build full path for prefix matching
-                        var check_buf: [std.fs.max_path_bytes]u8 = undefined;
-                        const check_path = if (self.dir_prefix_len > 0)
-                            std.fmt.bufPrint(&check_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch entry.name
-                        else
-                            entry.name;
-                        if (self.isIgnored(entry.name, check_path)) continue;
+                        if (self.isIgnored(entry.name, visible_path)) continue;
                     }
                     const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
+                    const opened_as_alias = self.claimOpenedDirectory(sub, visible_path) orelse {
+                        sub.close(self.io);
+                        continue;
+                    };
                     errdefer sub.close(self.io);
                     const saved_len = self.name_buffer.items.len;
                     errdefer self.name_buffer.shrinkRetainingCapacity(saved_len);
@@ -519,7 +535,7 @@ pub const FilteredWalker = struct {
                     try self.stack.append(self.allocator, .{
                         .dir_handle = sub,
                         .iter = sub.iterate(),
-                        .through_symlink = top.through_symlink,
+                        .through_symlink = top.through_symlink or opened_as_alias,
                     });
                     continue;
                 }
@@ -540,7 +556,15 @@ pub const FilteredWalker = struct {
                     // Validate the already-open directory handle so retargeting
                     // the link cannot change the object that will be walked.
                     const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
-                    if (!self.claimOpenedSymlinkDirectory(sub)) {
+                    var visible_buf: [std.fs.max_path_bytes]u8 = undefined;
+                    const visible_path = if (self.dir_prefix_len > 0)
+                        std.fmt.bufPrint(&visible_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch {
+                            sub.close(self.io);
+                            continue;
+                        }
+                    else
+                        entry.name;
+                    if (self.claimOpenedDirectory(sub, visible_path) == null) {
                         sub.close(self.io);
                         continue;
                     }
@@ -575,7 +599,15 @@ pub const FilteredWalker = struct {
                     continue;
                 }
 
-                return .{ .path = self.name_buffer.items };
+                const stable_stat = top.dir_handle.statFile(self.io, entry.name, .{ .follow_symlinks = false }) catch {
+                    self.name_buffer.shrinkRetainingCapacity(self.dir_prefix_len);
+                    continue;
+                };
+                if (stable_stat.kind != .file) {
+                    self.name_buffer.shrinkRetainingCapacity(self.dir_prefix_len);
+                    continue;
+                }
+                return .{ .path = self.name_buffer.items, .size = stable_stat.size };
             } else {
                 // Directory exhausted — pop and restore parent prefix
                 if (self.stack.items.len > 1) {
@@ -607,19 +639,6 @@ pub fn trigramFileCap() usize {
     return std.fmt.parseInt(usize, raw, 10) catch 15_000;
 }
 
-// Paths are collected serially first, then stat calls fan out across disjoint
-// chunks. Workers only publish size/stat_succeeded into their own entries; the
-// caller records snapshots serially in discovery order after every join. That
-// keeps sequence assignment deterministic and avoids shared worker error state.
-fn statScanForInitial(io: std.Io, dir: std.Io.Dir, recs: []InitialScanEntry) void {
-    for (recs) |*record| {
-        const ds = dir.statFile(io, record.path, .{ .follow_symlinks = false }) catch continue;
-        if (ds.kind != .file) continue;
-        record.size = ds.size;
-        record.stat_succeeded = true;
-    }
-}
-
 fn collectInitialScanEntries(io: std.Io, store: *Store, dir: std.Io.Dir, allocator: std.mem.Allocator, skip_trigram: bool) !std.ArrayList(InitialScanEntry) {
     var walker = try FilteredWalker.init(io, dir, allocator);
     defer walker.deinit();
@@ -631,68 +650,20 @@ fn collectInitialScanEntries(io: std.Io, store: *Store, dir: std.Io.Dir, allocat
     }
 
     const max_trigram_files = trigramFileCap();
-    // Paths collected serially first (via FilteredWalker, pure walk no stats).
+    // The walker stats each file relative to the stable opened parent handle.
+    // Deferring these stats by path would reopen the directory namespace after
+    // traversal and let a directory-retarget race inject outside sizes into the
+    // Store before content validation.
     while (try walker.next()) |entry| {
         try entries.append(allocator, .{
             .path = try allocator.dupe(u8, entry.path),
-            .size = 0,
-            .stat_succeeded = false,
+            .size = entry.size,
+            .stat_succeeded = true,
             .skip_trigram = false, // set after parallel stat fan
         });
     }
-    // Stats fan out across disjoint slices; per-stat errors are swallowed. After
-    // joining, snapshots are recorded serially so sequence order remains stable
-    // and record errors propagate without cross-thread error sharing.
-    if (entries.items.len > 0) {
-        const want_workers = blk: {
-            if (cio.posixGetenv("CODEDB_LOAD_WORKERS")) |raw| {
-                const parsed = std.fmt.parseInt(usize, raw, 10) catch 0;
-                if (parsed > 0) break :blk parsed;
-            }
-            if (entries.items.len < 256) break :blk 1;
-            const cpu_count = std.Thread.getCpuCount() catch 1;
-            break :blk @min(@as(usize, @intCast(cpu_count)), 4);
-        };
-        const n_workers = @max(@as(usize, 1), @min(want_workers, entries.items.len));
-        stat_fan: {
-            if (n_workers <= 1) {
-                statScanForInitial(io, dir, entries.items);
-                break :stat_fan;
-            }
-            const threads = allocator.alloc(std.Thread, n_workers) catch {
-                statScanForInitial(io, dir, entries.items);
-                break :stat_fan;
-            };
-            defer allocator.free(threads);
-
-            const chunk = entries.items.len / n_workers;
-            const rem = entries.items.len % n_workers;
-            var off: usize = 0;
-            var spawned: usize = 0;
-            var spawn_failed = false;
-            for (0..n_workers) |i| {
-                const extra: usize = if (i < rem) 1 else 0;
-                const start = off;
-                off += chunk + extra;
-                const recs = entries.items[start..off];
-                if (spawn_failed) {
-                    statScanForInitial(io, dir, recs);
-                    continue;
-                }
-                if (std.Thread.spawn(.{}, statScanForInitial, .{ io, dir, recs })) |t| {
-                    threads[spawned] = t;
-                    spawned += 1;
-                } else |_| {
-                    statScanForInitial(io, dir, recs);
-                    spawn_failed = true;
-                }
-            }
-            for (threads[0..spawned]) |t| t.join();
-        }
-        for (entries.items) |entry| {
-            if (!entry.stat_succeeded) continue;
-            _ = try store.recordSnapshot(entry.path, entry.size, 0);
-        }
+    for (entries.items) |entry| {
+        _ = try store.recordSnapshot(entry.path, entry.size, 0);
     }
     // Set skip_trigram using serial count (preserves original cap semantics on discovery order).
     var file_count: usize = 0;
@@ -762,13 +733,7 @@ fn parseInitialScanWorkerEntry(
     };
 }
 
-fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, root: []const u8, entries: []const InitialScanEntry, word_shard: ?*WordIndex, trigram_shard: ?*TrigramIndex) void {
-    const dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch {
-        for (0..entries.len) |index| results.publish(io, index, null);
-        return;
-    };
-    defer dir.close(io);
-
+fn initialScanWorker(io: std.Io, results: *WorkerParsedResults, dir: std.Io.Dir, entries: []const InitialScanEntry, word_shard: ?*WordIndex, trigram_shard: ?*TrigramIndex) void {
     // Read content directly into the persistent result arena, while allocating
     // transient parser state in a per-file scratch arena that is reset between
     // files. The final outline uses packed libc-owned storage so the main thread
@@ -809,8 +774,15 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
         explorer.word_index.skip_file_words = false;
         explorer.mu.unlock();
     };
-    const dir = try std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true });
-    defer dir.close(io);
+    var owned_dir: ?std.Io.Dir = null;
+    const dir = if (explorer.root_dir) |stable| blk: {
+        if (!project_file.rootMatchesPath(io, stable, root)) return error.ProjectRootChanged;
+        break :blk stable;
+    } else blk: {
+        owned_dir = try std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true });
+        break :blk owned_dir.?;
+    };
+    defer if (owned_dir) |owned| owned.close(io);
 
     var entries = try collectInitialScanEntries(io, store, dir, allocator, skip_trigram);
     const profile_collect_done: i128 = if (profile) cio.nanoTimestamp() else 0;
@@ -898,7 +870,7 @@ pub fn initialScanWithWorkerCount(io: std.Io, store: *Store, explorer: *Explorer
             sh[i].skip_file_words = true;
             shard_ptr = &sh[i];
         }
-        threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk, shard_ptr, null });
+        threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, dir, chunk, shard_ptr, null });
         spawned += 1;
     }
     const profile_spawn_done: i128 = if (profile) cio.nanoTimestamp() else 0;
@@ -996,13 +968,7 @@ fn extractTrigramMasks(
 // Build a private trigram shard from a chunk of InitialScanEntry items — reads
 // each file, extracts trigrams, and inserts postings directly, all on the worker.
 // Used by the skip_outlines fast path in initialScanWithTrigrams.
-fn readAndBuildTrigramShardWorker(io: std.Io, shard: *TrigramIndex, root: []const u8, entries: []const InitialScanEntry, build_error: *?anyerror) void {
-    const dir = std.Io.Dir.cwd().openDir(io, root, .{}) catch |err| {
-        build_error.* = err;
-        return;
-    };
-    defer dir.close(io);
-
+fn readAndBuildTrigramShardWorker(io: std.Io, shard: *TrigramIndex, dir: std.Io.Dir, entries: []const InitialScanEntry, build_error: *?anyerror) void {
     const index_m = @import("index.zig");
     var local = std.AutoHashMap(index_m.Trigram, index_m.PostingMask).init(std.heap.c_allocator);
     defer local.deinit();
@@ -1168,8 +1134,15 @@ pub fn initialScanWithTrigrams(
     trigram_alloc: std.mem.Allocator,
     skip_outlines: bool,
 ) !?*TrigramIndex {
-    const dir = try std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true });
-    defer dir.close(io);
+    var owned_dir: ?std.Io.Dir = null;
+    const dir = if (explorer.root_dir) |stable| blk: {
+        if (!project_file.rootMatchesPath(io, stable, root)) return error.ProjectRootChanged;
+        break :blk stable;
+    } else blk: {
+        owned_dir = try std.Io.Dir.cwd().openDir(io, root, .{ .iterate = true });
+        break :blk owned_dir.?;
+    };
+    defer if (owned_dir) |owned| owned.close(io);
 
     var entries = try collectInitialScanEntries(io, store, dir, allocator, true);
     defer {
@@ -1239,7 +1212,7 @@ pub fn initialScanWithTrigrams(
             offset += count;
             shard.index.ensureTotalCapacity(32768) catch {};
             shard.path_to_id.ensureTotalCapacity(@intCast(count)) catch {};
-            threads[i] = try std.Thread.spawn(.{}, readAndBuildTrigramShardWorker, .{ io, shard, root, chunk, &build_errors[i] });
+            threads[i] = try std.Thread.spawn(.{}, readAndBuildTrigramShardWorker, .{ io, shard, dir, chunk, &build_errors[i] });
             spawned += 1;
         }
         for (threads[0..spawned]) |thread| thread.join();
@@ -1271,7 +1244,7 @@ pub fn initialScanWithTrigrams(
             const chunk = entries.items[offset .. offset + count];
             offset += count;
             try worker.prepare(count);
-            threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, root, chunk, null, &shards[i] });
+            threads[i] = try std.Thread.spawn(.{}, initialScanWorker, .{ io, worker, dir, chunk, null, &shards[i] });
             spawned += 1;
         }
         // Commit outlines serially while workers may still be parsing. Trigram
@@ -2228,22 +2201,20 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
             var rescan_arena = std.heap.ArenaAllocator.init(backing);
             defer rescan_arena.deinit();
             const tmp = rescan_arena.allocator();
-            const dir = stable_root.openDir(io, ".", .{ .iterate = true, .follow_symlinks = false }) catch continue;
-            defer dir.close(io);
+            const dir = stable_root;
             var walker = FilteredWalker.init(io, dir, tmp) catch continue;
             defer walker.deinit();
             const max_trigram_files = trigramFileCap();
             var file_count: usize = 0;
             while (walker.next() catch null) |entry| {
-                const stat = dir.statFile(io, entry.path, .{ .follow_symlinks = false }) catch continue;
-                if (stat.kind != .file) continue;
-                _ = store.recordSnapshot(entry.path, stat.size, 0) catch {};
+                _ = store.recordSnapshot(entry.path, entry.size, 0) catch {};
                 file_count += 1;
                 const effective_skip = file_count > max_trigram_files;
                 indexFileContent(io, explorer, dir, entry.path, backing, effective_skip) catch {};
+                const stat = project_file.statNoFollow(io, dir, entry.path) catch continue;
                 const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
                 const duped = backing.dupe(u8, entry.path) catch continue;
-                known.put(duped, .{ .mtime = mtime, .size = stat.size, .hash = 0, .seen = false }) catch backing.free(duped);
+                known.put(duped, .{ .mtime = mtime, .size = entry.size, .hash = 0, .seen = false }) catch backing.free(duped);
             }
             armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
             continue;
@@ -2345,9 +2316,7 @@ pub fn incrementalDiffDirty(
     dirty: ?*const DirtySet,
 ) !void {
     _ = root;
-    const root_dir = explorer.root_dir orelse return error.ProjectRootUnavailable;
-    const dir = try root_dir.openDir(io, ".", .{ .iterate = true, .follow_symlinks = false });
-    defer dir.close(io);
+    const dir = explorer.root_dir orelse return error.ProjectRootUnavailable;
 
     // Mark all known files unseen for this cycle.
     var known_iter = known.iterator();
@@ -2388,24 +2357,25 @@ fn applyKnownFile(
     queue: *EventQueue,
     known: *FileMap,
     dir: std.Io.Dir,
-    path: []const u8,
+    logical_path: []const u8,
+    read_path: []const u8,
     stat: std.Io.Dir.Stat,
     force_read: bool,
 ) !void {
-    const known_entry = known.getEntry(path) orelse return;
+    const known_entry = known.getEntry(logical_path) orelse return;
     const old = known_entry.value_ptr;
     old.seen = true;
     const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
     const exact_metadata_matches = old.mtime_ns != 0 and old.mtime_ns == stat.mtime.nanoseconds and old.ctime_ns == stat.ctime.nanoseconds and old.inode == stat.inode and old.size == stat.size;
     if (!force_read and exact_metadata_matches) {
-        store.noteMtime(path, mtime);
+        store.noteMtime(logical_path, mtime);
         return;
     }
     if (!force_read and old.mtime_ns == 0 and old.mtime == mtime and old.size == stat.size) {
         old.mtime_ns = stat.mtime.nanoseconds;
         old.ctime_ns = stat.ctime.nanoseconds;
         old.inode = stat.inode;
-        store.noteMtime(path, mtime);
+        store.noteMtime(logical_path, mtime);
         return;
     }
 
@@ -2414,8 +2384,8 @@ fn applyKnownFile(
     var content: ?[]const u8 = null;
     var content_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer content_arena.deinit();
-    if (!shouldSkipFile(path) and stat.size <= max_indexed_file_bytes) {
-        if (project_file.readAllocNoFollow(io, dir, path, content_arena.allocator(), .limited(max_indexed_file_bytes))) |buf| {
+    if (!shouldSkipFile(logical_path) and stat.size <= max_indexed_file_bytes) {
+        if (project_file.readAllocNoFollow(io, dir, read_path, content_arena.allocator(), .limited(max_indexed_file_bytes))) |buf| {
             content = buf;
             hash = std.hash.Wyhash.hash(0, buf);
         } else |_| {
@@ -2429,18 +2399,18 @@ fn applyKnownFile(
         old.ctime_ns = stat.ctime.nanoseconds;
         old.inode = stat.inode;
         old.size = stat.size;
-        store.noteMtime(path, mtime);
+        store.noteMtime(logical_path, mtime);
         return;
     }
 
-    const seq = try store.recordSnapshot(path, stat.size, hash);
+    const seq = try store.recordSnapshot(logical_path, stat.size, hash);
     old.mtime = mtime;
     old.mtime_ns = stat.mtime.nanoseconds;
     old.ctime_ns = stat.ctime.nanoseconds;
     old.inode = stat.inode;
     old.size = stat.size;
     old.hash = hash;
-    store.noteMtime(path, mtime);
+    store.noteMtime(logical_path, mtime);
     if (FsEvent.init(stable_path, .modified, seq)) |ev| pushEventOrWait(queue, ev);
     if (content) |buf| indexContentBuffer(explorer, stable_path, buf, false) catch {};
 }
@@ -2510,11 +2480,21 @@ fn walkRel(
     dirty: ?*const DirtySet,
     through_symlink: bool,
 ) !void {
-    // Incremental walks recurse independently of FilteredWalker.next(). Apply
-    // the same canonical boundary before statting or opening a symlinked
-    // prefix, then retain the watcher identity checks used for atomic saves.
-    if (through_symlink and !resolvedDirectoryTargetAllowed(io, dir, ignore.real_root, prefix)) return;
-    const current_dir_state = dirState(io, dir, prefix);
+    // Open once, then validate the actual handle before observing its mtime,
+    // identity, names, or sizes. Iterator kind and a pre-open realpath are
+    // both racy; the full identity tuple also catches atomic directory swaps.
+    const listing = if (prefix.len == 0)
+        dir
+    else
+        dir.openDir(io, prefix, .{ .iterate = true }) catch return;
+    defer if (prefix.len != 0) listing.close(io);
+    var effective_through_symlink = through_symlink;
+    if (prefix.len != 0) {
+        const opened_as_alias = ignore.claimOpenedDirectory(listing, prefix) orelse return;
+        effective_through_symlink = effective_through_symlink or opened_as_alias;
+    }
+
+    const current_dir_state = dirState(io, listing, "");
     const cached_dir_state = if (dirs) |d| d.get(prefix) else null;
     const force_scan = dirtyForcesDirectoryScan(dirty, known, prefix);
     const dir_unchanged = !force_scan and current_dir_state != null and cached_dir_state != null and std.meta.eql(current_dir_state.?, cached_dir_state.?);
@@ -2529,10 +2509,11 @@ fn walkRel(
                     }
                 }
                 debug_unchanged_file_stats += 1;
-                if (through_symlink and !resolvedFileTargetAllowed(io, dir, ignore.real_root, path)) continue;
-                const stat = dir.statFile(io, path, .{ .follow_symlinks = false }) catch continue;
+                const local_name = std.fs.path.basename(path);
+                if (effective_through_symlink and !resolvedFileTargetAllowed(io, listing, ignore.real_root, local_name)) continue;
+                const stat = listing.statFile(io, local_name, .{ .follow_symlinks = false }) catch continue;
                 if (stat.kind != .file) continue;
-                try applyKnownFile(io, store, explorer, queue, known, dir, path, stat, dirtyForcesFileRead(dirty, prefix, path));
+                try applyKnownFile(io, store, explorer, queue, known, listing, path, local_name, stat, dirtyForcesFileRead(dirty, prefix, path));
             }
         }
         if (parents.child_dirs.get(prefix)) |children| {
@@ -2541,24 +2522,19 @@ fn walkRel(
                 if (shouldSkipDir(name.*)) continue;
                 const child = try joinRel(tmp, prefix, name.*);
                 if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(name.*, child)) continue;
-                const child_stat = dir.statFile(io, child, .{ .follow_symlinks = false }) catch continue;
+                const child_stat = listing.statFile(io, name.*, .{ .follow_symlinks = false }) catch continue;
                 if (child_stat.kind != .directory and child_stat.kind != .sym_link) continue;
-                const child_through_symlink = through_symlink or child_stat.kind == .sym_link;
+                const child_through_symlink = effective_through_symlink or child_stat.kind == .sym_link;
                 try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty, child_through_symlink);
             }
         }
         return;
     }
 
-    const listing = if (prefix.len == 0)
-        dir
-    else
-        dir.openDir(io, prefix, .{ .iterate = true }) catch return;
-    defer if (prefix.len != 0) listing.close(io);
     var it = listing.iterate();
     while (try it.next(io)) |entry| {
         if (entry.kind == .directory or entry.kind == .sym_link) {
-            const child_through_symlink = through_symlink or entry.kind == .sym_link;
+            const child_through_symlink = effective_through_symlink or entry.kind == .sym_link;
             if (entry.kind == .sym_link and !resolvedDirectoryTargetAllowed(io, listing, ignore.real_root, entry.name)) continue;
             if (shouldSkipDir(entry.name)) continue;
             const child = try joinRel(tmp, prefix, entry.name);
@@ -2572,11 +2548,11 @@ fn walkRel(
         const rel = try joinRel(tmp, prefix, entry.name);
         if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, rel)) continue;
         if (shouldSkipFile(rel)) continue;
-        if (through_symlink and !resolvedFileTargetAllowed(io, dir, ignore.real_root, rel)) continue;
-        const stat = dir.statFile(io, rel, .{ .follow_symlinks = false }) catch continue;
+        if (effective_through_symlink and !resolvedFileTargetAllowed(io, listing, ignore.real_root, entry.name)) continue;
+        const stat = listing.statFile(io, entry.name, .{ .follow_symlinks = false }) catch continue;
         if (stat.kind != .file) continue;
         if (known.getEntry(rel)) |known_entry| {
-            try applyKnownFile(io, store, explorer, queue, known, dir, known_entry.key_ptr.*, stat, dirtyForcesFileRead(dirty, prefix, rel));
+            try applyKnownFile(io, store, explorer, queue, known, listing, known_entry.key_ptr.*, entry.name, stat, dirtyForcesFileRead(dirty, prefix, rel));
         } else {
             const mtime: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms));
             const duped = try persistent.dupe(u8, rel);
@@ -2585,7 +2561,7 @@ fn walkRel(
             try known.put(duped, .{ .mtime = mtime, .size = stat.size, .hash = 0, .seen = true });
             store.noteMtime(duped, mtime);
             if (FsEvent.init(duped, .created, seq)) |ev| pushEventOrWait(queue, ev);
-            indexFileContent(io, explorer, dir, duped, tmp, false) catch {};
+            indexFileContentAt(io, explorer, listing, entry.name, duped, tmp, false) catch {};
         }
     }
 
@@ -2695,16 +2671,28 @@ pub fn isSensitivePath(path: []const u8) bool {
 }
 
 fn indexFileContent(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []const u8, allocator: std.mem.Allocator, skip_trigram: bool) !void {
+    return indexFileContentAt(io, explorer, dir, path, path, allocator, skip_trigram);
+}
+
+fn indexFileContentAt(
+    io: std.Io,
+    explorer: *Explorer,
+    dir: std.Io.Dir,
+    read_path: []const u8,
+    logical_path: []const u8,
+    allocator: std.mem.Allocator,
+    skip_trigram: bool,
+) !void {
     _ = allocator;
-    if (shouldSkipFile(path)) return;
-    const stat = try dir.statFile(io, path, .{ .follow_symlinks = false });
+    if (shouldSkipFile(logical_path)) return;
+    const stat = try dir.statFile(io, read_path, .{ .follow_symlinks = false });
     if (stat.kind != .file) return;
     // Use page_allocator arena for content — pages returned to OS immediately
     // via munmap on deinit, eliminating GPA page retention from content churn.
     var content_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer content_arena.deinit();
-    const content = (try readIndexableFile(io, dir, path, content_arena.allocator(), stat.size, false)) orelse return;
-    try indexContentBuffer(explorer, path, content, skip_trigram);
+    const content = (try readIndexableFile(io, dir, read_path, content_arena.allocator(), stat.size, false)) orelse return;
+    try indexContentBuffer(explorer, logical_path, content, skip_trigram);
 }
 
 // ── muonry interop ───────────────────────────────────────────────────────────
@@ -2888,7 +2876,7 @@ test "issue-685: watcher diff updates document edges for modify add and delete" 
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
     try initialScanWithWorkerCount(io, &store, &explorer, root, testing.allocator, false, 1);
     try testing.expectEqual(@as(usize, 1), explorer.document_graph.getForwardDeps("docs/a.md").?.len);
 
@@ -2950,7 +2938,7 @@ test "dir-mtime prune still stats known files and notices new siblings" {
     defer store.deinit();
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
-    explorer.setRoot(io, root);
+    try explorer.setRoot(io, root);
 
     var known = FileMap.init(testing.allocator);
     defer {

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -1305,6 +1305,56 @@ pub fn initialScan(io: std.Io, store: *Store, explorer: *Explorer, root: []const
     try initialScanWithWorkerCount(io, store, explorer, root, allocator, skip_trigram, worker_count);
 }
 
+/// Re-read the complete indexable repository through the already-open root
+/// capability and return a deterministic content-only fingerprint. The
+/// semantic-index builder uses this immediately before publication so edits,
+/// additions, and deletions that happened during remote embedding cannot
+/// produce a sidecar for a mixed repository generation. Sensitive, ignored,
+/// binary, oversized, and symlink-escaped files follow the exact scan policy.
+pub fn liveIndexedContentFingerprint(
+    io: std.Io,
+    root: std.Io.Dir,
+    allocator: std.mem.Allocator,
+) !u64 {
+    const Identity = struct {
+        path: []u8,
+        content_hash: u64,
+        size: u64,
+    };
+
+    var walker = try FilteredWalker.init(io, root, allocator);
+    defer walker.deinit();
+    var identities: std.ArrayList(Identity) = .empty;
+    defer {
+        for (identities.items) |identity| allocator.free(identity.path);
+        identities.deinit(allocator);
+    }
+
+    while (try walker.next()) |entry| {
+        if (shouldSkipFile(entry.path)) continue;
+        const content = (try readIndexableFile(io, root, entry.path, allocator, entry.size, false)) orelse continue;
+        defer allocator.free(content);
+        const owned_path = try allocator.dupe(u8, entry.path);
+        errdefer allocator.free(owned_path);
+        try identities.append(allocator, .{
+            .path = owned_path,
+            .content_hash = std.hash.Wyhash.hash(0, content),
+            .size = @intCast(content.len),
+        });
+    }
+    std.mem.sort(Identity, identities.items, {}, struct {
+        fn lessThan(_: void, a: Identity, b: Identity) bool {
+            return std.mem.order(u8, a.path, b.path) == .lt;
+        }
+    }.lessThan);
+
+    var hash = Store.semanticContentHasher();
+    for (identities.items) |identity| {
+        Store.updateSemanticContentFingerprint(&hash, identity.path, identity.content_hash, identity.size);
+    }
+    return hash.final();
+}
+
 /// Fast index: parse symbols/outline only, skip expensive word+trigram indexes.
 fn indexFileOutline(io: std.Io, explorer: *Explorer, dir: std.Io.Dir, path: []const u8, allocator: std.mem.Allocator) !void {
     if (shouldSkipFile(path)) return;

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -2112,6 +2112,9 @@ test "failed directory watch admission retries through dirty reconciliation" {
 
 /// Background thread: polls for incremental FS changes.
 pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, root: []const u8, shutdown: *std.atomic.Value(bool), scan_done: *std.atomic.Value(bool)) void {
+    explorer.expectStartupReconcile();
+    var startup_reconcile_finished = false;
+    defer if (!startup_reconcile_finished) explorer.finishStartupReconcile();
     var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const backing = gpa.allocator();
@@ -2158,6 +2161,8 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
     var watch = FileChangeWatch.init(backing);
     defer watch.deinit(io);
     armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
+    explorer.finishStartupReconcile();
+    startup_reconcile_finished = true;
 
     // Track current git HEAD to detect branch switches (#116)
     var last_git_head: ?[40]u8 = git_mod.getGitHeadDir(io, stable_root, backing) catch null;

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -322,15 +322,34 @@ fn shouldSkipDir(name: []const u8) bool {
 fn isWithinCanonicalRoot(root: []const u8, candidate: []const u8) bool {
     if (!std.mem.startsWith(u8, candidate, root)) return false;
     if (candidate.len == root.len) return true;
-    return root.len > 0 and (std.fs.path.isSep(root[root.len - 1]) or std.fs.path.isSep(candidate[root.len]));
+    return root.len > 0 and (isPortablePathSep(root[root.len - 1]) or isPortablePathSep(candidate[root.len]));
 }
 
-fn canonicalTargetRelative(root: []const u8, target: []const u8) ?[]const u8 {
+fn isPortablePathSep(ch: u8) bool {
+    return ch == '/' or ch == '\\';
+}
+
+/// Return a slash-normalized repository-relative spelling for a canonical
+/// target. Windows realPath uses backslashes, but every sensitive-path and
+/// skip policy in codedb intentionally consumes portable forward slashes.
+fn canonicalTargetRelative(root: []const u8, target: []const u8, normalized: []u8) ?[]const u8 {
     if (!isWithinCanonicalRoot(root, target) or target.len == root.len) return null;
     var start = root.len;
-    while (start < target.len and std.fs.path.isSep(target[start])) start += 1;
+    while (start < target.len and isPortablePathSep(target[start])) start += 1;
     if (start == target.len) return null;
-    return target[start..];
+    const rel = target[start..];
+    if (rel.len > normalized.len) return null;
+    for (rel, normalized[0..rel.len]) |ch, *out| out.* = if (isPortablePathSep(ch)) '/' else ch;
+    return normalized[0..rel.len];
+}
+
+test "canonical Windows targets are normalized before sensitive policy checks" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const rel = canonicalTargetRelative("C:\\repo", "C:\\repo\\safe\\.ssh\\config", &buf) orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("safe/.ssh/config", rel);
+    try std.testing.expect(shouldSkipFile(rel));
+    try std.testing.expect(canonicalTargetRelative("C:\\repo", "C:\\repo-other\\src", &buf) == null);
 }
 
 /// Resolve every candidate under the canonical root and require both its
@@ -341,7 +360,8 @@ fn resolvedFileTargetAllowed(io: std.Io, root_dir: std.Io.Dir, canonical_root: [
     if (canonical_root.len == 0 or shouldSkip(alias_path) or shouldSkipFile(alias_path)) return false;
     var target_buf: [std.fs.max_path_bytes]u8 = undefined;
     const target_len = root_dir.realPathFile(io, alias_path, &target_buf) catch return false;
-    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len]) orelse return false;
+    var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len], &normalized_buf) orelse return false;
     return !shouldSkip(target_rel) and !shouldSkipFile(target_rel);
 }
 
@@ -349,7 +369,8 @@ fn resolvedDirectoryTargetAllowed(io: std.Io, root_dir: std.Io.Dir, canonical_ro
     if (alias_path.len == 0) return canonical_root.len > 0;
     var target_buf: [std.fs.max_path_bytes]u8 = undefined;
     const target_len = root_dir.realPathFile(io, alias_path, &target_buf) catch return false;
-    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len]) orelse return false;
+    var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target_rel = canonicalTargetRelative(canonical_root, target_buf[0..target_len], &normalized_buf) orelse return false;
     return !shouldSkip(target_rel) and !shouldSkipFile(target_rel);
 }
 
@@ -480,7 +501,8 @@ pub const FilteredWalker = struct {
         var target_buf: [std.fs.max_path_bytes]u8 = undefined;
         const target_len = dir.realPathFile(self.io, ".", &target_buf) catch return null;
         const real_target = target_buf[0..target_len];
-        const target_rel = canonicalTargetRelative(self.real_root, real_target) orelse return null;
+        var normalized_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const target_rel = canonicalTargetRelative(self.real_root, real_target, &normalized_buf) orelse return null;
         if (shouldSkip(target_rel) or shouldSkipFile(target_rel)) return null;
         const opened_as_alias = !std.mem.eql(u8, target_rel, visible_path);
         // Ordinary directories may also be reachable through a deliberate

--- a/vendor/openpuffer/LICENSE
+++ b/vendor/openpuffer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 justrach
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/openpuffer/README.md
+++ b/vendor/openpuffer/README.md
@@ -1,0 +1,182 @@
+# openpuffer
+
+An in-memory vector search engine written in Zig 0.17-dev — HNSW index with
+int8-quantized traversal and exact f32 rerank — plus a **turbopuffer-compatible
+HTTP server** with object-storage persistence, a benchmark harness that runs it
+head-to-head against [turbopuffer](https://turbopuffer.com), and an
+**autonomous optimization loop** in the style of
+[karpathy/autoresearch](https://github.com/karpathy/autoresearch).
+
+## Zig library
+
+The in-process engine is a Zig module rooted at `src/lib.zig`. Dependents do
+**not** pull HTTP serve, S3, or the CLI:
+
+```sh
+zig fetch --save git+https://github.com/justrach/openpuffer
+```
+
+```zig
+// build.zig
+const openpuffer_dep = b.dependency("openpuffer", .{
+    .target = target,
+    .optimize = optimize,
+});
+exe.root_module.addImport("openpuffer", openpuffer_dep.module("openpuffer"));
+```
+
+```zig
+const std = @import("std");
+const openpuffer = @import("openpuffer");
+
+const Index = openpuffer.Hnsw(void);
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    var idx = Index.init(alloc, 1536, .{});
+    defer idx.deinit();
+
+    const vec = [_]f32{1} ++ [_]f32{0} ** 1535;
+    _ = try idx.insert(&vec);
+    const hits = try idx.search(&vec, 10, 64, alloc);
+    defer alloc.free(hits);
+}
+```
+
+Memory knobs (same as the binary):
+
+- `Options.store_f32 = false` (CLI `--no-f32`) skips the packed f32 slab; search
+  is int8-only and `vector()` / `vectorConst()` are empty.
+- `index.writeSlabs(path)` then `loaded.loadMmap(path)` demand-pages a snapshot
+  (`MAP_PRIVATE` + heap append). `isMmapBacked()` is true after load.
+
+Public surface: `Hnsw`, `Options`, `SearchResult`, and vector helpers
+(`dot`, `cosineDistance`, `l2Norm`, `normalize`, `dotI8`).
+
+## Engine highlights (`src/hnsw.zig`)
+
+- HNSW index over f32 vectors, cosine distance (vectors L2-normalized on insert)
+- int8-quantized graph traversal + exact f32 rerank (`searchAdvanced`'s
+  `rerank_mult` is the recall/latency knob) — cuts memory traffic 4x at ≥1536 dims
+- Explicit `@Vector(16)` dot-product reductions for SIMD without fast-math
+- Heuristic neighbor selection with keep-pruned backfill (hnswlib-style)
+- Per-layer visited sets (a shared set silently disconnects the graph)
+- Optional `store_f32=false` / `--no-f32` drops the f32 slab (int8-only search)
+- `loadMmap` reopens a slab snapshot with POSIX `MAP_PRIVATE` (demand-paged RSS)
+
+## Server (`src/server.zig`) — drop-in turbopuffer API
+
+`./zig-out/bin/openpuffer serve` exposes the local engine over the same HTTP
+API shape as turbopuffer's v2 REST surface: write (`upsert_columns` /
+`upsert_rows`), ANN query (`rank_by ["vector","ANN",[...]]`), stats, and
+namespace delete. Persistence mirrors turbopuffer's architecture
+(`src/persist.zig`): every write batch appends a WAL segment object to any
+S3-compatible bucket (AWS S3 or Cloudflare R2 via `src/s3.zig`, SigV4),
+snapshots compact consumed WAL entries, reads stay local and in-memory.
+
+## Commands
+
+```sh
+zig build -Doptimize=ReleaseFast
+
+# correctness tests
+zig build test
+
+# local ANN vs brute force on random vectors
+./zig-out/bin/openpuffer bench-synthetic --n 20000 --queries 200 --dim 1536 --k 10 --ef 128
+
+# full loop: Gemini embeddings -> build local HNSW AND upload to turbopuffer
+# -> query both -> latency percentiles + recall@k against exact ground truth
+export TURBOPUFFER_API_KEY=...
+export GEMINI_API_KEY=...
+./zig-out/bin/openpuffer bench-live --namespace openpuffer-bench-5 \
+    --n 1000 --queries 40 --dim 1536 --k 10 --ef 256
+
+# turbopuffer-compatible server (S3/R2 persistence via AWS_* env vars)
+./zig-out/bin/openpuffer serve --port 8080 --bucket my-bucket
+```
+
+Options for both bench commands: `--n`, `--queries`, `--dim` (MRL output
+dimensionality sent to Gemini), `--k`, `--ef`, `--namespace`, `--model`.
+
+## Measured results (M1 Mac, gcp-us-central1 turbopuffer region)
+
+### Head-to-head vs turbopuffer (live gemini-embedding-2 data, k=10)
+
+| dataset | openpuffer p50 | openpuffer recall@10 | turbopuffer p50 | tpuf recall@10 | openpuffer speedup |
+|---|---|---|---|---|---|
+| 1000 × 1536, ef=256 | **0.72 ms** | 0.960 | 213 ms | 1.000 | ~295x latency |
+| 1000 × 3072, ef=256 | **1.01 ms** | 0.965 | 216 ms | 1.000 | ~215x latency |
+
+Caveat: openpuffer is an in-process library (no network hop), turbopuffer a cloud
+service measured over WAN — the multiple reflects access model as much as
+engine. The apples-to-apples local comparison:
+
+### Local: openpuffer ANN (int8 traversal + f32 rerank) vs exact brute-force scan
+
+| dataset | openpuffer p50 | exact scan p50 | speedup | recall@10 |
+|---|---|---|---|---|
+| 20k × 1536 random, ef=128 | **1.08 ms** | 3.38 ms | 3.1x | 0.313* |
+| 20k × 3072 random, ef=128 | **1.60 ms** | 5.43 ms | 3.4x | 0.272* |
+| 1000 × 1536 live embeddings, ef=256 | **0.72 ms** | ~6 ms† | ~8x | 0.960 |
+
+\* uniformly random high-dim vectors are the worst case for ANN — real
+embedding space clusters and lands at 0.95+.
+\† extrapolated from scan throughput at that scale.
+
+## Autonomous optimization loop
+
+This repo runs an autoresearch-style experiment loop ([`program.md`](program.md)):
+an agent proposes ONE change at a time to `src/hnsw.zig` / `src/vector.zig`,
+gates it on `zig build test`, measures it with the fixed `bench-synthetic`
+command above, and keeps it only if p50 improves ≥4% reproduced (run-to-run
+noise here is ±3%). Everything lands in the append-only ledger at
+[`experiments/log.md`](experiments/log.md), rendered live by
+`tools/plot_results.py`:
+
+![p50 per experiment](experiments/results.svg)
+
+### Findings so far
+
+- **E001** dry-run validated the cycle mechanics end-to-end.
+- **E002/E003** widening the int8 dot product from 16 to 64 lanes (two
+  formulations): *neutral* on M1 NEON — the 16-lane lowering was already near
+  the hardware's widening-multiply throughput.
+- **E004/E005** flattening the quantized pool + eliminating per-query
+  allocations: measured wins evaporated under controlled comparison — at this
+  scale the cost is distance evaluations, not memory layout or allocator churn.
+- **E005 bonus**: found and fixed a mixed-allocator ownership bug (scratch grown
+  under a caller arena, freed under the index's allocator → invalid free).
+- Meta-lesson: the ±3% noise floor vs 4% keep bar has rejected every
+  "obvious" optimization so far — exactly what it exists to do. Remaining
+  headroom is fewer/faster distance evaluations, not micro-layout.
+- **E006** (peer-run) simplified quantized scoring to a monotonic f32 form;
+  correctly discarded without a measurement when the benchmark could not run.
+
+## Layout
+
+- `src/lib.zig` — public module root (`@import("openpuffer")`; no HTTP serve)
+- `src/vector.zig` — SIMD dot product / cosine distance / normalization
+- `src/hnsw.zig` — HNSW index (+ connectivity/recall unit tests)
+- `build.zig.zon` — Zig package manifest for in-process dependents
+- `src/server.zig` — turbopuffer-compatible HTTP API over the local engine
+- `src/persist.zig` — WAL-segment + snapshot persistence to object storage
+- `src/s3.zig` — minimal S3/R2 SigV4 client
+- `src/gemini.zig` — `batchEmbedContents` client (RETRIEVAL_DOCUMENT/QUERY task types)
+- `src/tpuf.zig` — turbopuffer v2 REST client (`upsert_columns`, ANN `query`)
+- `src/main.zig` — CLI + benchmark harness
+- `program.md` — the autonomous research protocol (point any coding agent at it)
+- `experiments/` — append-only results ledger + generated chart
+- `tools/plot_results.py` — regenerates `experiments/results.svg` from the ledger
+- `train.py` — reference copy of karpathy/autoresearch's training script (MIT),
+  vendored as the pattern's source material
+
+## Credits & license
+
+The autonomous-loop design follows
+[karpathy/autoresearch](https://github.com/karpathy/autoresearch); `train.py`
+is cherry-picked from [nanochat](https://github.com/karpathy/nanochat) (MIT).
+MIT licensed — see [LICENSE](LICENSE).

--- a/vendor/openpuffer/UPSTREAM.md
+++ b/vendor/openpuffer/UPSTREAM.md
@@ -1,0 +1,32 @@
+# OpenPuffer vendored engine
+
+This directory contains only the pure-Zig in-process HNSW engine from
+[justrach/openpuffer](https://github.com/justrach/openpuffer), plus its Zig
+package files and MIT license.
+
+- Upstream revision: `90a06a713c18ec0e35a4727f013c6ac0f0551a5b`
+- Upstream library merge: [PR #16](https://github.com/justrach/openpuffer/pull/16)
+- The codedb adapter's 512D search profile (`ef=48`, rerank x2) comes from the
+  real-repository/synthetic recall gate merged in upstream
+  [PR #24](https://github.com/justrach/openpuffer/pull/24) at
+  `df5d3671d3783f8874620561a719195656e22936`.
+- Included from upstream: `src/lib.zig`, `src/hnsw.zig`, `src/vector.zig`,
+  `build.zig.zon`, `LICENSE`, `README.md`
+- Local adapter: `build.zig` exposes only upstream's `src/lib.zig` module and
+  runs the included library/HNSW/vector tests; the omitted executable/server
+  sources are not needed.
+- Local hardening in `src/hnsw.zig`: portable POSIX slab I/O on macOS (instead
+  of Linux-only syscalls), 0600 slab creation, checked offset/layout arithmetic,
+  parent-directory fsync after atomic slab rename, and validation of entry
+  points, graph degrees, and neighbor IDs before a persisted graph is attached
+  or searched. Graph validation is capped at 128 MiB of faulted adjacency pages
+  so a self-consistent sparse-file header cannot force unbounded query RSS;
+  legacy heap-copy loaders are separately capped at 256 MiB and validate
+  counts, levels, degrees, and neighbor IDs before exposing the graph.
+- Excluded: HTTP server, server-side object persistence/S3, Gemini,
+  turbopuffer client, benchmark harness, and research tooling
+
+Refresh by reviewing the upstream diff from the revision above, reapplying or
+dropping each documented local hardening patch deliberately, and retaining the
+engine-only build adapter. Run `zig build test` inside this directory,
+`zig build test-ann`, and the full codedb test suite afterward.

--- a/vendor/openpuffer/UPSTREAM.md
+++ b/vendor/openpuffer/UPSTREAM.md
@@ -10,6 +10,10 @@ package files and MIT license.
   real-repository/synthetic recall gate merged in upstream
   [PR #24](https://github.com/justrach/openpuffer/pull/24) at
   `df5d3671d3783f8874620561a719195656e22936`.
+- Finite/non-zero vector ingress validation is backported from upstream
+  [PR #30](https://github.com/justrach/openpuffer/pull/30), merged at
+  `5596b785faf0c4fcf3a77f999a1d6883789ae454`. The accompanying server-only
+  Zig 0.17 fix is intentionally absent because codedb vendors no server code.
 - Included from upstream: `src/lib.zig`, `src/hnsw.zig`, `src/vector.zig`,
   `build.zig.zon`, `LICENSE`, `README.md`
 - Local adapter: `build.zig` exposes only upstream's `src/lib.zig` module and

--- a/vendor/openpuffer/build.zig
+++ b/vendor/openpuffer/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Engine-only vendor adapter. HTTP, persistence, and CLI sources are
+    // omitted; local hnsw hardening is documented in UPSTREAM.md.
+    const lib_mod = b.addModule("openpuffer", .{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib_tests = b.addTest(.{ .root_module = lib_mod });
+    const hnsw_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hnsw.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const vector_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/vector.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const test_step = b.step("test", "Run engine-only OpenPuffer tests");
+    test_step.dependOn(&b.addRunArtifact(lib_tests).step);
+    test_step.dependOn(&b.addRunArtifact(hnsw_tests).step);
+    test_step.dependOn(&b.addRunArtifact(vector_tests).step);
+}

--- a/vendor/openpuffer/build.zig.zon
+++ b/vendor/openpuffer/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .openpuffer,
+    .fingerprint = 0xbec19ff826bee6bd,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.17.0-dev.813+2153f8143",
+    .dependencies = .{},
+    .paths = .{
+        "src/lib.zig",
+        "src/hnsw.zig",
+        "src/vector.zig",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+        "UPSTREAM.md",
+    },
+}

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -1,0 +1,2423 @@
+//! HNSW (Hierarchical Navigable Small World) ANN index, in-memory.
+//! Cosine distance; vectors are L2-normalized on insert so
+//! cosine distance == 1 - dot, which keeps the inner loop tight.
+//!
+//! Memory layout is flat / mmap-shaped (one slab per array, not one malloc
+//! per vector or per neighbor list). Snapshots persist those slabs as one
+//! HMLS file and can be reopened with POSIX mmap (MAP_PRIVATE) so RSS is
+//! demand-paged — no copy-in of vectors_flat / qvecs_flat / packed CSR.
+//!
+//! Growth after mmap: in-memory append buffer (the existing ArrayLists).
+//! Splices/updates on mapped nodes write MAP_PRIVATE COW pages; the snapshot
+//! file is never mutated. Crash mid-insert leaves the file intact. Durable
+//! persist is an atomic rewrite (tmp + fsync + rename).
+//!
+//! On-disk next step is append-only segments: RecordID → {segment, offset,
+//! generation}. This file does not implement NVMe/SPDK/ZNS; see
+//! experiments/log.md.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const vecmath = @import("vector.zig");
+const posix = std.posix;
+const linux = std.os.linux;
+
+/// Persist envelope magic ('OPSN' le). Duplicated so this file does not
+/// import persist.zig (persist already imports hnsw).
+const SNAP_MAGIC_DUP: u32 = 0x4E53504F;
+
+pub const Options = struct {
+    m: u32 = 16,
+    m0_factor: u32 = 2,
+    ef_construction: u32 = 100,
+    ml: f64 = 1.0 / @log(16.0),
+    seed: u64 = 0x9e3779b97f4a7c15,
+    /// Keep a packed f32 copy of every vector for exact rerank / `update`.
+    /// Default true so the scored 20k bench stays comparable. Set false
+    /// (`--no-f32`) to drop ~4×dim bytes per row; search then uses int8 only.
+    store_f32: bool = true,
+};
+
+pub const SearchResult = struct { id: u32, distance: f32 };
+
+pub fn Hnsw(comptime D: type) type {
+    _ = D;
+    return struct {
+        const Self = @This();
+        pub const Candidate = struct { id: u32, d: f32 };
+
+        allocator: std.mem.Allocator,
+        dim: usize,
+        opts: Options,
+        rng: std.Random.DefaultPrng,
+
+        /// Packed f32 payload, stride `dim`. Replaces ArrayList([]f32).
+        vectors_flat: std.ArrayList(f32) = .empty,
+        /// Packed int8 payload, stride `dim`. Replaces ArrayList([]i8).
+        qvecs_flat: std.ArrayList(i8) = .empty,
+        qscales: std.ArrayList(f32) = .empty,
+        levels: std.ArrayList(u32) = .empty,
+
+        /// Layer-0 packed adjacency (CSR with fixed slack).
+        /// l0_nbrs stride = m0()+1 so a splice can temporarily exceed M.
+        l0_deg: std.ArrayList(u16) = .empty,
+        l0_nbrs: std.ArrayList(u32) = .empty,
+
+        /// Higher layers (1..level) packed the same way.
+        /// hi_start[id] indexes the first higher-layer slot in hi_deg / hi_nbrs.
+        hi_start: std.ArrayList(u32) = .empty,
+        hi_deg: std.ArrayList(u16) = .empty,
+        hi_nbrs: std.ArrayList(u32) = .empty,
+
+        /// MAP_PRIVATE view of a slab snapshot. ArrayLists above are the
+        /// post-mmap append buffer (empty until the first insert after load).
+        slab_map: ?SlabMap = null,
+
+        /// Per-node generation for RCU-style neighbor snapshots.
+        /// Even = stable; odd = a writer is replacing that node's adjacency.
+        /// `pushNeighbor` does not bump this (write-then-release-degree is enough).
+        /// Heap-sized to `len()` including mmap-backed ids (zeros on load).
+        nbr_gen: std.ArrayList(u32) = .empty,
+        /// Per-node seqlock for in-place vector updates. Distances retry
+        /// when the generation is odd or changes mid-dot.
+        vec_gen: std.ArrayList(u32) = .empty,
+
+        /// Visible node count. `vectors_flat.items` may be ahead while a
+        /// writer fills a new row; readers use this acquire-load.
+        published: usize = 0,
+        /// Sentinel `maxInt(u32)` = none. Atomic so publish need not take
+        /// the namespace exclusive lock.
+        entry_id: u32 = std.math.maxInt(u32),
+        max_level: u32 = 0,
+
+        pub const SLAB_MAGIC: u32 = 0x534C4D48; // 'HMLS' le
+        pub const SLAB_VERSION: u32 = 1;
+        pub const SLAB_HEADER_SIZE: usize = 256;
+        /// `loadMmap` validates every adjacency entry before publishing the
+        /// graph. Bound the pages that validation may fault into RSS even for
+        /// a syntactically self-consistent but adversarial sparse file.
+        pub const MAX_GRAPH_VALIDATION_BYTES: usize = 128 * 1024 * 1024;
+        /// Copy-in loaders are compatibility APIs, not codedb's mmap query
+        /// path. Bound their heap commitment before parsing attacker-controlled
+        /// counts so they cannot recreate the old 650-700 MiB RSS profile.
+        pub const MAX_COPY_LOAD_BYTES: usize = 256 * 1024 * 1024;
+
+        /// Live mmap of one HMLS (or persist-envelope + HMLS) file.
+        pub const SlabMap = struct {
+            bytes: []align(std.heap.page_size_min) u8,
+            n: usize,
+            hi_slots: usize,
+            levels: []u32,
+            qscales: []f32,
+            vectors: []f32,
+            qvecs: []i8,
+            l0_deg: []u16,
+            l0_nbrs: []u32,
+            hi_start: []u32,
+            hi_deg: []u16,
+            hi_nbrs: []u32,
+        };
+
+        pub fn entryPoint(self: *const Self) ?u32 {
+            const v = @atomicLoad(u32, &self.entry_id, .acquire);
+            return if (v == std.math.maxInt(u32)) null else v;
+        }
+
+        fn setEntryPoint(self: *Self, id: u32) void {
+            @atomicStore(u32, &self.entry_id, id, .release);
+        }
+
+        pub fn getMaxLevel(self: *const Self) u32 {
+            return @atomicLoad(u32, &self.max_level, .acquire);
+        }
+
+        fn setMaxLevel(self: *Self, lvl: u32) void {
+            @atomicStore(u32, &self.max_level, lvl, .release);
+        }
+
+        pub fn init(allocator: std.mem.Allocator, dim: usize, opts: Options) Self {
+            return .{
+                .allocator = allocator,
+                .dim = dim,
+                .opts = opts,
+                .rng = std.Random.DefaultPrng.init(opts.seed),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            if (self.slab_map) |m| posix.munmap(m.bytes);
+            self.slab_map = null;
+            self.vectors_flat.deinit(self.allocator);
+            self.qvecs_flat.deinit(self.allocator);
+            self.qscales.deinit(self.allocator);
+            self.levels.deinit(self.allocator);
+            self.l0_deg.deinit(self.allocator);
+            self.l0_nbrs.deinit(self.allocator);
+            self.hi_start.deinit(self.allocator);
+            self.hi_deg.deinit(self.allocator);
+            self.hi_nbrs.deinit(self.allocator);
+            self.nbr_gen.deinit(self.allocator);
+            self.vec_gen.deinit(self.allocator);
+            self.* = undefined;
+        }
+
+        inline fn mappedCount(self: *const Self) usize {
+            return if (self.slab_map) |m| m.n else 0;
+        }
+
+        pub fn len(self: *const Self) usize {
+            return @atomicLoad(usize, &self.published, .acquire);
+        }
+
+        /// True when this index retains the f32 slab (exact rerank / snapshot f32).
+        pub fn hasStoredF32(self: *const Self) bool {
+            return self.opts.store_f32;
+        }
+
+        pub fn isMmapBacked(self: *const Self) bool {
+            return self.slab_map != null;
+        }
+
+        /// True when one more insert will not realloc any packed slab.
+        pub fn hasInsertRoom(self: *const Self, extra: usize) bool {
+            if (self.dim == 0) return false;
+            const heap_n = self.qscales.items.len;
+            const mapped = self.mappedCount();
+            const total = mapped + heap_n + extra;
+            const need_heap = heap_n + extra;
+            if (self.opts.store_f32 and self.vectors_flat.capacity < need_heap * self.dim) return false;
+            if (self.qvecs_flat.capacity < need_heap * self.dim) return false;
+            if (self.qscales.capacity < need_heap) return false;
+            if (self.levels.capacity < need_heap) return false;
+            if (self.l0_deg.capacity < need_heap) return false;
+            if (self.l0_nbrs.capacity < need_heap * self.l0Stride()) return false;
+            if (self.hi_start.capacity < need_heap) return false;
+            if (self.nbr_gen.capacity < total) return false;
+            if (self.vec_gen.capacity < total) return false;
+            const hi_extra = extra * 8;
+            if (self.hi_deg.capacity < self.hi_deg.items.len + hi_extra) return false;
+            if (self.hi_nbrs.capacity < self.hi_nbrs.items.len + hi_extra * self.hiStride()) return false;
+            return true;
+        }
+
+        /// Grow slabs. Caller must hold exclusive so live readers cannot
+        /// hold dangling `items` pointers across the realloc.
+        pub fn ensureInsertRoom(self: *Self, extra: usize) !void {
+            const alloc = self.allocator;
+            const heap_n = self.qscales.items.len;
+            const mapped = self.mappedCount();
+            const total = mapped + heap_n + extra;
+            const need_heap = heap_n + extra;
+            if (self.opts.store_f32) {
+                try self.vectors_flat.ensureTotalCapacity(alloc, need_heap * @max(self.dim, 1));
+            }
+            try self.qvecs_flat.ensureTotalCapacity(alloc, need_heap * @max(self.dim, 1));
+            try self.qscales.ensureTotalCapacity(alloc, need_heap);
+            try self.levels.ensureTotalCapacity(alloc, need_heap);
+            try self.l0_deg.ensureTotalCapacity(alloc, need_heap);
+            try self.l0_nbrs.ensureTotalCapacity(alloc, need_heap * self.l0Stride());
+            try self.hi_start.ensureTotalCapacity(alloc, need_heap);
+            try self.nbr_gen.ensureTotalCapacity(alloc, total);
+            try self.vec_gen.ensureTotalCapacity(alloc, total);
+            try self.hi_deg.ensureTotalCapacity(alloc, self.hi_deg.items.len + extra * 8);
+            try self.hi_nbrs.ensureTotalCapacity(alloc, self.hi_nbrs.items.len + extra * 8 * self.hiStride());
+        }
+
+        inline fn m0(self: *const Self) usize {
+            return @as(usize, self.opts.m) * @as(usize, self.opts.m0_factor);
+        }
+
+        inline fn l0Stride(self: *const Self) usize {
+            return self.m0() + 1;
+        }
+
+        inline fn hiStride(self: *const Self) usize {
+            return @as(usize, self.opts.m) + 1;
+        }
+
+        fn heapId(self: *const Self, id: u32) u32 {
+            return id - @as(u32, @intCast(self.mappedCount()));
+        }
+
+        /// Mutable f32 row. Server snapshot/WAL and `update` use this.
+        /// Empty when `store_f32=false` (callers must check `hasStoredF32`).
+        pub fn vector(self: *Self, id: u32) []f32 {
+            if (!self.opts.store_f32) return &.{};
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    if (m.vectors.len == 0) return &.{};
+                    const off = @as(usize, id) * self.dim;
+                    return m.vectors[off..][0..self.dim];
+                }
+                if (self.vectors_flat.items.len == 0) return &.{};
+                const off = @as(usize, self.heapId(id)) * self.dim;
+                return self.vectors_flat.items[off..][0..self.dim];
+            }
+            if (self.vectors_flat.items.len == 0) return &.{};
+            const off = @as(usize, id) * self.dim;
+            return self.vectors_flat.items[off..][0..self.dim];
+        }
+
+        pub fn vectorConst(self: *const Self, id: u32) []const f32 {
+            if (!self.opts.store_f32) return &.{};
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    if (m.vectors.len == 0) return &.{};
+                    const off = @as(usize, id) * self.dim;
+                    return m.vectors[off..][0..self.dim];
+                }
+                if (self.vectors_flat.items.len == 0) return &.{};
+                const off = @as(usize, self.heapId(id)) * self.dim;
+                return self.vectors_flat.items[off..][0..self.dim];
+            }
+            if (self.vectors_flat.items.len == 0) return &.{};
+            const off = @as(usize, id) * self.dim;
+            return self.vectors_flat.items[off..][0..self.dim];
+        }
+
+        pub fn qvec(self: *Self, id: u32) []i8 {
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    const off = @as(usize, id) * self.dim;
+                    return m.qvecs[off..][0..self.dim];
+                }
+                const off = @as(usize, self.heapId(id)) * self.dim;
+                return self.qvecs_flat.items[off..][0..self.dim];
+            }
+            const off = @as(usize, id) * self.dim;
+            return self.qvecs_flat.items[off..][0..self.dim];
+        }
+
+        pub fn qvecConst(self: *const Self, id: u32) []const i8 {
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    const off = @as(usize, id) * self.dim;
+                    return m.qvecs[off..][0..self.dim];
+                }
+                const off = @as(usize, self.heapId(id)) * self.dim;
+                return self.qvecs_flat.items[off..][0..self.dim];
+            }
+            const off = @as(usize, id) * self.dim;
+            return self.qvecs_flat.items[off..][0..self.dim];
+        }
+
+        fn levelOf(self: *const Self, id: u32) u32 {
+            if (self.slab_map) |m| {
+                if (id < m.n) return m.levels[id];
+                return self.levels.items[self.heapId(id)];
+            }
+            return self.levels.items[id];
+        }
+
+        fn qscaleOf(self: *const Self, id: u32) f32 {
+            if (self.slab_map) |m| {
+                if (id < m.n) return m.qscales[id];
+                return self.qscales.items[self.heapId(id)];
+            }
+            return self.qscales.items[id];
+        }
+
+        fn setQscaleOf(self: *Self, id: u32, scale: f32) void {
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    m.qscales[id] = scale;
+                    return;
+                }
+                self.qscales.items[self.heapId(id)] = scale;
+                return;
+            }
+            self.qscales.items[id] = scale;
+        }
+
+        pub fn layerCount(self: *const Self, id: u32) u32 {
+            return self.levelOf(id) + 1;
+        }
+
+        pub fn neighbors(self: *const Self, id: u32, layer: u32) []const u32 {
+            const deg = self.degree(id, layer);
+            return self.neighborSlotsConst(id, layer)[0..deg];
+        }
+
+        fn degPtr(self: *const Self, id: u32, layer: u32) *u16 {
+            if (layer == 0) {
+                if (self.slab_map) |m| {
+                    if (id < m.n) return &m.l0_deg[id];
+                    return @constCast(&self.l0_deg.items[self.heapId(id)]);
+                }
+                return @constCast(&self.l0_deg.items[id]);
+            }
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    const slot = m.hi_start[id] + (layer - 1);
+                    return &m.hi_deg[slot];
+                }
+                const slot = self.hi_start.items[self.heapId(id)] + (layer - 1);
+                return @constCast(&self.hi_deg.items[slot]);
+            }
+            const slot = self.hi_start.items[id] + (layer - 1);
+            return @constCast(&self.hi_deg.items[slot]);
+        }
+
+        fn degree(self: *const Self, id: u32, layer: u32) usize {
+            return @atomicLoad(u16, self.degPtr(id, layer), .acquire);
+        }
+
+        fn neighborSlotsConst(self: *const Self, id: u32, layer: u32) []const u32 {
+            if (layer == 0) {
+                const stride = self.l0Stride();
+                if (self.slab_map) |m| {
+                    if (id < m.n) {
+                        const off = @as(usize, id) * stride;
+                        return m.l0_nbrs[off..][0..stride];
+                    }
+                    const off = @as(usize, self.heapId(id)) * stride;
+                    return self.l0_nbrs.items[off..][0..stride];
+                }
+                const off = @as(usize, id) * stride;
+                return self.l0_nbrs.items[off..][0..stride];
+            }
+            const stride = self.hiStride();
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    const slot = m.hi_start[id] + (layer - 1);
+                    const off = slot * stride;
+                    return m.hi_nbrs[off..][0..stride];
+                }
+                const slot = self.hi_start.items[self.heapId(id)] + (layer - 1);
+                const off = slot * stride;
+                return self.hi_nbrs.items[off..][0..stride];
+            }
+            const slot = self.hi_start.items[id] + (layer - 1);
+            const off = slot * stride;
+            return self.hi_nbrs.items[off..][0..stride];
+        }
+
+        fn neighborSlots(self: *Self, id: u32, layer: u32) []u32 {
+            if (layer == 0) {
+                const stride = self.l0Stride();
+                if (self.slab_map) |m| {
+                    if (id < m.n) {
+                        const off = @as(usize, id) * stride;
+                        return m.l0_nbrs[off..][0..stride];
+                    }
+                    const off = @as(usize, self.heapId(id)) * stride;
+                    return self.l0_nbrs.items[off..][0..stride];
+                }
+                const off = @as(usize, id) * stride;
+                return self.l0_nbrs.items[off..][0..stride];
+            }
+            const stride = self.hiStride();
+            if (self.slab_map) |m| {
+                if (id < m.n) {
+                    const slot = m.hi_start[id] + (layer - 1);
+                    const off = slot * stride;
+                    return m.hi_nbrs[off..][0..stride];
+                }
+                const slot = self.hi_start.items[self.heapId(id)] + (layer - 1);
+                const off = slot * stride;
+                return self.hi_nbrs.items[off..][0..stride];
+            }
+            const slot = self.hi_start.items[id] + (layer - 1);
+            const off = slot * stride;
+            return self.hi_nbrs.items[off..][0..stride];
+        }
+
+        fn setDegree(self: *Self, id: u32, layer: u32, deg: u16) void {
+            @atomicStore(u16, self.degPtr(id, layer), deg, .release);
+        }
+
+        /// Copy a stable neighbor list. Retries if a writer is mid-replace
+        /// (`nbr_gen` odd or changed). `pushNeighbor` is wait-free for readers:
+        /// it writes the slack slot first, then publishes degree.
+        fn snapshotNeighbors(self: *const Self, id: u32, layer: u32, buf: []u32) []const u32 {
+            var spins: u32 = 0;
+            while (true) {
+                const g1 = @atomicLoad(u32, &self.nbr_gen.items[id], .acquire);
+                if ((g1 & 1) != 0) {
+                    spins +%= 1;
+                    if (spins > 8) std.atomic.spinLoopHint();
+                    continue;
+                }
+                const deg = self.degree(id, layer);
+                const slots = self.neighborSlotsConst(id, layer);
+                const n = @min(deg, @min(buf.len, slots.len));
+                if (n > 0) @memcpy(buf[0..n], slots[0..n]);
+                const g2 = @atomicLoad(u32, &self.nbr_gen.items[id], .acquire);
+                if (g1 == g2) return buf[0..n];
+            }
+        }
+
+        fn pushNeighbor(self: *Self, id: u32, layer: u32, nid: u32) void {
+            const deg = self.degree(id, layer);
+            self.neighborSlots(id, layer)[deg] = nid;
+            self.setDegree(id, layer, @intCast(deg + 1));
+        }
+
+        fn replaceNeighbors(self: *Self, id: u32, layer: u32, ids: []const u32) void {
+            const g = @atomicLoad(u32, &self.nbr_gen.items[id], .monotonic);
+            @atomicStore(u32, &self.nbr_gen.items[id], g +% 1, .release);
+            const slots = self.neighborSlots(id, layer);
+            @memcpy(slots[0..ids.len], ids);
+            self.setDegree(id, layer, @intCast(ids.len));
+            @atomicStore(u32, &self.nbr_gen.items[id], g +% 2, .release);
+        }
+
+        fn randomLevel(self: *Self) u32 {
+            var r = self.rng.random().float(f64);
+            if (r <= 0) r = std.math.floatMin(f64);
+            // standard: level = floor(-ln(uniform(0,1)) * mL)
+            return @intFromFloat(std.math.floor(-std.math.log(f64, std.math.e, r) * self.opts.ml));
+        }
+
+        pub fn nextLevel(self: *Self) u32 {
+            return self.randomLevel();
+        }
+
+        inline fn distTo(self: *const Self, q: []const f32, id: u32) f32 {
+            while (true) {
+                const g1 = @atomicLoad(u32, &self.vec_gen.items[id], .acquire);
+                if ((g1 & 1) != 0) {
+                    std.atomic.spinLoopHint();
+                    continue;
+                }
+                const d = vecmath.cosineDistance(q, self.vectorConst(id));
+                const g2 = @atomicLoad(u32, &self.vec_gen.items[id], .acquire);
+                if (g1 == g2) return d;
+            }
+        }
+
+        /// Pairwise distance used while splicing the graph. Exact when f32
+        /// is stored; otherwise the same int8 score search already uses.
+        inline fn distPair(self: *const Self, src: u32, dst: u32) f32 {
+            if (self.opts.store_f32) return self.distTo(self.vectorConst(src), dst);
+            return self.distQ(self.qvecConst(src), self.qscaleOf(src), dst);
+        }
+
+        inline fn distQ(self: *const Self, qq: []const i8, qs: f32, id: u32) f32 {
+            // stored vectors are unit-norm; a ~= aq * scale, so
+            // cos(a,b) ~= dot(aq,bq) * qs * scale_b
+            while (true) {
+                const g1 = @atomicLoad(u32, &self.vec_gen.items[id], .acquire);
+                if ((g1 & 1) != 0) {
+                    std.atomic.spinLoopHint();
+                    continue;
+                }
+                const approx = @as(f64, @floatFromInt(vecmath.dotI8(qq, self.qvecConst(id)))) *
+                    qs * self.qscaleOf(id);
+                const g2 = @atomicLoad(u32, &self.vec_gen.items[id], .acquire);
+                if (g1 == g2) return @max(0.0, 1.0 - @as(f32, @floatCast(approx)));
+            }
+        }
+
+        /// Distance contexts let searchLayer run on either exact or quantized math.
+        pub const F32Dist = struct {
+            s: *const Self,
+            q: []const f32,
+            pub inline fn dist(d: @This(), id: u32) f32 {
+                return d.s.distTo(d.q, id);
+            }
+        };
+        pub const QDist = struct {
+            s: *const Self,
+            qq: []const i8,
+            qs: f32,
+            pub inline fn dist(d: @This(), id: u32) f32 {
+                return d.s.distQ(d.qq, d.qs, id);
+            }
+        };
+
+        fn markVisited(visited: *std.DynamicBitSetUnmanaged, alloc: std.mem.Allocator, id: u32) !void {
+            if (id >= visited.capacity()) {
+                try visited.resize(alloc, @max(@as(usize, id) + 256, visited.capacity() * 2), false);
+            }
+            visited.set(id);
+        }
+
+        fn alreadyVisited(visited: *std.DynamicBitSetUnmanaged, alloc: std.mem.Allocator, id: u32) !bool {
+            if (id >= visited.capacity()) {
+                try visited.resize(alloc, @max(@as(usize, id) + 256, visited.capacity() * 2), false);
+                visited.set(id);
+                return false;
+            }
+            if (visited.isSet(id)) return true;
+            visited.set(id);
+            return false;
+        }
+
+        /// greedy search on a single layer; `ef` bounds result set size.
+        fn searchLayer(
+            self: *const Self,
+            dist_ctx: anytype,
+            entry_points: []const Candidate,
+            ef: usize,
+            layer: u32,
+            visited: *std.DynamicBitSetUnmanaged,
+            alloc: std.mem.Allocator,
+        ) !std.ArrayList(Candidate) {
+            // visited state is per-layer: upper-layer expansions must not
+            // suppress re-expansion at lower layers (their adjacency differs).
+            visited.setRangeValue(.{ .start = 0, .end = visited.capacity() }, false);
+            // candidates: min-heap by distance (use PriorityQueue)
+            const CandCtx = struct {
+                pub fn compare(_: void, a: Candidate, b: Candidate) std.math.Order {
+                    return std.math.order(a.d, b.d);
+                }
+            };
+
+            var candidates = std.PriorityQueue(Candidate, void, CandCtx.compare).initContext({});
+            defer candidates.deinit(alloc);
+            try candidates.ensureTotalCapacity(alloc, ef + 64);
+            // results: max-heap by distance (store negated via reverse order)
+            const RevCtx = struct {
+                pub fn compare(_: void, a: Candidate, b: Candidate) std.math.Order {
+                    return std.math.order(b.d, a.d);
+                }
+            };
+            var results = std.PriorityQueue(Candidate, void, RevCtx.compare).initContext({});
+            defer results.deinit(alloc);
+
+            for (entry_points) |c| {
+                try markVisited(visited, alloc, c.id);
+                try candidates.push(alloc, c);
+                try results.push(alloc, c);
+            }
+
+            while (candidates.count() > 0) {
+                const c = candidates.pop().?;
+                const worst = if (results.count() > 0) results.peek().?.d else c.d;
+                if (c.d > worst and results.count() >= ef) break;
+
+                if (layer >= self.layerCount(c.id)) {
+                    std.debug.print("VIOLATION c.id={d} its_layers={d} layer={d} max_level={d} ep={any} ep_layers={d}\n", .{ c.id, self.layerCount(c.id), layer, self.getMaxLevel(), self.entryPoint(), if (self.entryPoint()) |e| self.layerCount(e) else 0 });
+                    @panic("hnsw invariant broken");
+                }
+                var nbr_buf: [64]u32 = undefined;
+                const nbrs = self.snapshotNeighbors(c.id, layer, &nbr_buf);
+                for (nbrs, 0..) |nid, ni| {
+                    // one-ahead software prefetch: the next neighbor's int8
+                    // vector starts its memory fetch while we dot this one.
+                    // Skip already-visited neighbors (wasted prefetches).
+                    if (ni + 1 < nbrs.len) {
+                        const nxt = nbrs[ni + 1];
+                        if (nxt >= visited.capacity() or !visited.isSet(nxt)) {
+                            @prefetch(self.qvecConst(nxt).ptr, .{
+                                .rw = .read,
+                                .locality = 3,
+                                .cache = .data,
+                            });
+                        }
+                    }
+                    if (try alreadyVisited(visited, alloc, nid)) continue;
+                    const d = dist_ctx.dist(nid);
+                    const w = if (results.count() > 0) results.peek().?.d else std.math.floatMax(f32);
+                    if (results.count() < ef or d < w) {
+                        try candidates.push(alloc, .{ .id = nid, .d = d });
+                        try results.push(alloc, .{ .id = nid, .d = d });
+                        if (results.count() > ef) _ = results.pop();
+                    }
+                }
+            }
+
+            var out: std.ArrayList(Candidate) = .empty;
+            try out.ensureTotalCapacity(alloc, results.count());
+            while (results.pop()) |r| out.appendAssumeCapacity(r);
+            std.mem.sort(Candidate, out.items, {}, struct {
+                fn cmp(_: void, a: Candidate, b: Candidate) bool {
+                    return a.d < b.d;
+                }
+            }.cmp);
+            return out;
+        }
+
+        fn selectNeighborsHeuristic(
+            self: *const Self,
+            base: []const Candidate,
+            max_m: u32,
+            alloc: std.mem.Allocator,
+        ) ![]Candidate {
+            var selected: std.ArrayList(Candidate) = .empty;
+            errdefer selected.deinit(alloc);
+            try selected.ensureTotalCapacity(alloc, max_m);
+            // keepPruned: fill leftover slots with closest discarded candidates
+            var pruned: std.ArrayList(Candidate) = .empty;
+            defer pruned.deinit(alloc);
+            outer: for (base) |c| {
+                if (selected.items.len >= max_m) {
+                    try pruned.append(alloc, c);
+                    continue;
+                }
+                for (selected.items) |s| {
+                    if (self.distPair(c.id, s.id) < c.d) {
+                        try pruned.append(alloc, c);
+                        continue :outer;
+                    }
+                }
+                selected.appendAssumeCapacity(c);
+            }
+            var pi: usize = 0;
+            while (selected.items.len < max_m and pi < pruned.items.len) : (pi += 1) {
+                try selected.append(alloc, pruned.items[pi]);
+            }
+            return selected.toOwnedSlice(alloc);
+        }
+
+        /// Replace the vector at `id` in place (requantize; graph links stay).
+        /// Safe under a shared lock: seqlock so in-flight dots retry.
+        pub fn update(self: *Self, id: u32, vector_in: []const f32) !void {
+            if (id >= self.len()) return error.NotFound;
+            if (vector_in.len != self.dim) return error.DimensionMismatch;
+            var stack: [2048]f32 = undefined;
+            var heap_tmp: ?[]f32 = null;
+            defer if (heap_tmp) |h| self.allocator.free(h);
+            const copy: []f32 = if (self.opts.store_f32) self.vector(id) else if (self.dim <= stack.len)
+                stack[0..self.dim]
+            else blk: {
+                heap_tmp = try self.allocator.alloc(f32, self.dim);
+                break :blk heap_tmp.?;
+            };
+            const g = @atomicLoad(u32, &self.vec_gen.items[id], .monotonic);
+            @atomicStore(u32, &self.vec_gen.items[id], g +% 1, .release);
+            @memcpy(copy, vector_in);
+            vecmath.normalize(copy);
+            var amax: f32 = 0;
+            for (copy) |x| amax = @max(amax, @abs(x));
+            const scale = amax / 127.0;
+            const q8 = self.qvec(id);
+            if (scale == 0) {
+                @memset(q8, 0);
+            } else {
+                for (copy, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
+            }
+            self.setQscaleOf(id, scale);
+            @atomicStore(u32, &self.vec_gen.items[id], g +% 2, .release);
+        }
+
+        /// Neighbor picks for one insert. `copy`/`q8` are owned by the index
+        /// allocator; `layers` slices are owned by `scratch`.
+        pub const InsertPlan = struct {
+            copy: []f32,
+            q8: []i8,
+            scale: f32,
+            level: u32,
+            /// layers[i] = selected neighbor ids at graph layer i
+            layers: [][]u32,
+            scratch: std.mem.Allocator,
+
+            pub fn discard(self: InsertPlan, index_alloc: std.mem.Allocator) void {
+                if (self.copy.len != 0) index_alloc.free(self.copy);
+                if (self.q8.len != 0) index_alloc.free(self.q8);
+                for (self.layers) |ids| self.scratch.free(ids);
+                if (self.layers.len != 0) self.scratch.free(self.layers);
+            }
+        };
+
+        fn quantizeOwned(self: *const Self, vector_in: []const f32) !struct { copy: []f32, q8: []i8, scale: f32 } {
+            const alloc = self.allocator;
+            const copy = try alloc.alloc(f32, self.dim);
+            errdefer alloc.free(copy);
+            @memcpy(copy, vector_in);
+            vecmath.normalize(copy);
+            var amax: f32 = 0;
+            for (copy) |x| amax = @max(amax, @abs(x));
+            const scale = amax / 127.0;
+            const q8 = try alloc.alloc(i8, self.dim);
+            errdefer alloc.free(q8);
+            if (scale == 0) {
+                @memset(q8, 0);
+            } else {
+                for (copy, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
+            }
+            return .{ .copy = copy, .q8 = q8, .scale = scale };
+        }
+
+        fn appendRecord(self: *Self, copy: []const f32, q8: []const i8, scale: f32, level: u32) !u32 {
+            if (level > 64) return error.InvalidLevel;
+            const alloc = self.allocator;
+            const id: u32 = @intCast(self.mappedCount() + self.qscales.items.len);
+            if (self.opts.store_f32) {
+                try self.vectors_flat.appendSlice(alloc, copy);
+            }
+            try self.qvecs_flat.appendSlice(alloc, q8);
+            try self.qscales.append(alloc, scale);
+            try self.levels.append(alloc, level);
+            try self.l0_deg.append(alloc, 0);
+            const l0_pad = try self.l0_nbrs.addManyAsSlice(alloc, self.l0Stride());
+            @memset(l0_pad, 0);
+            try self.hi_start.append(alloc, @intCast(self.hi_deg.items.len));
+            try self.nbr_gen.append(alloc, 0);
+            try self.vec_gen.append(alloc, 0);
+            if (level > 0) {
+                const slots: usize = level;
+                const degs = try self.hi_deg.addManyAsSlice(alloc, slots);
+                @memset(degs, 0);
+                const neighbor_slots = std.math.mul(usize, slots, self.hiStride()) catch return error.InvalidSlabLayout;
+                const nbrs = try self.hi_nbrs.addManyAsSlice(alloc, neighbor_slots);
+                @memset(nbrs, 0);
+            }
+            @atomicStore(usize, &self.published, @as(usize, id) + 1, .release);
+            return id;
+        }
+
+        /// Read-only neighbor search for a new node. Caller must hold a shared
+        /// (or exclusive) lock so the graph arrays are stable.
+        pub fn planInsert(self: *const Self, vector_in: []const f32, level: u32, scratch: std.mem.Allocator) !InsertPlan {
+            if (vector_in.len != self.dim) return error.DimensionMismatch;
+            if (level > 64) return error.InvalidLevel;
+            const q = try self.quantizeOwned(vector_in);
+            errdefer {
+                self.allocator.free(q.copy);
+                self.allocator.free(q.q8);
+            }
+            const n_layers: usize = @as(usize, @min(level, self.getMaxLevel())) + 1;
+            const layers = try scratch.alloc([]u32, n_layers);
+            errdefer scratch.free(layers);
+            for (layers) |*slot| slot.* = &.{};
+
+            if (self.entryPoint() == null) {
+                return .{ .copy = q.copy, .q8 = q.q8, .scale = q.scale, .level = level, .layers = layers, .scratch = scratch };
+            }
+
+            var visited = try std.DynamicBitSetUnmanaged.initEmpty(scratch, self.len() + 2048);
+            defer visited.deinit(scratch);
+            const qctx = QDist{ .s = self, .qq = q.q8, .qs = q.scale };
+            const ep_id = self.entryPoint().?;
+            var ep: [1]Candidate = .{.{ .id = ep_id, .d = qctx.dist(ep_id) }};
+            var cur = self.getMaxLevel();
+            while (cur > level) : (cur -= 1) {
+                var res = try self.searchLayer(qctx, &ep, 1, cur, &visited, scratch);
+                defer res.deinit(scratch);
+                ep[0] = res.items[0];
+            }
+            var eps: std.ArrayList(Candidate) = .empty;
+            defer eps.deinit(scratch);
+            try eps.append(scratch, ep[0]);
+            const max_m0: u32 = @intCast(self.m0());
+            var li: i64 = @intCast(n_layers - 1);
+            while (li >= 0) : (li -= 1) {
+                const layer: u32 = @intCast(li);
+                const max_m: u32 = if (layer == 0) max_m0 else self.opts.m;
+                var found = try self.searchLayer(qctx, eps.items, self.opts.ef_construction, layer, &visited, scratch);
+                defer found.deinit(scratch);
+                const selected = try self.selectNeighborsHeuristic(found.items, max_m, scratch);
+                defer scratch.free(selected);
+                const ids = try scratch.alloc(u32, selected.len);
+                for (selected, ids) |s, *out| out.* = s.id;
+                layers[layer] = ids;
+                eps.clearRetainingCapacity();
+                for (found.items) |f| try eps.append(scratch, f);
+            }
+            return .{ .copy = q.copy, .q8 = q.q8, .scale = q.scale, .level = level, .layers = layers, .scratch = scratch };
+        }
+
+        /// Publish a planned node: append the payload row, write outgoing
+        /// edges, and (if needed) swing `entry_point`. Does not splice
+        /// back-edges. Caller must hold exclusive lock so ArrayList growth
+        /// cannot race readers. Frees `plan.copy` / `plan.q8`; leaves
+        /// `plan.layers` for `spliceBackEdges`.
+        pub fn publishInsert(self: *Self, plan: *InsertPlan) !u32 {
+            const alloc = self.allocator;
+            const id = try self.appendRecord(plan.copy, plan.q8, plan.scale, plan.level);
+            alloc.free(plan.copy);
+            alloc.free(plan.q8);
+            plan.copy = &.{};
+            plan.q8 = &.{};
+
+            const connect_n = @min(plan.layers.len, self.layerCount(id));
+            var layer: u32 = 0;
+            while (layer < connect_n) : (layer += 1) {
+                for (plan.layers[layer]) |nid| {
+                    if (nid >= self.len() or layer >= self.layerCount(nid)) continue;
+                    self.pushNeighbor(id, layer, nid);
+                }
+            }
+            return id;
+        }
+
+        /// Swing entry point after the new row is mapped in `doc_ids`.
+        pub fn publishEntry(self: *Self, id: u32, level: u32) void {
+            if (self.entryPoint() == null or level > self.getMaxLevel()) {
+                self.setMaxLevel(level);
+                self.setEntryPoint(id);
+            }
+        }
+
+        /// Splice back-edges + prune. Safe under a shared lock: adjacency
+        /// writes are generation-published so `snapshotNeighbors` retries
+        /// instead of walking a torn list. Does not grow the packed arrays.
+        /// Always frees `plan.layers`.
+        pub fn spliceBackEdges(self: *Self, plan: *InsertPlan, id: u32) !void {
+            defer {
+                for (plan.layers) |ids| plan.scratch.free(ids);
+                if (plan.layers.len != 0) plan.scratch.free(plan.layers);
+                plan.layers = &.{};
+            }
+            const alloc = self.allocator;
+            const max_m0: u32 = @intCast(self.m0());
+            const connect_n = @min(plan.layers.len, self.layerCount(id));
+            var layer: u32 = 0;
+            while (layer < connect_n) : (layer += 1) {
+                const max_m: u32 = if (layer == 0) max_m0 else self.opts.m;
+                for (plan.layers[layer]) |nid| {
+                    if (nid >= self.len() or layer >= self.layerCount(nid)) continue;
+                    self.pushNeighbor(nid, layer, id);
+                    if (self.degree(nid, layer) > max_m) {
+                        var cands: std.ArrayList(Candidate) = .empty;
+                        defer cands.deinit(alloc);
+                        var back_buf: [64]u32 = undefined;
+                        const back = self.snapshotNeighbors(nid, layer, &back_buf);
+                        try cands.ensureTotalCapacity(alloc, back.len);
+                        for (back) |n| {
+                            cands.appendAssumeCapacity(.{ .id = n, .d = self.distPair(nid, n) });
+                        }
+                        std.mem.sort(Candidate, cands.items, {}, struct {
+                            fn cmp(_: void, a: Candidate, b: Candidate) bool {
+                                return a.d < b.d;
+                            }
+                        }.cmp);
+                        const pruned = try self.selectNeighborsHeuristic(cands.items, max_m, alloc);
+                        defer alloc.free(pruned);
+                        var ids: std.ArrayList(u32) = .empty;
+                        defer ids.deinit(alloc);
+                        try ids.ensureTotalCapacity(alloc, pruned.len);
+                        for (pruned) |p| ids.appendAssumeCapacity(p.id);
+                        self.replaceNeighbors(nid, layer, ids.items);
+                    }
+                }
+            }
+        }
+
+        /// Splice a planned node into the graph (publish + back-edges).
+        /// Single-threaded / exclusive-lock callers (tests, `insert`).
+        pub fn commitInsert(self: *Self, plan: InsertPlan) !u32 {
+            var p = plan;
+            const id = try self.publishInsert(&p);
+            self.publishEntry(id, p.level);
+            try self.spliceBackEdges(&p, id);
+            return id;
+        }
+
+        /// Insert a vector (copies it). Returns its id.
+        pub fn insert(self: *Self, vector_in: []const f32) !u32 {
+            if (vector_in.len != self.dim) return error.DimensionMismatch;
+            const level = self.randomLevel();
+            const plan = try self.planInsert(vector_in, level, self.allocator);
+            return self.commitInsert(plan);
+        }
+
+        /// k-ANN search: graph traversal runs on int8 distances (4x less memory
+        /// traffic at high dim), then the top `rerank_mult * k` candidates are
+        /// reranked with exact f32 cosine so reported results keep full precision.
+        pub fn search(
+            self: *Self,
+            query: []const f32,
+            k: usize,
+            ef_search: u32,
+            alloc: std.mem.Allocator,
+        ) ![]SearchResult {
+            return self.searchAdvanced(query, k, ef_search, 4, alloc);
+        }
+
+        /// `rerank_mult` is the recall/latency knob (CLI `--rerank-mult`, default 4).
+        /// 1 disables rerank (int8 order only). Raising it only helps if the true
+        /// neighbors are already in the ef-sized candidate list.
+        pub fn searchAdvanced(
+            self: *Self,
+            query: []const f32,
+            k: usize,
+            ef_search: u32,
+            rerank_mult: usize,
+            alloc: std.mem.Allocator,
+        ) ![]SearchResult {
+            if (query.len != self.dim) return error.DimensionMismatch;
+            const ep_id = self.entryPoint() orelse return alloc.alloc(SearchResult, 0);
+            var norm_buf: [512]f32 = undefined;
+            var heap_nq: ?[]f32 = null;
+            defer if (heap_nq) |h| alloc.free(h);
+            const nq: []const f32 = if (query.len <= norm_buf.len) blk: {
+                @memcpy(norm_buf[0..query.len], query);
+                vecmath.normalize(norm_buf[0..query.len]);
+                break :blk norm_buf[0..query.len];
+            } else blk: {
+                heap_nq = try alloc.alloc(f32, query.len);
+                @memcpy(heap_nq.?, query);
+                vecmath.normalize(heap_nq.?);
+                break :blk heap_nq.?;
+            };
+
+            // quantize the normalized query once; reuse the amax scan for qs
+            var qbuf: [512]i8 = undefined;
+            var amax: f32 = 0;
+            for (nq) |x| amax = @max(amax, @abs(x));
+            const scale = amax / 127.0;
+            const qs: f32 = scale;
+            var heap_qq: ?[]i8 = null;
+            defer if (heap_qq) |h| alloc.free(h);
+            const qq: []const i8 = blk: {
+                const buf = if (nq.len <= qbuf.len) qbuf[0..nq.len] else blk2: {
+                    heap_qq = try alloc.alloc(i8, nq.len);
+                    break :blk2 heap_qq.?;
+                };
+                if (scale == 0) {
+                    @memset(buf, 0);
+                } else {
+                    for (nq, 0..) |x, i| buf[i] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
+                }
+                break :blk buf;
+            };
+            const ctx = QDist{ .s = self, .qq = qq, .qs = qs };
+
+            var visited = try std.DynamicBitSetUnmanaged.initEmpty(alloc, self.len() + 2048);
+            defer visited.deinit(alloc);
+
+            var ep: [1]Candidate = .{.{ .id = ep_id, .d = ctx.dist(ep_id) }};
+            var cur = self.getMaxLevel();
+            while (cur > 0) : (cur -= 1) {
+                var res = try self.searchLayer(ctx, &ep, 1, cur, &visited, alloc);
+                defer res.deinit(alloc);
+                ep[0] = res.items[0];
+            }
+
+            var res = try self.searchLayer(ctx, &ep, @max(ef_search, k), 0, &visited, alloc);
+            defer res.deinit(alloc);
+
+            // exact rerank only when the f32 slab is present. Without it,
+            // reported order is the int8 traversal order (still valid ANN).
+            if (!self.opts.store_f32) {
+                const out_n = @min(k, res.items.len);
+                const out = try alloc.alloc(SearchResult, out_n);
+                for (out, 0..) |*o, i| o.* = .{ .id = res.items[i].id, .distance = res.items[i].d };
+                return out;
+            }
+
+            const rerank_n = @min(res.items.len, @max(k * rerank_mult, k));
+            const Rerank = struct { id: u32, d: f32 };
+            var rr: std.ArrayList(Rerank) = .empty;
+            defer rr.deinit(alloc);
+            try rr.ensureTotalCapacity(alloc, rerank_n);
+            for (res.items[0..rerank_n]) |c| {
+                rr.appendAssumeCapacity(.{ .id = c.id, .d = self.distTo(nq, c.id) });
+            }
+            std.mem.sort(Rerank, rr.items, {}, struct {
+                fn lt(_: void, a: Rerank, b: Rerank) bool {
+                    return a.d < b.d;
+                }
+            }.lt);
+
+            const out = try alloc.alloc(SearchResult, @min(k, rr.items.len));
+            for (out, 0..) |*o, i| o.* = .{ .id = rr.items[i].id, .distance = rr.items[i].d };
+            return out;
+        }
+
+        pub const GRAPH_MAGIC: u32 = 0x57534E48; // 'HNSW' le
+        pub const GRAPH_VERSION: u32 = 1;
+        /// Version 2: f32 slab is optional (FLAG_HAS_F32). Version 1 always has f32.
+        pub const GRAPH_VERSION_OPT_F32: u32 = 2;
+        pub const FLAG_HAS_QVECS: u32 = 1;
+        pub const FLAG_HAS_F32: u32 = 2;
+
+        pub fn serializedSize(self: *const Self) usize {
+            var n: usize = 48; // header
+            const count = self.len();
+            n += count * 4; // levels
+            n += count * 4; // qscales
+            if (self.opts.store_f32) n += count * self.dim * 4; // f32
+            n += count * self.dim; // i8
+            var id: u32 = 0;
+            while (id < count) : (id += 1) {
+                const n_layers = self.layerCount(id);
+                n += 4; // n_layers
+                var layer: u32 = 0;
+                while (layer < n_layers) : (layer += 1) {
+                    n += 4 + self.degree(id, layer) * 4;
+                }
+            }
+            return n;
+        }
+
+        /// Little-endian graph blob: header + levels + qscales + f32 + i8 + links.
+        /// Does not include external document ids. On-disk format is unchanged.
+        pub fn serialize(self: *const Self, alloc: std.mem.Allocator) ![]u8 {
+            const buf = try alloc.alloc(u8, self.serializedSize());
+            errdefer alloc.free(buf);
+            var i: usize = 0;
+            const wr = struct {
+                fn u32le(b: []u8, off: *usize, v: u32) void {
+                    std.mem.writeInt(u32, b[off.*..][0..4], v, .little);
+                    off.* += 4;
+                }
+                fn u64le(b: []u8, off: *usize, v: u64) void {
+                    std.mem.writeInt(u64, b[off.*..][0..8], v, .little);
+                    off.* += 8;
+                }
+            };
+            wr.u32le(buf, &i, GRAPH_MAGIC);
+            const version: u32 = if (self.opts.store_f32) GRAPH_VERSION else GRAPH_VERSION_OPT_F32;
+            wr.u32le(buf, &i, version);
+            wr.u64le(buf, &i, self.dim);
+            wr.u64le(buf, &i, self.len());
+            wr.u32le(buf, &i, self.entryPoint() orelse std.math.maxInt(u32));
+            wr.u32le(buf, &i, self.getMaxLevel());
+            wr.u32le(buf, &i, self.opts.m);
+            wr.u32le(buf, &i, self.opts.m0_factor);
+            wr.u32le(buf, &i, self.opts.ef_construction);
+            var flags: u32 = FLAG_HAS_QVECS;
+            if (self.opts.store_f32) flags |= FLAG_HAS_F32;
+            wr.u32le(buf, &i, flags);
+
+            var sid: u32 = 0;
+            while (sid < self.len()) : (sid += 1) wr.u32le(buf, &i, self.levelOf(sid));
+            sid = 0;
+            while (sid < self.len()) : (sid += 1) {
+                const bits: u32 = @bitCast(self.qscaleOf(sid));
+                wr.u32le(buf, &i, bits);
+            }
+            if (self.opts.store_f32) {
+                sid = 0;
+                while (sid < self.len()) : (sid += 1) {
+                    const row = self.vectorConst(sid);
+                    const fbytes = std.mem.sliceAsBytes(row);
+                    @memcpy(buf[i..][0..fbytes.len], fbytes);
+                    i += fbytes.len;
+                }
+            }
+            sid = 0;
+            while (sid < self.len()) : (sid += 1) {
+                const row = self.qvecConst(sid);
+                const qbytes = std.mem.sliceAsBytes(row);
+                @memcpy(buf[i..][0..qbytes.len], qbytes);
+                i += qbytes.len;
+            }
+            var id: u32 = 0;
+            while (id < self.len()) : (id += 1) {
+                const n_layers = self.layerCount(id);
+                wr.u32le(buf, &i, n_layers);
+                var layer: u32 = 0;
+                while (layer < n_layers) : (layer += 1) {
+                    const nbrs = self.neighbors(id, layer);
+                    wr.u32le(buf, &i, @intCast(nbrs.len));
+                    for (nbrs) |nid| wr.u32le(buf, &i, nid);
+                }
+            }
+            if (i != buf.len) return error.SerializeSizeMismatch;
+            return buf;
+        }
+
+        /// Populate an empty index from `serialize` output. No HNSW rebuild.
+        /// Accepts the legacy GRAPH blob or an HMLS slab image (copy-in).
+        pub fn load(self: *Self, bytes: []const u8) !void {
+            if (self.len() != 0) return error.NotEmpty;
+            if (bytes.len >= 4) {
+                const magic = std.mem.readInt(u32, bytes[0..4], .little);
+                if (magic == SLAB_MAGIC) return self.loadSlabsCopy(bytes);
+            }
+            const original_allocator = self.allocator;
+            const original_dim = self.dim;
+            const original_options = self.opts;
+            errdefer {
+                self.deinit();
+                self.* = Self.init(original_allocator, original_dim, original_options);
+            }
+            if (bytes.len < 48) return error.Truncated;
+            var i: usize = 0;
+            const rd = struct {
+                fn u32le(b: []const u8, off: *usize) !u32 {
+                    if (off.* > b.len or 4 > b.len - off.*) return error.Truncated;
+                    const v = std.mem.readInt(u32, b[off.*..][0..4], .little);
+                    off.* += 4;
+                    return v;
+                }
+                fn u64le(b: []const u8, off: *usize) !u64 {
+                    if (off.* > b.len or 8 > b.len - off.*) return error.Truncated;
+                    const v = std.mem.readInt(u64, b[off.*..][0..8], .little);
+                    off.* += 8;
+                    return v;
+                }
+            };
+            if (try rd.u32le(bytes, &i) != GRAPH_MAGIC) return error.BadMagic;
+            const version = try rd.u32le(bytes, &i);
+            if (version != GRAPH_VERSION and version != GRAPH_VERSION_OPT_F32) return error.UnsupportedVersion;
+            if (bytes.len > MAX_COPY_LOAD_BYTES) return error.CopyLoadBudgetExceeded;
+            const dim = std.math.cast(usize, try rd.u64le(bytes, &i)) orelse return error.InvalidSlabLayout;
+            const n = std.math.cast(usize, try rd.u64le(bytes, &i)) orelse return error.InvalidSlabLayout;
+            const ep_raw = try rd.u32le(bytes, &i);
+            const max_level = try rd.u32le(bytes, &i);
+            const m = try rd.u32le(bytes, &i);
+            const m0_factor = try rd.u32le(bytes, &i);
+            const efc = try rd.u32le(bytes, &i);
+            const flags = try rd.u32le(bytes, &i);
+            // v1 always stored f32; v2 honors FLAG_HAS_F32 so a no-f32 snapshot
+            // (and a later WAL compact of that ns) cannot crash on a missing slab.
+            const has_f32 = version == GRAPH_VERSION or (flags & FLAG_HAS_F32) != 0;
+            if (dim == 0 or dim > std.math.maxInt(u16) or n > std.math.maxInt(u32)) return error.InvalidSlabLayout;
+            if (m == 0 or m > 1024 or m0_factor == 0 or m0_factor > 16 or max_level > 64) return error.InvalidSlabLayout;
+            if ((flags & FLAG_HAS_QVECS) == 0 or (flags & ~(FLAG_HAS_QVECS | FLAG_HAS_F32)) != 0) return error.InvalidSlabLayout;
+            if ((n == 0 and (ep_raw != std.math.maxInt(u32) or max_level != 0)) or
+                (n != 0 and ep_raw == std.math.maxInt(u32))) return error.InvalidNeighborId;
+            if (self.dim == 0) self.dim = dim;
+            if (self.dim != dim) return error.DimensionMismatch;
+            self.opts.m = m;
+            self.opts.m0_factor = m0_factor;
+            self.opts.ef_construction = efc;
+            self.opts.store_f32 = has_f32;
+            self.setMaxLevel(max_level);
+            if (ep_raw != std.math.maxInt(u32) and ep_raw >= n) return error.InvalidNeighborId;
+            if (ep_raw == std.math.maxInt(u32)) {
+                @atomicStore(u32, &self.entry_id, std.math.maxInt(u32), .release);
+            } else {
+                self.setEntryPoint(ep_raw);
+            }
+
+            const alloc = self.allocator;
+            const vector_count = std.math.mul(usize, n, dim) catch return error.InvalidSlabLayout;
+            const l0_count = std.math.mul(usize, n, self.l0Stride()) catch return error.InvalidSlabLayout;
+            const baseline_layout = try SlabLayout.compute(n, dim, 0, self.l0Stride(), self.hiStride());
+            if (try baseline_layout.graphValidationBytes(self.l0Stride(), self.hiStride()) > MAX_GRAPH_VALIDATION_BYTES) {
+                return error.GraphValidationBudgetExceeded;
+            }
+            var minimum_payload = std.math.mul(usize, n, 8) catch return error.InvalidSlabLayout; // levels + qscales
+            minimum_payload = std.math.add(usize, minimum_payload, vector_count) catch return error.InvalidSlabLayout;
+            if (has_f32) {
+                const f32_bytes = std.math.mul(usize, vector_count, @sizeOf(f32)) catch return error.InvalidSlabLayout;
+                minimum_payload = std.math.add(usize, minimum_payload, f32_bytes) catch return error.InvalidSlabLayout;
+            }
+            const layer_count_bytes = std.math.mul(usize, n, @sizeOf(u32)) catch return error.InvalidSlabLayout;
+            minimum_payload = std.math.add(usize, minimum_payload, layer_count_bytes) catch return error.InvalidSlabLayout;
+            if (i > bytes.len or minimum_payload > bytes.len - i) return error.Truncated;
+            try self.levels.ensureTotalCapacity(alloc, n);
+            try self.qscales.ensureTotalCapacity(alloc, n);
+            if (has_f32) try self.vectors_flat.ensureTotalCapacity(alloc, vector_count);
+            try self.qvecs_flat.ensureTotalCapacity(alloc, vector_count);
+            try self.l0_deg.ensureTotalCapacity(alloc, n);
+            try self.l0_nbrs.ensureTotalCapacity(alloc, l0_count);
+            try self.hi_start.ensureTotalCapacity(alloc, n);
+            try self.nbr_gen.ensureTotalCapacity(alloc, n);
+            try self.vec_gen.ensureTotalCapacity(alloc, n);
+
+            for (0..n) |_| self.levels.appendAssumeCapacity(try rd.u32le(bytes, &i));
+            for (0..n) |_| {
+                const bits = try rd.u32le(bytes, &i);
+                self.qscales.appendAssumeCapacity(@bitCast(bits));
+            }
+            if (has_f32) {
+                const fnbytes = std.math.mul(usize, vector_count, @sizeOf(f32)) catch return error.InvalidSlabLayout;
+                if (i > bytes.len or fnbytes > bytes.len - i) return error.Truncated;
+                const fdest = try self.vectors_flat.addManyAsSlice(alloc, vector_count);
+                @memcpy(std.mem.sliceAsBytes(fdest), bytes[i..][0..fnbytes]);
+                i += fnbytes;
+            }
+            const qnbytes = vector_count;
+            if (i > bytes.len or qnbytes > bytes.len - i) return error.Truncated;
+            const qdest = try self.qvecs_flat.addManyAsSlice(alloc, vector_count);
+            @memcpy(std.mem.sliceAsBytes(qdest), bytes[i..][0..qnbytes]);
+            i += qnbytes;
+
+            var id: u32 = 0;
+            var hi_slots_total: usize = 0;
+            while (id < n) : (id += 1) {
+                const n_layers: usize = @intCast(try rd.u32le(bytes, &i));
+                if (n_layers == 0 or n_layers > 65) return error.InvalidSlabLayout;
+                const level: u32 = @intCast(n_layers - 1);
+                if (id >= self.levels.items.len) return error.Truncated;
+                if (self.levels.items[id] != level or level > max_level) return error.InvalidSlabLayout;
+                self.levels.items[id] = level;
+                self.l0_deg.appendAssumeCapacity(0);
+                self.nbr_gen.appendAssumeCapacity(0);
+                self.vec_gen.appendAssumeCapacity(0);
+                const l0_pad = try self.l0_nbrs.addManyAsSlice(alloc, self.l0Stride());
+                @memset(l0_pad, 0);
+                try self.hi_start.append(alloc, @intCast(self.hi_deg.items.len));
+                if (level > 0) {
+                    const slots: usize = level;
+                    hi_slots_total = std.math.add(usize, hi_slots_total, slots) catch return error.InvalidSlabLayout;
+                    const max_hi_slots = std.math.mul(usize, n, 64) catch return error.InvalidSlabLayout;
+                    if (hi_slots_total > max_hi_slots or hi_slots_total > std.math.maxInt(u32)) return error.InvalidSlabLayout;
+                    const bounded_layout = try SlabLayout.compute(n, dim, hi_slots_total, self.l0Stride(), self.hiStride());
+                    if (try bounded_layout.graphValidationBytes(self.l0Stride(), self.hiStride()) > MAX_GRAPH_VALIDATION_BYTES) {
+                        return error.GraphValidationBudgetExceeded;
+                    }
+                    const degs = try self.hi_deg.addManyAsSlice(alloc, slots);
+                    @memset(degs, 0);
+                    const neighbor_slots = std.math.mul(usize, slots, self.hiStride()) catch return error.InvalidSlabLayout;
+                    const nbrs = try self.hi_nbrs.addManyAsSlice(alloc, neighbor_slots);
+                    @memset(nbrs, 0);
+                }
+                var layer: u32 = 0;
+                while (layer < n_layers) : (layer += 1) {
+                    const deg: usize = @intCast(try rd.u32le(bytes, &i));
+                    if (deg > self.neighborSlots(id, layer).len) return error.DegreeOverflow;
+                    var k: usize = 0;
+                    while (k < deg) : (k += 1) {
+                        const neighbor = try rd.u32le(bytes, &i);
+                        if (neighbor >= n) return error.InvalidNeighborId;
+                        self.neighborSlots(id, layer)[k] = neighbor;
+                    }
+                    self.setDegree(id, layer, @intCast(deg));
+                }
+            }
+            if (i != bytes.len) return error.TrailingBytes;
+            @atomicStore(usize, &self.published, n, .release);
+            try self.validateOwnedGraph();
+        }
+
+        fn pageAlign(n: usize) !usize {
+            const mask = std.heap.page_size_min - 1;
+            const rounded = std.math.add(usize, n, mask) catch return error.InvalidSlabLayout;
+            return rounded & ~mask;
+        }
+
+        fn hiSlotCount(self: *const Self) usize {
+            const extra = self.hi_deg.items.len;
+            return if (self.slab_map) |m| m.hi_slots + extra else extra;
+        }
+
+        const SlabLayout = struct {
+            n: usize,
+            dim: usize,
+            hi_slots: usize,
+            levels_off: usize,
+            qscales_off: usize,
+            vectors_off: usize,
+            qvecs_off: usize,
+            l0_deg_off: usize,
+            l0_nbrs_off: usize,
+            hi_start_off: usize,
+            hi_deg_off: usize,
+            hi_nbrs_off: usize,
+            file_len: usize,
+
+            fn regionEnd(off: usize, count: usize, elem_size: usize) !usize {
+                const bytes = std.math.mul(usize, count, elem_size) catch return error.InvalidSlabLayout;
+                return pageAlign(std.math.add(usize, off, bytes) catch return error.InvalidSlabLayout);
+            }
+
+            fn product(a: usize, b: usize) !usize {
+                return std.math.mul(usize, a, b) catch return error.InvalidSlabLayout;
+            }
+
+            fn compute(n: usize, dim: usize, hi_slots: usize, l0_stride: usize, hi_stride: usize) !SlabLayout {
+                var off: usize = try pageAlign(SLAB_HEADER_SIZE);
+                const levels_off = off;
+                off = try regionEnd(off, n, @sizeOf(u32));
+                const qscales_off = off;
+                off = try regionEnd(off, n, @sizeOf(f32));
+                const vectors_off = off;
+                off = try regionEnd(off, try product(n, dim), @sizeOf(f32));
+                const qvecs_off = off;
+                off = try regionEnd(off, try product(n, dim), @sizeOf(i8));
+                const l0_deg_off = off;
+                off = try regionEnd(off, n, @sizeOf(u16));
+                const l0_nbrs_off = off;
+                off = try regionEnd(off, try product(n, l0_stride), @sizeOf(u32));
+                const hi_start_off = off;
+                off = try regionEnd(off, n, @sizeOf(u32));
+                const hi_deg_off = off;
+                off = try regionEnd(off, hi_slots, @sizeOf(u16));
+                const hi_nbrs_off = off;
+                off = try regionEnd(off, try product(hi_slots, hi_stride), @sizeOf(u32));
+                return .{
+                    .n = n,
+                    .dim = dim,
+                    .hi_slots = hi_slots,
+                    .levels_off = levels_off,
+                    .qscales_off = qscales_off,
+                    .vectors_off = vectors_off,
+                    .qvecs_off = qvecs_off,
+                    .l0_deg_off = l0_deg_off,
+                    .l0_nbrs_off = l0_nbrs_off,
+                    .hi_start_off = hi_start_off,
+                    .hi_deg_off = hi_deg_off,
+                    .hi_nbrs_off = hi_nbrs_off,
+                    .file_len = off,
+                };
+            }
+
+            fn graphValidationBytes(self: SlabLayout, l0_stride: usize, hi_stride: usize) !usize {
+                var total: usize = 0;
+                total = std.math.add(usize, total, std.math.mul(usize, self.n, @sizeOf(u32)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                total = std.math.add(usize, total, std.math.mul(usize, self.n, @sizeOf(u16)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                total = std.math.add(usize, total, std.math.mul(usize, try product(self.n, l0_stride), @sizeOf(u32)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                total = std.math.add(usize, total, std.math.mul(usize, self.n, @sizeOf(u32)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                total = std.math.add(usize, total, std.math.mul(usize, self.hi_slots, @sizeOf(u16)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                total = std.math.add(usize, total, std.math.mul(usize, try product(self.hi_slots, hi_stride), @sizeOf(u32)) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+                return total;
+            }
+        };
+
+        fn writeHeaderBytes(buf: []u8, layout: SlabLayout, self: *const Self) void {
+            @memset(buf[0..SLAB_HEADER_SIZE], 0);
+            std.mem.writeInt(u32, buf[0..4], SLAB_MAGIC, .little);
+            std.mem.writeInt(u32, buf[4..8], SLAB_VERSION, .little);
+            std.mem.writeInt(u64, buf[8..16], layout.dim, .little);
+            std.mem.writeInt(u64, buf[16..24], layout.n, .little);
+            std.mem.writeInt(u32, buf[24..28], self.entryPoint() orelse 0, .little);
+            std.mem.writeInt(u32, buf[28..32], self.getMaxLevel(), .little);
+            std.mem.writeInt(u32, buf[32..36], self.opts.m, .little);
+            std.mem.writeInt(u32, buf[36..40], self.opts.m0_factor, .little);
+            std.mem.writeInt(u32, buf[40..44], self.opts.ef_construction, .little);
+            std.mem.writeInt(u32, buf[44..48], 1, .little);
+            std.mem.writeInt(u64, buf[48..56], layout.hi_slots, .little);
+            std.mem.writeInt(u64, buf[56..64], layout.levels_off, .little);
+            std.mem.writeInt(u64, buf[64..72], layout.qscales_off, .little);
+            std.mem.writeInt(u64, buf[72..80], layout.vectors_off, .little);
+            std.mem.writeInt(u64, buf[80..88], layout.qvecs_off, .little);
+            std.mem.writeInt(u64, buf[88..96], layout.l0_deg_off, .little);
+            std.mem.writeInt(u64, buf[96..104], layout.l0_nbrs_off, .little);
+            std.mem.writeInt(u64, buf[104..112], layout.hi_start_off, .little);
+            std.mem.writeInt(u64, buf[112..120], layout.hi_deg_off, .little);
+            std.mem.writeInt(u64, buf[120..128], layout.hi_nbrs_off, .little);
+            std.mem.writeInt(u64, buf[128..136], layout.file_len, .little);
+        }
+
+        fn parseLayout(bytes: []const u8) !struct { layout: SlabLayout, entry: u32, max_level: u32, m: u32, m0_factor: u32, efc: u32 } {
+            if (bytes.len < SLAB_HEADER_SIZE) return error.Truncated;
+            if (std.mem.readInt(u32, bytes[0..4], .little) != SLAB_MAGIC) return error.BadMagic;
+            if (std.mem.readInt(u32, bytes[4..8], .little) != SLAB_VERSION) return error.UnsupportedVersion;
+            const dim = std.math.cast(usize, std.mem.readInt(u64, bytes[8..16], .little)) orelse return error.InvalidSlabLayout;
+            const n = std.math.cast(usize, std.mem.readInt(u64, bytes[16..24], .little)) orelse return error.InvalidSlabLayout;
+            const entry = std.mem.readInt(u32, bytes[24..28], .little);
+            const max_level = std.mem.readInt(u32, bytes[28..32], .little);
+            const m = std.mem.readInt(u32, bytes[32..36], .little);
+            const m0_factor = std.mem.readInt(u32, bytes[36..40], .little);
+            const efc = std.mem.readInt(u32, bytes[40..44], .little);
+            const hi_slots = std.math.cast(usize, std.mem.readInt(u64, bytes[48..56], .little)) orelse return error.InvalidSlabLayout;
+            if (dim == 0 or dim > std.math.maxInt(u16) or n > std.math.maxInt(u32)) return error.InvalidSlabLayout;
+            if (m == 0 or m > 1024 or m0_factor == 0 or m0_factor > 16) return error.InvalidSlabLayout;
+            if (n == 0) {
+                if (entry != 0 or max_level != 0 or hi_slots != 0) return error.InvalidSlabLayout;
+            } else if (entry >= n) return error.InvalidNeighborId;
+            const max_hi_slots = std.math.mul(usize, n, 64) catch return error.InvalidSlabLayout;
+            if (hi_slots > max_hi_slots) return error.InvalidSlabLayout;
+            const layout = SlabLayout{
+                .n = n,
+                .dim = dim,
+                .hi_slots = hi_slots,
+                .levels_off = std.math.cast(usize, std.mem.readInt(u64, bytes[56..64], .little)) orelse return error.InvalidSlabLayout,
+                .qscales_off = std.math.cast(usize, std.mem.readInt(u64, bytes[64..72], .little)) orelse return error.InvalidSlabLayout,
+                .vectors_off = std.math.cast(usize, std.mem.readInt(u64, bytes[72..80], .little)) orelse return error.InvalidSlabLayout,
+                .qvecs_off = std.math.cast(usize, std.mem.readInt(u64, bytes[80..88], .little)) orelse return error.InvalidSlabLayout,
+                .l0_deg_off = std.math.cast(usize, std.mem.readInt(u64, bytes[88..96], .little)) orelse return error.InvalidSlabLayout,
+                .l0_nbrs_off = std.math.cast(usize, std.mem.readInt(u64, bytes[96..104], .little)) orelse return error.InvalidSlabLayout,
+                .hi_start_off = std.math.cast(usize, std.mem.readInt(u64, bytes[104..112], .little)) orelse return error.InvalidSlabLayout,
+                .hi_deg_off = std.math.cast(usize, std.mem.readInt(u64, bytes[112..120], .little)) orelse return error.InvalidSlabLayout,
+                .hi_nbrs_off = std.math.cast(usize, std.mem.readInt(u64, bytes[120..128], .little)) orelse return error.InvalidSlabLayout,
+                .file_len = std.math.cast(usize, std.mem.readInt(u64, bytes[128..136], .little)) orelse return error.InvalidSlabLayout,
+            };
+            // Neighbor arrays reserve one overflow/candidate slot beyond M;
+            // persistence uses the same physical strides as l0Stride/hiStride.
+            const m0_count = std.math.mul(usize, m, m0_factor) catch return error.InvalidSlabLayout;
+            const l0_stride = std.math.add(usize, m0_count, 1) catch return error.InvalidSlabLayout;
+            const hi_stride = std.math.add(usize, m, 1) catch return error.InvalidSlabLayout;
+            const expected = try SlabLayout.compute(n, dim, hi_slots, l0_stride, hi_stride);
+            if (try expected.graphValidationBytes(l0_stride, hi_stride) > MAX_GRAPH_VALIDATION_BYTES) {
+                return error.GraphValidationBudgetExceeded;
+            }
+            if (layout.levels_off != expected.levels_off or
+                layout.qscales_off != expected.qscales_off or
+                layout.vectors_off != expected.vectors_off or
+                layout.qvecs_off != expected.qvecs_off or
+                layout.l0_deg_off != expected.l0_deg_off or
+                layout.l0_nbrs_off != expected.l0_nbrs_off or
+                layout.hi_start_off != expected.hi_start_off or
+                layout.hi_deg_off != expected.hi_deg_off or
+                layout.hi_nbrs_off != expected.hi_nbrs_off or
+                layout.file_len != expected.file_len) return error.InvalidSlabLayout;
+            return .{ .layout = layout, .entry = entry, .max_level = max_level, .m = m, .m0_factor = m0_factor, .efc = efc };
+        }
+
+        fn validateMappedGraph(self: *const Self) !void {
+            const mapped = self.slab_map orelse return error.NotMmapBacked;
+            const n = mapped.n;
+            if (n == 0) return;
+            const entry = self.entryPoint() orelse return error.InvalidNeighborId;
+            if (entry >= n) return error.InvalidNeighborId;
+            const max_level = self.getMaxLevel();
+            var observed_max_level: u32 = 0;
+            const l0_stride = self.l0Stride();
+            const hi_stride = self.hiStride();
+            for (0..n) |id| {
+                const level = mapped.levels[id];
+                if (level > max_level or level > 64) return error.InvalidSlabLayout;
+                observed_max_level = @max(observed_max_level, level);
+                const degree0: usize = mapped.l0_deg[id];
+                if (degree0 > l0_stride) return error.DegreeOverflow;
+                const base0 = id * l0_stride;
+                for (mapped.l0_nbrs[base0..][0..degree0]) |neighbor| {
+                    if (neighbor >= n) return error.InvalidNeighborId;
+                }
+                const hi_start: usize = mapped.hi_start[id];
+                if (hi_start > mapped.hi_slots or level > mapped.hi_slots - hi_start) return error.InvalidSlabLayout;
+                for (0..level) |slot_offset| {
+                    const slot = hi_start + slot_offset;
+                    const high_degree: usize = mapped.hi_deg[slot];
+                    if (high_degree > hi_stride) return error.DegreeOverflow;
+                    const base = slot * hi_stride;
+                    for (mapped.hi_nbrs[base..][0..high_degree]) |neighbor| {
+                        if (neighbor >= n) return error.InvalidNeighborId;
+                    }
+                }
+            }
+            if (observed_max_level != max_level or mapped.levels[entry] != max_level) return error.InvalidSlabLayout;
+        }
+
+        fn validateOwnedGraph(self: *const Self) !void {
+            const n = self.len();
+            const l0_stride = self.l0Stride();
+            const hi_stride = self.hiStride();
+            const vector_count = std.math.mul(usize, n, self.dim) catch return error.InvalidSlabLayout;
+            const l0_count = std.math.mul(usize, n, l0_stride) catch return error.InvalidSlabLayout;
+            const hi_count = std.math.mul(usize, self.hi_deg.items.len, hi_stride) catch return error.InvalidSlabLayout;
+            if (self.levels.items.len != n or self.qscales.items.len != n or
+                self.qvecs_flat.items.len != vector_count or self.l0_deg.items.len != n or
+                self.l0_nbrs.items.len != l0_count or self.hi_start.items.len != n or
+                self.hi_nbrs.items.len != hi_count) return error.InvalidSlabLayout;
+            if (n == 0) {
+                if (self.entryPoint() != null or self.getMaxLevel() != 0 or self.hi_deg.items.len != 0) return error.InvalidSlabLayout;
+                return;
+            }
+            const entry = self.entryPoint() orelse return error.InvalidNeighborId;
+            if (entry >= n) return error.InvalidNeighborId;
+            const max_level = self.getMaxLevel();
+            var observed_max_level: u32 = 0;
+            for (0..n) |id| {
+                const level = self.levels.items[id];
+                if (level > max_level or level > 64) return error.InvalidSlabLayout;
+                observed_max_level = @max(observed_max_level, level);
+                const degree0: usize = self.l0_deg.items[id];
+                if (degree0 > l0_stride) return error.DegreeOverflow;
+                const base0 = std.math.mul(usize, id, l0_stride) catch return error.InvalidSlabLayout;
+                for (self.l0_nbrs.items[base0..][0..degree0]) |neighbor| {
+                    if (neighbor >= n) return error.InvalidNeighborId;
+                }
+                const hi_start: usize = self.hi_start.items[id];
+                if (hi_start > self.hi_deg.items.len or level > self.hi_deg.items.len - hi_start) return error.InvalidSlabLayout;
+                for (0..level) |slot_offset| {
+                    const slot = hi_start + slot_offset;
+                    const high_degree: usize = self.hi_deg.items[slot];
+                    if (high_degree > hi_stride) return error.DegreeOverflow;
+                    const base = std.math.mul(usize, slot, hi_stride) catch return error.InvalidSlabLayout;
+                    for (self.hi_nbrs.items[base..][0..high_degree]) |neighbor| {
+                        if (neighbor >= n) return error.InvalidNeighborId;
+                    }
+                }
+            }
+            if (observed_max_level != max_level or self.levels.items[entry] != max_level) return error.InvalidSlabLayout;
+        }
+
+        fn sysWriteAll(fd: posix.fd_t, bytes: []const u8) !void {
+            var off: usize = 0;
+            while (off < bytes.len) {
+                const n = posix.system.write(fd, bytes[off..].ptr, bytes.len - off);
+                switch (posix.errno(n)) {
+                    .SUCCESS => off += @intCast(n),
+                    .INTR => continue,
+                    else => return error.WriteFailed,
+                }
+            }
+        }
+
+        fn sysPwriteAll(fd: posix.fd_t, bytes: []const u8, offset: u64) !void {
+            var off: usize = 0;
+            while (off < bytes.len) {
+                const write_offset = std.math.add(u64, offset, off) catch return error.InvalidSlabLayout;
+                const file_offset = std.math.cast(posix.off_t, write_offset) orelse return error.InvalidSlabLayout;
+                const n = posix.system.pwrite(fd, bytes[off..].ptr, bytes.len - off, file_offset);
+                switch (posix.errno(n)) {
+                    .SUCCESS => off += @intCast(n),
+                    .INTR => continue,
+                    else => return error.WriteFailed,
+                }
+            }
+        }
+
+        fn sysPreadAll(fd: posix.fd_t, dest: []u8, offset: u64) !void {
+            var off: usize = 0;
+            while (off < dest.len) {
+                const read_offset = std.math.add(u64, offset, off) catch return error.InvalidSlabLayout;
+                const file_offset = std.math.cast(posix.off_t, read_offset) orelse return error.InvalidSlabLayout;
+                const n = posix.system.pread(fd, dest[off..].ptr, dest.len - off, file_offset);
+                switch (posix.errno(n)) {
+                    .SUCCESS => {
+                        if (n == 0) return error.Truncated;
+                        off += @intCast(n);
+                    },
+                    .INTR => continue,
+                    else => return error.ReadFailed,
+                }
+            }
+        }
+
+        fn writeConcat(fd: posix.fd_t, file_off: u64, a: []const u8, b: []const u8) !void {
+            if (a.len > 0) try sysPwriteAll(fd, a, file_off);
+            if (b.len > 0) try sysPwriteAll(fd, b, std.math.add(u64, file_off, a.len) catch return error.InvalidSlabLayout);
+        }
+
+        fn syncParentDir(path: []const u8) !void {
+            if (comptime builtin.os.tag == .windows) return;
+            const parent = std.fs.path.dirname(path) orelse ".";
+            const dir_fd = try posix.openat(posix.AT.FDCWD, parent, .{
+                .ACCMODE = .RDONLY,
+                .CLOEXEC = true,
+                .DIRECTORY = true,
+            }, 0);
+            defer _ = posix.system.close(dir_fd);
+            switch (posix.errno(posix.system.fsync(dir_fd))) {
+                .SUCCESS => {},
+                else => return error.SyncFailed,
+            }
+        }
+
+        fn mappedLevels(self: *const Self) []const u32 {
+            return if (self.slab_map) |m| m.levels else &.{};
+        }
+        fn mappedQscales(self: *const Self) []const f32 {
+            return if (self.slab_map) |m| m.qscales else &.{};
+        }
+        fn mappedVectors(self: *const Self) []const f32 {
+            return if (self.slab_map) |m| m.vectors else &.{};
+        }
+        fn mappedQvecs(self: *const Self) []const i8 {
+            return if (self.slab_map) |m| m.qvecs else &.{};
+        }
+        fn mappedL0Deg(self: *const Self) []const u16 {
+            return if (self.slab_map) |m| m.l0_deg else &.{};
+        }
+        fn mappedL0Nbrs(self: *const Self) []const u32 {
+            return if (self.slab_map) |m| m.l0_nbrs else &.{};
+        }
+        fn mappedHiStart(self: *const Self) []const u32 {
+            return if (self.slab_map) |m| m.hi_start else &.{};
+        }
+        fn mappedHiDeg(self: *const Self) []const u16 {
+            return if (self.slab_map) |m| m.hi_deg else &.{};
+        }
+        fn mappedHiNbrs(self: *const Self) []const u32 {
+            return if (self.slab_map) |m| m.hi_nbrs else &.{};
+        }
+
+        /// Byte size of a standalone HMLS image for this index.
+        pub fn slabImageSize(self: *const Self) !usize {
+            const n = self.len();
+            return (try SlabLayout.compute(n, self.dim, self.hiSlotCount(), self.l0Stride(), self.hiStride())).file_len;
+        }
+
+        /// Atomically write an HMLS slab file (`path.tmp` → fsync → rename).
+        /// The live snapshot is never opened writeable; a crash leaves `path` intact.
+        pub fn writeSlabs(self: *const Self, path: []const u8) !void {
+            var tmp_buf: [posix.PATH_MAX]u8 = undefined;
+            const tmp = try std.fmt.bufPrint(&tmp_buf, "{s}.tmp", .{path});
+            const fd = try posix.openat(posix.AT.FDCWD, tmp, .{
+                .ACCMODE = .WRONLY,
+                .CREAT = true,
+                .TRUNC = true,
+                .CLOEXEC = true,
+            }, 0o600);
+            var closed = false;
+            defer {
+                if (!closed) _ = posix.system.close(fd);
+            }
+            errdefer {
+                if (posix.toPosixPath(tmp)) |z| {
+                    _ = posix.system.unlink(&z);
+                } else |_| {}
+            }
+            _ = try self.writeSlabsAt(fd, 0);
+            switch (posix.errno(posix.system.fdatasync(fd))) {
+                .SUCCESS => {},
+                else => return error.SyncFailed,
+            }
+            _ = posix.system.close(fd);
+            closed = true;
+            const z_tmp = try posix.toPosixPath(tmp);
+            const z_dst = try posix.toPosixPath(path);
+            switch (posix.errno(posix.system.renameat(posix.AT.FDCWD, &z_tmp, posix.AT.FDCWD, &z_dst))) {
+                .SUCCESS => {},
+                else => return error.RenameFailed,
+            }
+            try syncParentDir(path);
+        }
+
+        /// Write an HMLS image starting at `hmls_off` in an already-open file.
+        /// Used by persist to prefix a SNAP envelope. Returns image size.
+        pub fn writeSlabsAt(self: *const Self, fd: posix.fd_t, hmls_off: u64) !u64 {
+            const n = self.len();
+            const layout = try SlabLayout.compute(n, self.dim, self.hiSlotCount(), self.l0Stride(), self.hiStride());
+            const end = std.math.add(u64, hmls_off, layout.file_len) catch return error.InvalidSlabLayout;
+            const at = struct {
+                fn offset(base: u64, relative: usize) !u64 {
+                    return std.math.add(u64, base, relative) catch return error.InvalidSlabLayout;
+                }
+            }.offset;
+            var hdr: [SLAB_HEADER_SIZE]u8 = undefined;
+            writeHeaderBytes(&hdr, layout, self);
+            try sysPwriteAll(fd, &hdr, hmls_off);
+
+            const base = hmls_off;
+            try writeConcat(fd, try at(base, layout.levels_off), std.mem.sliceAsBytes(self.mappedLevels()), std.mem.sliceAsBytes(self.levels.items));
+            try writeConcat(fd, try at(base, layout.qscales_off), std.mem.sliceAsBytes(self.mappedQscales()), std.mem.sliceAsBytes(self.qscales.items));
+            try writeConcat(fd, try at(base, layout.vectors_off), std.mem.sliceAsBytes(self.mappedVectors()), std.mem.sliceAsBytes(self.vectors_flat.items));
+            try writeConcat(fd, try at(base, layout.qvecs_off), std.mem.sliceAsBytes(self.mappedQvecs()), std.mem.sliceAsBytes(self.qvecs_flat.items));
+            try writeConcat(fd, try at(base, layout.l0_deg_off), std.mem.sliceAsBytes(self.mappedL0Deg()), std.mem.sliceAsBytes(self.l0_deg.items));
+            try writeConcat(fd, try at(base, layout.l0_nbrs_off), std.mem.sliceAsBytes(self.mappedL0Nbrs()), std.mem.sliceAsBytes(self.l0_nbrs.items));
+
+            const mapped_hi = if (self.slab_map) |m| m.hi_slots else 0;
+            try writeConcat(fd, try at(base, layout.hi_start_off), std.mem.sliceAsBytes(self.mappedHiStart()), &.{});
+            if (self.hi_start.items.len > 0) {
+                var bias_buf: std.ArrayList(u32) = .empty;
+                defer bias_buf.deinit(self.allocator);
+                try bias_buf.ensureTotalCapacity(self.allocator, self.hi_start.items.len);
+                const bias = std.math.cast(u32, mapped_hi) orelse return error.InvalidSlabLayout;
+                for (self.hi_start.items) |v| {
+                    bias_buf.appendAssumeCapacity(std.math.add(u32, v, bias) catch return error.InvalidSlabLayout);
+                }
+                const mapped_hi_start_bytes = std.math.mul(usize, self.mappedHiStart().len, @sizeOf(u32)) catch return error.InvalidSlabLayout;
+                const hi_start_relative = std.math.add(usize, layout.hi_start_off, mapped_hi_start_bytes) catch return error.InvalidSlabLayout;
+                try sysPwriteAll(fd, std.mem.sliceAsBytes(bias_buf.items), try at(base, hi_start_relative));
+            }
+            try writeConcat(fd, try at(base, layout.hi_deg_off), std.mem.sliceAsBytes(self.mappedHiDeg()), std.mem.sliceAsBytes(self.hi_deg.items));
+            try writeConcat(fd, try at(base, layout.hi_nbrs_off), std.mem.sliceAsBytes(self.mappedHiNbrs()), std.mem.sliceAsBytes(self.hi_nbrs.items));
+
+            const truncate_end = std.math.cast(posix.off_t, end) orelse return error.InvalidSlabLayout;
+            switch (posix.errno(posix.system.ftruncate(fd, truncate_end))) {
+                .SUCCESS => {},
+                else => return error.TruncateFailed,
+            }
+            return layout.file_len;
+        }
+
+        /// Sparse HMLS of `n` zero vectors / empty graph. Cheap RSS fixture.
+        pub fn writeBlankSlabs(path: []const u8, n: usize, dim: usize, opts: Options) !void {
+            var index = Self.init(std.heap.page_allocator, dim, opts);
+            defer index.deinit();
+            if (n == 0) {
+                @atomicStore(u32, &index.entry_id, std.math.maxInt(u32), .release);
+            } else {
+                index.setEntryPoint(0);
+            }
+            const layout = try SlabLayout.compute(n, dim, 0, index.l0Stride(), index.hiStride());
+            const truncate_end = std.math.cast(posix.off_t, layout.file_len) orelse return error.InvalidSlabLayout;
+            var tmp_buf: [posix.PATH_MAX]u8 = undefined;
+            const tmp = try std.fmt.bufPrint(&tmp_buf, "{s}.tmp", .{path});
+            const fd = try posix.openat(posix.AT.FDCWD, tmp, .{
+                .ACCMODE = .WRONLY,
+                .CREAT = true,
+                .TRUNC = true,
+                .CLOEXEC = true,
+            }, 0o600);
+            var hdr: [SLAB_HEADER_SIZE]u8 = undefined;
+            writeHeaderBytes(&hdr, layout, &index);
+            const wr = sysPwriteAll(fd, &hdr, 0);
+            const tr = posix.system.ftruncate(fd, truncate_end);
+            const ds = posix.system.fdatasync(fd);
+            _ = posix.system.close(fd);
+            wr catch {
+                const z = posix.toPosixPath(tmp) catch return error.WriteFailed;
+                _ = posix.system.unlink(&z);
+                return error.WriteFailed;
+            };
+            if (posix.errno(tr) != .SUCCESS or posix.errno(ds) != .SUCCESS) {
+                const z = posix.toPosixPath(tmp) catch return error.WriteFailed;
+                _ = posix.system.unlink(&z);
+                return error.WriteFailed;
+            }
+            const z_tmp = try posix.toPosixPath(tmp);
+            const z_dst = try posix.toPosixPath(path);
+            switch (posix.errno(posix.system.renameat(posix.AT.FDCWD, &z_tmp, posix.AT.FDCWD, &z_dst))) {
+                .SUCCESS => {},
+                else => return error.RenameFailed,
+            }
+            try syncParentDir(path);
+        }
+
+        fn sliceField(comptime T: type, bytes: []u8, off: usize, count: usize) ![]T {
+            const nbytes = std.math.mul(usize, count, @sizeOf(T)) catch return error.InvalidSlabLayout;
+            if (off > bytes.len or nbytes > bytes.len - off) return error.Truncated;
+            if (count == 0) return @as([*]T, undefined)[0..0];
+            if (off % @alignOf(T) != 0) return error.Misaligned;
+            const raw = bytes[off..][0..nbytes];
+            return @as([*]T, @ptrCast(@alignCast(raw.ptr)))[0..count];
+        }
+
+        fn attachMapped(self: *Self, bytes: []align(std.heap.page_size_min) u8, hmls_off: usize) !void {
+            if (hmls_off > bytes.len or SLAB_HEADER_SIZE > bytes.len - hmls_off) return error.Truncated;
+            const parsed = try parseLayout(bytes[hmls_off..]);
+            const L = parsed.layout;
+            if (self.dim == 0) self.dim = L.dim;
+            if (self.dim != L.dim) return error.DimensionMismatch;
+            self.opts.m = parsed.m;
+            self.opts.m0_factor = parsed.m0_factor;
+            self.opts.ef_construction = parsed.efc;
+            self.setMaxLevel(parsed.max_level);
+            if (L.n == 0) {
+                @atomicStore(u32, &self.entry_id, std.math.maxInt(u32), .release);
+            } else {
+                self.setEntryPoint(parsed.entry);
+            }
+            @atomicStore(usize, &self.published, L.n, .release);
+
+            const base = hmls_off;
+            const l0_stride = self.l0Stride();
+            const hi_stride = self.hiStride();
+            const vector_count = std.math.mul(usize, L.n, L.dim) catch return error.InvalidSlabLayout;
+            const l0_count = std.math.mul(usize, L.n, l0_stride) catch return error.InvalidSlabLayout;
+            const hi_count = std.math.mul(usize, L.hi_slots, hi_stride) catch return error.InvalidSlabLayout;
+            const at = struct {
+                fn offset(root: usize, relative: usize) !usize {
+                    return std.math.add(usize, root, relative) catch return error.InvalidSlabLayout;
+                }
+            }.offset;
+            const need = std.math.add(usize, base, L.file_len) catch return error.InvalidSlabLayout;
+            if (bytes.len < need) return error.Truncated;
+
+            self.slab_map = .{
+                .bytes = bytes,
+                .n = L.n,
+                .hi_slots = L.hi_slots,
+                .levels = try sliceField(u32, bytes, try at(base, L.levels_off), L.n),
+                .qscales = try sliceField(f32, bytes, try at(base, L.qscales_off), L.n),
+                .vectors = try sliceField(f32, bytes, try at(base, L.vectors_off), vector_count),
+                .qvecs = try sliceField(i8, bytes, try at(base, L.qvecs_off), vector_count),
+                .l0_deg = try sliceField(u16, bytes, try at(base, L.l0_deg_off), L.n),
+                .l0_nbrs = try sliceField(u32, bytes, try at(base, L.l0_nbrs_off), l0_count),
+                .hi_start = try sliceField(u32, bytes, try at(base, L.hi_start_off), L.n),
+                .hi_deg = try sliceField(u16, bytes, try at(base, L.hi_deg_off), L.hi_slots),
+                .hi_nbrs = try sliceField(u32, bytes, try at(base, L.hi_nbrs_off), hi_count),
+            };
+        }
+
+        fn hmlsOffsetIn(bytes: []const u8) !usize {
+            if (bytes.len < 4) return error.Truncated;
+            const magic = std.mem.readInt(u32, bytes[0..4], .little);
+            if (magic == SLAB_MAGIC) return 0;
+            if (magic != SNAP_MAGIC_DUP) return error.BadMagic;
+            if (bytes.len < 32) return error.Truncated;
+            const version = std.mem.readInt(u32, bytes[4..8], .little);
+            const n = std.math.cast(usize, std.mem.readInt(u64, bytes[24..32], .little)) orelse return error.InvalidSlabLayout;
+            const raw_off = std.math.add(usize, 32, std.math.mul(usize, n, 8) catch return error.InvalidSlabLayout) catch return error.InvalidSlabLayout;
+            // v2 persist slab snapshots page-align the HMLS image.
+            if (version == 2) return try pageAlign(raw_off);
+            return raw_off;
+        }
+
+        /// mmap a raw HMLS file or a persist v2 envelope+HMLS file.
+        /// MAP_PRIVATE: reads demand-page; writes COW and never dirty the file.
+        pub fn loadMmap(self: *Self, path: []const u8) !void {
+            if (self.len() != 0) return error.NotEmpty;
+            const original_allocator = self.allocator;
+            const original_dim = self.dim;
+            const original_options = self.opts;
+            const fd = try posix.openat(posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY, .CLOEXEC = true }, 0);
+            const size64 = posix.system.lseek(fd, 0, posix.system.SEEK.END);
+            if (posix.errno(size64) != .SUCCESS) {
+                _ = posix.system.close(fd);
+                return error.SeekFailed;
+            }
+            const size = std.math.cast(usize, size64) orelse {
+                _ = posix.system.close(fd);
+                return error.InvalidSlabLayout;
+            };
+            if (size == 0) {
+                _ = posix.system.close(fd);
+                return error.Truncated;
+            }
+            const mapped = posix.mmap(
+                null,
+                size,
+                .{ .READ = true, .WRITE = true },
+                .{ .TYPE = .PRIVATE },
+                fd,
+                0,
+            ) catch {
+                _ = posix.system.close(fd);
+                return error.MmapFailed;
+            };
+            _ = posix.system.close(fd);
+            var attached = false;
+            errdefer {
+                if (attached) {
+                    self.deinit();
+                } else {
+                    posix.munmap(mapped);
+                }
+                self.* = Self.init(original_allocator, original_dim, original_options);
+            }
+            const off = try hmlsOffsetIn(mapped);
+            try self.attachMapped(mapped, off);
+            attached = true;
+            try self.validateMappedGraph();
+            const n = self.mappedCount();
+            try self.nbr_gen.ensureTotalCapacity(self.allocator, n);
+            try self.vec_gen.ensureTotalCapacity(self.allocator, n);
+            var gi: usize = 0;
+            while (gi < n) : (gi += 1) {
+                self.nbr_gen.appendAssumeCapacity(0);
+                self.vec_gen.appendAssumeCapacity(0);
+            }
+        }
+
+        fn copySlabInto(comptime T: type, list: *std.ArrayList(T), alloc: std.mem.Allocator, src: []const T) !void {
+            const dest = try list.addManyAsSlice(alloc, src.len);
+            if (src.len > 0) @memcpy(dest, src);
+        }
+
+        /// Copy-in HMLS image (load-via-alloc). Same bytes as `loadMmap`, full RSS.
+        pub fn loadSlabsCopy(self: *Self, bytes: []const u8) !void {
+            if (self.len() != 0) return error.NotEmpty;
+            const original_allocator = self.allocator;
+            const original_dim = self.dim;
+            const original_options = self.opts;
+            errdefer {
+                self.deinit();
+                self.* = Self.init(original_allocator, original_dim, original_options);
+            }
+            if (bytes.len > MAX_COPY_LOAD_BYTES) return error.CopyLoadBudgetExceeded;
+            const off = try hmlsOffsetIn(bytes);
+            if (off > bytes.len or SLAB_HEADER_SIZE > bytes.len - off) return error.Truncated;
+            const parsed = try parseLayout(bytes[off..]);
+            const L = parsed.layout;
+            if (self.dim == 0) self.dim = L.dim;
+            if (self.dim != L.dim) return error.DimensionMismatch;
+            self.opts.m = parsed.m;
+            self.opts.m0_factor = parsed.m0_factor;
+            self.opts.ef_construction = parsed.efc;
+            self.setMaxLevel(parsed.max_level);
+            if (L.n == 0) {
+                @atomicStore(u32, &self.entry_id, std.math.maxInt(u32), .release);
+            } else {
+                self.setEntryPoint(parsed.entry);
+            }
+            @atomicStore(usize, &self.published, L.n, .release);
+            if (off > bytes.len or L.file_len > bytes.len - off) return error.Truncated;
+
+            const alloc = self.allocator;
+            const l0_stride = self.l0Stride();
+            const hi_stride = self.hiStride();
+            const vector_count = std.math.mul(usize, L.n, L.dim) catch return error.InvalidSlabLayout;
+            const l0_count = std.math.mul(usize, L.n, l0_stride) catch return error.InvalidSlabLayout;
+            const hi_count = std.math.mul(usize, L.hi_slots, hi_stride) catch return error.InvalidSlabLayout;
+            const base = bytes[off..];
+
+            const take = struct {
+                fn sl(comptime T: type, b: []const u8, o: usize, c: usize) ![]const T {
+                    const nbytes = std.math.mul(usize, c, @sizeOf(T)) catch return error.InvalidSlabLayout;
+                    if (o > b.len or nbytes > b.len - o) return error.Truncated;
+                    if (c == 0) return &[_]T{};
+                    return @as([*]const T, @ptrCast(@alignCast(b[o..].ptr)))[0..c];
+                }
+            };
+            try copySlabInto(u32, &self.levels, alloc, try take.sl(u32, base, L.levels_off, L.n));
+            try copySlabInto(f32, &self.qscales, alloc, try take.sl(f32, base, L.qscales_off, L.n));
+            try copySlabInto(f32, &self.vectors_flat, alloc, try take.sl(f32, base, L.vectors_off, vector_count));
+            try copySlabInto(i8, &self.qvecs_flat, alloc, try take.sl(i8, base, L.qvecs_off, vector_count));
+            try copySlabInto(u16, &self.l0_deg, alloc, try take.sl(u16, base, L.l0_deg_off, L.n));
+            try copySlabInto(u32, &self.l0_nbrs, alloc, try take.sl(u32, base, L.l0_nbrs_off, l0_count));
+            try copySlabInto(u32, &self.hi_start, alloc, try take.sl(u32, base, L.hi_start_off, L.n));
+            try copySlabInto(u16, &self.hi_deg, alloc, try take.sl(u16, base, L.hi_deg_off, L.hi_slots));
+            try copySlabInto(u32, &self.hi_nbrs, alloc, try take.sl(u32, base, L.hi_nbrs_off, hi_count));
+            try self.validateOwnedGraph();
+            try self.nbr_gen.ensureTotalCapacity(alloc, L.n);
+            try self.vec_gen.ensureTotalCapacity(alloc, L.n);
+            var gi: usize = 0;
+            while (gi < L.n) : (gi += 1) {
+                self.nbr_gen.appendAssumeCapacity(0);
+                self.vec_gen.appendAssumeCapacity(0);
+            }
+        }
+
+        /// Read an HMLS (or persist v2) file into heap ArrayLists. No mmap.
+        pub fn loadSlabsFile(self: *Self, path: []const u8) !void {
+            if (self.len() != 0) return error.NotEmpty;
+            const original_allocator = self.allocator;
+            const original_dim = self.dim;
+            const original_options = self.opts;
+            errdefer {
+                self.deinit();
+                self.* = Self.init(original_allocator, original_dim, original_options);
+            }
+            const fd = try posix.openat(posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY, .CLOEXEC = true }, 0);
+            defer _ = posix.system.close(fd);
+            const size_raw = posix.system.lseek(fd, 0, posix.system.SEEK.END);
+            if (posix.errno(size_raw) != .SUCCESS) return error.SeekFailed;
+            const file_size = std.math.cast(usize, size_raw) orelse return error.InvalidSlabLayout;
+            if (file_size > MAX_COPY_LOAD_BYTES) return error.CopyLoadBudgetExceeded;
+            var peek: [4096]u8 = undefined;
+            try sysPreadAll(fd, peek[0..32], 0);
+            const off = try hmlsOffsetIn(peek[0..32]);
+            var hdr: [SLAB_HEADER_SIZE]u8 = undefined;
+            try sysPreadAll(fd, &hdr, off);
+            const parsed = try parseLayout(&hdr);
+            const L = parsed.layout;
+            const image_end = std.math.add(usize, off, L.file_len) catch return error.InvalidSlabLayout;
+            if (image_end > file_size) return error.Truncated;
+            if (self.dim == 0) self.dim = L.dim;
+            if (self.dim != L.dim) return error.DimensionMismatch;
+            self.opts.m = parsed.m;
+            self.opts.m0_factor = parsed.m0_factor;
+            self.opts.ef_construction = parsed.efc;
+            self.setMaxLevel(parsed.max_level);
+            if (L.n == 0) {
+                @atomicStore(u32, &self.entry_id, std.math.maxInt(u32), .release);
+            } else {
+                self.setEntryPoint(parsed.entry);
+            }
+            @atomicStore(usize, &self.published, L.n, .release);
+
+            const alloc = self.allocator;
+            const l0_stride = self.l0Stride();
+            const hi_stride = self.hiStride();
+            const vector_count = std.math.mul(usize, L.n, L.dim) catch return error.InvalidSlabLayout;
+            const l0_count = std.math.mul(usize, L.n, l0_stride) catch return error.InvalidSlabLayout;
+            const hi_count = std.math.mul(usize, L.hi_slots, hi_stride) catch return error.InvalidSlabLayout;
+            const at = struct {
+                fn offset(base: usize, relative: usize) !u64 {
+                    const value = std.math.add(usize, base, relative) catch return error.InvalidSlabLayout;
+                    return std.math.cast(u64, value) orelse return error.InvalidSlabLayout;
+                }
+            }.offset;
+
+            const readInto = struct {
+                fn go(comptime T: type, list: *std.ArrayList(T), a: std.mem.Allocator, f: posix.fd_t, file_off: u64, count: usize) !void {
+                    const dest = try list.addManyAsSlice(a, count);
+                    if (count == 0) return;
+                    try sysPreadAll(f, std.mem.sliceAsBytes(dest), file_off);
+                }
+            };
+            try readInto.go(u32, &self.levels, alloc, fd, try at(off, L.levels_off), L.n);
+            try readInto.go(f32, &self.qscales, alloc, fd, try at(off, L.qscales_off), L.n);
+            try readInto.go(f32, &self.vectors_flat, alloc, fd, try at(off, L.vectors_off), vector_count);
+            try readInto.go(i8, &self.qvecs_flat, alloc, fd, try at(off, L.qvecs_off), vector_count);
+            try readInto.go(u16, &self.l0_deg, alloc, fd, try at(off, L.l0_deg_off), L.n);
+            try readInto.go(u32, &self.l0_nbrs, alloc, fd, try at(off, L.l0_nbrs_off), l0_count);
+            try readInto.go(u32, &self.hi_start, alloc, fd, try at(off, L.hi_start_off), L.n);
+            try readInto.go(u16, &self.hi_deg, alloc, fd, try at(off, L.hi_deg_off), L.hi_slots);
+            try readInto.go(u32, &self.hi_nbrs, alloc, fd, try at(off, L.hi_nbrs_off), hi_count);
+            try self.validateOwnedGraph();
+            try self.nbr_gen.ensureTotalCapacity(alloc, L.n);
+            try self.vec_gen.ensureTotalCapacity(alloc, L.n);
+            var gi: usize = 0;
+            while (gi < L.n) : (gi += 1) {
+                self.nbr_gen.appendAssumeCapacity(0);
+                self.vec_gen.appendAssumeCapacity(0);
+            }
+        }
+    };
+}
+
+test "hnsw finds planted neighbor" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 16;
+    var rng = std.Random.DefaultPrng.init(42);
+    var index = Hnsw(void).init(alloc, dim, .{});
+    defer index.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..500) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+    // plant a distinctive vector
+    @memset(&v, 0);
+    v[3] = 1;
+    const target = try index.insert(&v);
+
+    const results = try index.search(&v, 1, 64, alloc);
+    try std.testing.expectEqual(target, results[0].id);
+}
+
+test "layer-0 connectivity and recall on clustered data" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 1536;
+    const n = 400;
+    const clusters = 8;
+    var rng = std.Random.DefaultPrng.init(9);
+
+    var centers: [clusters][dim]f32 = undefined;
+    for (&centers) |*c| {
+        for (c) |*x| x.* = rng.random().floatNorm(f32);
+        vecmath.normalize(c);
+    }
+
+    var index = Hnsw(void).init(alloc, dim, .{});
+    defer index.deinit();
+    var v: [dim]f32 = undefined;
+    for (0..n) |i| {
+        const cl = i % clusters;
+        for (&v, 0..) |_, d| v[d] = centers[cl][d] + 0.05 * rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+
+    // BFS reachability from entry point at layer 0
+    var visited = try std.DynamicBitSetUnmanaged.initEmpty(alloc, n);
+    defer visited.deinit(alloc);
+    var queue: std.ArrayList(u32) = .empty;
+    try queue.append(alloc, index.entryPoint().?);
+    visited.set(index.entryPoint().?);
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const id = queue.items[head];
+        for (index.neighbors(id, 0)) |nb| {
+            if (!visited.isSet(nb)) {
+                visited.set(nb);
+                try queue.append(alloc, nb);
+            }
+        }
+    }
+    var total: usize = 0;
+    var it = visited.iterator(.{});
+    while (it.next()) |_| total += 1;
+    std.debug.print("reachable {d}/{d} from entry\n", .{ total, n });
+
+    var q: [dim]f32 = undefined;
+    for (&q, 0..) |_, d| q[d] = centers[3][d] + 0.05 * rng.random().floatNorm(f32);
+    const res = try index.search(&q, 10, 200, alloc);
+    std.debug.print("returned {d} results, best d={d:.4}\n", .{ res.len, res[0].distance });
+
+    // brute force top-10 over the same stored vectors
+    const GT = struct { id: u32, d: f32 };
+    var all: std.ArrayList(GT) = .empty;
+    const nq = try alloc.dupe(f32, &q);
+    vecmath.normalize(nq);
+    var idx: u32 = 0;
+    while (idx < index.len()) : (idx += 1) {
+        try all.append(alloc, .{ .id = idx, .d = vecmath.cosineDistance(nq, index.vectorConst(idx)) });
+    }
+    std.mem.sort(GT, all.items, {}, struct {
+        fn lt(_: void, a: GT, b: GT) bool {
+            return a.d < b.d;
+        }
+    }.lt);
+    var hits: usize = 0;
+    for (res) |r| {
+        for (all.items[0..10]) |g| {
+            if (g.id == r.id) {
+                hits += 1;
+                break;
+            }
+        }
+    }
+    const recall = @as(f64, @floatFromInt(hits)) / 10.0;
+    std.debug.print("recall@10 vs brute force: {d:.3} (ann best {d:.4} vs gt best {d:.4} id {d})\n", .{
+        recall, res[0].distance, all.items[0].d, all.items[0].id,
+    });
+    try std.testing.expectEqual(@as(usize, 10), hits);
+}
+
+test "hnsw update replaces vector without growing the index" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+    var index = Hnsw(void).init(alloc, 4, .{});
+    defer index.deinit();
+    const a = [_]f32{ 1, 0, 0, 0 };
+    const b = [_]f32{ 0, 1, 0, 0 };
+    const id = try index.insert(&a);
+    _ = try index.insert(&b);
+    try std.testing.expectEqual(@as(usize, 2), index.len());
+    const flipped = [_]f32{ 0, 0, 0, 1 };
+    try index.update(id, &flipped);
+    try std.testing.expectEqual(@as(usize, 2), index.len());
+    const res = try index.search(&flipped, 1, 8, alloc);
+    try std.testing.expectEqual(id, res[0].id);
+}
+
+test "hnsw serialize/load preserves neighbors and search" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 32;
+    var rng = std.Random.DefaultPrng.init(7);
+    var index = Hnsw(void).init(alloc, dim, .{});
+    defer index.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..80) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+    @memset(&v, 0);
+    v[1] = 1;
+    const planted = try index.insert(&v);
+    const before = try index.search(&v, 5, 64, alloc);
+
+    const blob = try index.serialize(alloc);
+    defer alloc.free(blob);
+
+    var loaded = Hnsw(void).init(alloc, dim, .{});
+    defer loaded.deinit();
+    try loaded.load(blob);
+
+    try std.testing.expectEqual(index.len(), loaded.len());
+    try std.testing.expectEqual(index.entryPoint(), loaded.entryPoint());
+    try std.testing.expectEqual(index.getMaxLevel(), loaded.getMaxLevel());
+    var id: u32 = 0;
+    while (id < index.len()) : (id += 1) {
+        try std.testing.expectEqual(index.layerCount(id), loaded.layerCount(id));
+        var layer: u32 = 0;
+        while (layer < index.layerCount(id)) : (layer += 1) {
+            try std.testing.expectEqualSlices(u32, index.neighbors(id, layer), loaded.neighbors(id, layer));
+        }
+    }
+    const after = try loaded.search(&v, 5, 64, alloc);
+    try std.testing.expectEqual(planted, after[0].id);
+    try std.testing.expectEqual(before[0].id, after[0].id);
+    try std.testing.expectEqual(before.len, after.len);
+    for (before, after) |b, a| {
+        try std.testing.expectEqual(b.id, a.id);
+        try std.testing.expectApproxEqAbs(b.distance, a.distance, 1e-6);
+    }
+}
+
+test "hnsw store_f32=false search still finds planted neighbor" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 16;
+    var rng = std.Random.DefaultPrng.init(42);
+    var index = Hnsw(void).init(alloc, dim, .{ .store_f32 = false });
+    defer index.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..500) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+    try std.testing.expect(!index.hasStoredF32());
+    try std.testing.expectEqual(@as(usize, 0), index.vectors_flat.items.len);
+    try std.testing.expectEqual(@as(usize, 500), index.len());
+
+    @memset(&v, 0);
+    v[3] = 1;
+    const target = try index.insert(&v);
+    const results = try index.search(&v, 1, 64, alloc);
+    try std.testing.expectEqual(target, results[0].id);
+}
+
+test "hnsw store_f32=false serialize/load and update" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 32;
+    var rng = std.Random.DefaultPrng.init(7);
+    var index = Hnsw(void).init(alloc, dim, .{ .store_f32 = false });
+    defer index.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..80) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+    @memset(&v, 0);
+    v[1] = 1;
+    const planted = try index.insert(&v);
+    const before = try index.search(&v, 5, 64, alloc);
+
+    const blob = try index.serialize(alloc);
+    defer alloc.free(blob);
+    try std.testing.expectEqual(index.serializedSize(), blob.len);
+    try std.testing.expectEqual(Hnsw(void).GRAPH_VERSION_OPT_F32, std.mem.readInt(u32, blob[4..8], .little));
+    try std.testing.expectEqual(@as(usize, 0), index.vectors_flat.items.len);
+
+    var loaded = Hnsw(void).init(alloc, dim, .{});
+    defer loaded.deinit();
+    try loaded.load(blob);
+    try std.testing.expect(!loaded.hasStoredF32());
+    try std.testing.expectEqual(index.len(), loaded.len());
+    try std.testing.expectEqual(index.entryPoint(), loaded.entryPoint());
+    try std.testing.expectEqual(@as(usize, 0), loaded.vectors_flat.items.len);
+    var id: u32 = 0;
+    while (id < index.len()) : (id += 1) {
+        try std.testing.expectEqualSlices(u32, index.neighbors(id, 0), loaded.neighbors(id, 0));
+    }
+
+    const after = try loaded.search(&v, 5, 64, alloc);
+    try std.testing.expectEqual(planted, after[0].id);
+    try std.testing.expectEqual(before[0].id, after[0].id);
+
+    var flip: [dim]f32 = undefined;
+    @memset(&flip, 0);
+    flip[4] = 1;
+    try loaded.update(planted, &flip);
+    const updated = try loaded.search(&flip, 1, 64, alloc);
+    try std.testing.expectEqual(planted, updated[0].id);
+}
+
+fn rssKiBSelf() ?u64 {
+    const fd = posix.openat(posix.AT.FDCWD, "/proc/self/status", .{ .ACCMODE = .RDONLY }, 0) catch return null;
+    defer _ = linux.close(fd);
+    var buf: [4096]u8 = undefined;
+    const n = linux.read(fd, &buf, buf.len);
+    if (posix.errno(n) != .SUCCESS) return null;
+    const text = buf[0..n];
+    const key = "VmRSS:";
+    const idx = std.mem.indexOf(u8, text, key) orelse return null;
+    var rest = text[idx + key.len ..];
+    while (rest.len > 0 and (rest[0] == ' ' or rest[0] == '\t')) rest = rest[1..];
+    var end: usize = 0;
+    while (end < rest.len and rest[end] >= '0' and rest[end] <= '9') end += 1;
+    return std.fmt.parseInt(u64, rest[0..end], 10) catch null;
+}
+
+test "hnsw slab mmap reopen + insert append buffer" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+
+    const dim = 32;
+    var rng = std.Random.DefaultPrng.init(11);
+    var index = Hnsw(void).init(alloc, dim, .{});
+    defer index.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..60) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try index.insert(&v);
+    }
+    @memset(&v, 0);
+    v[2] = 1;
+    const planted = try index.insert(&v);
+    const before = try index.search(&v, 5, 64, alloc);
+
+    const path = "/tmp/openpuffer-mmap-roundtrip.slabs";
+    try index.writeSlabs(path);
+
+    var loaded = Hnsw(void).init(alloc, dim, .{});
+    defer loaded.deinit();
+    try loaded.loadMmap(path);
+    try std.testing.expect(loaded.isMmapBacked());
+    try std.testing.expectEqual(index.len(), loaded.len());
+    try std.testing.expectEqual(index.entryPoint(), loaded.entryPoint());
+    var id: u32 = 0;
+    while (id < index.len()) : (id += 1) {
+        try std.testing.expectEqual(index.layerCount(id), loaded.layerCount(id));
+        var layer: u32 = 0;
+        while (layer < index.layerCount(id)) : (layer += 1) {
+            try std.testing.expectEqualSlices(u32, index.neighbors(id, layer), loaded.neighbors(id, layer));
+        }
+    }
+    const after = try loaded.search(&v, 5, 64, alloc);
+    try std.testing.expectEqual(planted, after[0].id);
+    for (before, after) |b, a| {
+        try std.testing.expectEqual(b.id, a.id);
+        try std.testing.expectApproxEqAbs(b.distance, a.distance, 1e-6);
+    }
+
+    var extra: [dim]f32 = undefined;
+    @memset(&extra, 0);
+    extra[5] = 1;
+    const new_id = try loaded.insert(&extra);
+    try std.testing.expectEqual(index.len() + 1, loaded.len());
+    try std.testing.expect(new_id >= index.len());
+    const found = try loaded.search(&extra, 1, 16, alloc);
+    try std.testing.expectEqual(new_id, found[0].id);
+
+    var flipped_v: [dim]f32 = undefined;
+    @memset(&flipped_v, 0);
+    flipped_v[7] = 1;
+    try loaded.update(planted, &flipped_v);
+    const flipped = try loaded.search(&flipped_v, 3, 32, alloc);
+    try std.testing.expectEqual(planted, flipped[0].id);
+
+    var copied = Hnsw(void).init(alloc, dim, .{});
+    defer copied.deinit();
+    try copied.loadSlabsFile(path);
+    try std.testing.expect(!copied.isMmapBacked());
+    try std.testing.expectEqual(index.len(), copied.len());
+}
+
+test "slab mmap vs alloc RSS (blank slabs)" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const scale = builtin.mode != .debug;
+    const cases = [_]struct { n: usize, dim: usize }{
+        .{ .n = if (scale) 20_000 else 256, .dim = if (scale) 1536 else 64 },
+        .{ .n = if (scale) 200_000 else 0, .dim = 1536 },
+    };
+    const gpa = std.heap.page_allocator;
+    for (cases) |c| {
+        if (c.n == 0) continue;
+        var path_buf: [128]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "/tmp/openpuffer-mmap-rss-{d}.slabs", .{c.n});
+        try Hnsw(void).writeBlankSlabs(path, c.n, c.dim, .{});
+
+        const baseline = rssKiBSelf() orelse 0;
+
+        var mapped = Hnsw(void).init(gpa, c.dim, .{});
+        try mapped.loadMmap(path);
+        const mmap_idle = rssKiBSelf() orelse 0;
+        const _touch = mapped.vectorConst(0)[0];
+        _ = _touch;
+        mapped.deinit();
+
+        var copied = Hnsw(void).init(gpa, c.dim, .{});
+        const vector_bytes = c.n * c.dim * 5;
+        if (vector_bytes > Hnsw(void).MAX_COPY_LOAD_BYTES) {
+            try std.testing.expectError(error.CopyLoadBudgetExceeded, copied.loadSlabsFile(path));
+            copied.deinit();
+            continue;
+        }
+        try copied.loadSlabsFile(path);
+        const alloc_rss = rssKiBSelf() orelse 0;
+        copied.deinit();
+
+        const mmap_delta = mmap_idle -| baseline;
+        const alloc_delta = alloc_rss -| baseline;
+        if (c.n >= 10_000) {
+            try std.testing.expect(mmap_delta * 4 < alloc_delta);
+            try std.testing.expect(alloc_delta + 1024 >= (c.n * c.dim * 5) / 1024 / 2);
+        }
+    }
+}
+
+test "publishInsert then spliceBackEdges matches commitInsert" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+    const dim = 8;
+    var rng = std.Random.DefaultPrng.init(3);
+
+    var via_commit = Hnsw(void).init(alloc, dim, .{ .seed = 99 });
+    defer via_commit.deinit();
+    var via_split = Hnsw(void).init(alloc, dim, .{ .seed = 99 });
+    defer via_split.deinit();
+
+    var v: [dim]f32 = undefined;
+    for (0..40) |_| {
+        for (&v) |*x| x.* = rng.random().floatNorm(f32);
+        _ = try via_commit.insert(&v);
+        _ = try via_split.insert(&v);
+    }
+    for (&v) |*x| x.* = rng.random().floatNorm(f32);
+    const level = via_split.nextLevel();
+    _ = via_commit.nextLevel();
+    var plan_split = try via_split.planInsert(&v, level, alloc);
+    const plan_commit = try via_commit.planInsert(&v, level, alloc);
+    const id = try via_split.publishInsert(&plan_split);
+    try via_split.spliceBackEdges(&plan_split, id);
+    _ = try via_commit.commitInsert(plan_commit);
+
+    try std.testing.expectEqual(via_commit.len(), via_split.len());
+    try std.testing.expectEqual(via_commit.entryPoint(), via_split.entryPoint());
+    var nid: u32 = 0;
+    while (nid < via_commit.len()) : (nid += 1) {
+        var layer: u32 = 0;
+        while (layer < via_commit.layerCount(nid)) : (layer += 1) {
+            try std.testing.expectEqualSlices(u32, via_commit.neighbors(nid, layer), via_split.neighbors(nid, layer));
+        }
+    }
+    const q = via_split.vectorConst(id);
+    const a = try via_commit.search(q, 5, 32, alloc);
+    const b = try via_split.search(q, 5, 32, alloc);
+    try std.testing.expectEqual(a.len, b.len);
+    for (a, b) |x, y| {
+        try std.testing.expectEqual(x.id, y.id);
+        try std.testing.expectApproxEqAbs(x.distance, y.distance, 1e-6);
+    }
+}

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -587,10 +587,11 @@ pub fn Hnsw(comptime D: type) type {
                 const worst = if (results.count() > 0) results.peek().?.d else c.d;
                 if (c.d > worst and results.count() >= ef) break;
 
-                if (layer >= self.layerCount(c.id)) {
-                    std.debug.print("VIOLATION c.id={d} its_layers={d} layer={d} max_level={d} ep={any} ep_layers={d}\n", .{ c.id, self.layerCount(c.id), layer, self.getMaxLevel(), self.entryPoint(), if (self.entryPoint()) |e| self.layerCount(e) else 0 });
-                    @panic("hnsw invariant broken");
-                }
+                // Persisted graphs are validated before becoming visible, but
+                // keep search fallible as a final defense against an invalid
+                // concurrently supplied/in-memory graph. Untrusted sidecars
+                // must never turn an invariant violation into a process panic.
+                if (layer >= self.layerCount(c.id)) return error.InvalidNeighborLayer;
                 var nbr_buf: [64]u32 = undefined;
                 const nbrs = self.snapshotNeighbors(c.id, layer, &nbr_buf);
                 for (nbrs, 0..) |nid, ni| {
@@ -1451,8 +1452,13 @@ pub fn Hnsw(comptime D: type) type {
                     const high_degree: usize = mapped.hi_deg[slot];
                     if (high_degree > hi_stride) return error.DegreeOverflow;
                     const base = slot * hi_stride;
+                    const graph_layer: u32 = @intCast(slot_offset + 1);
                     for (mapped.hi_nbrs[base..][0..high_degree]) |neighbor| {
                         if (neighbor >= n) return error.InvalidNeighborId;
+                        // An edge at graph layer L may only point to a node
+                        // that owns L. Otherwise searchLayer will eventually
+                        // expand a layer that does not exist for that node.
+                        if (mapped.levels[neighbor] < graph_layer) return error.InvalidNeighborLayer;
                     }
                 }
             }
@@ -1495,8 +1501,10 @@ pub fn Hnsw(comptime D: type) type {
                     const high_degree: usize = self.hi_deg.items[slot];
                     if (high_degree > hi_stride) return error.DegreeOverflow;
                     const base = std.math.mul(usize, slot, hi_stride) catch return error.InvalidSlabLayout;
+                    const graph_layer: u32 = @intCast(slot_offset + 1);
                     for (self.hi_nbrs.items[base..][0..high_degree]) |neighbor| {
                         if (neighbor >= n) return error.InvalidNeighborId;
+                        if (self.levels.items[neighbor] < graph_layer) return error.InvalidNeighborLayer;
                     }
                 }
             }

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -145,7 +145,11 @@ pub fn Hnsw(comptime D: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            if (self.slab_map) |m| posix.munmap(m.bytes);
+            // `loadMmap` is UnsupportedPlatform on Windows (#25), therefore a
+            // Windows index can never own a POSIX mapping.
+            if (comptime builtin.os.tag != .windows) {
+                if (self.slab_map) |m| posix.munmap(m.bytes);
+            }
             self.slab_map = null;
             self.vectors_flat.deinit(self.allocator);
             self.qvecs_flat.deinit(self.allocator);
@@ -1611,6 +1615,11 @@ pub fn Hnsw(comptime D: type) type {
         /// Atomically write an HMLS slab file (`path.tmp` → fsync → rename).
         /// The live snapshot is never opened writeable; a crash leaves `path` intact.
         pub fn writeSlabs(self: *const Self, path: []const u8) !void {
+            // The slab implementation is intentionally POSIX mmap/openat only
+            // until native Windows support lands (justrach/openpuffer#25).
+            // Keep consumers cross-compilable and fail explicitly at runtime;
+            // never substitute the copy-in/heap path on Windows.
+            if (comptime builtin.os.tag == .windows) return error.UnsupportedPlatform;
             var tmp_buf: [posix.PATH_MAX]u8 = undefined;
             const tmp = try std.fmt.bufPrint(&tmp_buf, "{s}.tmp", .{path});
             const fd = try posix.openat(posix.AT.FDCWD, tmp, .{
@@ -1809,6 +1818,9 @@ pub fn Hnsw(comptime D: type) type {
         /// mmap a raw HMLS file or a persist v2 envelope+HMLS file.
         /// MAP_PRIVATE: reads demand-page; writes COW and never dirty the file.
         pub fn loadMmap(self: *Self, path: []const u8) !void {
+            // Native Windows mmap support is tracked in justrach/openpuffer#25.
+            // Fail closed rather than silently using the high-RSS copy-in loader.
+            if (comptime builtin.os.tag == .windows) return error.UnsupportedPlatform;
             if (self.len() != 0) return error.NotEmpty;
             const original_allocator = self.allocator;
             const original_dim = self.dim;

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -674,25 +674,22 @@ pub fn Hnsw(comptime D: type) type {
             var stack: [2048]f32 = undefined;
             var heap_tmp: ?[]f32 = null;
             defer if (heap_tmp) |h| self.allocator.free(h);
-            const copy: []f32 = if (self.opts.store_f32) self.vector(id) else if (self.dim <= stack.len)
+            const normalized: []f32 = if (self.dim <= stack.len)
                 stack[0..self.dim]
             else blk: {
                 heap_tmp = try self.allocator.alloc(f32, self.dim);
                 break :blk heap_tmp.?;
             };
+            @memcpy(normalized, vector_in);
+            try vecmath.normalizeChecked(normalized);
+            var amax: f32 = 0;
+            for (normalized) |x| amax = @max(amax, @abs(x));
+            const scale = amax / 127.0;
             const g = @atomicLoad(u32, &self.vec_gen.items[id], .monotonic);
             @atomicStore(u32, &self.vec_gen.items[id], g +% 1, .release);
-            @memcpy(copy, vector_in);
-            vecmath.normalize(copy);
-            var amax: f32 = 0;
-            for (copy) |x| amax = @max(amax, @abs(x));
-            const scale = amax / 127.0;
+            if (self.opts.store_f32) @memcpy(self.vector(id), normalized);
             const q8 = self.qvec(id);
-            if (scale == 0) {
-                @memset(q8, 0);
-            } else {
-                for (copy, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
-            }
+            for (normalized, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
             self.setQscaleOf(id, scale);
             @atomicStore(u32, &self.vec_gen.items[id], g +% 2, .release);
         }
@@ -721,17 +718,13 @@ pub fn Hnsw(comptime D: type) type {
             const copy = try alloc.alloc(f32, self.dim);
             errdefer alloc.free(copy);
             @memcpy(copy, vector_in);
-            vecmath.normalize(copy);
+            try vecmath.normalizeChecked(copy);
             var amax: f32 = 0;
             for (copy) |x| amax = @max(amax, @abs(x));
             const scale = amax / 127.0;
             const q8 = try alloc.alloc(i8, self.dim);
             errdefer alloc.free(q8);
-            if (scale == 0) {
-                @memset(q8, 0);
-            } else {
-                for (copy, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
-            }
+            for (copy, 0..) |x, di| q8[di] = @intFromFloat(std.math.clamp(@round(x / scale), -127.0, 127.0));
             return .{ .copy = copy, .q8 = q8, .scale = scale };
         }
 
@@ -940,12 +933,12 @@ pub fn Hnsw(comptime D: type) type {
             defer if (heap_nq) |h| alloc.free(h);
             const nq: []const f32 = if (query.len <= norm_buf.len) blk: {
                 @memcpy(norm_buf[0..query.len], query);
-                vecmath.normalize(norm_buf[0..query.len]);
+                try vecmath.normalizeChecked(norm_buf[0..query.len]);
                 break :blk norm_buf[0..query.len];
             } else blk: {
                 heap_nq = try alloc.alloc(f32, query.len);
                 @memcpy(heap_nq.?, query);
-                vecmath.normalize(heap_nq.?);
+                try vecmath.normalizeChecked(heap_nq.?);
                 break :blk heap_nq.?;
             };
 
@@ -1440,6 +1433,8 @@ pub fn Hnsw(comptime D: type) type {
             const l0_stride = self.l0Stride();
             const hi_stride = self.hiStride();
             for (0..n) |id| {
+                const qscale = mapped.qscales[id];
+                if (!std.math.isFinite(qscale) or qscale < 0) return error.InvalidVectorValue;
                 const level = mapped.levels[id];
                 if (level > max_level or level > 64) return error.InvalidSlabLayout;
                 observed_max_level = @max(observed_max_level, level);
@@ -1489,6 +1484,8 @@ pub fn Hnsw(comptime D: type) type {
             const max_level = self.getMaxLevel();
             var observed_max_level: u32 = 0;
             for (0..n) |id| {
+                const qscale = self.qscales.items[id];
+                if (!std.math.isFinite(qscale) or qscale < 0) return error.InvalidVectorValue;
                 const level = self.levels.items[id];
                 if (level > max_level or level > 64) return error.InvalidSlabLayout;
                 observed_max_level = @max(observed_max_level, level);
@@ -2044,6 +2041,41 @@ test "hnsw finds planted neighbor" {
 
     const results = try index.search(&v, 1, 64, alloc);
     try std.testing.expectEqual(target, results[0].id);
+}
+
+test "hnsw rejects invalid vectors without mutating the index" {
+    const testing = std.testing;
+    var index = Hnsw(void).init(testing.allocator, 4, .{ .seed = 101 });
+    defer index.deinit();
+    const valid = [_]f32{ 1, 0, 0, 0 };
+    _ = try index.insert(&valid);
+
+    const zero = [_]f32{ 0, 0, 0, 0 };
+    const nan = [_]f32{ std.math.nan(f32), 0, 0, 0 };
+    const infinity = [_]f32{ std.math.inf(f32), 0, 0, 0 };
+    try testing.expectError(error.ZeroNormVector, index.insert(&zero));
+    try testing.expectError(error.InvalidVectorValue, index.insert(&nan));
+    try testing.expectError(error.InvalidVectorValue, index.insert(&infinity));
+    try testing.expectEqual(@as(usize, 1), index.len());
+
+    try testing.expectError(error.ZeroNormVector, index.update(0, &zero));
+    try testing.expectError(error.InvalidVectorValue, index.update(0, &nan));
+    try testing.expectError(error.InvalidVectorValue, index.update(0, &infinity));
+    try testing.expectApproxEqAbs(@as(f32, 1), index.vectorConst(0)[0], 1e-6);
+
+    try testing.expectError(error.ZeroNormVector, index.searchAdvanced(&zero, 1, 16, 2, testing.allocator));
+    try testing.expectError(error.InvalidVectorValue, index.searchAdvanced(&nan, 1, 16, 2, testing.allocator));
+    try testing.expectError(error.InvalidVectorValue, index.searchAdvanced(&infinity, 1, 16, 2, testing.allocator));
+}
+
+test "hnsw validates vectors in int8-only mode" {
+    const testing = std.testing;
+    var index = Hnsw(void).init(testing.allocator, 4, .{ .seed = 103, .store_f32 = false });
+    defer index.deinit();
+    _ = try index.insert(&[_]f32{ 1, 0, 0, 0 });
+    const nan = [_]f32{ 0, std.math.nan(f32), 0, 0 };
+    try testing.expectError(error.InvalidVectorValue, index.update(0, &nan));
+    try testing.expectError(error.InvalidVectorValue, index.search(&nan, 1, 16, testing.allocator));
 }
 
 test "layer-0 connectivity and recall on clustered data" {

--- a/vendor/openpuffer/src/lib.zig
+++ b/vendor/openpuffer/src/lib.zig
@@ -1,0 +1,46 @@
+//! Public in-process HNSW engine.
+//!
+//! Dependents `@import("openpuffer")` and get `Hnsw`, `Options`, `SearchResult`,
+//! and the SIMD vector helpers. HTTP serve (`src/server.zig`), persistence
+//! clients, and the CLI are not part of this root.
+
+const hnsw = @import("hnsw.zig");
+const vecmath = @import("vector.zig");
+
+pub const Hnsw = hnsw.Hnsw;
+pub const Options = hnsw.Options;
+pub const SearchResult = hnsw.SearchResult;
+
+pub const vector = vecmath;
+pub const dot = vecmath.dot;
+pub const cosineDistance = vecmath.cosineDistance;
+pub const l2Norm = vecmath.l2Norm;
+pub const normalize = vecmath.normalize;
+pub const dotI8 = vecmath.dotI8;
+
+test "library root re-exports init/insert/search" {
+    const std = @import("std");
+    const Index = Hnsw(void);
+    var idx = Index.init(std.testing.allocator, 4, .{});
+    defer idx.deinit();
+    _ = try idx.insert(&.{ 1, 0, 0, 0 });
+    _ = try idx.insert(&.{ 0, 1, 0, 0 });
+    const hits = try idx.search(&.{ 0.9, 0.1, 0, 0 }, 1, 16, std.testing.allocator);
+    defer std.testing.allocator.free(hits);
+    try std.testing.expectEqual(@as(usize, 1), hits.len);
+    try std.testing.expectEqual(@as(u32, 0), hits[0].id);
+    try std.testing.expect(idx.hasStoredF32());
+}
+
+test "library store_f32=false leaves the f32 slab empty" {
+    const std = @import("std");
+    const Index = Hnsw(void);
+    var idx = Index.init(std.testing.allocator, 4, .{ .store_f32 = false });
+    defer idx.deinit();
+    _ = try idx.insert(&.{ 1, 0, 0, 0 });
+    try std.testing.expect(!idx.hasStoredF32());
+    try std.testing.expectEqual(@as(usize, 0), idx.vectorConst(0).len);
+    const hits = try idx.search(&.{ 1, 0, 0, 0 }, 1, 8, std.testing.allocator);
+    defer std.testing.allocator.free(hits);
+    try std.testing.expectEqual(@as(u32, 0), hits[0].id);
+}

--- a/vendor/openpuffer/src/vector.zig
+++ b/vendor/openpuffer/src/vector.zig
@@ -1,0 +1,59 @@
+//! Core vector math: cosine distance over f32 vectors.
+
+const std = @import("std");
+
+pub fn dot(a: []const f32, b: []const f32) f64 {
+    const lane = 16;
+    var acc: @Vector(lane, f32) = @splat(0);
+    var i: usize = 0;
+    while (i + lane <= a.len) : (i += lane) {
+        const va: @Vector(lane, f32) = a[i..][0..lane].*;
+        const vb: @Vector(lane, f32) = b[i..][0..lane].*;
+        acc += va * vb;
+    }
+    var sum: f32 = @reduce(.Add, acc);
+    while (i < a.len) : (i += 1) sum += a[i] * b[i];
+    return @floatCast(sum);
+}
+
+/// Cosine distance in [0, 2]. For normalized vectors this is 1 - dot.
+pub fn cosineDistance(a: []const f32, b: []const f32) f32 {
+    return @max(0.0, 1.0 - @as(f32, @floatCast(dot(a, b))));
+}
+
+pub fn l2Norm(v: []const f32) f32 {
+    return @sqrt(@as(f32, @floatCast(dot(v, v))));
+}
+
+pub fn normalize(v: []f32) void {
+    var n = l2Norm(v);
+    if (n == 0) n = 1;
+    for (v) |*x| x.* /= n;
+}
+
+/// Vectorized int8 dot product for quantized distance evaluation.
+/// 64 i8 lanes = 512 bits, matching AVX-512 register width. Integer
+/// products are still widened to i32 (max |product| = 16129).
+pub fn dotI8(a: []const i8, b: []const i8) i32 {
+    const lane = 64;
+    var acc: @Vector(lane, i32) = @splat(0);
+    var i: usize = 0;
+    while (i + lane <= a.len) : (i += lane) {
+        const va: @Vector(lane, i8) = a[i..][0..lane].*;
+        const vb: @Vector(lane, i8) = b[i..][0..lane].*;
+        const wide_a: @Vector(lane, i32) = @intCast(va);
+        const wide_b: @Vector(lane, i32) = @intCast(vb);
+        acc += wide_a * wide_b;
+    }
+    var sum: i32 = @reduce(.Add, acc);
+    while (i < a.len) : (i += 1) sum += @as(i32, a[i]) * @as(i32, b[i]);
+    return sum;
+}
+
+test "cosine basics" {
+    const a = [_]f32{ 1, 0, 0 };
+    const b = [_]f32{ 1, 0, 0 };
+    const c = [_]f32{ 0, 1, 0 };
+    try std.testing.expectApproxEqAbs(@as(f32, 0), cosineDistance(&a, &b), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 1), cosineDistance(&a, &c), 1e-6);
+}

--- a/vendor/openpuffer/src/vector.zig
+++ b/vendor/openpuffer/src/vector.zig
@@ -31,6 +31,34 @@ pub fn normalize(v: []f32) void {
     for (v) |*x| x.* /= n;
 }
 
+/// Normalize a caller-provided vector while enforcing the HNSW cosine-space
+/// contract. Keeping this check next to the vector math prevents NaN/Inf from
+/// reaching quantization and rejects an all-zero vector whose cosine direction
+/// is undefined.
+pub fn normalizeChecked(v: []f32) !void {
+    if (v.len == 0) return error.InvalidVectorDimensions;
+    const lane = 16;
+    var squared: @Vector(lane, f32) = @splat(0);
+    const finite_limit: @Vector(lane, f32) = @splat(std.math.floatMax(f32));
+    var i: usize = 0;
+    while (i + lane <= v.len) : (i += lane) {
+        const values: @Vector(lane, f32) = v[i..][0..lane].*;
+        if (!@reduce(.And, @abs(values) <= finite_limit)) return error.InvalidVectorValue;
+        squared += values * values;
+    }
+    var norm_squared: f32 = @reduce(.Add, squared);
+    while (i < v.len) : (i += 1) {
+        const value = v[i];
+        if (!std.math.isFinite(value)) return error.InvalidVectorValue;
+        norm_squared += value * value;
+    }
+    if (!std.math.isFinite(norm_squared)) return error.InvalidVectorValue;
+    if (norm_squared == 0) return error.ZeroNormVector;
+    const inverse_norm = 1.0 / @sqrt(norm_squared);
+    if (!std.math.isFinite(inverse_norm)) return error.InvalidVectorValue;
+    for (v) |*value| value.* *= inverse_norm;
+}
+
 /// Vectorized int8 dot product for quantized distance evaluation.
 /// 64 i8 lanes = 512 bits, matching AVX-512 register width. Integer
 /// products are still widened to i32 (max |product| = 16129).
@@ -56,4 +84,18 @@ test "cosine basics" {
     const c = [_]f32{ 0, 1, 0 };
     try std.testing.expectApproxEqAbs(@as(f32, 0), cosineDistance(&a, &b), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 1), cosineDistance(&a, &c), 1e-6);
+}
+
+test "checked normalization rejects invalid cosine vectors" {
+    var valid = [_]f32{ 3, 4 };
+    try normalizeChecked(&valid);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.6), valid[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.8), valid[1], 1e-6);
+
+    var zero = [_]f32{ 0, 0 };
+    try std.testing.expectError(error.ZeroNormVector, normalizeChecked(&zero));
+    var nan = [_]f32{ 1, std.math.nan(f32) };
+    try std.testing.expectError(error.InvalidVectorValue, normalizeChecked(&nan));
+    var infinity = [_]f32{ 1, std.math.inf(f32) };
+    try std.testing.expectError(error.InvalidVectorValue, normalizeChecked(&infinity));
 }


### PR DESCRIPTION
## Release integration

Merge the fully tested `release/0.2.5843` line into the repository default branch, `main`.

The release branch is 22 commits ahead of `main` and zero commits behind, with merge base `43bc3ca265a581de13aa7bb7bc18ce13cfa3f514`.

This includes:

- case-insensitive sensitive-path blocking and symlink/root-capability hardening
- watcher atomic-save and startup freshness fixes
- vendored OpenPuffer HNSW ANN
- opt-in Qwen 512D semantic indexing/retrieval with no CPU embedding fallback
- semantic sidecar corruption, staleness, and concurrent-source-change hardening
- validated per-project mmap sidecar caching and warm-query telemetry

## Verified release head

Exact head: `1d64f9a6df7dd180d8b9dfc684ffd70da7c9fb12`

- hosted benchmark/parity gates passed on component PRs #708, #711, and #712
- full `zig build test` passed from a detached release checkout
- ReleaseSafe native build passed
- x86_64 Linux and Windows ReleaseSafe cross-builds passed
- MCP E2E passed 75/75 from the release merge checkout
- live 8,842-record semantic sidecar smoke remained mmap-backed with no CPU fallback
- merged warm-query result: 0.108 ms validation and 1.374 ms ANN search
- three retrieval probes retained exact base/candidate top-8 ordering

No cloud deployment or secret-bearing configuration is included in this merge.
