### PR TITLE
Fix architecture context ranking and callpath language scope

### DIFF
--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -115,6 +115,21 @@ pub fn buildEdges(
     resolve: *const std.StringHashMap([]const NodeId),
     allow_self: bool,
 ) !std.ArrayList(Edge) {
+    return buildEdgesWithinGroups(allocator, funcs, resolve, null, allow_self);
+}
+
+/// Like buildEdges, but only resolves a call to definitions in the caller's
+/// language family. `groups` is indexed by NodeId. This prevents a generic
+/// name such as `route` or `run` from creating a synthetic Zig -> Python edge
+/// while still allowing deliberately compatible families (for example
+/// JavaScript/TypeScript) to share definitions.
+pub fn buildEdgesWithinGroups(
+    allocator: std.mem.Allocator,
+    funcs: []const FuncInput,
+    resolve: *const std.StringHashMap([]const NodeId),
+    groups: ?[]const u8,
+    allow_self: bool,
+) !std.ArrayList(Edge) {
     var edges: std.ArrayList(Edge) = .empty;
     errdefer edges.deinit(allocator);
     for (funcs) |f| {
@@ -123,8 +138,20 @@ pub fn buildEdges(
         for (callees) |name| {
             const cands = resolve.get(name) orelse continue;
             if (cands.len == 0) continue;
-            const w: f32 = 1.0 / @as(f32, @floatFromInt(cands.len));
+            const scoped_count: usize = if (groups) |node_groups| blk: {
+                if (f.id >= node_groups.len) break :blk 0;
+                var count: usize = 0;
+                for (cands) |to| {
+                    if (to < node_groups.len and node_groups[to] == node_groups[f.id]) count += 1;
+                }
+                break :blk count;
+            } else cands.len;
+            if (scoped_count == 0) continue;
+            const w: f32 = 1.0 / @as(f32, @floatFromInt(scoped_count));
             for (cands) |to| {
+                if (groups) |node_groups| {
+                    if (to >= node_groups.len or f.id >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
+                }
                 if (!allow_self and to == f.id) continue;
                 try edges.append(allocator, .{ .from = f.id, .to = to, .weight = w });
             }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -257,6 +257,18 @@ pub fn detectLanguage(path: []const u8) Language {
     return .unknown;
 }
 
+/// Resolution boundary for the approximate call graph. Closely interoperable
+/// source families share a group; unrelated languages never resolve one
+/// another's same-named functions.
+fn callGraphLanguageGroup(language: Language) u8 {
+    return switch (language) {
+        .c, .cpp => 1,
+        .javascript, .typescript, .svelte, .vue, .astro => 2,
+        .java, .kotlin => 3,
+        else => 16 + @as(u8, @intFromEnum(language)),
+    };
+}
+
 /// Returns true for languages whose content is primarily prose / data /
 /// markup rather than executable code. Used to deprioritise these files in
 /// content search so a CHANGELOG.md or design doc cannot starve a canonical
@@ -5674,6 +5686,7 @@ pub const Explorer = struct {
         var node_path: std.ArrayList([]const u8) = .empty;
         var node_name: std.ArrayList([]const u8) = .empty;
         var node_line: std.ArrayList(u32) = .empty;
+        var node_language_group: std.ArrayList(u8) = .empty;
         var funcs: std.ArrayList(codegraph.FuncInput) = .empty;
         var name_to_ids = std.StringHashMap(std.ArrayList(codegraph.NodeId)).init(a);
 
@@ -5700,6 +5713,7 @@ pub const Explorer = struct {
                 node_path.append(a, path) catch return;
                 node_name.append(a, sym.name) catch return;
                 node_line.append(a, sym.line_start) catch return;
+                node_language_group.append(a, callGraphLanguageGroup(detectLanguage(path))) catch return;
                 funcs.append(a, .{ .id = id, .body = content[start..end] }) catch return;
                 const gop = name_to_ids.getOrPut(sym.name) catch return;
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
@@ -5713,7 +5727,7 @@ pub const Explorer = struct {
         var n2i = name_to_ids.iterator();
         while (n2i.next()) |e| resolve.put(e.key_ptr.*, e.value_ptr.items) catch return;
 
-        var edges_tmp = codegraph.buildEdges(a, funcs.items, &resolve, false) catch return;
+        var edges_tmp = codegraph.buildEdgesWithinGroups(a, funcs.items, &resolve, node_language_group.items, false) catch return;
         defer edges_tmp.deinit(a);
 
         const edges_owned = self.allocator.alloc(codegraph.Edge, edges_tmp.items.len) catch return;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2069,7 +2069,10 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         return;
     };
-    prioritizeGenericEntrypoint(name, fuzzy, results);
+    // Explain is the opinionated one-shot neighborhood tool; keep the lower-
+    // level codedb_symbol ordering byte-for-byte stable for callers that rely
+    // on its deterministic structural index order.
+    if (getBool(args, "prefer_entrypoint")) prioritizeGenericEntrypoint(name, fuzzy, results);
     defer {
         for (results) |r| {
             alloc.free(r.path);
@@ -2771,6 +2774,7 @@ fn handleExplain(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     defer def_args.deinit(alloc);
     def_args.put(alloc, "name", .{ .string = name }) catch {};
     def_args.put(alloc, "body", .{ .bool = true }) catch {};
+    def_args.put(alloc, "prefer_entrypoint", .{ .bool = true }) catch {};
 
     var def_out: std.ArrayList(u8) = .empty;
     defer def_out.deinit(alloc);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1984,6 +1984,33 @@ fn renderOutlineOrSkeleton(
     return explorer.renderOutline(path, alloc, out, compact);
 }
 
+fn genericEntrypointPathPriority(path: []const u8) i32 {
+    if (isLowSignalArchitecturePath(path)) return -1000;
+    const base = std.fs.path.basename(path);
+    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
+    if (!std.ascii.eqlIgnoreCase(stem, "main")) return 0;
+    if (std.mem.startsWith(u8, path, "src/")) return 1000;
+    if (std.mem.indexOfScalar(u8, path, '/') == null) return 900;
+    if (pathHasSegmentIgnoreCase(path, "cmd")) return 800;
+    return 200;
+}
+
+fn prioritizeGenericEntrypoint(name: ?[]const u8, fuzzy: bool, results: []Explorer.ScoredSymbolResult) void {
+    const exact_name = name orelse return;
+    if (fuzzy or !std.ascii.eqlIgnoreCase(exact_name, "main")) return;
+    std.mem.sort(Explorer.ScoredSymbolResult, results, {}, struct {
+        fn lessThan(_: void, a: Explorer.ScoredSymbolResult, b: Explorer.ScoredSymbolResult) bool {
+            const ap = genericEntrypointPathPriority(a.path);
+            const bp = genericEntrypointPathPriority(b.path);
+            if (ap != bp) return ap > bp;
+            if (a.score != b.score) return a.score > b.score;
+            const path_order = std.mem.order(u8, a.path, b.path);
+            if (path_order != .eq) return path_order == .lt;
+            return a.symbol.line_start < b.symbol.line_start;
+        }
+    }.lessThan);
+}
+
 fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const name = getStr(args, "name");
     const prefix = getStr(args, "prefix");
@@ -2042,6 +2069,7 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         return;
     };
+    prioritizeGenericEntrypoint(name, fuzzy, results);
     defer {
         for (results) |r| {
             alloc.free(r.path);
@@ -3170,6 +3198,93 @@ const CONTEXT_MAX_RESULTS_PER_KW: usize = 8;
 const CONTEXT_TOP_FILES: usize = 5;
 const CONTEXT_TOP_LINES_PER_FILE: usize = 3;
 
+fn asciiContainsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0 or haystack.len < needle.len) return false;
+    var i: usize = 0;
+    outer: while (i + needle.len <= haystack.len) : (i += 1) {
+        for (needle, 0..) |expected, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(expected)) continue :outer;
+        }
+        return true;
+    }
+    return false;
+}
+
+fn asciiStartsWithIgnoreCase(text: []const u8, prefix: []const u8) bool {
+    return text.len >= prefix.len and std.ascii.eqlIgnoreCase(text[0..prefix.len], prefix);
+}
+
+fn pathHasSegmentIgnoreCase(path: []const u8, wanted: []const u8) bool {
+    var segments = std.mem.tokenizeAny(u8, path, "/\\");
+    while (segments.next()) |segment| {
+        if (std.ascii.eqlIgnoreCase(segment, wanted)) return true;
+    }
+    return false;
+}
+
+/// Architecture overview requests need repository-map priors, not the normal
+/// code-search prior that deliberately down-ranks Markdown. Keep this gate
+/// narrow so ordinary implementation and symbol tasks retain their tuned BM25
+/// and hybrid behavior.
+pub fn isArchitectureOverviewTask(task: []const u8) bool {
+    const architecture = asciiContainsIgnoreCase(task, "architecture") or
+        asciiContainsIgnoreCase(task, "codebase structure") or
+        asciiContainsIgnoreCase(task, "source layout");
+    if (!architecture) return false;
+    return asciiContainsIgnoreCase(task, "overview") or
+        asciiContainsIgnoreCase(task, "entrypoint") or
+        asciiContainsIgnoreCase(task, "routing") or
+        asciiContainsIgnoreCase(task, "source layout") or
+        asciiContainsIgnoreCase(task, "how the") or
+        asciiContainsIgnoreCase(task, "map");
+}
+
+fn isLowSignalArchitecturePath(path: []const u8) bool {
+    const base = std.fs.path.basename(path);
+    return pathHasSegmentIgnoreCase(path, "experiments") or
+        pathHasSegmentIgnoreCase(path, "bench") or
+        pathHasSegmentIgnoreCase(path, "benchmarks") or
+        pathHasSegmentIgnoreCase(path, "e2e") or
+        pathHasSegmentIgnoreCase(path, "test") or
+        pathHasSegmentIgnoreCase(path, "tests") or
+        pathHasSegmentIgnoreCase(path, "fixtures") or
+        pathHasSegmentIgnoreCase(path, "generated") or
+        pathHasSegmentIgnoreCase(path, ".wrangler") or
+        pathHasSegmentIgnoreCase(path, ".open-next") or
+        asciiStartsWithIgnoreCase(base, "bench-") or
+        asciiStartsWithIgnoreCase(base, "bench_") or
+        asciiStartsWithIgnoreCase(base, "e2e-") or
+        asciiStartsWithIgnoreCase(base, "e2e_") or
+        asciiStartsWithIgnoreCase(base, "test-") or
+        asciiStartsWithIgnoreCase(base, "test_");
+}
+
+/// Query-specific path prior used only for architecture-overview composition.
+/// Values are tiers, not relevance scores: retrieval order remains the
+/// tiebreak inside a tier.
+pub fn architecturePathPriority(path: []const u8) i32 {
+    if (isLowSignalArchitecturePath(path)) return -1000;
+
+    if (std.ascii.eqlIgnoreCase(path, "ARCHITECTURE.md")) return 1000;
+    if (std.ascii.eqlIgnoreCase(path, "CODEBASE.md")) return 980;
+
+    const base = std.fs.path.basename(path);
+    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
+    if (std.ascii.eqlIgnoreCase(stem, "architecture")) return 950;
+    if (std.ascii.eqlIgnoreCase(stem, "codebase")) return 930;
+
+    if (std.mem.startsWith(u8, path, "src/")) {
+        if (std.ascii.eqlIgnoreCase(stem, "main")) return 900;
+        if (std.ascii.eqlIgnoreCase(stem, "server")) return 880;
+        if (std.ascii.eqlIgnoreCase(stem, "api")) return 860;
+        if (std.ascii.eqlIgnoreCase(stem, "router") or std.ascii.eqlIgnoreCase(stem, "routes")) return 820;
+        if (std.ascii.eqlIgnoreCase(stem, "cli")) return 800;
+        return 100;
+    }
+    if (std.ascii.eqlIgnoreCase(stem, "readme") and std.mem.indexOfScalar(u8, path, '/') == null) return 700;
+    return 0;
+}
+
 pub fn extractContextCandidates(task: []const u8, alloc: std.mem.Allocator, out: *std.ArrayList([]const u8)) void {
     var seen = std.StringHashMap(void).init(alloc);
     defer seen.deinit();
@@ -3463,6 +3578,7 @@ fn handleContext(
         return;
     }
     const semantic_requested = std.mem.eql(u8, semantic_mode, "hybrid");
+    const architecture_intent = isArchitectureOverviewTask(task);
     var retrieval: ContextRetrievalProvenance = .{};
     const format = getStr(args, "format") orelse "markdown";
     const structured = std.mem.eql(u8, format, "json");
@@ -3629,8 +3745,10 @@ fn handleContext(
     for (candidates.items) |kw| {
         // Symbol definitions (best-effort; ignore failures).
         if (explorer.findAllSymbols(kw, A)) |defs| {
-            const take = @min(defs.len, 3);
-            for (defs[0..take]) |d| {
+            var accepted: usize = 0;
+            for (defs) |d| {
+                if (accepted >= 3) break;
+                if (architecture_intent and isLowSignalArchitecturePath(d.path)) continue;
                 const key = std.fmt.allocPrint(A, "{s}|{s}|{d}", .{ d.path, kw, d.symbol.line_start }) catch continue;
                 if (seen_syms.contains(key)) continue;
                 seen_syms.put(key, {}) catch continue;
@@ -3641,6 +3759,7 @@ fn handleContext(
                     .line = d.symbol.line_start,
                     .line_end = d.symbol.line_end,
                 }) catch break;
+                accepted += 1;
             }
         } else |_| {}
 
@@ -3676,6 +3795,7 @@ fn handleContext(
         hybrid_score: f32 = 0,
         lexical_present: bool = true,
         semantic_present: bool = false,
+        retrieval_rank: usize = 0,
     };
     var ranked: std.ArrayList(FileRank) = .empty;
     var iter = by_file.iterator();
@@ -3952,6 +4072,61 @@ fn handleContext(
             retrieval.semantic = "no_candidates";
         }
     }
+
+    if (architecture_intent) {
+        // Canonical repository-map files are sparse by nature: an
+        // ARCHITECTURE.md can explain every subsystem without repeating all
+        // task tokens, so lexical/ANN retrieval may never nominate it. Seed
+        // only the small set of high-priority architecture/entrypoint paths,
+        // then use the current fused order as the tiebreak within each tier.
+        var known_paths = std.StringHashMap(void).init(A);
+        for (ranked.items) |file| known_paths.put(file.path, {}) catch {};
+
+        var seed_paths: std.ArrayList([]const u8) = .empty;
+        explorer.mu.lockShared();
+        var outline_paths = explorer.outlines.keyIterator();
+        while (outline_paths.next()) |path| {
+            if (architecturePathPriority(path.*) >= 700 and !known_paths.contains(path.*)) {
+                seed_paths.append(A, path.*) catch break;
+            }
+        }
+        explorer.mu.unlockShared();
+
+        std.mem.sort([]const u8, seed_paths.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                const ap = architecturePathPriority(a);
+                const bp = architecturePathPriority(b);
+                if (ap != bp) return ap > bp;
+                return std.mem.lessThan(u8, a, b);
+            }
+        }.lessThan);
+        for (seed_paths.items) |path| {
+            var preview: std.ArrayList(PerFileHit) = .empty;
+            if (semanticSourcePreview(explorer, A, path, 1)) |text_preview| {
+                preview.append(A, .{ .line = 1, .text = text_preview }) catch {};
+            }
+            ranked.append(A, .{
+                .path = path,
+                .hits = 0,
+                .score = 0,
+                .top = preview.items,
+                .lexical_rank = ranked.items.len,
+                .semantic_rank = ranked.items.len,
+                .lexical_present = false,
+            }) catch break;
+        }
+
+        for (ranked.items, 0..) |*file, rank| file.retrieval_rank = rank;
+        std.mem.sort(FileRank, ranked.items, {}, struct {
+            fn lessThan(_: void, a: FileRank, b: FileRank) bool {
+                const ap = architecturePathPriority(a.path);
+                const bp = architecturePathPriority(b.path);
+                if (ap != bp) return ap > bp;
+                if (a.retrieval_rank != b.retrieval_rank) return a.retrieval_rank < b.retrieval_rank;
+                return std.mem.lessThan(u8, a.path, b.path);
+            }
+        }.lessThan);
+    }
     const top_n = @min(ranked.items.len, CONTEXT_TOP_FILES);
     const pf_rank = cio.nanoTimestamp();
 
@@ -4043,6 +4218,7 @@ fn handleContext(
                 var shown_for_sym: u32 = 0;
                 for (scoped) |r| {
                     if (shown_for_sym >= 2 or total_shown >= 6) break;
+                    if (architecture_intent and isLowSignalArchitecturePath(r.path)) continue;
                     if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
                     // Skip the definition site itself
                     if (r.line_num == sr.line and std.mem.eql(u8, r.path, sr.path)) continue;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2201,6 +2201,10 @@ test "walker: generated tool-output dirs are not indexed" {
     try tmp_dir.dir.writeFile(io, .{ .sub_path = ".graff/state.json", .data = "{\"packTrigram\":1}\n" });
     try tmp_dir.dir.createDirPath(io, ".harness");
     try tmp_dir.dir.writeFile(io, .{ .sub_path = ".harness/trace.jsonl", .data = "{\"packTrigram\":1}\n" });
+    try tmp_dir.dir.createDirPath(io, ".wrangler/tmp/bundle");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = ".wrangler/tmp/bundle/index.js", .data = "const packTrigram = true;\n" });
+    try tmp_dir.dir.createDirPath(io, ".open-next/server-functions");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = ".open-next/server-functions/index.js", .data = "const packTrigram = true;\n" });
 
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
     const root_len = try tmp_dir.dir.realPathFile(io, ".", &root_buf);
@@ -2220,6 +2224,8 @@ test "walker: generated tool-output dirs are not indexed" {
     try testing.expect(!explorer.contents.contains("graphify-out/cache/ast/v0.9.32/deadbeef.json"));
     try testing.expect(!explorer.contents.contains(".graff/state.json"));
     try testing.expect(!explorer.contents.contains(".harness/trace.jsonl"));
+    try testing.expect(!explorer.contents.contains(".wrangler/tmp/bundle/index.js"));
+    try testing.expect(!explorer.contents.contains(".open-next/server-functions/index.js"));
 
     var it = explorer.contents.iterator();
     while (it.next()) |kv| {
@@ -2227,6 +2233,8 @@ test "walker: generated tool-output dirs are not indexed" {
         try testing.expect(std.mem.indexOf(u8, p, "graphify-out") == null);
         try testing.expect(std.mem.indexOf(u8, p, ".graff") == null);
         try testing.expect(std.mem.indexOf(u8, p, ".harness") == null);
+        try testing.expect(std.mem.indexOf(u8, p, ".wrangler") == null);
+        try testing.expect(std.mem.indexOf(u8, p, ".open-next") == null);
     }
 
     // ...and the generated blobs contribute nothing to the word index, so a
@@ -2922,6 +2930,29 @@ test "issue-656: call graph is stale and dangling after a file edit" {
     const after = try explorer_inst.findCallPath("alpha", "beta", testing.allocator, 4);
     defer if (after) |steps| testing.allocator.free(steps);
     try testing.expect(after != null);
+}
+
+test "issue-718: call paths do not cross languages through name collisions" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("src/http.zig",
+        \\pub fn handle() void {
+        \\    route();
+        \\}
+        \\pub fn parseRequest() void {}
+    );
+    try explorer_inst.indexFile("experiments/router.py",
+        \\def route():
+        \\    parseRequest()
+    );
+
+    // Name-only resolution used to invent:
+    //   Zig handle -> Python route -> Zig parseRequest.
+    // There is no same-language `route`, so the honest answer is no path.
+    const path = try explorer_inst.findCallPath("handle", "parseRequest", testing.allocator, 4);
+    defer if (path) |steps| testing.allocator.free(steps);
+    try testing.expect(path == null);
 }
 
 test "render caches preserve output and invalidate on mutation" {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2576,6 +2576,80 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     try testing.expect(std.mem.indexOf(u8, out.items, "ranking") != null);
 }
 
+test "issue-718: architecture context prefers canonical docs and entrypoints" {
+    try testing.expect(mcp_mod.isArchitectureOverviewTask("overview of the project architecture and source layout"));
+    try testing.expect(!mcp_mod.isArchitectureOverviewTask("fix architecturePathPriority"));
+    try testing.expect(mcp_mod.architecturePathPriority("ARCHITECTURE.md") > mcp_mod.architecturePathPriority("experiments/e2e-attach.sh"));
+
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
+
+    try explorer.indexFile("ARCHITECTURE.md", "# Architecture\nThe server, API, CLI, routing, git plumbing, merge queue, and workspace sync.\n");
+    try explorer.indexFile("CODEBASE.md", "# Source layout\nCanonical codebase map and package boundaries.\n");
+    try explorer.indexFile("src/main.zig", "pub fn main() void { startServer(); }\n");
+    try explorer.indexFile("src/server.zig", "pub fn startServer() void { routeHttp(); }\n");
+    try explorer.indexFile("src/api.zig", "pub fn routeHttp() void {}\n");
+    try explorer.indexFile("src/workspace_sync.zig", "// architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+    try explorer.indexFile("experiments/e2e-attach.sh", "CLI=\"\" # architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+    try explorer.indexFile("website/generated/frontend.js", "// architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"task":"overview of project architecture: server entrypoint, HTTP routing, git plumbing APIs, CLI, merge queue, workspace sync, and source layout","semantic":"local"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    const files_start = std.mem.indexOf(u8, out.items, "## Most-relevant files") orelse return error.TestUnexpectedResult;
+    const sites_start = std.mem.indexOfPos(u8, out.items, files_start, "## Top sites") orelse out.items.len;
+    const files = out.items[files_start..sites_start];
+    for ([_][]const u8{ "ARCHITECTURE.md", "CODEBASE.md", "src/main.zig", "src/server.zig", "src/api.zig" }) |gold| {
+        try testing.expect(std.mem.indexOf(u8, files, gold) != null);
+    }
+    try testing.expect(std.mem.indexOf(u8, files, "experiments/e2e-attach.sh") == null);
+    try testing.expect(std.mem.indexOf(u8, files, "website/generated/frontend.js") == null);
+}
+
+test "issue-718: explain main puts the package entrypoint first" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
+    try explorer.indexFile("experiments/probe.py", "def main():\n    return 1\n");
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"name":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_explain, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    const entrypoint_pos = std.mem.indexOf(u8, out.items, "src/main.zig") orelse return error.TestUnexpectedResult;
+    const experiment_pos = std.mem.indexOf(u8, out.items, "experiments/probe.py") orelse return error.TestUnexpectedResult;
+    try testing.expect(entrypoint_pos < experiment_pos);
+}
+
 test "issue-688: codedb_context json exposes typed provenance and preserves markdown default" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -249,6 +249,8 @@ const skip_dirs = [_][]const u8{
     ".zig-cache",
     "zig-out",
     ".next",
+    ".open-next",
+    ".wrangler",
     ".nuxt",
     ".svelte-kit",
     "dist",


### PR DESCRIPTION
Closes #718.

## What changed
- exclude `.wrangler` and `.open-next` generated caches from indexing/ANN corpus
- add a narrowly gated architecture-overview prior after hybrid fusion
- seed canonical architecture/codebase docs and shallow source entrypoints
- demote experiments, e2e, generated, test, and benchmark paths for overview tasks
- prefer package `src/main.*` definitions for generic `codedb_explain main`
- resolve call-graph edges only within compatible language families

## Regression coverage
- architecture fixture requires all 5 gold files in top-5 and rejects e2e/generated files
- generated cache walker coverage for Wrangler/OpenNext
- generic main ordering test
- cross-language synthetic callpath rejection

## Verification
- `zig build test --summary all`: 1033 passed, 4 skipped
- MCP E2E: 76/76 passed
- `@hasmcp/mcp-spec-test` 2026-07-28: 27 passed, 0 failed
- live hybrid ANN: 8926 chunks, Qwen 512D, mmap=true; architecture docs/entrypoints retained after fusion