### PR TITLE
Release 0.2.5846

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -15,6 +15,45 @@ env:
   PAIRED_5829_SHA: 24e89c70d4f9cdaf5542a78d83d1890a42b4a046
 
 jobs:
+  macos-resource-regression:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pinned Zig toolchain
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            arm64)
+              zig_arch=aarch64
+              zig_sha=36673d2513afa4a96c86780648ba504beedd7f0451389091cf9d53e38d5b4840
+              ;;
+            x86_64)
+              zig_arch=x86_64
+              zig_sha=3938c46ae4bca3c13f423b09503e3ef00bb4b7ef12b8bc1e5122ede366057a5b
+              ;;
+            *)
+              echo "unsupported macOS architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          archive="zig-${zig_arch}-macos-${ZIG_VERSION}.tar.xz"
+          directory="zig-${zig_arch}-macos-${ZIG_VERSION}"
+          curl --fail --show-error --location --retry 3 \
+            "https://ziglang.org/builds/${archive}" -o zig-macos.tar.xz || \
+          curl --fail --show-error --location --retry 3 \
+            "https://pkg.machengine.org/zig/${archive}" -o zig-macos.tar.xz
+          echo "${zig_sha}  zig-macos.tar.xz" | shasum -a 256 --check
+          tar -xf zig-macos.tar.xz
+          test "$("$PWD/${directory}/zig" version)" = "$ZIG_VERSION"
+          echo "$PWD/${directory}" >> "$GITHUB_PATH"
+
+      - name: Run macOS watcher unit and process gates
+        run: |
+          zig build test-index -Dtest-filter=issue-709
+          zig build -Doptimize=ReleaseFast
+          python3 scripts/fd_regression_test.py --binary zig-out/bin/codedb
+
   bench:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 0.2.5846 - 2026-08-28
+
+- **Bounded, correct filesystem watching** (#704, #709). macOS vnode watches
+  now obey `max_watched` (default 1024; `0` selects polling-only), prioritize
+  directories, and poll overflow paths without losing updates. Cold and
+  incremental walks now honor full nested gitignore semantics, including
+  `**`, negation, and `.git/info/exclude`, while `.codedbignore` remains
+  authoritative. A process-level macOS FD-slope gate prevents recurrence.
+- **MCP 2026 revision conformance** (#705). Pre-handshake `server/discover`
+  works with cache metadata, per-request revision selection overrides the
+  handshake fallback, and legacy clients no longer receive 2026-only result
+  envelope fields.
+- **Architecture-aware hybrid context** (#718). Overview tasks seed and rank
+  canonical architecture/codebase docs and source entrypoints after ANN
+  fusion, while experiments, e2e scripts, generated output, tests, and
+  benchmarks are demoted. Wrangler/OpenNext caches are excluded from the
+  corpus, `codedb_explain main` prefers the package entrypoint, and call paths
+  can no longer jump across unrelated languages through name collisions.
+
 ## 0.2.5845 - 2026-08-28
 
 - **Pareto-frontier hybrid retrieval is now the default.** `codedb_context`

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5845",
+    .version = "0.2.5846",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -219,6 +219,7 @@ comments. Unknown keys are ignored.
 # .codedbrc
 max_cached   = 16384   # in-memory ContentCache size (files); default 16384
 max_versions = 100     # versions kept per file in the change log; default 100
+max_watched  = 1024    # macOS vnode-FD ceiling; 0 = polling only
 rerank_trace = false   # write per-search rerank-trace.jsonl (debug only)
 ```
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -106,6 +106,7 @@ that project. Full keys + defaults:
 # .codedbrc
 max_cached   = 16384   # in-memory ContentCache size (files); v0.2.5815+
 max_versions = 100     # versions kept per file in the change log
+max_watched  = 1024    # macOS vnode-FD ceiling; overflow paths are polled
 rerank_trace = false   # write per-search rerank-trace.jsonl (debug)
 ```
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5845",
+  "version": "0.2.5846",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/scripts/e2e_mcp_test.py
+++ b/scripts/e2e_mcp_test.py
@@ -3,6 +3,7 @@
 E2E MCP test harness for codedb.
 
 Scenarios covered:
+  0. issue-705 regression: server/discover responds before initialize.
   1. issue-346 regression: spawn from cwd=/, complete MCP handshake via roots, wait
      for scan to finish, verify core tools return real data from the project.
   2. Normal mode: spawn with explicit --root <path>, verify scan runs immediately
@@ -270,6 +271,39 @@ class TestResult:
         self.passed = False
         self.message = msg
         return self
+
+
+def run_scenario_0_issue705_pre_handshake_discover(binary: str) -> list[TestResult]:
+    """MCP 2026-07-28 discovery is stateless and must work pre-handshake."""
+    results: list[TestResult] = []
+    r = TestResult("[S0] server/discover responds before initialize")
+    results.append(r)
+    with tempfile.TemporaryDirectory(prefix="codedb-discover-") as project_tmp:
+        root = Path(project_tmp).resolve()
+        (root / "pyproject.toml").write_text("[project]\nname='discover-fixture'\nversion='0'\n")
+        (root / "main.py").write_text("def main():\n    return 0\n")
+        p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
+        try:
+            p.send({
+                "jsonrpc": "2.0",
+                "id": 705,
+                "method": "server/discover",
+                "params": {},
+            })
+            response = p.recv(timeout=3.0)
+            result = response.get("result", {}) if response else {}
+            versions = result.get("supportedVersions", [])
+            if response is None:
+                r.fail("timed out after 3s")
+            elif response.get("id") != 705 or result.get("resultType") != "complete":
+                r.fail(f"malformed discovery result: {response!r}")
+            elif "2026-07-28" not in versions:
+                r.fail(f"2026-07-28 missing from supportedVersions: {versions!r}")
+            else:
+                r.ok(f"responded pre-handshake with {len(versions)} version(s)")
+        finally:
+            p.close()
+    return results
 
 
 def run_scenario_1_issue346_regression(binary: str, project: str) -> list[TestResult]:
@@ -1306,7 +1340,10 @@ def main() -> int:
 
     all_results: list[TestResult] = []
 
-    print(f"{CYAN}── Scenario 1: issue-346 regression (spawn from /, roots handshake) ──{RESET}")
+    print(f"{CYAN}── Scenario 0: issue-705 pre-handshake discovery ──{RESET}")
+    all_results += run_scenario_0_issue705_pre_handshake_discover(binary)
+
+    print(f"\n{CYAN}── Scenario 1: issue-346 regression (spawn from /, roots handshake) ──{RESET}")
     all_results += run_scenario_1_issue346_regression(binary, project)
 
     print(f"\n{CYAN}── Scenario 2: normal mode (explicit --root) ──{RESET}")

--- a/scripts/fd_regression_test.py
+++ b/scripts/fd_regression_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Black-box regression gate for #709's macOS descriptor-per-file slope."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from e2e_mcp_test import MCPProcess, do_initialize, wait_for_scan
+
+
+def descriptor_count(pid: int) -> int:
+    proc_fd = Path(f"/proc/{pid}/fd")
+    if proc_fd.is_dir():
+        return len(list(proc_fd.iterdir()))
+    output = subprocess.check_output(
+        ["lsof", "-a", "-p", str(pid), "-Fn"], text=True, timeout=10
+    )
+    return sum(1 for line in output.splitlines() if line.startswith("n"))
+
+
+def measure(binary: str, file_count: int, budget: int) -> int:
+    with tempfile.TemporaryDirectory(prefix=f"codedb-fd-{file_count}-") as tmp:
+        root = Path(tmp).resolve()
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        (root / "pyproject.toml").write_text(
+            f"[project]\nname='fd-fixture-{file_count}'\nversion='0'\n"
+        )
+        (root / ".codedbrc").write_text(f"max_watched = {budget}\n")
+        for i in range(file_count):
+            directory = root / "src" / f"bucket-{i % 64:02d}"
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / f"file-{i:05d}.py").write_text(
+                f"def value_{i}():\n    return {i}\n"
+            )
+
+        env = {
+            **os.environ,
+            "CODEDB_NO_AUTO_UPDATE": "1",
+            "CODEDB_NO_CLI_DAEMON": "1",
+            "CODEDB_NO_TELEMETRY": "1",
+            "CODEDB_QUIET": "1",
+        }
+        p = MCPProcess(
+            binary,
+            [],
+            cwd=str(root),
+            env=env,
+            command=[
+                binary,
+                str(root),
+                "mcp",
+                f"--config-file={root / '.codedbrc'}",
+                "--no-telemetry",
+            ],
+        )
+        try:
+            if not do_initialize(p, with_roots=False):
+                raise RuntimeError("initialize failed")
+            if not wait_for_scan(p, timeout=90):
+                raise RuntimeError("index did not become ready")
+            # `scan: ready` is published just before the watcher completes its
+            # first arm/reconcile pass. Sample only after that bounded handoff,
+            # otherwise a tiny fixture can look artificially lower than the
+            # large fixture and create a false positive slope.
+            time.sleep(1.0)
+            return descriptor_count(p.proc.pid)
+        finally:
+            p.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", default="zig-out/bin/codedb")
+    parser.add_argument("--budget", type=int, default=32)
+    parser.add_argument("--small", type=int, default=128)
+    parser.add_argument("--large", type=int, default=2048)
+    args = parser.parse_args()
+    binary = str(Path(args.binary).resolve())
+    if platform.system() != "Darwin":
+        print("SKIP: #709 is a macOS kqueue descriptor regression")
+        return 0
+
+    small = measure(binary, args.small, args.budget)
+    large = measure(binary, args.large, args.budget)
+    fixed_overhead_allowance = 48
+    slope_allowance = 8
+    print(
+        f"macOS descriptors: small({args.small})={small}, "
+        f"large({args.large})={large}, budget={args.budget}"
+    )
+    if large > args.budget + fixed_overhead_allowance:
+        raise SystemExit(
+            f"FAIL: {large} descriptors exceeds budget + fixed overhead "
+            f"({args.budget + fixed_overhead_allowance})"
+        )
+    if large - small > slope_allowance:
+        raise SystemExit(
+            f"FAIL: descriptor count still scales with corpus (+{large - small})"
+        )
+    print("PASS: descriptor acquisition is bounded and corpus-size independent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/background.zig
+++ b/src/background.zig
@@ -295,7 +295,7 @@ pub fn watcherDeferredLoop(ctx: *mcp_server.DeferredScan) void {
         ctx.explorer.finishStartupReconcile();
         return;
     }
-    watcher.incrementalLoop(ctx.io, ctx.store, ctx.explorer, ctx.queue, ctx.resolved_root, ctx.shutdown, ctx.scan_done);
+    watcher.incrementalLoop(ctx.io, ctx.store, ctx.explorer, ctx.queue, ctx.resolved_root, ctx.shutdown, ctx.scan_done, ctx.max_watched);
 }
 
 pub fn idleWatchdog(shutdown: *std.atomic.Value(bool)) void {

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -115,6 +115,21 @@ pub fn buildEdges(
     resolve: *const std.StringHashMap([]const NodeId),
     allow_self: bool,
 ) !std.ArrayList(Edge) {
+    return buildEdgesWithinGroups(allocator, funcs, resolve, null, allow_self);
+}
+
+/// Like buildEdges, but only resolves a call to definitions in the caller's
+/// language family. `groups` is indexed by NodeId. This prevents a generic
+/// name such as `route` or `run` from creating a synthetic Zig -> Python edge
+/// while still allowing deliberately compatible families (for example
+/// JavaScript/TypeScript) to share definitions.
+pub fn buildEdgesWithinGroups(
+    allocator: std.mem.Allocator,
+    funcs: []const FuncInput,
+    resolve: *const std.StringHashMap([]const NodeId),
+    groups: ?[]const u8,
+    allow_self: bool,
+) !std.ArrayList(Edge) {
     var edges: std.ArrayList(Edge) = .empty;
     errdefer edges.deinit(allocator);
     for (funcs) |f| {
@@ -123,8 +138,20 @@ pub fn buildEdges(
         for (callees) |name| {
             const cands = resolve.get(name) orelse continue;
             if (cands.len == 0) continue;
-            const w: f32 = 1.0 / @as(f32, @floatFromInt(cands.len));
+            const scoped_count: usize = if (groups) |node_groups| blk: {
+                if (f.id >= node_groups.len) break :blk 0;
+                var count: usize = 0;
+                for (cands) |to| {
+                    if (to < node_groups.len and node_groups[to] == node_groups[f.id]) count += 1;
+                }
+                break :blk count;
+            } else cands.len;
+            if (scoped_count == 0) continue;
+            const w: f32 = 1.0 / @as(f32, @floatFromInt(scoped_count));
             for (cands) |to| {
+                if (groups) |node_groups| {
+                    if (to >= node_groups.len or f.id >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
+                }
                 if (!allow_self and to == f.id) continue;
                 try edges.append(allocator, .{ .from = f.id, .to = to, .weight = w });
             }

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -353,7 +353,7 @@ pub fn runCliDaemon(ctx: *RunCtx) !void {
     defer allocator.destroy(queue);
     queue.* = watcher.EventQueue{};
     explorer.expectStartupReconcile();
-    const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done });
+    const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done, ctx.cfg.max_watched });
     watch_thread.detach();
 
     std.log.info("cli-daemon: {d} files indexed, idle_timeout={d}ms", .{ store.currentSeq(), idle_ms });
@@ -421,7 +421,7 @@ pub fn runServe(ctx: *RunCtx) !void {
     defer allocator.destroy(queue);
     queue.* = watcher.EventQueue{};
     explorer.expectStartupReconcile();
-    const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done });
+    const watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_already_done, ctx.cfg.max_watched });
     defer watch_thread.join();
 
     const reap_thread = try std.Thread.spawn(.{}, reapLoop, .{ &agents, &shutdown });
@@ -507,6 +507,7 @@ pub fn runMcp(ctx: *RunCtx) !void {
             .shutdown = &shutdown,
             .telem = &telem,
             .queue = queue,
+            .max_watched = cfg.max_watched,
             .startup_t0 = startup_t0,
             .fallback_cwd = abs_root,
             .triggerFn = triggerScanFromRoots,
@@ -532,7 +533,7 @@ pub fn runMcp(ctx: *RunCtx) !void {
             mcp_server.setScanState(.ready);
         }
         explorer.expectStartupReconcile();
-        watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_done });
+        watch_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ io, store, explorer, queue, root, &shutdown, &scan_done, cfg.max_watched });
     }
 
     const idle_thread = try std.Thread.spawn(.{}, idleWatchdog, .{&shutdown});

--- a/src/config.zig
+++ b/src/config.zig
@@ -11,12 +11,15 @@ const std = @import("std");
 /// are ignored. Unknown keys are silently ignored so upgrades don't break
 /// older configs.
 ///
-/// Addresses #101 (max_versions) and #102 (max_cached).
+/// Addresses #101 (max_versions), #102 (max_cached), and #709 (max_watched).
 pub const Config = struct {
     /// Cap per-file version history in the Store. Default 100.
     max_versions: usize = 100,
     /// Cap on files kept in the Explorer's in-memory content cache. Default 16384.
     max_cached: u32 = 16384,
+    /// macOS only: maximum vnode descriptors held by the live watcher.
+    /// Overflow paths remain correct through bounded-interval polling.
+    max_watched: u32 = 1024,
     /// When true, append one JSON line per searchContent invocation to
     /// <data_dir>/rerank-traces.jsonl. v0 logger for offline rerank-tuning
     /// experiments. Off by default — opt in via .codedbrc.
@@ -41,6 +44,8 @@ pub const Config = struct {
             } else if (std.mem.eql(u8, key, "max_cached")) {
                 cfg.max_cached = std.fmt.parseInt(u32, val, 10) catch return error.InvalidMaxCached;
                 if (cfg.max_cached == 0) return error.InvalidMaxCached;
+            } else if (std.mem.eql(u8, key, "max_watched")) {
+                cfg.max_watched = std.fmt.parseInt(u32, val, 10) catch return error.InvalidMaxWatched;
             } else if (std.mem.eql(u8, key, "rerank_trace")) {
                 cfg.rerank_trace = parseBool(val) catch return error.InvalidRerankTrace;
             }
@@ -111,12 +116,14 @@ test "config: defaults" {
     const cfg = Config.default;
     try testing.expectEqual(@as(usize, 100), cfg.max_versions);
     try testing.expectEqual(@as(u32, 16384), cfg.max_cached);
+    try testing.expectEqual(@as(u32, 1024), cfg.max_watched);
 }
 
 test "config: parse single key" {
     const cfg = try Config.parse("max_versions = 42\n");
     try testing.expectEqual(@as(usize, 42), cfg.max_versions);
     try testing.expectEqual(@as(u32, 16384), cfg.max_cached);
+    try testing.expectEqual(@as(u32, 1024), cfg.max_watched);
 }
 
 test "config: parse both keys with comments and whitespace" {
@@ -125,11 +132,13 @@ test "config: parse both keys with comments and whitespace" {
         \\
         \\max_versions = 200
         \\  max_cached   =   2048
+        \\  max_watched  =   256
         \\# trailing comment
         \\
     );
     try testing.expectEqual(@as(usize, 200), cfg.max_versions);
     try testing.expectEqual(@as(u32, 2048), cfg.max_cached);
+    try testing.expectEqual(@as(u32, 256), cfg.max_watched);
 }
 
 test "config: unknown keys are ignored" {
@@ -141,6 +150,8 @@ test "config: malformed value rejected" {
     try testing.expectError(error.InvalidMaxVersions, Config.parse("max_versions = not_a_number\n"));
     try testing.expectError(error.InvalidMaxVersions, Config.parse("max_versions = 0\n"));
     try testing.expectError(error.InvalidMaxCached, Config.parse("max_cached = 0\n"));
+    try testing.expectError(error.InvalidMaxWatched, Config.parse("max_watched = nope\n"));
+    try testing.expectEqual(@as(u32, 0), (try Config.parse("max_watched = 0\n")).max_watched);
 }
 
 test "config: rerank_trace defaults off and parses true/false" {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -257,6 +257,18 @@ pub fn detectLanguage(path: []const u8) Language {
     return .unknown;
 }
 
+/// Resolution boundary for the approximate call graph. Closely interoperable
+/// source families share a group; unrelated languages never resolve one
+/// another's same-named functions.
+fn callGraphLanguageGroup(language: Language) u8 {
+    return switch (language) {
+        .c, .cpp => 1,
+        .javascript, .typescript, .svelte, .vue, .astro => 2,
+        .java, .kotlin => 3,
+        else => 16 + @as(u8, @intFromEnum(language)),
+    };
+}
+
 /// Returns true for languages whose content is primarily prose / data /
 /// markup rather than executable code. Used to deprioritise these files in
 /// content search so a CHANGELOG.md or design doc cannot starve a canonical
@@ -5674,6 +5686,7 @@ pub const Explorer = struct {
         var node_path: std.ArrayList([]const u8) = .empty;
         var node_name: std.ArrayList([]const u8) = .empty;
         var node_line: std.ArrayList(u32) = .empty;
+        var node_language_group: std.ArrayList(u8) = .empty;
         var funcs: std.ArrayList(codegraph.FuncInput) = .empty;
         var name_to_ids = std.StringHashMap(std.ArrayList(codegraph.NodeId)).init(a);
 
@@ -5700,6 +5713,7 @@ pub const Explorer = struct {
                 node_path.append(a, path) catch return;
                 node_name.append(a, sym.name) catch return;
                 node_line.append(a, sym.line_start) catch return;
+                node_language_group.append(a, callGraphLanguageGroup(detectLanguage(path))) catch return;
                 funcs.append(a, .{ .id = id, .body = content[start..end] }) catch return;
                 const gop = name_to_ids.getOrPut(sym.name) catch return;
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
@@ -5713,7 +5727,7 @@ pub const Explorer = struct {
         var n2i = name_to_ids.iterator();
         while (n2i.next()) |e| resolve.put(e.key_ptr.*, e.value_ptr.items) catch return;
 
-        var edges_tmp = codegraph.buildEdges(a, funcs.items, &resolve, false) catch return;
+        var edges_tmp = codegraph.buildEdgesWithinGroups(a, funcs.items, &resolve, node_language_group.items, false) catch return;
         defer edges_tmp.deinit(a);
 
         const edges_owned = self.allocator.alloc(codegraph.Edge, edges_tmp.items.len) catch return;

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -1,4 +1,4 @@
-//! gitignore matching for `codedb list_dir`.
+//! Shared gitignore matching for live listings and repository indexing.
 //!
 //! Subset of git's rules: comments, `!` negation, trailing-`/` directories,
 //! leading-`/` (or mid-slash) anchored to the ignore file's directory, `*` / `?`
@@ -93,39 +93,48 @@ fn globSeg(pat: []const u8, s: []const u8) bool {
     return false;
 }
 
-fn matchSegs(pat: []const []const u8, path: []const []const u8) bool {
-    if (pat.len == 0) return path.len == 0;
-    if (std.mem.eql(u8, pat[0], "**")) {
-        if (pat.len == 1) return true;
-        var i: usize = 0;
-        while (i <= path.len) : (i += 1) {
-            if (matchSegs(pat[1..], path[i..])) return true;
+const Segment = struct {
+    value: []const u8,
+    next: usize,
+};
+
+fn nextSegment(s: []const u8, start: usize) ?Segment {
+    var begin = start;
+    while (begin < s.len and s[begin] == '/') begin += 1;
+    if (begin >= s.len) return null;
+    const end = std.mem.indexOfScalarPos(u8, s, begin, '/') orelse s.len;
+    return .{ .value = s[begin..end], .next = end };
+}
+
+/// Allocation-free segment matcher. Indexing calls this once per path, so the
+/// old split-into-ArrayList implementation accumulated scan-sized scratch
+/// allocations when its caller used a long-lived arena.
+fn matchSegs(pattern: []const u8, pattern_at: usize, path: []const u8, path_at: usize) bool {
+    const pat = nextSegment(pattern, pattern_at) orelse return nextSegment(path, path_at) == null;
+    if (std.mem.eql(u8, pat.value, "**")) {
+        if (nextSegment(pattern, pat.next) == null) return true;
+        if (matchSegs(pattern, pat.next, path, path_at)) return true;
+        var cursor = path_at;
+        while (nextSegment(path, cursor)) |segment| {
+            cursor = segment.next;
+            if (matchSegs(pattern, pat.next, path, cursor)) return true;
         }
         return false;
     }
-    if (path.len == 0) return false;
-    if (!globSeg(pat[0], path[0])) return false;
-    return matchSegs(pat[1..], path[1..]);
-}
-
-fn split(arena: Allocator, s: []const u8) ![]const []const u8 {
-    var list: std.ArrayList([]const u8) = .empty;
-    var it = std.mem.splitScalar(u8, s, '/');
-    while (it.next()) |p| {
-        if (p.len == 0) continue;
-        try list.append(arena, p);
-    }
-    return list.items;
+    const part = nextSegment(path, path_at) orelse return false;
+    if (!globSeg(pat.value, part.value)) return false;
+    return matchSegs(pattern, pat.next, path, part.next);
 }
 
 fn matchPattern(arena: Allocator, pattern: []const u8, local: []const u8, anchored: bool) !bool {
+    _ = arena;
     if (pattern.len == 0) return false;
-    const p = try split(arena, pattern);
-    const segs = try split(arena, local);
-    if (anchored) return matchSegs(p, segs);
-    var i: usize = 0;
-    while (i <= segs.len) : (i += 1) {
-        if (matchSegs(p, segs[i..])) return true;
+    if (anchored) return matchSegs(pattern, 0, local, 0);
+    if (matchSegs(pattern, 0, local, 0)) return true;
+    var cursor: usize = 0;
+    while (nextSegment(local, cursor)) |segment| {
+        cursor = segment.next;
+        if (matchSegs(pattern, 0, local, cursor)) return true;
     }
     return false;
 }

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2069,7 +2069,10 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         return;
     };
-    prioritizeGenericEntrypoint(name, fuzzy, results);
+    // Explain is the opinionated one-shot neighborhood tool; keep the lower-
+    // level codedb_symbol ordering byte-for-byte stable for callers that rely
+    // on its deterministic structural index order.
+    if (getBool(args, "prefer_entrypoint")) prioritizeGenericEntrypoint(name, fuzzy, results);
     defer {
         for (results) |r| {
             alloc.free(r.path);
@@ -2771,6 +2774,7 @@ fn handleExplain(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     defer def_args.deinit(alloc);
     def_args.put(alloc, "name", .{ .string = name }) catch {};
     def_args.put(alloc, "body", .{ .bool = true }) catch {};
+    def_args.put(alloc, "prefer_entrypoint", .{ .bool = true }) catch {};
 
     var def_out: std.ArrayList(u8) = .empty;
     defer def_out.deinit(alloc);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -40,6 +40,7 @@ pub const DeferredScan = struct {
     shutdown: *std.atomic.Value(bool),
     telem: *telemetry_mod.Telemetry,
     queue: *watcher.EventQueue,
+    max_watched: u32,
     startup_t0: i64,
     triggered: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     scan_thread: ?std.Thread = null,
@@ -576,7 +577,7 @@ pub const BenchContext = struct {
         agents: *AgentRegistry,
         telem: *telemetry_mod.Telemetry,
     ) void {
-        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null, null, null);
+        handleCall(io, alloc, root, stdout, id, store, explorer, agents, &self.cache, telem, null, null, null, true);
     }
 
     pub fn runToolCall(
@@ -728,6 +729,9 @@ pub const ToolsListOpts = struct {
     profile_core: bool = false,
     profile_slim: bool = false,
     profile_mini: bool = false,
+    /// MCP 2026-07-28 adds CacheableResult hints to list results. Legacy
+    /// handshake clients must not receive those newer-revision fields.
+    modern_results: bool = true,
 };
 
 /// CODEDB_TOOLS_PROFILE=mini (agent default) advertises the one-shot
@@ -892,7 +896,10 @@ fn isCoreProfileTool(name: []const u8) bool {
 /// allocator-owned slice the caller must free.
 pub fn buildToolsListResponse(alloc: std.mem.Allocator, opts: ToolsListOpts) ![]u8 {
     if (opts.bundle_enabled and opts.discriminated_opt_in) {
-        return buildAugmentedToolsList(alloc);
+        const augmented = try buildAugmentedToolsList(alloc);
+        if (opts.modern_results) return augmented;
+        defer alloc.free(augmented);
+        return stripModernListFields(alloc, augmented);
     }
 
     var arena = std.heap.ArenaAllocator.init(alloc);
@@ -902,6 +909,10 @@ pub fn buildToolsListResponse(alloc: std.mem.Allocator, opts: ToolsListOpts) ![]
     var parsed = try std.json.parseFromSlice(std.json.Value, a, tools_list, .{});
 
     const root_obj = &parsed.value.object;
+    if (!opts.modern_results) {
+        _ = root_obj.swapRemove("ttlMs");
+        _ = root_obj.swapRemove("cacheScope");
+    }
     const tools_val = root_obj.getPtr("tools") orelse return error.MalformedToolsList;
     if (tools_val.* != .array) return error.MalformedToolsList;
 
@@ -958,6 +969,15 @@ pub fn buildToolsListResponse(alloc: std.mem.Allocator, opts: ToolsListOpts) ![]
 
     const out_in_arena = try std.json.Stringify.valueAlloc(a, parsed.value, .{});
     return try alloc.dupe(u8, out_in_arena);
+}
+
+fn stripModernListFields(alloc: std.mem.Allocator, payload: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, payload, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.MalformedToolsList;
+    _ = parsed.value.object.swapRemove("ttlMs");
+    _ = parsed.value.object.swapRemove("cacheScope");
+    return std.json.Stringify.valueAlloc(alloc, parsed.value, .{});
 }
 
 pub fn buildAugmentedToolsList(alloc: std.mem.Allocator) ![]u8 {
@@ -1087,6 +1107,9 @@ const Session = struct {
     client_supports_roots: bool = false,
     client_roots_list_changed: bool = false,
     client_name: ?[]const u8 = null,
+    /// Default response revision. Stateless requests start modern; a legacy
+    /// initialize handshake changes the fallback for requests without _meta.
+    modern_results: bool = true,
     pending_roots_id: ?i64 = null,
     roots: std.ArrayList(Root) = .empty,
     deferred_scan: ?*DeferredScan = null,
@@ -1360,21 +1383,27 @@ pub fn run(
             }
         } else if (mcpj.eql(method, "tools/list")) {
             if (!is_notification) {
+                const modern_results = requestUsesModernResults(root, session.modern_results);
                 const mini_default = !profile_explicit and !mcpEmitRichBlocks(session.client_name);
+                var resp_owned = true;
                 const resp = buildToolsListResponse(alloc, .{
                     .bundle_enabled = bundle_enabled,
                     .discriminated_opt_in = discriminated_opt_in,
                     .profile_core = profile_core,
                     .profile_slim = profile_slim,
                     .profile_mini = profile_mini or mini_default,
-                }) catch tools_list;
-                defer if (resp.ptr != tools_list.ptr) alloc.free(resp);
-                writeResult(alloc, stdout, id, resp);
+                    .modern_results = modern_results,
+                }) catch blk: {
+                    resp_owned = false;
+                    break :blk if (modern_results) tools_list else "{\"tools\":[]}";
+                };
+                defer if (resp_owned) alloc.free(resp);
+                writeResultVersioned(alloc, stdout, id, resp, modern_results);
             }
         } else if (mcpj.eql(method, "tools/call")) {
-            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, &session.governor, session.client_name);
+            handleCall(io, alloc, root, stdout, id, store, explorer, agents, &cache, telem, session.deferred_scan, &session.governor, session.client_name, requestUsesModernResults(root, session.modern_results));
         } else if (mcpj.eql(method, "ping")) {
-            if (!is_notification) writeResult(alloc, stdout, id, "{}");
+            if (!is_notification) writeResultVersioned(alloc, stdout, id, "{}", requestUsesModernResults(root, session.modern_results));
         } else if (mcpj.eql(method, "server/discover")) {
             if (!is_notification) writeResult(alloc, stdout, id, discover_result);
         } else {
@@ -1419,11 +1448,12 @@ fn handleInitialize(s: *Session, root: *const std.json.ObjectMap, id: ?std.json.
         const requested = mcpj.getStr(&p.object, "protocolVersion") orelse break :proto;
         if (negotiateProtocolVersion(requested)) |v| negotiated = v;
     }
+    s.modern_results = std.mem.eql(u8, negotiated, "2026-07-28");
     const init_result = std.fmt.allocPrint(s.alloc,
         \\{{"protocolVersion":"{s}","capabilities":{{"tools":{{"listChanged":false}},"extensions":{{}}}},"serverInfo":{{"name":"codedb","version":"{s}"}},"instructions":"{s}"}}
     , .{ negotiated, release_info.semver, mcp_instructions }) catch return;
     defer s.alloc.free(init_result);
-    writeResult(s.alloc, s.stdout, id, init_result);
+    writeResultVersioned(s.alloc, s.stdout, id, init_result, s.modern_results);
 }
 /// Versions of the MCP spec this server has been verified against. Listed
 /// newest-first because clients that send a newer version than we know
@@ -1492,6 +1522,17 @@ pub fn unsupportedMetaProtocolVersion(root: *const std.json.ObjectMap) ?[]const 
         if (std.mem.eql(u8, s, v)) return null;
     }
     return v;
+}
+
+/// Choose the result schema for this request. MCP 2026 is stateless, so an
+/// explicit per-request version wins over any earlier initialize handshake.
+pub fn requestUsesModernResults(root: *const std.json.ObjectMap, fallback: bool) bool {
+    const p = root.get("params") orelse return fallback;
+    if (p != .object) return fallback;
+    const m = p.object.get("_meta") orelse return fallback;
+    if (m != .object) return fallback;
+    const version = mcpj.getStr(&m.object, "io.modelcontextprotocol/protocolVersion") orelse return fallback;
+    return std.mem.eql(u8, version, "2026-07-28");
 }
 
 fn writeUnsupportedProtocolVersionError(alloc: std.mem.Allocator, stdout: cio.File, id: ?std.json.Value, requested: []const u8) void {
@@ -1601,6 +1642,7 @@ fn handleCall(
     deferred_scan: ?*DeferredScan,
     governor: ?*ConvergenceGovernor,
     client_name: ?[]const u8,
+    modern_results: bool,
 ) void {
     const is_notification = id == null;
 
@@ -1714,7 +1756,7 @@ fn handleCall(
     var result: std.ArrayList(u8) = .empty;
     defer result.deinit(alloc);
     if (!assembleMcpContentEnvelope(alloc, summary.items, out.items, guidance.items, is_error, &result)) return;
-    writeResult(alloc, stdout, id, result.items);
+    writeResultVersioned(alloc, stdout, id, result.items, modern_results);
 }
 
 fn isDirectCallAdminKey(key: []const u8) bool {
@@ -6409,12 +6451,16 @@ pub fn projectRelPath(path: []const u8, root: []const u8) ?[]const u8 {
 pub const result_meta_prelude = "{\"resultType\":\"complete\",\"_meta\":{\"io.modelcontextprotocol/serverInfo\":{\"name\":\"codedb\",\"version\":\"" ++ release_info.semver ++ "\"}}";
 
 pub fn assembleJsonRpcResult(alloc: std.mem.Allocator, id: ?std.json.Value, result: []const u8, buf: *std.ArrayList(u8)) bool {
+    return assembleJsonRpcResultVersioned(alloc, id, result, buf, true);
+}
+
+pub fn assembleJsonRpcResultVersioned(alloc: std.mem.Allocator, id: ?std.json.Value, result: []const u8, buf: *std.ArrayList(u8), modern_results: bool) bool {
     buf.ensureTotalCapacity(alloc, result.len + 64 + result_meta_prelude.len) catch {};
     buf.appendSlice(alloc, "{\"jsonrpc\":\"2.0\",\"id\":") catch return false;
     appendId(alloc, buf, id);
     buf.appendSlice(alloc, ",\"result\":") catch return false;
     var payload = result;
-    if (result.len >= 2 and result[0] == '{' and !std.mem.startsWith(u8, result, "{\"resultType\"")) {
+    if (modern_results and result.len >= 2 and result[0] == '{' and !std.mem.startsWith(u8, result, "{\"resultType\"")) {
         buf.appendSlice(alloc, result_meta_prelude) catch return false;
         if (std.mem.eql(u8, result, "{}")) {
             buf.appendSlice(alloc, "}") catch return false;
@@ -6443,9 +6489,13 @@ pub fn assembleJsonRpcResult(alloc: std.mem.Allocator, id: ?std.json.Value, resu
 }
 
 fn writeResult(alloc: std.mem.Allocator, stdout: cio.File, id: ?std.json.Value, result: []const u8) void {
+    writeResultVersioned(alloc, stdout, id, result, true);
+}
+
+fn writeResultVersioned(alloc: std.mem.Allocator, stdout: cio.File, id: ?std.json.Value, result: []const u8, modern_results: bool) void {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(alloc);
-    if (!assembleJsonRpcResult(alloc, id, result, &buf)) return;
+    if (!assembleJsonRpcResultVersioned(alloc, id, result, &buf, modern_results)) return;
     stdout.writeAll(buf.items) catch {
         stdout_broken.store(true, .release);
         return;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1984,6 +1984,33 @@ fn renderOutlineOrSkeleton(
     return explorer.renderOutline(path, alloc, out, compact);
 }
 
+fn genericEntrypointPathPriority(path: []const u8) i32 {
+    if (isLowSignalArchitecturePath(path)) return -1000;
+    const base = std.fs.path.basename(path);
+    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
+    if (!std.ascii.eqlIgnoreCase(stem, "main")) return 0;
+    if (std.mem.startsWith(u8, path, "src/")) return 1000;
+    if (std.mem.indexOfScalar(u8, path, '/') == null) return 900;
+    if (pathHasSegmentIgnoreCase(path, "cmd")) return 800;
+    return 200;
+}
+
+fn prioritizeGenericEntrypoint(name: ?[]const u8, fuzzy: bool, results: []Explorer.ScoredSymbolResult) void {
+    const exact_name = name orelse return;
+    if (fuzzy or !std.ascii.eqlIgnoreCase(exact_name, "main")) return;
+    std.mem.sort(Explorer.ScoredSymbolResult, results, {}, struct {
+        fn lessThan(_: void, a: Explorer.ScoredSymbolResult, b: Explorer.ScoredSymbolResult) bool {
+            const ap = genericEntrypointPathPriority(a.path);
+            const bp = genericEntrypointPathPriority(b.path);
+            if (ap != bp) return ap > bp;
+            if (a.score != b.score) return a.score > b.score;
+            const path_order = std.mem.order(u8, a.path, b.path);
+            if (path_order != .eq) return path_order == .lt;
+            return a.symbol.line_start < b.symbol.line_start;
+        }
+    }.lessThan);
+}
+
 fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const name = getStr(args, "name");
     const prefix = getStr(args, "prefix");
@@ -2042,6 +2069,7 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         return;
     };
+    prioritizeGenericEntrypoint(name, fuzzy, results);
     defer {
         for (results) |r| {
             alloc.free(r.path);
@@ -3170,6 +3198,93 @@ const CONTEXT_MAX_RESULTS_PER_KW: usize = 8;
 const CONTEXT_TOP_FILES: usize = 5;
 const CONTEXT_TOP_LINES_PER_FILE: usize = 3;
 
+fn asciiContainsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0 or haystack.len < needle.len) return false;
+    var i: usize = 0;
+    outer: while (i + needle.len <= haystack.len) : (i += 1) {
+        for (needle, 0..) |expected, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(expected)) continue :outer;
+        }
+        return true;
+    }
+    return false;
+}
+
+fn asciiStartsWithIgnoreCase(text: []const u8, prefix: []const u8) bool {
+    return text.len >= prefix.len and std.ascii.eqlIgnoreCase(text[0..prefix.len], prefix);
+}
+
+fn pathHasSegmentIgnoreCase(path: []const u8, wanted: []const u8) bool {
+    var segments = std.mem.tokenizeAny(u8, path, "/\\");
+    while (segments.next()) |segment| {
+        if (std.ascii.eqlIgnoreCase(segment, wanted)) return true;
+    }
+    return false;
+}
+
+/// Architecture overview requests need repository-map priors, not the normal
+/// code-search prior that deliberately down-ranks Markdown. Keep this gate
+/// narrow so ordinary implementation and symbol tasks retain their tuned BM25
+/// and hybrid behavior.
+pub fn isArchitectureOverviewTask(task: []const u8) bool {
+    const architecture = asciiContainsIgnoreCase(task, "architecture") or
+        asciiContainsIgnoreCase(task, "codebase structure") or
+        asciiContainsIgnoreCase(task, "source layout");
+    if (!architecture) return false;
+    return asciiContainsIgnoreCase(task, "overview") or
+        asciiContainsIgnoreCase(task, "entrypoint") or
+        asciiContainsIgnoreCase(task, "routing") or
+        asciiContainsIgnoreCase(task, "source layout") or
+        asciiContainsIgnoreCase(task, "how the") or
+        asciiContainsIgnoreCase(task, "map");
+}
+
+fn isLowSignalArchitecturePath(path: []const u8) bool {
+    const base = std.fs.path.basename(path);
+    return pathHasSegmentIgnoreCase(path, "experiments") or
+        pathHasSegmentIgnoreCase(path, "bench") or
+        pathHasSegmentIgnoreCase(path, "benchmarks") or
+        pathHasSegmentIgnoreCase(path, "e2e") or
+        pathHasSegmentIgnoreCase(path, "test") or
+        pathHasSegmentIgnoreCase(path, "tests") or
+        pathHasSegmentIgnoreCase(path, "fixtures") or
+        pathHasSegmentIgnoreCase(path, "generated") or
+        pathHasSegmentIgnoreCase(path, ".wrangler") or
+        pathHasSegmentIgnoreCase(path, ".open-next") or
+        asciiStartsWithIgnoreCase(base, "bench-") or
+        asciiStartsWithIgnoreCase(base, "bench_") or
+        asciiStartsWithIgnoreCase(base, "e2e-") or
+        asciiStartsWithIgnoreCase(base, "e2e_") or
+        asciiStartsWithIgnoreCase(base, "test-") or
+        asciiStartsWithIgnoreCase(base, "test_");
+}
+
+/// Query-specific path prior used only for architecture-overview composition.
+/// Values are tiers, not relevance scores: retrieval order remains the
+/// tiebreak inside a tier.
+pub fn architecturePathPriority(path: []const u8) i32 {
+    if (isLowSignalArchitecturePath(path)) return -1000;
+
+    if (std.ascii.eqlIgnoreCase(path, "ARCHITECTURE.md")) return 1000;
+    if (std.ascii.eqlIgnoreCase(path, "CODEBASE.md")) return 980;
+
+    const base = std.fs.path.basename(path);
+    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
+    if (std.ascii.eqlIgnoreCase(stem, "architecture")) return 950;
+    if (std.ascii.eqlIgnoreCase(stem, "codebase")) return 930;
+
+    if (std.mem.startsWith(u8, path, "src/")) {
+        if (std.ascii.eqlIgnoreCase(stem, "main")) return 900;
+        if (std.ascii.eqlIgnoreCase(stem, "server")) return 880;
+        if (std.ascii.eqlIgnoreCase(stem, "api")) return 860;
+        if (std.ascii.eqlIgnoreCase(stem, "router") or std.ascii.eqlIgnoreCase(stem, "routes")) return 820;
+        if (std.ascii.eqlIgnoreCase(stem, "cli")) return 800;
+        return 100;
+    }
+    if (std.ascii.eqlIgnoreCase(stem, "readme") and std.mem.indexOfScalar(u8, path, '/') == null) return 700;
+    return 0;
+}
+
 pub fn extractContextCandidates(task: []const u8, alloc: std.mem.Allocator, out: *std.ArrayList([]const u8)) void {
     var seen = std.StringHashMap(void).init(alloc);
     defer seen.deinit();
@@ -3463,6 +3578,7 @@ fn handleContext(
         return;
     }
     const semantic_requested = std.mem.eql(u8, semantic_mode, "hybrid");
+    const architecture_intent = isArchitectureOverviewTask(task);
     var retrieval: ContextRetrievalProvenance = .{};
     const format = getStr(args, "format") orelse "markdown";
     const structured = std.mem.eql(u8, format, "json");
@@ -3629,8 +3745,10 @@ fn handleContext(
     for (candidates.items) |kw| {
         // Symbol definitions (best-effort; ignore failures).
         if (explorer.findAllSymbols(kw, A)) |defs| {
-            const take = @min(defs.len, 3);
-            for (defs[0..take]) |d| {
+            var accepted: usize = 0;
+            for (defs) |d| {
+                if (accepted >= 3) break;
+                if (architecture_intent and isLowSignalArchitecturePath(d.path)) continue;
                 const key = std.fmt.allocPrint(A, "{s}|{s}|{d}", .{ d.path, kw, d.symbol.line_start }) catch continue;
                 if (seen_syms.contains(key)) continue;
                 seen_syms.put(key, {}) catch continue;
@@ -3641,6 +3759,7 @@ fn handleContext(
                     .line = d.symbol.line_start,
                     .line_end = d.symbol.line_end,
                 }) catch break;
+                accepted += 1;
             }
         } else |_| {}
 
@@ -3676,6 +3795,7 @@ fn handleContext(
         hybrid_score: f32 = 0,
         lexical_present: bool = true,
         semantic_present: bool = false,
+        retrieval_rank: usize = 0,
     };
     var ranked: std.ArrayList(FileRank) = .empty;
     var iter = by_file.iterator();
@@ -3952,6 +4072,61 @@ fn handleContext(
             retrieval.semantic = "no_candidates";
         }
     }
+
+    if (architecture_intent) {
+        // Canonical repository-map files are sparse by nature: an
+        // ARCHITECTURE.md can explain every subsystem without repeating all
+        // task tokens, so lexical/ANN retrieval may never nominate it. Seed
+        // only the small set of high-priority architecture/entrypoint paths,
+        // then use the current fused order as the tiebreak within each tier.
+        var known_paths = std.StringHashMap(void).init(A);
+        for (ranked.items) |file| known_paths.put(file.path, {}) catch {};
+
+        var seed_paths: std.ArrayList([]const u8) = .empty;
+        explorer.mu.lockShared();
+        var outline_paths = explorer.outlines.keyIterator();
+        while (outline_paths.next()) |path| {
+            if (architecturePathPriority(path.*) >= 700 and !known_paths.contains(path.*)) {
+                seed_paths.append(A, path.*) catch break;
+            }
+        }
+        explorer.mu.unlockShared();
+
+        std.mem.sort([]const u8, seed_paths.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                const ap = architecturePathPriority(a);
+                const bp = architecturePathPriority(b);
+                if (ap != bp) return ap > bp;
+                return std.mem.lessThan(u8, a, b);
+            }
+        }.lessThan);
+        for (seed_paths.items) |path| {
+            var preview: std.ArrayList(PerFileHit) = .empty;
+            if (semanticSourcePreview(explorer, A, path, 1)) |text_preview| {
+                preview.append(A, .{ .line = 1, .text = text_preview }) catch {};
+            }
+            ranked.append(A, .{
+                .path = path,
+                .hits = 0,
+                .score = 0,
+                .top = preview.items,
+                .lexical_rank = ranked.items.len,
+                .semantic_rank = ranked.items.len,
+                .lexical_present = false,
+            }) catch break;
+        }
+
+        for (ranked.items, 0..) |*file, rank| file.retrieval_rank = rank;
+        std.mem.sort(FileRank, ranked.items, {}, struct {
+            fn lessThan(_: void, a: FileRank, b: FileRank) bool {
+                const ap = architecturePathPriority(a.path);
+                const bp = architecturePathPriority(b.path);
+                if (ap != bp) return ap > bp;
+                if (a.retrieval_rank != b.retrieval_rank) return a.retrieval_rank < b.retrieval_rank;
+                return std.mem.lessThan(u8, a.path, b.path);
+            }
+        }.lessThan);
+    }
     const top_n = @min(ranked.items.len, CONTEXT_TOP_FILES);
     const pf_rank = cio.nanoTimestamp();
 
@@ -4043,6 +4218,7 @@ fn handleContext(
                 var shown_for_sym: u32 = 0;
                 for (scoped) |r| {
                     if (shown_for_sym >= 2 or total_shown >= 6) break;
+                    if (architecture_intent and isLowSignalArchitecturePath(r.path)) continue;
                     if (!langHasCallSites(explore_mod.detectLanguage(r.path))) continue;
                     // Skip the definition site itself
                     if (r.line_num == sr.line and std.mem.eql(u8, r.path, sr.path)) continue;

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5845";
+pub const semver = "0.2.5846";

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -2201,6 +2201,10 @@ test "walker: generated tool-output dirs are not indexed" {
     try tmp_dir.dir.writeFile(io, .{ .sub_path = ".graff/state.json", .data = "{\"packTrigram\":1}\n" });
     try tmp_dir.dir.createDirPath(io, ".harness");
     try tmp_dir.dir.writeFile(io, .{ .sub_path = ".harness/trace.jsonl", .data = "{\"packTrigram\":1}\n" });
+    try tmp_dir.dir.createDirPath(io, ".wrangler/tmp/bundle");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = ".wrangler/tmp/bundle/index.js", .data = "const packTrigram = true;\n" });
+    try tmp_dir.dir.createDirPath(io, ".open-next/server-functions");
+    try tmp_dir.dir.writeFile(io, .{ .sub_path = ".open-next/server-functions/index.js", .data = "const packTrigram = true;\n" });
 
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
     const root_len = try tmp_dir.dir.realPathFile(io, ".", &root_buf);
@@ -2220,6 +2224,8 @@ test "walker: generated tool-output dirs are not indexed" {
     try testing.expect(!explorer.contents.contains("graphify-out/cache/ast/v0.9.32/deadbeef.json"));
     try testing.expect(!explorer.contents.contains(".graff/state.json"));
     try testing.expect(!explorer.contents.contains(".harness/trace.jsonl"));
+    try testing.expect(!explorer.contents.contains(".wrangler/tmp/bundle/index.js"));
+    try testing.expect(!explorer.contents.contains(".open-next/server-functions/index.js"));
 
     var it = explorer.contents.iterator();
     while (it.next()) |kv| {
@@ -2227,6 +2233,8 @@ test "walker: generated tool-output dirs are not indexed" {
         try testing.expect(std.mem.indexOf(u8, p, "graphify-out") == null);
         try testing.expect(std.mem.indexOf(u8, p, ".graff") == null);
         try testing.expect(std.mem.indexOf(u8, p, ".harness") == null);
+        try testing.expect(std.mem.indexOf(u8, p, ".wrangler") == null);
+        try testing.expect(std.mem.indexOf(u8, p, ".open-next") == null);
     }
 
     // ...and the generated blobs contribute nothing to the word index, so a
@@ -2922,6 +2930,29 @@ test "issue-656: call graph is stale and dangling after a file edit" {
     const after = try explorer_inst.findCallPath("alpha", "beta", testing.allocator, 4);
     defer if (after) |steps| testing.allocator.free(steps);
     try testing.expect(after != null);
+}
+
+test "issue-718: call paths do not cross languages through name collisions" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("src/http.zig",
+        \\pub fn handle() void {
+        \\    route();
+        \\}
+        \\pub fn parseRequest() void {}
+    );
+    try explorer_inst.indexFile("experiments/router.py",
+        \\def route():
+        \\    parseRequest()
+    );
+
+    // Name-only resolution used to invent:
+    //   Zig handle -> Python route -> Zig parseRequest.
+    // There is no same-language `route`, so the honest answer is no path.
+    const path = try explorer_inst.findCallPath("handle", "parseRequest", testing.allocator, 4);
+    defer if (path) |steps| testing.allocator.free(steps);
+    try testing.expect(path == null);
 }
 
 test "render caches preserve output and invalidate on mutation" {

--- a/src/test_index.zig
+++ b/src/test_index.zig
@@ -3672,7 +3672,7 @@ test "issue-690: incrementalLoop startup indexes files missing from the snapshot
     defer testing.allocator.destroy(queue);
     queue.* = .{};
     const thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{
-        io, &store, &explorer, queue, root, &shutdown, &scan_done,
+        io, &store, &explorer, queue, root, &shutdown, &scan_done, 1024,
     });
 
     var found = false;

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2576,6 +2576,80 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     try testing.expect(std.mem.indexOf(u8, out.items, "ranking") != null);
 }
 
+test "issue-718: architecture context prefers canonical docs and entrypoints" {
+    try testing.expect(mcp_mod.isArchitectureOverviewTask("overview of the project architecture and source layout"));
+    try testing.expect(!mcp_mod.isArchitectureOverviewTask("fix architecturePathPriority"));
+    try testing.expect(mcp_mod.architecturePathPriority("ARCHITECTURE.md") > mcp_mod.architecturePathPriority("experiments/e2e-attach.sh"));
+
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
+
+    try explorer.indexFile("ARCHITECTURE.md", "# Architecture\nThe server, API, CLI, routing, git plumbing, merge queue, and workspace sync.\n");
+    try explorer.indexFile("CODEBASE.md", "# Source layout\nCanonical codebase map and package boundaries.\n");
+    try explorer.indexFile("src/main.zig", "pub fn main() void { startServer(); }\n");
+    try explorer.indexFile("src/server.zig", "pub fn startServer() void { routeHttp(); }\n");
+    try explorer.indexFile("src/api.zig", "pub fn routeHttp() void {}\n");
+    try explorer.indexFile("src/workspace_sync.zig", "// architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+    try explorer.indexFile("experiments/e2e-attach.sh", "CLI=\"\" # architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+    try explorer.indexFile("website/generated/frontend.js", "// architecture server entrypoint HTTP routing git plumbing APIs CLI merge queue workspace sync source layout\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"task":"overview of project architecture: server entrypoint, HTTP routing, git plumbing APIs, CLI, merge queue, workspace sync, and source layout","semantic":"local"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    const files_start = std.mem.indexOf(u8, out.items, "## Most-relevant files") orelse return error.TestUnexpectedResult;
+    const sites_start = std.mem.indexOfPos(u8, out.items, files_start, "## Top sites") orelse out.items.len;
+    const files = out.items[files_start..sites_start];
+    for ([_][]const u8{ "ARCHITECTURE.md", "CODEBASE.md", "src/main.zig", "src/server.zig", "src/api.zig" }) |gold| {
+        try testing.expect(std.mem.indexOf(u8, files, gold) != null);
+    }
+    try testing.expect(std.mem.indexOf(u8, files, "experiments/e2e-attach.sh") == null);
+    try testing.expect(std.mem.indexOf(u8, files, "website/generated/frontend.js") == null);
+}
+
+test "issue-718: explain main puts the package entrypoint first" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
+    try explorer.indexFile("experiments/probe.py", "def main():\n    return 1\n");
+    try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const args_json =
+        \\{"name":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_explain, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    const entrypoint_pos = std.mem.indexOf(u8, out.items, "src/main.zig") orelse return error.TestUnexpectedResult;
+    const experiment_pos = std.mem.indexOf(u8, out.items, "experiments/probe.py") orelse return error.TestUnexpectedResult;
+    try testing.expect(entrypoint_pos < experiment_pos);
+}
+
 test "issue-688: codedb_context json exposes typed provenance and preserves markdown default" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2322,6 +2322,37 @@ test "mcp-2026-07-28: payload declaring resultType is not double-wrapped" {
     try testing.expectEqual(@as(usize, 1), std.mem.count(u8, buf.items, "\"resultType\""));
 }
 
+test "issue-705: legacy clients receive no 2026 result or cache fields" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try testing.expect(mcp_mod.assembleJsonRpcResultVersioned(testing.allocator, null, "{\"tools\":[]}", &buf, false));
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, buf.items, .{});
+    defer parsed.deinit();
+    const result = parsed.value.object.get("result").?.object;
+    try testing.expect(result.get("resultType") == null);
+    try testing.expect(result.get("_meta") == null);
+
+    const list = try mcp_mod.buildToolsListResponse(testing.allocator, .{ .profile_mini = true, .modern_results = false });
+    defer testing.allocator.free(list);
+    const parsed_list = try std.json.parseFromSlice(std.json.Value, testing.allocator, list, .{});
+    defer parsed_list.deinit();
+    try testing.expect(parsed_list.value.object.get("ttlMs") == null);
+    try testing.expect(parsed_list.value.object.get("cacheScope") == null);
+    try testing.expect(parsed_list.value.object.get("tools").?.array.items.len > 0);
+}
+
+test "issue-705: per-request protocol version overrides handshake fallback" {
+    const modern_req = "{\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"2026-07-28\"}}}";
+    const modern = try std.json.parseFromSlice(std.json.Value, testing.allocator, modern_req, .{});
+    defer modern.deinit();
+    try testing.expect(mcp_mod.requestUsesModernResults(&modern.value.object, false));
+
+    const legacy_req = "{\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"2025-11-25\"}}}";
+    const legacy = try std.json.parseFromSlice(std.json.Value, testing.allocator, legacy_req, .{});
+    defer legacy.deinit();
+    try testing.expect(!mcp_mod.requestUsesModernResults(&legacy.value.object, true));
+}
+
 test "mcp-2026-07-28: unsupported params._meta protocol version is flagged, supported ones pass" {
     {
         const req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/protocolVersion\":\"2030-01-01\"}}}";

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -249,6 +249,8 @@ const skip_dirs = [_][]const u8{
     ".zig-cache",
     "zig-out",
     ".next",
+    ".open-next",
+    ".wrangler",
     ".nuxt",
     ".svelte-kit",
     "dist",

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -8,6 +8,7 @@ const TrigramIndex = @import("index.zig").TrigramIndex;
 const WordIndex = @import("index.zig").WordIndex;
 const explore_mod = @import("explore.zig");
 const git_mod = @import("git.zig");
+const gitignore = @import("gitignore.zig");
 const project_file = @import("project_file.zig");
 const project_path = @import("project_path.zig");
 
@@ -389,7 +390,9 @@ pub const FilteredWalker = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     dir_prefix_len: usize = 0,
-    ignore_patterns: std.ArrayList([]const u8) = .empty,
+    codedb_rules: std.ArrayList(gitignore.Rule) = .empty,
+    git_rules: std.ArrayList(gitignore.Rule) = .empty,
+    loaded_gitignore_dirs: std.StringHashMapUnmanaged(void) = .empty,
     real_root: []const u8 = &.{},
     visited_real_paths: std.StringHashMapUnmanaged(void) = .empty,
 
@@ -410,6 +413,7 @@ pub const FilteredWalker = struct {
             .iter = root.iterate(),
             .through_symlink = false,
         });
+        errdefer self.deinit();
 
         var rr_buf: [std.fs.max_path_bytes]u8 = undefined;
         if (root.realPathFile(io, ".", &rr_buf)) |rr_len| {
@@ -419,31 +423,22 @@ pub const FilteredWalker = struct {
             try self.visited_real_paths.put(allocator, seed, {});
         } else |_| {}
 
-        // Load .codedbignore if it exists
-        if (project_file.readAllocNoFollow(io, root, ".codedbignore", allocator, .limited(64 * 1024))) |content| {
-            defer allocator.free(content);
-            var lines = std.mem.splitScalar(u8, content, '\n');
-            while (lines.next()) |line| {
-                const trimmed = std.mem.trim(u8, line, " \t\r");
-                if (trimmed.len == 0 or trimmed[0] == '#') continue;
-                const duped = try allocator.dupe(u8, trimmed);
-                try self.ignore_patterns.append(allocator, duped);
-            }
-        } else |_| {}
+        if (self.real_root.len > 0) {
+            // Explicit CodeDB policy is authoritative over Git re-includes.
+            try self.loadOwnedIgnoreFile(root, ".codedbignore", self.real_root, &self.codedb_rules);
 
-        // Also load .gitignore patterns (respect git's ignore rules)
-        if (project_file.readAllocNoFollow(io, root, ".gitignore", allocator, .limited(64 * 1024))) |content| {
-            defer allocator.free(content);
-            var lines = std.mem.splitScalar(u8, content, '\n');
-            while (lines.next()) |line| {
-                const trimmed = std.mem.trim(u8, line, " \t\r");
-                if (trimmed.len == 0 or trimmed[0] == '#') continue;
-                // Skip negation patterns (!) — too complex for simple matching
-                if (trimmed[0] == '!') continue;
-                const duped = try allocator.dupe(u8, trimmed);
-                try self.ignore_patterns.append(allocator, duped);
-            }
-        } else |_| {}
+            // Git's repository-local exclude is lower precedence than any
+            // .gitignore. Load it first, then root and nested .gitignore files.
+            if (root.openDir(io, ".git", .{ .follow_symlinks = false })) |git_dir| {
+                defer git_dir.close(io);
+                if (git_dir.openDir(io, "info", .{ .follow_symlinks = false })) |info_dir| {
+                    defer info_dir.close(io);
+                    try self.loadOwnedIgnoreFile(info_dir, "exclude", self.real_root, &self.git_rules);
+                } else |_| {}
+            } else |_| {}
+            try self.loadOwnedIgnoreFile(root, ".gitignore", self.real_root, &self.git_rules);
+            try self.rememberLoadedIgnoreDir("");
+        }
 
         return self;
     }
@@ -454,41 +449,75 @@ pub const FilteredWalker = struct {
         }
         self.stack.deinit(self.allocator);
         self.name_buffer.deinit(self.allocator);
-        for (self.ignore_patterns.items) |p| self.allocator.free(p);
-        self.ignore_patterns.deinit(self.allocator);
+        self.freeRules(&self.codedb_rules);
+        self.freeRules(&self.git_rules);
+        var lit = self.loaded_gitignore_dirs.keyIterator();
+        while (lit.next()) |key| self.allocator.free(key.*);
+        self.loaded_gitignore_dirs.deinit(self.allocator);
         var it = self.visited_real_paths.keyIterator();
         while (it.next()) |k| self.allocator.free(k.*);
         self.visited_real_paths.deinit(self.allocator);
         if (self.real_root.len > 0) self.allocator.free(self.real_root);
     }
 
-    fn isIgnored(self: *FilteredWalker, name: []const u8, full_path: []const u8) bool {
-        for (self.ignore_patterns.items) |pattern| {
-            // Root-anchored pattern (starts with /) — only match at project root
-            if (pattern.len > 1 and pattern[0] == '/') {
-                const anchored = pattern[1..];
-                const clean = if (std.mem.endsWith(u8, anchored, "/")) anchored[0 .. anchored.len - 1] else anchored;
-                if (std.mem.eql(u8, full_path, clean) or std.mem.startsWith(u8, full_path, anchored)) return true;
-                continue;
-            }
-            // Directory pattern (ends with /) — match directory names at any depth
-            if (std.mem.endsWith(u8, pattern, "/")) {
-                const dir_name = pattern[0 .. pattern.len - 1];
-                if (std.mem.eql(u8, name, dir_name)) return true;
-                continue;
-            }
-            // Glob suffix match (e.g. *.log)
-            if (pattern.len > 1 and pattern[0] == '*') {
-                if (std.mem.endsWith(u8, name, pattern[1..])) return true;
-                continue;
-            }
-            // Exact name match (matches at any depth)
-            if (std.mem.eql(u8, name, pattern)) return true;
-            // Path prefix match (must match at / boundary)
-            if (std.mem.startsWith(u8, full_path, pattern) and
-                full_path.len > pattern.len and full_path[pattern.len] == '/') return true;
+    fn freeRules(self: *FilteredWalker, rules: *std.ArrayList(gitignore.Rule)) void {
+        for (rules.items) |rule| {
+            self.allocator.free(rule.pattern);
+            self.allocator.free(rule.base);
         }
-        return false;
+        rules.deinit(self.allocator);
+    }
+
+    fn appendOwnedRules(self: *FilteredWalker, text: []const u8, base: []const u8, out: *std.ArrayList(gitignore.Rule)) !void {
+        var scratch = std.heap.ArenaAllocator.init(self.allocator);
+        defer scratch.deinit();
+        const parsed = try gitignore.parse(scratch.allocator(), text, base);
+        for (parsed) |rule| {
+            const pattern = try self.allocator.dupe(u8, rule.pattern);
+            errdefer self.allocator.free(pattern);
+            const owned_base = try self.allocator.dupe(u8, rule.base);
+            errdefer self.allocator.free(owned_base);
+            try out.append(self.allocator, .{
+                .negated = rule.negated,
+                .dir_only = rule.dir_only,
+                .anchored = rule.anchored,
+                .pattern = pattern,
+                .base = owned_base,
+            });
+        }
+    }
+
+    fn loadOwnedIgnoreFile(self: *FilteredWalker, dir: std.Io.Dir, name: []const u8, base: []const u8, out: *std.ArrayList(gitignore.Rule)) !void {
+        const content = project_file.readAllocNoFollow(self.io, dir, name, self.allocator, .limited(64 * 1024)) catch return;
+        defer self.allocator.free(content);
+        try self.appendOwnedRules(content, base, out);
+    }
+
+    fn rememberLoadedIgnoreDir(self: *FilteredWalker, rel: []const u8) !void {
+        if (self.loaded_gitignore_dirs.contains(rel)) return;
+        const owned = try self.allocator.dupe(u8, rel);
+        errdefer self.allocator.free(owned);
+        try self.loaded_gitignore_dirs.put(self.allocator, owned, {});
+    }
+
+    fn loadNestedGitignore(self: *FilteredWalker, dir: std.Io.Dir, rel: []const u8) !void {
+        if (self.real_root.len == 0 or self.loaded_gitignore_dirs.contains(rel)) return;
+        var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const base = std.fmt.bufPrint(&base_buf, "{s}/{s}", .{ self.real_root, rel }) catch return;
+        try self.loadOwnedIgnoreFile(dir, ".gitignore", base, &self.git_rules);
+        try self.rememberLoadedIgnoreDir(rel);
+    }
+
+    fn hasIgnoreRules(self: *const FilteredWalker) bool {
+        return self.codedb_rules.items.len > 0 or self.git_rules.items.len > 0;
+    }
+
+    fn isIgnored(self: *FilteredWalker, full_path: []const u8, is_dir: bool) bool {
+        if (self.real_root.len == 0) return false;
+        var abs_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const abs = std.fmt.bufPrint(&abs_buf, "{s}/{s}", .{ self.real_root, full_path }) catch return false;
+        if (gitignore.ignored(self.allocator, self.codedb_rules.items, self.real_root, abs, is_dir) catch false) return true;
+        return gitignore.ignored(self.allocator, self.git_rules.items, self.real_root, abs, is_dir) catch false;
     }
 
     /// Validate the directory object that was actually opened, regardless of
@@ -536,14 +565,13 @@ pub const FilteredWalker = struct {
                     else
                         entry.name;
                     // Check .codedbignore patterns
-                    if (self.ignore_patterns.items.len > 0) {
-                        if (self.isIgnored(entry.name, visible_path)) continue;
-                    }
+                    if (self.hasIgnoreRules() and self.isIgnored(visible_path, true)) continue;
                     const sub = top.dir_handle.openDir(self.io, entry.name, .{ .iterate = true }) catch continue;
                     const opened_as_alias = self.claimOpenedDirectory(sub, visible_path) orelse {
                         sub.close(self.io);
                         continue;
                     };
+                    try self.loadNestedGitignore(sub, visible_path);
                     errdefer sub.close(self.io);
                     const saved_len = self.name_buffer.items.len;
                     errdefer self.name_buffer.shrinkRetainingCapacity(saved_len);
@@ -565,13 +593,13 @@ pub const FilteredWalker = struct {
                 if (entry.kind != .file) {
                     if (entry.kind != .sym_link) continue;
                     if (shouldSkipDir(entry.name)) continue;
-                    if (self.ignore_patterns.items.len > 0) {
+                    if (self.hasIgnoreRules()) {
                         var check_buf: [std.fs.max_path_bytes]u8 = undefined;
                         const check_path = if (self.dir_prefix_len > 0)
                             std.fmt.bufPrint(&check_buf, "{s}/{s}", .{ self.name_buffer.items[0..self.dir_prefix_len], entry.name }) catch entry.name
                         else
                             entry.name;
-                        if (self.isIgnored(entry.name, check_path)) continue;
+                        if (self.isIgnored(check_path, true)) continue;
                     }
                     // Opening as a directory is also the file-symlink gate:
                     // regular-file targets fail with NotDir and are skipped.
@@ -590,6 +618,7 @@ pub const FilteredWalker = struct {
                         sub.close(self.io);
                         continue;
                     }
+                    try self.loadNestedGitignore(sub, visible_path);
                     errdefer sub.close(self.io);
                     const saved_len_sym = self.name_buffer.items.len;
                     errdefer self.name_buffer.shrinkRetainingCapacity(saved_len_sym);
@@ -616,7 +645,7 @@ pub const FilteredWalker = struct {
                 try self.name_buffer.appendSlice(self.allocator, entry.name);
 
                 // Check .codedbignore patterns for files
-                if (self.ignore_patterns.items.len > 0 and self.isIgnored(entry.name, self.name_buffer.items)) {
+                if (self.hasIgnoreRules() and self.isIgnored(self.name_buffer.items, false)) {
                     self.name_buffer.shrinkRetainingCapacity(self.dir_prefix_len);
                     continue;
                 }
@@ -649,6 +678,96 @@ pub const FilteredWalker = struct {
         return null;
     }
 };
+
+test "issue-704: index walker honors double-star, nested gitignore, and negation" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, ".jest-cache");
+    try tmp.dir.createDirPath(io, "child/lib");
+    try tmp.dir.createDirPath(io, "child/src");
+    try tmp.dir.writeFile(io, .{ .sub_path = ".gitignore", .data = "**/.jest-cache/\n*.log\n!important.log\n!must-hide.zig\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".codedbignore", .data = "must-hide.zig\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/.gitignore", .data = "lib/\n" });
+    try tmp.dir.writeFile(io, .{ .sub_path = ".jest-cache/generated.js", .data = "generated" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/lib/generated.zig", .data = "pub const generated = true;" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/src/keep.zig", .data = "pub const keep = true;" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "noise.log", .data = "drop" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "important.log", .data = "keep" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "must-hide.zig", .data = "secret policy wins" });
+
+    const root = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer root.close(io);
+    var walker = try FilteredWalker.init(io, root, testing.allocator);
+    defer walker.deinit();
+    var saw_keep = false;
+    var saw_important = false;
+    while (try walker.next()) |entry| {
+        if (std.mem.eql(u8, entry.path, "child/src/keep.zig")) saw_keep = true;
+        if (std.mem.eql(u8, entry.path, "important.log")) saw_important = true;
+        try testing.expect(!std.mem.eql(u8, entry.path, ".jest-cache/generated.js"));
+        try testing.expect(!std.mem.eql(u8, entry.path, "child/lib/generated.zig"));
+        try testing.expect(!std.mem.eql(u8, entry.path, "noise.log"));
+        try testing.expect(!std.mem.eql(u8, entry.path, "must-hide.zig"));
+    }
+    try testing.expect(saw_keep);
+    try testing.expect(saw_important);
+}
+
+test "issue-704: nested gitignore content change removes cached indexed files" {
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "child");
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/.gitignore", .data = "" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/drop.zig", .data = "pub fn dropMe() void {}\n" });
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPathFile(io, ".", &root_buf);
+    const root_path = root_buf[0..root_len];
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.setRoot(io, root_path);
+    try initialScanWithWorkerCount(io, &store, &explorer, root_path, testing.allocator, true, 1);
+
+    var known = FileMap.init(testing.allocator);
+    defer {
+        var it = known.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    try seedKnownFromExplorer(&store, &explorer, &known, testing.allocator);
+    var dirs = DirMap.init(testing.allocator);
+    defer {
+        var it = dirs.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    var queue = EventQueue{};
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root_path, testing.allocator, arena.allocator());
+    }
+    try testing.expect(known.contains("child/drop.zig"));
+
+    // Rewriting the ignore file does not change the child directory's mtime;
+    // the cached-directory fast path must still apply the newly loaded rules.
+    try tmp.dir.writeFile(io, .{ .sub_path = "child/.gitignore", .data = "drop.zig\n" });
+    {
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        try incrementalDiffInner(io, &store, &explorer, &queue, &known, &dirs, root_path, testing.allocator, arena.allocator());
+    }
+    try testing.expect(!known.contains("child/drop.zig"));
+    var rendered: std.ArrayList(u8) = .empty;
+    defer rendered.deinit(testing.allocator);
+    try testing.expect(!try explorer.renderOutline("child/drop.zig", testing.allocator, &rendered, false));
+}
 
 /// Files beyond this count are indexed without trigrams and land in
 /// skip_trigram_files, which tier 3 of searchContent linearly content-scans
@@ -1371,17 +1490,11 @@ const watch_kqueue = switch (builtin.os.tag) {
 };
 const watch_inotify = builtin.os.tag == .linux;
 
-fn raiseNofileLimit() void {
-    if (builtin.os.tag == .windows) return;
-    var lim = std.posix.getrlimit(.NOFILE) catch return;
-    if (lim.cur < lim.max) {
-        lim.cur = lim.max;
-        std.posix.setrlimit(.NOFILE, lim) catch {};
-    }
-}
-
 const FileChangeWatch = struct {
     alloc: std.mem.Allocator,
+    /// Strict cap on macOS vnode descriptors. The kqueue descriptor itself is
+    /// fixed overhead; every directory/file admission is counted in `files`.
+    max_watched: u32,
     active: bool = false,
     armed_files: u32 = 0,
     armed_dirs: u32 = 0,
@@ -1394,9 +1507,10 @@ const FileChangeWatch = struct {
     ident_to_dir: std.AutoHashMap(usize, []u8),
     wd_to_dir: std.AutoHashMap(i32, []u8),
 
-    fn init(alloc: std.mem.Allocator) FileChangeWatch {
+    fn init(alloc: std.mem.Allocator, max_watched: u32) FileChangeWatch {
         return .{
             .alloc = alloc,
+            .max_watched = max_watched,
             .ident_to_path = .init(alloc),
             .ident_to_dir = .init(alloc),
             .wd_to_dir = .init(alloc),
@@ -1464,6 +1578,15 @@ const FileChangeWatch = struct {
         }
     }
 
+    fn forgetUnwatched(self: *FileChangeWatch, path: []const u8) void {
+        var i: usize = 0;
+        while (i < self.unwatched.items.len) : (i += 1) {
+            if (!std.mem.eql(u8, self.unwatched.items[i], path)) continue;
+            self.alloc.free(self.unwatched.swapRemove(i));
+            return;
+        }
+    }
+
     fn addUnwatched(self: *const FileChangeWatch, dirty: *DirtySet) void {
         for (self.unwatched.items) |path| {
             dirty.put(path, {}) catch {};
@@ -1484,8 +1607,6 @@ const FileChangeWatch = struct {
 
     fn armKqueue(self: *FileChangeWatch, root_dir: std.Io.Dir, known: *const FileMap, dirs: *const DirMap) void {
         if (comptime !watch_kqueue) return;
-        if (known.count() > 32768) return;
-        raiseNofileLimit();
         const kq = std.c.kqueue();
         if (kq < 0) return;
         self.kq = kq;
@@ -1499,23 +1620,31 @@ const FileChangeWatch = struct {
             if (rel.len == 0) continue;
             self.watchKqueueDir(root_dir.handle, rel, vnode_flags);
         }
+        // Cross-process update notification is useful but never allowed to
+        // break the same strict descriptor ceiling as repository watches.
+        if (self.files.items.len < self.max_watched) {
+            if (std.posix.openat(std.posix.AT.FDCWD, "/tmp/codedb-notify", .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true }, 0)) |nfd| {
+                if (self.addVnode(nfd, std.c.NOTE.WRITE | std.c.NOTE.EXTEND)) {
+                    self.files.append(self.alloc, nfd) catch cio.closeFd(nfd);
+                } else {
+                    cio.closeFd(nfd);
+                }
+            } else |_| {}
+        }
         var it = known.iterator();
         while (it.next()) |kv| {
             const path = kv.key_ptr.*;
             self.watchKqueueFile(root_dir.handle, path, vnode_flags);
         }
-        if (std.posix.openat(std.posix.AT.FDCWD, "/tmp/codedb-notify", .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true }, 0)) |nfd| {
-            if (self.addVnode(nfd, std.c.NOTE.WRITE | std.c.NOTE.EXTEND)) {
-                self.files.append(self.alloc, nfd) catch cio.closeFd(nfd);
-            } else {
-                cio.closeFd(nfd);
-            }
-        } else |_| {}
         self.active = self.ident_to_path.count() > 0 or self.ident_to_dir.count() > 0 or self.unwatched.items.len > 0 or self.unwatched_dirs.items.len > 0;
     }
 
     fn addKqueueFileWatch(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) ?std.posix.fd_t {
         if (comptime !watch_kqueue) return null;
+        if (self.files.items.len >= self.max_watched) {
+            self.rememberUnwatched(path);
+            return null;
+        }
         const fd = std.posix.openat(root_fd, path, .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true }, 0) catch {
             self.rememberUnwatched(path);
             return null;
@@ -1540,6 +1669,7 @@ const FileChangeWatch = struct {
             self.rememberUnwatched(path);
             return null;
         };
+        self.forgetUnwatched(path);
         return fd;
     }
 
@@ -1667,6 +1797,10 @@ const FileChangeWatch = struct {
 
     fn addKqueueDirWatch(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) ?std.posix.fd_t {
         if (comptime !watch_kqueue) return null;
+        if (self.files.items.len >= self.max_watched) {
+            self.rememberUnwatchedDir(rel);
+            return null;
+        }
         const open_rel = if (rel.len == 0) "." else rel;
         const fd = std.posix.openat(root_fd, open_rel, .{ .ACCMODE = .RDONLY, .EVTONLY = true, .CLOEXEC = true, .DIRECTORY = true }, 0) catch {
             self.rememberUnwatchedDir(rel);
@@ -1705,15 +1839,15 @@ const FileChangeWatch = struct {
     fn rearmKqueueDir(self: *FileChangeWatch, root_fd: std.posix.fd_t, rel: []const u8, fflags: u32) void {
         if (comptime !watch_kqueue) return;
         const old_fd = self.findKqueueDir(rel);
-        if (self.addKqueueDirWatch(root_fd, rel, fflags) == null) return;
         if (old_fd) |fd| self.dropKqueueDir(fd);
+        _ = self.addKqueueDirWatch(root_fd, rel, fflags);
     }
 
     fn rearmKqueueFile(self: *FileChangeWatch, root_fd: std.posix.fd_t, path: []const u8, fflags: u32) void {
         if (comptime !watch_kqueue) return;
         const old_fd = self.findKqueueFile(path);
-        if (self.addKqueueFileWatch(root_fd, path, fflags) == null) return;
         if (old_fd) |fd| self.dropKqueueFile(fd);
+        _ = self.addKqueueFileWatch(root_fd, path, fflags);
     }
 
     fn inotifyDirectoryMask() u32 {
@@ -1991,7 +2125,7 @@ test "file watcher remains pinned to opened root after pathname retarget" {
     }
     const root_key = try testing.allocator.dupe(u8, "");
     try dirs.put(root_key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
-    var watch = FileChangeWatch.init(testing.allocator);
+    var watch = FileChangeWatch.init(testing.allocator, 1024);
     defer watch.deinit(io);
     watch.arm(io, root_dir, &known, &dirs);
     try testing.expect(watch.active);
@@ -2063,7 +2197,7 @@ test "directory watches follow repeated equal-count subtree replacements" {
         const key = try testing.allocator.dupe(u8, path);
         try dirs.put(key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
     }
-    var watch = FileChangeWatch.init(testing.allocator);
+    var watch = FileChangeWatch.init(testing.allocator, 1024);
     defer watch.deinit(io);
     watch.arm(io, root_dir, &known, &dirs);
     try testing.expect(watch.active);
@@ -2139,7 +2273,7 @@ test "failed directory watch admission retries through dirty reconciliation" {
         const key = try testing.allocator.dupe(u8, path);
         try dirs.put(key, .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
     }
-    var watch = FileChangeWatch.init(testing.allocator);
+    var watch = FileChangeWatch.init(testing.allocator, 1024);
     defer watch.deinit(io);
     watch.arm(io, root_dir, &known, &dirs);
     try testing.expect(watch.active);
@@ -2160,8 +2294,52 @@ test "failed directory watch admission retries through dirty reconciliation" {
     try testing.expect(dirty.contains("late"));
 }
 
+test "issue-709: macOS vnode descriptor admission is strictly bounded" {
+    if (comptime !watch_kqueue) return;
+    const testing = std.testing;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var known = FileMap.init(testing.allocator);
+    defer {
+        var it = known.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        known.deinit();
+    }
+    var i: usize = 0;
+    while (i < 32) : (i += 1) {
+        var path_buf: [32]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "file-{d}.zig", .{i});
+        try tmp.dir.writeFile(io, .{ .sub_path = path, .data = "pub const value = 1;\n" });
+        const owned = try testing.allocator.dupe(u8, path);
+        try known.put(owned, .{ .mtime = 0, .size = 0, .hash = 0, .seen = false });
+    }
+    var dirs = DirMap.init(testing.allocator);
+    defer {
+        var it = dirs.keyIterator();
+        while (it.next()) |path| testing.allocator.free(path.*);
+        dirs.deinit();
+    }
+    try dirs.put(try testing.allocator.dupe(u8, ""), .{ .mtime_ns = 0, .ctime_ns = 0, .inode = 0 });
+    const root = try tmp.dir.openDir(io, ".", .{ .iterate = true });
+    defer root.close(io);
+
+    var watch = FileChangeWatch.init(testing.allocator, 4);
+    defer watch.deinit(io);
+    watch.arm(io, root, &known, &dirs);
+    try testing.expect(watch.active);
+    try testing.expect(watch.files.items.len <= 4);
+    try testing.expect(watch.unwatched.items.len > 0);
+
+    watch.max_watched = 0;
+    watch.arm(io, root, &known, &dirs);
+    try testing.expectEqual(@as(usize, 0), watch.files.items.len);
+    try testing.expectEqual(@as(usize, 32), watch.unwatched.items.len);
+    try testing.expectEqual(@as(usize, 1), watch.unwatched_dirs.items.len);
+}
+
 /// Background thread: polls for incremental FS changes.
-pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, root: []const u8, shutdown: *std.atomic.Value(bool), scan_done: *std.atomic.Value(bool)) void {
+pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, root: []const u8, shutdown: *std.atomic.Value(bool), scan_done: *std.atomic.Value(bool), max_watched: u32) void {
     explorer.expectStartupReconcile();
     var startup_reconcile_finished = false;
     defer if (!startup_reconcile_finished) explorer.finishStartupReconcile();
@@ -2208,7 +2386,7 @@ pub fn incrementalLoop(io: std.Io, store: *Store, explorer: *Explorer, queue: *E
         };
     }
 
-    var watch = FileChangeWatch.init(backing);
+    var watch = FileChangeWatch.init(backing, max_watched);
     defer watch.deinit(io);
     armAndCloseGap(io, &watch, stable_root, store, explorer, queue, &known, &dirs, root, backing);
     explorer.finishStartupReconcile();
@@ -2570,6 +2748,7 @@ fn walkRel(
         const opened_as_alias = ignore.claimOpenedDirectory(listing, prefix) orelse return;
         effective_through_symlink = effective_through_symlink or opened_as_alias;
     }
+    try ignore.loadNestedGitignore(listing, prefix);
 
     const current_dir_state = dirState(io, listing, "");
     const cached_dir_state = if (dirs) |d| d.get(prefix) else null;
@@ -2579,6 +2758,7 @@ fn walkRel(
     if (dir_unchanged) {
         if (parents.files.get(prefix)) |file_list| {
             for (file_list.items) |path| {
+                if (ignore.hasIgnoreRules() and ignore.isIgnored(path, false)) continue;
                 if (dirty) |d| {
                     if (d.get(path) == null) {
                         if (known.getPtr(path)) |st| st.seen = true;
@@ -2598,7 +2778,7 @@ fn walkRel(
             while (cit.next()) |name| {
                 if (shouldSkipDir(name.*)) continue;
                 const child = try joinRel(tmp, prefix, name.*);
-                if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(name.*, child)) continue;
+                if (ignore.hasIgnoreRules() and ignore.isIgnored(child, true)) continue;
                 const child_stat = listing.statFile(io, name.*, .{ .follow_symlinks = false }) catch continue;
                 if (child_stat.kind != .directory and child_stat.kind != .sym_link) continue;
                 const child_through_symlink = effective_through_symlink or child_stat.kind == .sym_link;
@@ -2615,7 +2795,7 @@ fn walkRel(
             if (entry.kind == .sym_link and !resolvedDirectoryTargetAllowed(io, listing, ignore.real_root, entry.name)) continue;
             if (shouldSkipDir(entry.name)) continue;
             const child = try joinRel(tmp, prefix, entry.name);
-            if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, child)) continue;
+            if (ignore.hasIgnoreRules() and ignore.isIgnored(child, true)) continue;
             try walkRel(io, store, explorer, queue, known, dirs, ignore, dir, child, persistent, tmp, parents, dirty, child_through_symlink);
             continue;
         }
@@ -2623,7 +2803,7 @@ fn walkRel(
         if (entry.kind != .file) continue;
 
         const rel = try joinRel(tmp, prefix, entry.name);
-        if (ignore.ignore_patterns.items.len > 0 and ignore.isIgnored(entry.name, rel)) continue;
+        if (ignore.hasIgnoreRules() and ignore.isIgnored(rel, false)) continue;
         if (shouldSkipFile(rel)) continue;
         if (effective_through_symlink and !resolvedFileTargetAllowed(io, listing, ignore.real_root, entry.name)) continue;
         const stat = listing.statFile(io, entry.name, .{ .follow_symlinks = false }) catch continue;


### PR DESCRIPTION
## Release 0.2.5846

Closes #704.
Closes #705.
Closes #709.
Closes #718.

- honor full nested gitignore semantics during cold and incremental indexing
- cap macOS vnode descriptors with correct polling overflow and a process-level FD-slope gate
- conform to MCP 2026 discovery/result envelopes while preserving legacy clients
- make architecture overview retrieval prefer canonical docs and source entrypoints after hybrid ANN fusion
- exclude Wrangler/OpenNext caches, scope call paths by compatible language families, and prefer package entrypoints in `codedb_explain main`

## Verification

- feature PRs #719 and #720 merged into the active release branch
- hosted paired benchmark, output parity, corpus parity, provenance, and macOS resource gates passed
- `zig build test --summary all`: 1186 passed, 4 skipped
- MCP E2E: 76/76 passed
- MCP 2026 external spec: 27 passed, 0 failed
- live hybrid ANN: Qwen3-Embedding-0.6B, 512D, 8926 chunks, mmap=true; architecture docs/entrypoints retained after fusion
- local same-corpus `codedb_context`: 345.9us base -> 344.9us head (-0.31%)