### PR TITLE
ci: fail closed on unnotarized macOS releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -52,6 +52,11 @@ jobs:
       APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
       APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
       CODEDB_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+      # Base64-encoded App Store Connect API key plus its key/issuer IDs.
+      # macOS jobs fail closed when any release credential is missing.
+      APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
+      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -80,8 +85,26 @@ jobs:
           test "$("$PWD/${zig_dir}/zig" version)" = "$ZIG_VERSION"
           echo "$PWD/${zig_dir}" >> "$GITHUB_PATH"
 
+      - name: Require macOS release credentials
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in \
+            APPLE_CERTIFICATE_P12 \
+            APPLE_CERTIFICATE_PASSWORD \
+            CODEDB_CODESIGN_IDENTITY \
+            APPLE_NOTARY_KEY_P8 \
+            APPLE_NOTARY_KEY_ID \
+            APPLE_NOTARY_ISSUER_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "missing required macOS release secret: ${name}" >&2
+              exit 1
+            fi
+          done
+
       - name: Import Apple signing certificate
-        if: runner.os == 'macOS' && env.APPLE_CERTIFICATE_P12 != ''
+        if: runner.os == 'macOS'
         shell: bash
         run: |
           set -euo pipefail
@@ -108,10 +131,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ runner.os }}" == "macOS" ]] &&
-             [[ "${{ matrix.zig_target }}" != "x86_64-macos" ]] &&
-             [[ -n "${CODEDB_CODESIGN_IDENTITY:-}" ]] &&
-             grep -q 'codesign-identity' build.zig; then
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
             zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }} -Dcodesign-identity="$CODEDB_CODESIGN_IDENTITY"
           else
             zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
@@ -120,6 +140,40 @@ jobs:
           [[ -f "$binary" ]] || binary=zig-out/bin/codedb.exe
           test -f "$binary"
           cp "$binary" "${{ matrix.asset_name }}"
+
+      - name: Verify and notarize macOS artifact
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="${{ matrix.asset_name }}"
+          codesign --verify --deep --strict --verbose=4 "$asset"
+          codesign -dvv "$asset" 2>&1 | grep -Fq 'Authority=Developer ID Application:'
+          codesign -dvv "$asset" 2>&1 | grep -Eq 'flags=0x[0-9a-fA-F]*10000\(runtime\)'
+
+          notary_key="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+          archive="$RUNNER_TEMP/${asset}.zip"
+          trap 'rm -f "$notary_key" "$archive"' EXIT
+          printf '%s' "$APPLE_NOTARY_KEY_P8" | base64 --decode > "$notary_key"
+          chmod 600 "$notary_key"
+          ditto -c -k --keepParent "$asset" "$archive"
+          xcrun notarytool submit "$archive" \
+            --key "$notary_key" \
+            --key-id "$APPLE_NOTARY_KEY_ID" \
+            --issuer "$APPLE_NOTARY_ISSUER_ID" \
+            --wait
+
+          # Bare Mach-O executables cannot carry a stapled ticket. Wait for
+          # Apple's online ticket lookup to recognize the exact code hash.
+          for attempt in {1..30}; do
+            if codesign -vvvv -R='notarized' --check-notarization "$asset"; then
+              exit 0
+            fi
+            echo "notarization ticket is not visible yet (attempt ${attempt}/30)"
+            sleep 10
+          done
+          echo "Apple accepted the submission but its ticket never became visible" >&2
+          exit 1
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -277,9 +277,15 @@ quarantine it. Apple Silicon release binaries from v0.2.5811+ are signed
 with a Developer ID and notarized via Apple — verify with:
 
 ```bash
-spctl -a -vv -t install /usr/local/bin/codedb
-# expected: accepted, source=Notarized Developer ID
+codesign -vvvv -R='notarized' --check-notarization /usr/local/bin/codedb
+# expected: valid on disk; explicit requirement satisfied
 ```
+
+`codedb` is a bare Mach-O command-line executable, so Apple's verification
+procedure for “other code” uses `codesign --check-notarization`; `spctl -t
+install` is for installer packages and can incorrectly report this artifact as
+unnotarized. Bare Mach-O files cannot carry a stapled ticket, so this check uses
+Apple's online ticket lookup.
 
 From 0.2.5833 the Intel `codedb-darwin-x86_64` slice is codesigned and
 notarized again. Earlier releases shipped it unsigned: the pinned Zig


### PR DESCRIPTION
This closes the release-safety gap found while validating v0.2.5846. macOS release jobs now require all signing and App Store Connect notarization credentials, sign both ARM64 and Intel artifacts, verify Developer ID plus hardened runtime, submit the exact binaries to Apple, and wait until the online notarization ticket is visible before upload. The docs now use Apple's correct verification command for bare Mach-O code.\n\nValidation: actionlint .github/workflows/release-binaries.yml; git diff --check; the final v0.2.5846 ARM64 and Intel assets passed the same codesign signature and notarization-required checks locally.