### PR TITLE
Allow release PRs through the main-branch guard

### DIFF
--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -6,7 +6,9 @@ permissions:
   pull-requests: write
 jobs:
   guard:
-    if: github.event.pull_request.base.ref == 'main'
+    # Feature work lands on the active release branch, but the release branch
+    # itself must be allowed to merge back to main.
+    if: github.event.pull_request.base.ref == 'main' && !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9


### PR DESCRIPTION
The PR base guard currently rejects every PR targeting `main`, including the repository’s official `release/* -> main` integration PRs. Exempt release branches while keeping the contributor feature-branch policy intact.

This is workflow-only and has no product binary or benchmark-path change.