### PR TITLE
Fix ambiguous symbol navigation and real-repo call graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ codedb hot                            # recently modified files
 | `codedb_word` | O(1) inverted index word lookup |
 | `codedb_callers` | Every call site of a symbol — word index ∩ outline scope, in one round-trip |
 | `codedb_explain` | Definition body + callers in one call (CLI aliases: `explain`, `around`) |
-| `codedb_callpath` | Shortest resolved call chain A→B (CLI alias: `path`) |
+| `codedb_callpath` | Shortest resolved call chain A→B (CLI alias: `path`); duplicate names list candidates—pass `from_path` / `to_path` (or CLI `--from-path` / `--to-path`) to select a file |
 | `codedb_context` | Task-shaped composer — Pareto-frontier hybrid retrieval by default: local BM25/symbol retrieval first, then local ANN search using a remote task embedding plus a fixed public calibration string when an explicit sidecar exists, or a bounded transient semantic rerank otherwise. Pass `semantic=local` for an on-device-only call. `format=json` adds typed provenance and retrieval-privacy metadata; `document_hops=1..2` expands linked Markdown |
 | `codedb_hot` | Most recently modified files |
 | `codedb_deps` | Typed dependency graph: imports by default, or Markdown links with `edge_type=documents`; document traversal is capped at 2 hops / 64 files |

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -30,16 +30,16 @@ const project_file = @import("project_file.zig");
 /// A walk+stat of the tree is a few ms and early-exits on the first drifted
 /// file; conservative (returns not-stale) on any IO error.
 fn snapshotIsStale(io: std.Io, abs_root: []const u8, data_dir: []const u8, allocator: std.mem.Allocator) bool {
-    // Stat the snapshot that would actually be served — same precedence as
-    // loadBestSnapshot: in-repo first, then the central data dir.
+    // Stat the newest available snapshot. The central cache is authoritative
+    // for read-only checkouts, while a newer in-repo snapshot remains a valid
+    // explicit refresh. This must match loadBestSnapshot's mtime ordering.
     var snap_stat: @TypeOf(std.Io.Dir.cwd().statFile(io, abs_root, .{}) catch unreachable) = undefined;
     var found = false;
     for ([_][]const u8{ abs_root, data_dir }) |base| {
-        if (found) break;
         const snap_path = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{base}) catch return false;
         defer allocator.free(snap_path);
         if (std.Io.Dir.cwd().statFile(io, snap_path, .{})) |st| {
-            snap_stat = st;
+            if (!found or st.mtime.nanoseconds > snap_stat.mtime.nanoseconds) snap_stat = st;
             found = true;
         } else |_| {}
     }
@@ -96,6 +96,11 @@ fn loadSnapshotFileIfHeadMatches(
     return snapshot_mod.loadSnapshotValidatedFromFile(io, snapshot_file, expected_root, explorer, store, allocator);
 }
 
+fn snapshotFileMtime(io: std.Io, file: std.Io.File) ?i128 {
+    const stat = file.stat(io) catch return null;
+    return stat.mtime.nanoseconds;
+}
+
 pub fn loadBestSnapshot(
     io: std.Io,
     explorer: *Explorer,
@@ -109,24 +114,41 @@ pub fn loadBestSnapshot(
     const canonical_root = explorer.root_path orelse return false;
     if (!project_file.rootMatchesPath(io, root_dir, abs_root)) return false;
 
-    if (root_dir.openFile(io, "codedb.snapshot", .{
+    const root_snapshot: ?std.Io.File = root_dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
-    })) |root_snapshot| {
-        defer root_snapshot.close(io);
-        if (loadSnapshotFileIfHeadMatches(io, root_snapshot, explorer, store, canonical_root, current_git_head, allocator)) return true;
-    } else |_| {}
+    }) catch null;
+    defer if (root_snapshot) |file| file.close(io);
 
-    var central_dir = std.Io.Dir.cwd().openDir(io, data_dir, .{ .follow_symlinks = false }) catch return false;
-    defer central_dir.close(io);
-    const central_snapshot = central_dir.openFile(io, "codedb.snapshot", .{
+    const central_dir: ?std.Io.Dir = std.Io.Dir.cwd().openDir(io, data_dir, .{ .follow_symlinks = false }) catch null;
+    defer if (central_dir) |dir| dir.close(io);
+    const central_snapshot: ?std.Io.File = if (central_dir) |dir| dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
-    }) catch return false;
-    defer central_snapshot.close(io);
-    return loadSnapshotFileIfHeadMatches(io, central_snapshot, explorer, store, canonical_root, current_git_head, allocator);
+    }) catch null else null;
+    defer if (central_snapshot) |file| file.close(io);
+
+    const root_mtime = if (root_snapshot) |file| snapshotFileMtime(io, file) else null;
+    const central_mtime = if (central_snapshot) |file| snapshotFileMtime(io, file) else null;
+    const central_first = central_mtime != null and (root_mtime == null or central_mtime.? > root_mtime.?);
+    if (central_first) {
+        if (central_snapshot) |file| {
+            if (loadSnapshotFileIfHeadMatches(io, file, explorer, store, canonical_root, current_git_head, allocator)) return true;
+        }
+        if (root_snapshot) |file| {
+            if (loadSnapshotFileIfHeadMatches(io, file, explorer, store, canonical_root, current_git_head, allocator)) return true;
+        }
+    } else {
+        if (root_snapshot) |file| {
+            if (loadSnapshotFileIfHeadMatches(io, file, explorer, store, canonical_root, current_git_head, allocator)) return true;
+        }
+        if (central_snapshot) |file| {
+            if (loadSnapshotFileIfHeadMatches(io, file, explorer, store, canonical_root, current_git_head, allocator)) return true;
+        }
+    }
+    return false;
 }
 
 pub fn getDataDir(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8) ![]u8 {

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -670,11 +670,15 @@ pub fn coldLoadOrScan(
                 explorer.buildCallCentrality(allocator);
                 if (index_profile) profile_centrality_ns = cio.nanoTimestamp() - t_centrality;
             }
-            const t_snapshot: i128 = if (index_profile) cio.nanoTimestamp() else 0;
-            snapshot_mod.writeProjectCacheSnapshot(io, explorer, abs_root, allocator) catch |err| {
-                std.log.warn("could not persist project-cache snapshot: {}", .{err});
-            };
-            if (index_profile) profile_snapshot_ns = cio.nanoTimestamp() - t_snapshot;
+            // `main` writes the root + cache copies atomically for reindex.
+            // Avoid serializing the same snapshot twice on that hot path.
+            if (!commandRebuildsIndex(cmd)) {
+                const t_snapshot: i128 = if (index_profile) cio.nanoTimestamp() else 0;
+                snapshot_mod.writeProjectCacheSnapshot(io, explorer, abs_root, allocator) catch |err| {
+                    std.log.warn("could not persist project-cache snapshot: {}", .{err});
+                };
+                if (index_profile) profile_snapshot_ns = cio.nanoTimestamp() - t_snapshot;
+            }
         }
         if (release_contents_after_cache) {
             explorer.releaseContents();

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -8,6 +8,7 @@ const Explorer = @import("explore.zig").Explorer;
 const Out = @import("out.zig").Out;
 const runQuery = @import("query.zig").runQuery;
 const watcher = @import("watcher.zig");
+const release_info = @import("release_info.zig");
 const cli_args = @import("cli_args.zig");
 const parsePositional = cli_args.parsePositional;
 const cliIsQueryCmd = cli_args.cliIsQueryCmd;
@@ -29,7 +30,8 @@ const cliIsQueryCmd = cli_args.cliIsQueryCmd;
 //
 // Wire protocol (little-endian, length-framed):
 //   request  (client→daemon): [u8 color][u32 blob_len][blob]
-//       blob = argv[1..] NUL-joined, e.g. "/proj\0find\0foo"
+//       legacy blob = argv[1..] NUL-joined, e.g. "/proj\0find\0foo"
+//       current blob = version marker, semver, then argv fields (all NUL-joined)
 //   response (daemon→client): [u8 exit_code][u32 out_len][out_bytes]
 const cli_blob_max: u32 = 64 * 1024;
 const cli_response_max: u32 = 16 * 1024 * 1024;
@@ -134,6 +136,50 @@ const cli_bind_retry_ms: u64 = 1000;
 /// always starts with a project root path (see cliTryProxy).
 pub const cli_yield_sentinel = "\x01codedb-cli-yield-v1\x01";
 pub const cli_refresh_sentinel = "\x01codedb-cli-refresh-v1\x01";
+const cli_version_marker = "\x01codedb-cli-version-v1\x01";
+const cli_versioned_response_flag: u8 = 0x80;
+const cli_version_mismatch_code: u8 = 0x7f;
+
+const CliVersionEnvelope = struct {
+    argv_blob: []const u8,
+    versioned: bool = false,
+    compatible: bool = true,
+};
+
+fn unwrapCliVersionEnvelope(blob: []const u8) CliVersionEnvelope {
+    if (!std.mem.startsWith(u8, blob, cli_version_marker) or
+        blob.len <= cli_version_marker.len or blob[cli_version_marker.len] != 0)
+    {
+        return .{ .argv_blob = blob };
+    }
+    const version_start = cli_version_marker.len + 1;
+    const version_end = std.mem.indexOfScalarPos(u8, blob, version_start, 0) orelse
+        return .{ .argv_blob = "", .versioned = true, .compatible = false };
+    return .{
+        .argv_blob = blob[version_end + 1 ..],
+        .versioned = true,
+        .compatible = std.mem.eql(u8, blob[version_start..version_end], release_info.semver),
+    };
+}
+
+test "CLI proxy version envelope preserves legacy requests and rejects stale daemons" {
+    const legacy = "/project\x00find\x00main";
+    const parsed_legacy = unwrapCliVersionEnvelope(legacy);
+    try std.testing.expect(!parsed_legacy.versioned);
+    try std.testing.expect(parsed_legacy.compatible);
+    try std.testing.expectEqualStrings(legacy, parsed_legacy.argv_blob);
+
+    const current = cli_version_marker ++ "\x00" ++ release_info.semver ++ "\x00/project\x00find\x00main";
+    const parsed_current = unwrapCliVersionEnvelope(current);
+    try std.testing.expect(parsed_current.versioned);
+    try std.testing.expect(parsed_current.compatible);
+    try std.testing.expectEqualStrings(legacy, parsed_current.argv_blob);
+
+    const stale = cli_version_marker ++ "\x000.0.0\x00/project\x00find\x00main";
+    const parsed_stale = unwrapCliVersionEnvelope(stale);
+    try std.testing.expect(parsed_stale.versioned);
+    try std.testing.expect(!parsed_stale.compatible);
+}
 
 /// Settle delay after sending a yield request before the very next bind
 /// attempt: gives the owner a moment to process the sentinel, unbind, and
@@ -792,6 +838,23 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
         return false;
     }
 
+    // New clients identify their binary version before argv. Legacy clients
+    // remain valid, while a version mismatch makes this daemon relinquish the
+    // socket so an updated binary cannot keep proxying to stale query logic.
+    const envelope = unwrapCliVersionEnvelope(blob);
+    const argv_blob = envelope.argv_blob;
+    const versioned = envelope.versioned;
+    if (versioned) {
+        if (!envelope.compatible) {
+            cliRespond(conn, cli_versioned_response_flag | cli_version_mismatch_code, "");
+            return true;
+        }
+        if (argv_blob.len == 0) {
+            cliRespond(conn, cli_versioned_response_flag | 1, "");
+            return false;
+        }
+    }
+
     // Rebuild argv = ["codedb"] ++ split(blob, '\0'), skipping empty fields.
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
@@ -799,7 +862,7 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
         cliRespond(conn, 1, "");
         return false;
     };
-    var it = std.mem.splitScalar(u8, blob, 0);
+    var it = std.mem.splitScalar(u8, argv_blob, 0);
     while (it.next()) |field| {
         if (field.len == 0) continue;
         argv.append(allocator, field) catch {
@@ -810,7 +873,7 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
 
     const parsed = parsePositional(argv.items);
     if (parsed.usage_exit or !cliIsQueryCmd(parsed.cmd)) {
-        cliRespond(conn, 1, "");
+        cliRespond(conn, (if (versioned) cli_versioned_response_flag else 0) | 1, "");
         return false;
     }
 
@@ -821,7 +884,7 @@ fn cliServeConn(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
     const code = runQuery(io, allocator, explorer, store, abs_root, parsed.cmd, argv.items, parsed.cmd_args_start, &out, s);
     out.flush();
 
-    cliRespond(conn, code, sink.items);
+    cliRespond(conn, (if (versioned) cli_versioned_response_flag else 0) | code, sink.items);
     return false;
 }
 
@@ -843,14 +906,20 @@ fn cliRespond(conn: CliConn, code: u8, out_bytes: []const u8) void {
 pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8, args: []const []const u8, color: bool) ?u8 {
     if (args.len < 2) return null;
 
-    const conn = cliConnect(io, allocator, abs_root, data_dir) orelse return null;
-    defer cliCloseConn(conn);
+    var maybe_conn: ?CliConn = cliConnect(io, allocator, abs_root, data_dir) orelse return null;
+    defer if (maybe_conn) |conn| cliCloseConn(conn);
+    const conn = maybe_conn.?;
 
-    // Build the NUL-joined blob from args[1..].
+    // Build a versioned, NUL-joined blob. A current daemon acknowledges the
+    // envelope in the response code; an old daemon cannot, so its output is
+    // discarded and the command safely falls back to the current process.
     var blob: std.ArrayList(u8) = .empty;
     defer blob.deinit(allocator);
-    for (args[1..], 0..) |a, i| {
-        if (i != 0) blob.append(allocator, 0) catch return null;
+    blob.appendSlice(allocator, cli_version_marker) catch return null;
+    blob.append(allocator, 0) catch return null;
+    blob.appendSlice(allocator, release_info.semver) catch return null;
+    for (args[1..]) |a| {
+        blob.append(allocator, 0) catch return null;
         blob.appendSlice(allocator, a) catch return null;
     }
     if (blob.items.len == 0 or blob.items.len > cli_blob_max) return null;
@@ -865,17 +934,43 @@ pub fn cliTryProxy(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u
     // Response header: [u8 code][u32 out_len]
     var resp_hdr: [5]u8 = undefined;
     if (!cliReadFull(conn, &resp_hdr)) return null;
-    const code = resp_hdr[0];
+    const wire_code = resp_hdr[0];
     const out_len = std.mem.readInt(u32, resp_hdr[1..5], .little);
     if (!cliResponseLenAllowed(out_len)) return null;
 
-    if (out_len > 0) {
+    const out_bytes = if (out_len > 0) blk: {
         const out_bytes = allocator.alloc(u8, out_len) catch return null;
-        defer allocator.free(out_bytes);
         if (!cliReadFull(conn, out_bytes)) return null;
-        cio.File.stdout().writeAll(out_bytes) catch {};
+        break :blk out_bytes;
+    } else null;
+    defer if (out_bytes) |bytes| allocator.free(bytes);
+
+    if (wire_code & cli_versioned_response_flag == 0) {
+        // An older daemon served the version envelope as if it were argv. Close
+        // this connection before asking it to yield: listeners are sequential.
+        cliCloseConn(conn);
+        maybe_conn = null;
+        cliRequestYield(io, allocator, abs_root, data_dir);
+        cio.sleepMs(cli_yield_settle_ms);
+        return null;
     }
+    const code = wire_code & ~cli_versioned_response_flag;
+    if (code == cli_version_mismatch_code) {
+        cio.sleepMs(cli_yield_settle_ms);
+        return null;
+    }
+    if (out_bytes) |bytes| cio.File.stdout().writeAll(bytes) catch {};
     return code;
+}
+
+fn cliRequestYield(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8) void {
+    const conn = cliConnect(io, allocator, abs_root, data_dir) orelse return;
+    defer cliCloseConn(conn);
+    var hdr: [5]u8 = undefined;
+    hdr[0] = 0;
+    std.mem.writeInt(u32, hdr[1..5], @intCast(cli_yield_sentinel.len), .little);
+    if (!cliWriteFull(conn, &hdr)) return;
+    _ = cliWriteFull(conn, cli_yield_sentinel);
 }
 
 pub fn cliNotifyRefresh(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, data_dir: ?[]const u8) ?bool {

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -736,9 +736,17 @@ pub fn cliDaemonListen(io: std.Io, allocator: std.mem.Allocator, explorer: *Expl
                 }
             }
             last_activity_ms.store(cio.milliTimestamp(), .release);
-            _ = cliServeConn(io, allocator, explorer, store, abs_root, pipe);
+            const yield_requested = cliServeConn(io, allocator, explorer, store, abs_root, pipe);
             _ = DisconnectNamedPipe(pipe);
             win.CloseHandle(pipe);
+            if (yield_requested) {
+                // Match the POSIX listener: both the explicit handover sentinel
+                // and a client-version mismatch retire this daemon completely.
+                // The shutdown flag releases the metadata monitor; the outer
+                // defers close the replacement pipe and remove owned metadata.
+                shutdown.store(true, .release);
+                return;
+            }
         }
         return;
     }

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -369,11 +369,17 @@ const ImportTarget = struct {
 };
 
 fn importedTarget(f: FuncInput, qualifier: []const u8) ImportTarget {
-    const alias_end = std.mem.indexOfScalar(u8, qualifier, '.') orelse qualifier.len;
-    const alias = qualifier[0..alias_end];
     var result: ImportTarget = .{};
+    var best_alias_len: usize = 0;
     for (f.imports) |binding| {
-        if (!std.mem.eql(u8, binding.alias, alias)) continue;
+        if (binding.alias.len > qualifier.len) continue;
+        if (!std.mem.startsWith(u8, qualifier, binding.alias)) continue;
+        if (binding.alias.len < qualifier.len and qualifier[binding.alias.len] != '.') continue;
+        if (binding.alias.len < best_alias_len) continue;
+        if (binding.alias.len > best_alias_len) {
+            best_alias_len = binding.alias.len;
+            result = .{};
+        }
         if (!result.found) {
             result.found = true;
             result.path = binding.target_path;

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -190,9 +190,8 @@ const SpawnCallbackParse = struct {
 };
 
 fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) SpawnCallbackParse {
-    var paren_depth: usize = 0;
-    var brace_depth: usize = 0;
-    var bracket_depth: usize = 0;
+    var closer_stack: [64]u8 = undefined;
+    var closer_len: usize = 0;
     var arg_index: usize = 0;
     var arg_start = open_paren + 1;
     var second_start: ?usize = null;
@@ -223,29 +222,33 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) SpawnCallbackPars
             continue;
         }
         switch (c) {
-            '(' => paren_depth += 1,
+            '(', '{', '[' => {
+                if (closer_len == closer_stack.len) return .{ .end = i };
+                closer_stack[closer_len] = switch (c) {
+                    '(' => ')',
+                    '{' => '}',
+                    '[' => ']',
+                    else => unreachable,
+                };
+                closer_len += 1;
+            },
             ')' => {
-                if (paren_depth > 0) {
-                    paren_depth -= 1;
+                if (closer_len > 0) {
+                    if (closer_stack[closer_len - 1] != ')') return .{ .end = i };
+                    closer_len -= 1;
                 } else {
-                    if (brace_depth != 0 or bracket_depth != 0 or arg_index != 2) return .{ .end = i };
+                    if (arg_index != 2) return .{ .end = i };
                     if (std.mem.trim(u8, body[arg_start..i], " \t\r\n").len == 0) return .{ .end = i };
                     const start = second_start orelse return .{ .end = i };
                     const end = second_end orelse return .{ .end = i };
                     return .{ .callback = functionValueOnly(body[start..end]), .end = i };
                 }
             },
-            '{' => brace_depth += 1,
-            '}' => {
-                if (brace_depth == 0) return .{ .end = i };
-                brace_depth -= 1;
+            '}', ']' => {
+                if (closer_len == 0 or closer_stack[closer_len - 1] != c) return .{ .end = i };
+                closer_len -= 1;
             },
-            '[' => bracket_depth += 1,
-            ']' => {
-                if (bracket_depth == 0) return .{ .end = i };
-                bracket_depth -= 1;
-            },
-            ',' => if (paren_depth == 0 and brace_depth == 0 and bracket_depth == 0) {
+            ',' => if (closer_len == 0) {
                 if (std.mem.trim(u8, body[arg_start..i], " \t\r\n").len == 0) return .{ .end = i };
                 if (arg_index == 0) {
                     second_start = i + 1;

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -182,12 +182,21 @@ fn functionValueOnly(raw: []const u8) ?ParsedCallee {
 /// Return the bare or module-qualified function value passed as the second
 /// argument to one exact Zig form: `std.Thread.spawn(config, callback, args)`.
 /// This intentionally does not infer arbitrary expressions or dynamic callbacks.
-fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?ParsedCallee {
+const SpawnCallbackParse = struct {
+    callback: ?ParsedCallee = null,
+    /// Last byte inspected. The outer scanner advances here so a malformed
+    /// spawn prefix cannot make every following `(` rescan the same suffix.
+    end: usize,
+};
+
+fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) SpawnCallbackParse {
     var paren_depth: usize = 0;
     var brace_depth: usize = 0;
     var bracket_depth: usize = 0;
     var arg_index: usize = 0;
+    var arg_start = open_paren + 1;
     var second_start: ?usize = null;
+    var second_end: ?usize = null;
     var i = open_paren + 1;
     while (i < body.len) : (i += 1) {
         const c = body[i];
@@ -199,15 +208,18 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?ParsedCallee {
         if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
             i += 2;
             while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            if (i + 1 >= body.len) return .{ .end = body.len };
             i += 1;
             continue;
         }
         if (c == '"' or c == '\'') {
+            const quote = c;
             i += 1;
-            while (i < body.len and body[i] != c) {
+            while (i < body.len and body[i] != quote) {
                 if (body[i] == '\\') i += 1;
                 i += 1;
             }
+            if (i >= body.len) return .{ .end = body.len };
             continue;
         }
         switch (c) {
@@ -216,30 +228,40 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?ParsedCallee {
                 if (paren_depth > 0) {
                     paren_depth -= 1;
                 } else {
-                    if (arg_index == 1) return functionValueOnly(body[second_start.?..i]);
-                    return null;
+                    if (brace_depth != 0 or bracket_depth != 0 or arg_index != 2) return .{ .end = i };
+                    if (std.mem.trim(u8, body[arg_start..i], " \t\r\n").len == 0) return .{ .end = i };
+                    const start = second_start orelse return .{ .end = i };
+                    const end = second_end orelse return .{ .end = i };
+                    return .{ .callback = functionValueOnly(body[start..end]), .end = i };
                 }
             },
             '{' => brace_depth += 1,
-            '}' => if (brace_depth > 0) {
+            '}' => {
+                if (brace_depth == 0) return .{ .end = i };
                 brace_depth -= 1;
             },
             '[' => bracket_depth += 1,
-            ']' => if (bracket_depth > 0) {
+            ']' => {
+                if (bracket_depth == 0) return .{ .end = i };
                 bracket_depth -= 1;
             },
             ',' => if (paren_depth == 0 and brace_depth == 0 and bracket_depth == 0) {
+                if (std.mem.trim(u8, body[arg_start..i], " \t\r\n").len == 0) return .{ .end = i };
                 if (arg_index == 0) {
                     second_start = i + 1;
                     arg_index = 1;
                 } else if (arg_index == 1) {
-                    return functionValueOnly(body[second_start.?..i]);
+                    second_end = i;
+                    arg_index = 2;
+                } else {
+                    return .{ .end = i };
                 }
+                arg_start = i + 1;
             },
             else => {},
         }
     }
-    return null;
+    return .{ .end = body.len };
 }
 
 pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []const u8) ![]Callee {
@@ -275,7 +297,9 @@ pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []cons
         if (!std.mem.eql(u8, parsed.callee.name, "spawn")) continue;
         const qualifier = parsed.callee.qualifier orelse continue;
         if (!std.mem.eql(u8, qualifier, "std.Thread")) continue;
-        const callback = zigThreadSpawnCallback(body, i) orelse continue;
+        const parsed_callback = zigThreadSpawnCallback(body, i);
+        i = parsed_callback.end;
+        const callback = parsed_callback.callback orelse continue;
         const g = try seen.getOrPut(callback.key);
         if (!g.found_existing) try out.append(allocator, callback.callee);
     }

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -15,19 +15,35 @@ const std = @import("std");
 
 pub const NodeId = u32;
 
-/// A resolved call edge `from` → `to`. `weight` splits 1.0 across the candidate
-/// definitions of an ambiguous callee name (1 candidate → 1.0), so a name that
-/// resolves cleanly contributes full weight and an ambiguous one is discounted.
+/// A resolved call edge `from` → `to`. Edges are emitted only when resolution
+/// selects one definition, so every retained call contributes its full weight.
 pub const Edge = struct {
     from: NodeId,
     to: NodeId,
     weight: f32,
 };
 
+pub const ImportBinding = struct {
+    alias: []const u8,
+    target_path: []const u8,
+};
+
 pub const FuncInput = struct {
     id: NodeId,
     /// The function's body text (caller slices it from content via line ranges).
     body: []const u8,
+    /// Optional resolution facts. The lightweight unit-test API can omit these;
+    /// Explorer supplies them for same-file and imported-module resolution.
+    path: []const u8 = "",
+    imports: []const ImportBinding = &.{},
+    extract_zig_thread_spawn_callbacks: bool = false,
+};
+
+pub const Callee = struct {
+    name: []const u8,
+    /// Dotted expression before the final callee name (`std.Thread` in
+    /// `std.Thread.spawn`). Null for a bare call such as `helper()`.
+    qualifier: ?[]const u8 = null,
 };
 
 /// True for identifiers that precede `(` but are language keywords / control flow,
@@ -55,14 +71,55 @@ inline fn isIdentChar(c: u8) bool {
     return isIdentStart(c) or (c >= '0' and c <= '9');
 }
 
-/// Extract deduped callee identifier names that appear as call sites (`ident(`)
-/// in a function body. The identifier immediately preceding an unmatched `(` is
-/// the candidate callee (`obj.foo(` yields `foo`; `a[i](` yields nothing). Items
-/// are slices into `body`; caller frees the returned array.
-pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![][]const u8 {
+const ParsedCallee = struct {
+    callee: Callee,
+    key: []const u8,
+};
+
+fn calleeBeforeOpenParen(body: []const u8, open_paren: usize) ?ParsedCallee {
+    var end = open_paren;
+    while (end > 0 and (body[end - 1] == ' ' or body[end - 1] == '\t')) end -= 1;
+
+    var start = end;
+    while (start > 0 and isIdentChar(body[start - 1])) start -= 1;
+    if (start == end) return null;
+    const name = body[start..end];
+    if (!isIdentStart(name[0]) or isCallKeyword(name)) return null;
+
+    var qualifier: ?[]const u8 = null;
+    var key_start = start;
+    if (start > 0 and body[start - 1] == '.') {
+        const qualifier_end = start - 1;
+        var cursor = qualifier_end;
+        var qualifier_start = qualifier_end;
+        while (cursor > 0) {
+            const segment_end = cursor;
+            while (cursor > 0 and isIdentChar(body[cursor - 1])) cursor -= 1;
+            if (cursor == segment_end or !isIdentStart(body[cursor])) break;
+            qualifier_start = cursor;
+            if (cursor == 0 or body[cursor - 1] != '.') break;
+            cursor -= 1;
+        }
+        if (qualifier_start < qualifier_end) {
+            qualifier = body[qualifier_start..qualifier_end];
+            key_start = qualifier_start;
+        }
+    }
+
+    return .{
+        .callee = .{ .name = name, .qualifier = qualifier },
+        .key = body[key_start..end],
+    };
+}
+
+/// Extract deduped call sites from a function body. Qualified calls retain the
+/// receiver/module expression (`server.run(` becomes `{run, server}`) so the
+/// edge builder can use import facts instead of fanning out by bare name.
+/// Items borrow from `body`; the caller frees only the returned array.
+pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![]Callee {
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
-    var out: std.ArrayList([]const u8) = .empty;
+    var out: std.ArrayList(Callee) = .empty;
     errdefer out.deinit(allocator);
 
     var i: usize = 0;
@@ -90,32 +147,132 @@ pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![][]const
             continue;
         }
         if (c != '(') continue;
-        // Skip spaces/tabs between the identifier and the '('.
-        var end = i;
-        while (end > 0 and (body[end - 1] == ' ' or body[end - 1] == '\t')) end -= 1;
-        // Walk back over identifier characters.
-        var start = end;
-        while (start > 0 and isIdentChar(body[start - 1])) start -= 1;
-        if (start == end) continue; // nothing before '(' (e.g. `(expr)`, `)(`)
-        const name = body[start..end];
-        if (!isIdentStart(name[0])) continue; // started on a digit → not an ident
-        if (isCallKeyword(name)) continue;
-        const g = try seen.getOrPut(name);
-        if (!g.found_existing) try out.append(allocator, name);
+        const parsed = calleeBeforeOpenParen(body, i) orelse continue;
+        const g = try seen.getOrPut(parsed.key);
+        if (!g.found_existing) try out.append(allocator, parsed.callee);
     }
     return out.toOwnedSlice(allocator);
 }
 
-/// Build resolved call edges for a set of functions. `resolve` maps a callee name
-/// to the node ids of its candidate definitions (codedb's `symbol_index`). Edge
-/// weight is split across candidates; self-edges are dropped unless `allow_self`.
+fn identifierOnly(raw: []const u8) ?[]const u8 {
+    const value = std.mem.trim(u8, raw, " \t\r\n");
+    if (value.len == 0 or !isIdentStart(value[0])) return null;
+    for (value[1..]) |c| if (!isIdentChar(c)) return null;
+    return value;
+}
+
+/// Return the identifier passed as the second argument to one exact Zig form:
+/// `std.Thread.spawn(config, callback, args)`. This intentionally does not try
+/// to infer arbitrary function values or dynamic callbacks.
+fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?[]const u8 {
+    var paren_depth: usize = 0;
+    var brace_depth: usize = 0;
+    var bracket_depth: usize = 0;
+    var arg_index: usize = 0;
+    var second_start: ?usize = null;
+    var i = open_paren + 1;
+    while (i < body.len) : (i += 1) {
+        const c = body[i];
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            i += 1;
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < body.len and body[i] != c) {
+                if (body[i] == '\\') i += 1;
+                i += 1;
+            }
+            continue;
+        }
+        switch (c) {
+            '(' => paren_depth += 1,
+            ')' => {
+                if (paren_depth > 0) {
+                    paren_depth -= 1;
+                } else {
+                    if (arg_index == 1) return identifierOnly(body[second_start.?..i]);
+                    return null;
+                }
+            },
+            '{' => brace_depth += 1,
+            '}' => if (brace_depth > 0) {
+                brace_depth -= 1;
+            },
+            '[' => bracket_depth += 1,
+            ']' => if (bracket_depth > 0) {
+                bracket_depth -= 1;
+            },
+            ',' => if (paren_depth == 0 and brace_depth == 0 and bracket_depth == 0) {
+                if (arg_index == 0) {
+                    second_start = i + 1;
+                    arg_index = 1;
+                } else if (arg_index == 1) {
+                    return identifierOnly(body[second_start.?..i]);
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []const u8) ![][]const u8 {
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < body.len) : (i += 1) {
+        const c = body[i];
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            i += 1;
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < body.len and body[i] != c) {
+                if (body[i] == '\\') i += 1;
+                i += 1;
+            }
+            continue;
+        }
+        if (c != '(') continue;
+        const parsed = calleeBeforeOpenParen(body, i) orelse continue;
+        if (!std.mem.eql(u8, parsed.callee.name, "spawn")) continue;
+        const qualifier = parsed.callee.qualifier orelse continue;
+        if (!std.mem.eql(u8, qualifier, "std.Thread")) continue;
+        const callback = zigThreadSpawnCallback(body, i) orelse continue;
+        const g = try seen.getOrPut(callback);
+        if (!g.found_existing) try out.append(allocator, callback);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build resolved call edges for a set of functions. Ambiguous names are skipped
+/// instead of fanning out to unrelated definitions.
 pub fn buildEdges(
     allocator: std.mem.Allocator,
     funcs: []const FuncInput,
     resolve: *const std.StringHashMap([]const NodeId),
     allow_self: bool,
 ) !std.ArrayList(Edge) {
-    return buildEdgesWithinGroups(allocator, funcs, resolve, null, allow_self);
+    return buildEdgesScoped(allocator, funcs, resolve, null, null, allow_self);
 }
 
 /// Like buildEdges, but only resolves a call to definitions in the caller's
@@ -130,30 +287,134 @@ pub fn buildEdgesWithinGroups(
     groups: ?[]const u8,
     allow_self: bool,
 ) !std.ArrayList(Edge) {
+    return buildEdgesScoped(allocator, funcs, resolve, null, groups, allow_self);
+}
+
+const CandidateChoice = struct {
+    id: ?NodeId = null,
+    count: usize = 0,
+};
+
+fn chooseCandidates(
+    f: FuncInput,
+    cands: []const NodeId,
+    node_paths: ?[]const []const u8,
+    groups: ?[]const u8,
+    required_path: ?[]const u8,
+) CandidateChoice {
+    var result: CandidateChoice = .{};
+    for (cands) |to| {
+        if (groups) |node_groups| {
+            if (f.id >= node_groups.len or to >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
+        }
+        if (required_path) |path| {
+            const paths = node_paths orelse continue;
+            if (to >= paths.len or !std.mem.eql(u8, paths[to], path)) continue;
+        }
+        result.count += 1;
+        if (result.count == 1) result.id = to else result.id = null;
+    }
+    return result;
+}
+
+const ImportTarget = struct {
+    found: bool = false,
+    ambiguous: bool = false,
+    path: ?[]const u8 = null,
+};
+
+fn importedTarget(f: FuncInput, qualifier: []const u8) ImportTarget {
+    const alias_end = std.mem.indexOfScalar(u8, qualifier, '.') orelse qualifier.len;
+    const alias = qualifier[0..alias_end];
+    var result: ImportTarget = .{};
+    for (f.imports) |binding| {
+        if (!std.mem.eql(u8, binding.alias, alias)) continue;
+        if (!result.found) {
+            result.found = true;
+            result.path = binding.target_path;
+        } else if (!std.mem.eql(u8, result.path.?, binding.target_path)) {
+            result.ambiguous = true;
+            result.path = null;
+        }
+    }
+    return result;
+}
+
+fn resolveDirectCallee(
+    f: FuncInput,
+    callee: Callee,
+    cands: []const NodeId,
+    node_paths: ?[]const []const u8,
+    groups: ?[]const u8,
+) ?NodeId {
+    if (callee.qualifier) |qualifier| {
+        const imported = importedTarget(f, qualifier);
+        if (imported.found) {
+            if (imported.ambiguous) return null;
+            const choice = chooseCandidates(f, cands, node_paths, groups, imported.path.?);
+            return if (choice.count == 1) choice.id else null;
+        }
+        // Preserve the old behavior for globally unique method names when the
+        // receiver is a value whose type codedb cannot infer.
+        const choice = chooseCandidates(f, cands, node_paths, groups, null);
+        return if (choice.count == 1) choice.id else null;
+    }
+
+    if (node_paths != null and f.path.len != 0) {
+        const local = chooseCandidates(f, cands, node_paths, groups, f.path);
+        if (local.count > 0) return if (local.count == 1) local.id else null;
+    }
+    const global = chooseCandidates(f, cands, node_paths, groups, null);
+    return if (global.count == 1) global.id else null;
+}
+
+fn appendUniqueEdge(
+    allocator: std.mem.Allocator,
+    edges: *std.ArrayList(Edge),
+    function_edge_start: usize,
+    from: NodeId,
+    to: NodeId,
+    allow_self: bool,
+) !void {
+    if (!allow_self and to == from) return;
+    for (edges.items[function_edge_start..]) |edge| {
+        if (edge.to == to) return;
+    }
+    try edges.append(allocator, .{ .from = from, .to = to, .weight = 1.0 });
+}
+
+/// Resolve using caller paths and per-file import bindings. Resolution priority
+/// is: imported module receiver, same-file bare helper, globally unique name.
+/// Every tier keeps the language-family guard; ambiguity emits no edge.
+pub fn buildEdgesScoped(
+    allocator: std.mem.Allocator,
+    funcs: []const FuncInput,
+    resolve: *const std.StringHashMap([]const NodeId),
+    node_paths: ?[]const []const u8,
+    groups: ?[]const u8,
+    allow_self: bool,
+) !std.ArrayList(Edge) {
     var edges: std.ArrayList(Edge) = .empty;
     errdefer edges.deinit(allocator);
     for (funcs) |f| {
+        const function_edge_start = edges.items.len;
         const callees = try extractCallees(allocator, f.body);
         defer allocator.free(callees);
-        for (callees) |name| {
-            const cands = resolve.get(name) orelse continue;
-            if (cands.len == 0) continue;
-            const scoped_count: usize = if (groups) |node_groups| blk: {
-                if (f.id >= node_groups.len) break :blk 0;
-                var count: usize = 0;
-                for (cands) |to| {
-                    if (to < node_groups.len and node_groups[to] == node_groups[f.id]) count += 1;
-                }
-                break :blk count;
-            } else cands.len;
-            if (scoped_count == 0) continue;
-            const w: f32 = 1.0 / @as(f32, @floatFromInt(scoped_count));
-            for (cands) |to| {
-                if (groups) |node_groups| {
-                    if (to >= node_groups.len or f.id >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
-                }
-                if (!allow_self and to == f.id) continue;
-                try edges.append(allocator, .{ .from = f.id, .to = to, .weight = w });
+        for (callees) |callee| {
+            const cands = resolve.get(callee.name) orelse continue;
+            const to = resolveDirectCallee(f, callee, cands, node_paths, groups) orelse continue;
+            try appendUniqueEdge(allocator, &edges, function_edge_start, f.id, to, allow_self);
+        }
+
+        if (f.extract_zig_thread_spawn_callbacks and node_paths != null and f.path.len != 0) {
+            const callbacks = try extractZigThreadSpawnCallbacks(allocator, f.body);
+            defer allocator.free(callbacks);
+            for (callbacks) |name| {
+                const cands = resolve.get(name) orelse continue;
+                const local = chooseCandidates(f, cands, node_paths, groups, f.path);
+                if (local.count != 1) continue;
+                const to = local.id.?;
+                try appendUniqueEdge(allocator, &edges, function_edge_start, f.id, to, allow_self);
             }
         }
     }

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -154,17 +154,35 @@ pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![]Callee 
     return out.toOwnedSlice(allocator);
 }
 
-fn identifierOnly(raw: []const u8) ?[]const u8 {
+fn functionValueOnly(raw: []const u8) ?ParsedCallee {
     const value = std.mem.trim(u8, raw, " \t\r\n");
     if (value.len == 0 or !isIdentStart(value[0])) return null;
-    for (value[1..]) |c| if (!isIdentChar(c)) return null;
-    return value;
+    var segment_start: usize = 0;
+    var last_dot: ?usize = null;
+    for (value, 0..) |c, i| {
+        if (c == '.') {
+            if (i == segment_start) return null;
+            last_dot = i;
+            segment_start = i + 1;
+            continue;
+        }
+        if (!isIdentChar(c) or (i == segment_start and !isIdentStart(c))) return null;
+    }
+    if (segment_start == value.len) return null;
+    const name = value[segment_start..];
+    return .{
+        .callee = .{
+            .name = name,
+            .qualifier = if (last_dot) |dot| value[0..dot] else null,
+        },
+        .key = value,
+    };
 }
 
-/// Return the identifier passed as the second argument to one exact Zig form:
-/// `std.Thread.spawn(config, callback, args)`. This intentionally does not try
-/// to infer arbitrary function values or dynamic callbacks.
-fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?[]const u8 {
+/// Return the bare or module-qualified function value passed as the second
+/// argument to one exact Zig form: `std.Thread.spawn(config, callback, args)`.
+/// This intentionally does not infer arbitrary expressions or dynamic callbacks.
+fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?ParsedCallee {
     var paren_depth: usize = 0;
     var brace_depth: usize = 0;
     var bracket_depth: usize = 0;
@@ -198,7 +216,7 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?[]const u8 {
                 if (paren_depth > 0) {
                     paren_depth -= 1;
                 } else {
-                    if (arg_index == 1) return identifierOnly(body[second_start.?..i]);
+                    if (arg_index == 1) return functionValueOnly(body[second_start.?..i]);
                     return null;
                 }
             },
@@ -215,7 +233,7 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?[]const u8 {
                     second_start = i + 1;
                     arg_index = 1;
                 } else if (arg_index == 1) {
-                    return identifierOnly(body[second_start.?..i]);
+                    return functionValueOnly(body[second_start.?..i]);
                 }
             },
             else => {},
@@ -224,10 +242,10 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) ?[]const u8 {
     return null;
 }
 
-pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []const u8) ![][]const u8 {
+pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []const u8) ![]Callee {
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
-    var out: std.ArrayList([]const u8) = .empty;
+    var out: std.ArrayList(Callee) = .empty;
     errdefer out.deinit(allocator);
 
     var i: usize = 0;
@@ -258,8 +276,8 @@ pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []cons
         const qualifier = parsed.callee.qualifier orelse continue;
         if (!std.mem.eql(u8, qualifier, "std.Thread")) continue;
         const callback = zigThreadSpawnCallback(body, i) orelse continue;
-        const g = try seen.getOrPut(callback);
-        if (!g.found_existing) try out.append(allocator, callback);
+        const g = try seen.getOrPut(callback.key);
+        if (!g.found_existing) try out.append(allocator, callback.callee);
     }
     return out.toOwnedSlice(allocator);
 }
@@ -368,6 +386,30 @@ fn resolveDirectCallee(
     return if (global.count == 1) global.id else null;
 }
 
+/// Thread callback values are resolved more strictly than direct calls: an
+/// imported qualifier must bind to exactly one function in that imported file;
+/// otherwise the callback must name exactly one function in the caller's file.
+/// There is deliberately no repository-global fallback for function values.
+fn resolveThreadCallback(
+    f: FuncInput,
+    callback: Callee,
+    cands: []const NodeId,
+    node_paths: ?[]const []const u8,
+    groups: ?[]const u8,
+) ?NodeId {
+    if (callback.qualifier) |qualifier| {
+        const imported = importedTarget(f, qualifier);
+        if (imported.found) {
+            if (imported.ambiguous) return null;
+            const choice = chooseCandidates(f, cands, node_paths, groups, imported.path.?);
+            return if (choice.count == 1) choice.id else null;
+        }
+    }
+    if (node_paths == null or f.path.len == 0) return null;
+    const local = chooseCandidates(f, cands, node_paths, groups, f.path);
+    return if (local.count == 1) local.id else null;
+}
+
 fn appendUniqueEdge(
     allocator: std.mem.Allocator,
     edges: *std.ArrayList(Edge),
@@ -409,11 +451,9 @@ pub fn buildEdgesScoped(
         if (f.extract_zig_thread_spawn_callbacks and node_paths != null and f.path.len != 0) {
             const callbacks = try extractZigThreadSpawnCallbacks(allocator, f.body);
             defer allocator.free(callbacks);
-            for (callbacks) |name| {
-                const cands = resolve.get(name) orelse continue;
-                const local = chooseCandidates(f, cands, node_paths, groups, f.path);
-                if (local.count != 1) continue;
-                const to = local.id.?;
+            for (callbacks) |callback| {
+                const cands = resolve.get(callback.name) orelse continue;
+                const to = resolveThreadCallback(f, callback, cands, node_paths, groups) orelse continue;
                 try appendUniqueEdge(allocator, &edges, function_edge_start, f.id, to, allow_self);
             }
         }

--- a/src/codegraph.zig
+++ b/src/codegraph.zig
@@ -36,7 +36,10 @@ pub const FuncInput = struct {
     /// Explorer supplies them for same-file and imported-module resolution.
     path: []const u8 = "",
     imports: []const ImportBinding = &.{},
+    skip_zig_multiline_strings: bool = false,
     extract_zig_thread_spawn_callbacks: bool = false,
+    preextracted_callees: ?[]const Callee = null,
+    preextracted_thread_callbacks: ?[]const Callee = null,
 };
 
 pub const Callee = struct {
@@ -117,6 +120,29 @@ fn calleeBeforeOpenParen(body: []const u8, open_paren: usize) ?ParsedCallee {
 /// edge builder can use import facts instead of fanning out by bare name.
 /// Items borrow from `body`; the caller frees only the returned array.
 pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![]Callee {
+    return extractCalleesImpl(allocator, body, false);
+}
+
+fn qualifierRootIsImported(qualifier: []const u8, imports: []const ImportBinding) bool {
+    const dot = std.mem.indexOfScalar(u8, qualifier, '.') orelse qualifier.len;
+    const root = qualifier[0..dot];
+    for (imports) |binding| {
+        if (std.mem.eql(u8, binding.alias, root)) return true;
+    }
+    return false;
+}
+
+/// Call-graph-specific extraction filters names with no indexed definition and
+/// normalizes qualifiers that cannot affect resolution. Imported receivers and
+/// ambiguous names retain their full qualifier; globally unique calls dedupe by
+/// name exactly as the older fast graph builder did.
+pub fn extractResolvableCallees(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    zig_multiline_strings: bool,
+    imports: []const ImportBinding,
+    resolve: *const std.StringHashMap([]const NodeId),
+) ![]Callee {
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
     var out: std.ArrayList(Callee) = .empty;
@@ -125,6 +151,83 @@ pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![]Callee 
     var i: usize = 0;
     while (i < body.len) : (i += 1) {
         const c = body[i];
+        if (zig_multiline_strings and isZigMultilineStringStart(body, i)) {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            i += 1;
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < body.len and body[i] != c) {
+                if (body[i] == '\\') i += 1;
+                i += 1;
+            }
+            continue;
+        }
+        if (c != '(') continue;
+        // Resolve the cheap final identifier before walking a dotted receiver.
+        // Most call-like tokens in a large source file have no indexed
+        // definition, so they should never pay qualifier parsing or hashing.
+        var end = i;
+        while (end > 0 and (body[end - 1] == ' ' or body[end - 1] == '\t')) end -= 1;
+        var start = end;
+        while (start > 0 and isIdentChar(body[start - 1])) start -= 1;
+        if (start == end) continue;
+        const name = body[start..end];
+        if (!isIdentStart(name[0]) or isCallKeyword(name)) continue;
+        const is_qualified = start > 0 and body[start - 1] == '.';
+        if (!is_qualified) {
+            const g = try seen.getOrPut(name);
+            if (g.found_existing) continue;
+            if (resolve.get(name) == null) continue;
+            try out.append(allocator, .{ .name = name });
+            continue;
+        }
+
+        const candidates = resolve.get(name) orelse continue;
+
+        var normalized = Callee{ .name = name };
+        var key = name;
+        if (candidates.len > 1 or imports.len > 0) {
+            const parsed = calleeBeforeOpenParen(body, i) orelse continue;
+            if (parsed.callee.qualifier) |qualifier| {
+                if (candidates.len > 1 or qualifierRootIsImported(qualifier, imports)) {
+                    normalized = parsed.callee;
+                    key = parsed.key;
+                }
+            }
+        }
+        const g = try seen.getOrPut(key);
+        if (!g.found_existing) try out.append(allocator, normalized);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn extractCalleesImpl(allocator: std.mem.Allocator, body: []const u8, zig_multiline_strings: bool) ![]Callee {
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+    var out: std.ArrayList(Callee) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < body.len) : (i += 1) {
+        const c = body[i];
+        if (zig_multiline_strings and isZigMultilineStringStart(body, i)) {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
         // Skip line comments, block comments, and string/char literals so an identifier
         // mentioned only inside one is not mistaken for a call site (#548 family).
         if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
@@ -152,6 +255,96 @@ pub fn extractCallees(allocator: std.mem.Allocator, body: []const u8) ![]Callee 
         if (!g.found_existing) try out.append(allocator, parsed.callee);
     }
     return out.toOwnedSlice(allocator);
+}
+
+fn extractCalleeNames(allocator: std.mem.Allocator, body: []const u8) ![]Callee {
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+    var out: std.ArrayList(Callee) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < body.len) : (i += 1) {
+        const c = body[i];
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < body.len and body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < body.len and !(body[i] == '*' and body[i + 1] == '/')) i += 1;
+            i += 1;
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < body.len and body[i] != c) {
+                if (body[i] == '\\') i += 1;
+                i += 1;
+            }
+            continue;
+        }
+        if (c != '(') continue;
+        var end = i;
+        while (end > 0 and (body[end - 1] == ' ' or body[end - 1] == '\t')) end -= 1;
+        var start = end;
+        while (start > 0 and isIdentChar(body[start - 1])) start -= 1;
+        if (start == end) continue;
+        const name = body[start..end];
+        if (!isIdentStart(name[0]) or isCallKeyword(name)) continue;
+        const g = try seen.getOrPut(name);
+        if (!g.found_existing) try out.append(allocator, .{ .name = name });
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Fast ranking graph used for centrality and query-distance boosts. Ambiguous
+/// names fan out with split weight, preserving the long-standing ranking signal;
+/// user-visible callpath uses the stricter scoped graph below.
+pub fn buildEdgesApproximate(
+    allocator: std.mem.Allocator,
+    funcs: []const FuncInput,
+    resolve: *const std.StringHashMap([]const NodeId),
+    groups: ?[]const u8,
+    allow_self: bool,
+) !std.ArrayList(Edge) {
+    var edges: std.ArrayList(Edge) = .empty;
+    errdefer edges.deinit(allocator);
+    for (funcs) |f| {
+        const callees = try extractCalleeNames(allocator, f.body);
+        defer allocator.free(callees);
+        for (callees) |callee| {
+            const candidates = resolve.get(callee.name) orelse continue;
+            var count: usize = 0;
+            for (candidates) |to| {
+                if (groups) |node_groups| {
+                    if (f.id >= node_groups.len or to >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
+                }
+                count += 1;
+            }
+            if (count == 0) continue;
+            const weight = 1.0 / @as(f32, @floatFromInt(count));
+            for (candidates) |to| {
+                if (groups) |node_groups| {
+                    if (f.id >= node_groups.len or to >= node_groups.len or node_groups[to] != node_groups[f.id]) continue;
+                }
+                if (!allow_self and to == f.id) continue;
+                try edges.append(allocator, .{ .from = f.id, .to = to, .weight = weight });
+            }
+        }
+    }
+    return edges;
+}
+
+fn isZigMultilineStringStart(body: []const u8, pos: usize) bool {
+    if (pos + 1 >= body.len or body[pos] != '\\' or body[pos + 1] != '\\') return false;
+    var cursor = pos;
+    while (cursor > 0 and body[cursor - 1] != '\n') {
+        if (body[cursor - 1] != ' ' and body[cursor - 1] != '\t' and body[cursor - 1] != '\r') return false;
+        cursor -= 1;
+    }
+    return true;
 }
 
 fn functionValueOnly(raw: []const u8) ?ParsedCallee {
@@ -199,6 +392,11 @@ fn zigThreadSpawnCallback(body: []const u8, open_paren: usize) SpawnCallbackPars
     var i = open_paren + 1;
     while (i < body.len) : (i += 1) {
         const c = body[i];
+        if (isZigMultilineStringStart(body, i)) {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
         if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
             i += 2;
             while (i < body.len and body[i] != '\n') i += 1;
@@ -276,6 +474,11 @@ pub fn extractZigThreadSpawnCallbacks(allocator: std.mem.Allocator, body: []cons
     var i: usize = 0;
     while (i < body.len) : (i += 1) {
         const c = body[i];
+        if (isZigMultilineStringStart(body, i)) {
+            i += 2;
+            while (i < body.len and body[i] != '\n') i += 1;
+            continue;
+        }
         if (c == '/' and i + 1 < body.len and body[i + 1] == '/') {
             i += 2;
             while (i < body.len and body[i] != '\n') i += 1;
@@ -383,7 +586,7 @@ fn importedTarget(f: FuncInput, qualifier: []const u8) ImportTarget {
         if (!result.found) {
             result.found = true;
             result.path = binding.target_path;
-        } else if (!std.mem.eql(u8, result.path.?, binding.target_path)) {
+        } else if (!result.ambiguous and !std.mem.eql(u8, result.path.?, binding.target_path)) {
             result.ambiguous = true;
             result.path = null;
         }
@@ -458,6 +661,67 @@ fn appendUniqueEdge(
     try edges.append(allocator, .{ .from = from, .to = to, .weight = 1.0 });
 }
 
+fn appendResolvedBodyEdges(
+    allocator: std.mem.Allocator,
+    edges: *std.ArrayList(Edge),
+    function_edge_start: usize,
+    f: FuncInput,
+    resolve: *const std.StringHashMap([]const NodeId),
+    node_paths: ?[]const []const u8,
+    groups: ?[]const u8,
+    allow_self: bool,
+) !void {
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+    var i: usize = 0;
+    while (i < f.body.len) : (i += 1) {
+        const c = f.body[i];
+        if ((f.skip_zig_multiline_strings or f.extract_zig_thread_spawn_callbacks) and isZigMultilineStringStart(f.body, i)) {
+            i += 2;
+            while (i < f.body.len and f.body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < f.body.len and f.body[i + 1] == '/') {
+            i += 2;
+            while (i < f.body.len and f.body[i] != '\n') i += 1;
+            continue;
+        }
+        if (c == '/' and i + 1 < f.body.len and f.body[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < f.body.len and !(f.body[i] == '*' and f.body[i + 1] == '/')) i += 1;
+            i += 1;
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            i += 1;
+            while (i < f.body.len and f.body[i] != c) {
+                if (f.body[i] == '\\') i += 1;
+                i += 1;
+            }
+            continue;
+        }
+        if (c != '(') continue;
+
+        var end = i;
+        while (end > 0 and (f.body[end - 1] == ' ' or f.body[end - 1] == '\t')) end -= 1;
+        var start = end;
+        while (start > 0 and isIdentChar(f.body[start - 1])) start -= 1;
+        if (start == end) continue;
+        const name = f.body[start..end];
+        if (!isIdentStart(name[0]) or isCallKeyword(name)) continue;
+        const candidates = resolve.get(name) orelse continue;
+        const parsed = if (start > 0 and f.body[start - 1] == '.')
+            calleeBeforeOpenParen(f.body, i) orelse continue
+        else
+            ParsedCallee{ .callee = .{ .name = name }, .key = name };
+        const g = try seen.getOrPut(parsed.key);
+        if (g.found_existing) continue;
+        const callee = parsed.callee;
+        const to = resolveDirectCallee(f, callee, candidates, node_paths, groups) orelse continue;
+        try appendUniqueEdge(allocator, edges, function_edge_start, f.id, to, allow_self);
+    }
+}
+
 /// Resolve using caller paths and per-file import bindings. Resolution priority
 /// is: imported module receiver, same-file bare helper, globally unique name.
 /// Every tier keeps the language-family guard; ambiguity emits no edge.
@@ -473,17 +737,32 @@ pub fn buildEdgesScoped(
     errdefer edges.deinit(allocator);
     for (funcs) |f| {
         const function_edge_start = edges.items.len;
-        const callees = try extractCallees(allocator, f.body);
-        defer allocator.free(callees);
-        for (callees) |callee| {
-            const cands = resolve.get(callee.name) orelse continue;
-            const to = resolveDirectCallee(f, callee, cands, node_paths, groups) orelse continue;
-            try appendUniqueEdge(allocator, &edges, function_edge_start, f.id, to, allow_self);
+        if (f.preextracted_callees) |callees| {
+            for (callees) |callee| {
+                const cands = resolve.get(callee.name) orelse continue;
+                const to = resolveDirectCallee(f, callee, cands, node_paths, groups) orelse continue;
+                try appendUniqueEdge(allocator, &edges, function_edge_start, f.id, to, allow_self);
+            }
+        } else {
+            try appendResolvedBodyEdges(
+                allocator,
+                &edges,
+                function_edge_start,
+                f,
+                resolve,
+                node_paths,
+                groups,
+                allow_self,
+            );
         }
 
         if (f.extract_zig_thread_spawn_callbacks and node_paths != null and f.path.len != 0) {
-            const callbacks = try extractZigThreadSpawnCallbacks(allocator, f.body);
-            defer allocator.free(callbacks);
+            const owned_callbacks = if (f.preextracted_thread_callbacks == null)
+                try extractZigThreadSpawnCallbacks(allocator, f.body)
+            else
+                null;
+            defer if (owned_callbacks) |callbacks| allocator.free(callbacks);
+            const callbacks = f.preextracted_thread_callbacks orelse owned_callbacks.?;
             for (callbacks) |callback| {
                 const cands = resolve.get(callback.name) orelse continue;
                 const to = resolveThreadCallback(f, callback, cands, node_paths, groups) orelse continue;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -662,6 +662,93 @@ pub const SymbolLocation = struct {
     line_end: u32,
 };
 
+fn symbolNavigationKindPriority(kind: SymbolKind) i32 {
+    return switch (kind) {
+        .function, .method => 100,
+        .struct_def, .class_def, .interface_def, .enum_def, .union_def, .trait_def => 90,
+        .impl_block => 80,
+        .type_alias, .macro_def => 70,
+        .constant => 60,
+        .variable => 50,
+        .test_decl => 10,
+        .import, .comment_block => -1000,
+    };
+}
+
+fn symbolNavigationPriority(name: []const u8, path: []const u8, kind: SymbolKind) i32 {
+    var score = symbolNavigationKindPriority(kind);
+    const class = classifyPath(path);
+    if (class.is_vendor) score -= 1200;
+    if (class.is_test) score -= 800;
+    if (class.is_example) score -= 500;
+    if (class.is_tooling) score -= 400;
+
+    // Mixed-language repositories commonly keep executable-looking probes in
+    // these directories. They are useful definitions, but poor default
+    // navigation targets when production definitions of the same name exist.
+    var segments = std.mem.tokenizeAny(u8, path, "/\\");
+    while (segments.next()) |segment| {
+        if (std.ascii.eqlIgnoreCase(segment, "experiments") or
+            std.ascii.eqlIgnoreCase(segment, "experiment") or
+            std.ascii.eqlIgnoreCase(segment, "e2e") or
+            std.ascii.eqlIgnoreCase(segment, "fixtures") or
+            std.ascii.eqlIgnoreCase(segment, "fixture") or
+            std.ascii.eqlIgnoreCase(segment, "generated"))
+        {
+            score -= 700;
+            break;
+        }
+    }
+
+    const basename = std.fs.path.basename(path);
+    const dot = std.mem.lastIndexOfScalar(u8, basename, '.') orelse basename.len;
+    const stem = basename[0..dot];
+    const eponymous = std.ascii.eqlIgnoreCase(stem, name);
+    if (eponymous) score += 400;
+    if (std.mem.startsWith(u8, path, "src/")) score += 120 else if (std.mem.indexOfScalar(u8, path, '/') == null) score += 80;
+
+    // `main` is the one generic name with a cross-language package-entrypoint
+    // convention. Keep this narrow; other common names remain visibly
+    // ambiguous rather than acquiring hard-coded language preferences.
+    if (eponymous and std.ascii.eqlIgnoreCase(name, "main")) {
+        if (std.mem.startsWith(u8, path, "src/")) {
+            score += 400;
+        } else if (std.mem.indexOfScalar(u8, path, '/') == null) {
+            score += 350;
+        } else if (pathHasSegmentIgnoreCase(path, "cmd")) {
+            score += 300;
+        }
+    }
+    return score;
+}
+
+fn symbolNavigationBefore(
+    name: []const u8,
+    a_path: []const u8,
+    a_kind: SymbolKind,
+    a_line: u32,
+    b_path: []const u8,
+    b_kind: SymbolKind,
+    b_line: u32,
+) bool {
+    const ap = symbolNavigationPriority(name, a_path, a_kind);
+    const bp = symbolNavigationPriority(name, b_path, b_kind);
+    if (ap != bp) return ap > bp;
+    const path_order = std.mem.order(u8, a_path, b_path);
+    if (path_order != .eq) return path_order == .lt;
+    return a_line < b_line;
+}
+
+fn symbolNavigationLocationBefore(name: []const u8, a: SymbolLocation, b: SymbolLocation) bool {
+    return symbolNavigationBefore(name, a.path, a.kind, a.line_start, b.path, b.kind, b.line_start);
+}
+
+fn symbolNavigationResultBefore(a: SymbolResult, b: SymbolResult) bool {
+    const name_order = std.mem.order(u8, a.symbol.name, b.symbol.name);
+    if (name_order != .eq) return name_order == .lt;
+    return symbolNavigationBefore(a.symbol.name, a.path, a.symbol.kind, a.symbol.line_start, b.path, b.symbol.kind, b.symbol.line_start);
+}
+
 pub fn matchGlob(pattern: []const u8, path: []const u8) bool {
     // Fast path: `**/*X` where X is a literal — degenerates to endsWith(X).
     // Covers the common agent-style pattern `**/*.ext`.
@@ -3657,7 +3744,14 @@ pub const Explorer = struct {
         // O(1) lookup via symbol_index
         if (self.symbol_index.get(name)) |locs| {
             if (locs.items.len > 0) {
-                const loc = locs.items[0];
+                // The hash lookup is O(1); choose deterministically among the
+                // definitions of this name instead of inheriting scan/commit
+                // order from the symbol-index append list. This is O(k) in the
+                // number of exact-name collisions, never O(all symbols).
+                var loc = locs.items[0];
+                for (locs.items[1..]) |candidate| {
+                    if (symbolNavigationLocationBefore(name, candidate, loc)) loc = candidate;
+                }
                 // Fetch detail from outline
                 var detail: ?[]const u8 = null;
                 if (self.outlines.getPtr(loc.path)) |outline| {
@@ -3782,6 +3876,14 @@ pub const Explorer = struct {
         kind: ?SymbolKind = null,
         fuzzy: bool = false,
         max_results: usize = 50,
+        rank_policy: SymbolRankPolicy = .structural,
+    };
+
+    pub const SymbolRankPolicy = enum {
+        /// Stable low-level order: match score, name, path, line.
+        structural,
+        /// Opinionated navigation order for resolving an exact common name.
+        navigation,
     };
 
     pub const ScoredSymbolResult = struct {
@@ -3834,6 +3936,7 @@ pub const Explorer = struct {
             path: []const u8,
             symbol: Symbol,
             score: f32,
+            navigation_priority: i32,
         };
 
         var candidates: std.ArrayList(Candidate) = .empty;
@@ -3849,13 +3952,13 @@ pub const Explorer = struct {
         };
 
         const SortCtx = struct {
-            // Total order: score desc, then name, path, line. line_start is
-            // the final tiebreak — without it, same-name symbols in one file
-            // compared equal and their order fell out of hash-map iteration,
-            // the residual nondeterminism the deterministic-ordering rewrite
-            // meant to eliminate.
+            // Total order: score desc, optional navigation priority, then name,
+            // path, line. line_start is the final tiebreak — without it,
+            // same-name symbols in one file compared equal and their order fell
+            // out of hash-map iteration.
             pub fn lessThan(_: void, a: Candidate, b: Candidate) bool {
                 if (a.score != b.score) return a.score > b.score;
+                if (a.navigation_priority != b.navigation_priority) return a.navigation_priority > b.navigation_priority;
                 const name_cmp = std.mem.order(u8, a.symbol.name, b.symbol.name);
                 if (name_cmp != .eq) return name_cmp == .lt;
                 const path_cmp = std.mem.order(u8, a.path, b.path);
@@ -3909,6 +4012,7 @@ pub const Explorer = struct {
                 path: []const u8,
                 sym: Symbol,
                 score: f32,
+                rank_policy: SymbolRankPolicy,
             ) !void {
                 if (max_results == 0) return;
                 if (Dedup.contains(list_ptr.items, path, sym.line_start)) return;
@@ -3916,6 +4020,10 @@ pub const Explorer = struct {
                     .path = path,
                     .symbol = sym,
                     .score = score,
+                    .navigation_priority = if (rank_policy == .navigation)
+                        symbolNavigationPriority(sym.name, path, sym.kind)
+                    else
+                        0,
                 };
                 if (list_ptr.items.len >= max_results and
                     !SortCtx.candidateBefore(candidate, list_ptr.items[list_ptr.items.len - 1]))
@@ -3989,7 +4097,7 @@ pub const Explorer = struct {
                                 .line_start = loc.line_start,
                                 .line_end = loc.line_end,
                                 .detail = detail,
-                            }, score);
+                            }, score, spec.rank_policy);
                         }
                     }
                 }
@@ -3997,11 +4105,23 @@ pub const Explorer = struct {
         } else if (spec.name != null and spec.prefix == null and spec.pattern == null) {
             // Exact names are already hash-indexed. Avoid scanning and scoring
             // every distinct symbol name for the overwhelmingly common MCP form
-            // `{ "name": "..." }`; appendOne preserves the existing result order.
+            // `{ "name": "..." }`. Opinionated navigation suppresses
+            // import/comment rows when at least one real definition exists;
+            // structural codedb_symbol order and membership stay unchanged.
             const sym_name = spec.name.?;
             if (self.symbol_index.get(sym_name)) |locs| {
+                var has_navigation_def = false;
+                if (spec.rank_policy == .navigation) {
+                    for (locs.items) |loc| {
+                        if (loc.kind != .import and loc.kind != .comment_block) {
+                            has_navigation_def = true;
+                            break;
+                        }
+                    }
+                }
                 for (locs.items) |loc| {
                     if (spec.kind) |k| if (loc.kind != k) continue;
+                    if (has_navigation_def and (loc.kind == .import or loc.kind == .comment_block)) continue;
                     var detail: ?[]const u8 = null;
                     if (self.outlines.getPtr(loc.path)) |outline| {
                         for (outline.symbols.items) |sym| {
@@ -4017,7 +4137,7 @@ pub const Explorer = struct {
                         .line_start = loc.line_start,
                         .line_end = loc.line_end,
                         .detail = detail,
-                    }, 1.0);
+                    }, 1.0, spec.rank_policy);
                 }
             }
         } else {
@@ -4042,7 +4162,7 @@ pub const Explorer = struct {
                         .line_start = loc.line_start,
                         .line_end = loc.line_end,
                         .detail = detail,
-                    }, score);
+                    }, score, spec.rank_policy);
                 }
             }
         }
@@ -4054,7 +4174,7 @@ pub const Explorer = struct {
                     const score = symbolMatchScore(spec, sym.name) orelse continue;
                     if (spec.kind) |k| if (sym.kind != k) continue;
                     if (Dedup.contains(candidates.items, entry.key_ptr.*, sym.line_start)) continue;
-                    try appendOne(&candidates, allocator, spec.max_results, entry.key_ptr.*, sym, score);
+                    try appendOne(&candidates, allocator, spec.max_results, entry.key_ptr.*, sym, score, spec.rank_policy);
                 }
             }
         }
@@ -4093,12 +4213,22 @@ pub const Explorer = struct {
             allocator.free(results);
         }
         if (results.len == 0) return false;
+        std.mem.sort(SymbolResult, @constCast(results), {}, struct {
+            fn lessThan(_: void, a: SymbolResult, b: SymbolResult) bool {
+                return symbolNavigationResultBefore(a, b);
+            }
+        }.lessThan);
         var has_def = false;
         for (results) |r| {
             if (r.symbol.kind != .import and r.symbol.kind != .comment_block) {
                 has_def = true;
                 break;
             }
+        }
+        var total: usize = 0;
+        for (results) |r| {
+            const is_def = r.symbol.kind != .import and r.symbol.kind != .comment_block;
+            if (!has_def or is_def) total += 1;
         }
         out.appendSlice(allocator, "exact symbol matches (codedb_symbol shows bodies):\n") catch return false;
         var n: usize = 0;
@@ -4112,6 +4242,10 @@ pub const Explorer = struct {
             var lb: [64]u8 = undefined;
             out.appendSlice(allocator, std.fmt.bufPrint(&lb, ":{d} ({s})\n", .{ r.symbol.line_start, @tagName(r.symbol.kind) }) catch continue) catch {};
             n += 1;
+        }
+        if (total > n) {
+            var tb: [128]u8 = undefined;
+            out.appendSlice(allocator, std.fmt.bufPrint(&tb, "… {d} more exact symbol matches truncated (raise max_results or use codedb_symbol)\n", .{total - n}) catch return n > 0) catch {};
         }
         return n > 0;
     }

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -4154,7 +4154,8 @@ pub const Explorer = struct {
         // commit, so for this high-precision/best-effort feature it is authoritative.
         self.mu.lockShared();
         defer self.mu.unlockShared();
-        for (callees) |name| {
+        for (callees) |callee| {
+            const name = callee.name;
             if (refs.items.len >= max) break;
             // Skip ubiquitous std/container/builtin method names. They are almost
             // always calls on some receiver (ArrayList.append, HashMap.get, ...),
@@ -5665,6 +5666,32 @@ pub const Explorer = struct {
         self.ensureCallCentrality(allocator);
     }
 
+    /// Build the narrow module-alias facts used by the call graph for Zig.
+    /// Zig file imports are relative even without a leading `./`, unlike the
+    /// generic dependency resolver, so resolve them against the importing file.
+    fn callGraphZigImportBindings(
+        self: *Explorer,
+        outline: *const FileOutline,
+        allocator: std.mem.Allocator,
+    ) ![]const codegraph.ImportBinding {
+        if (outline.language != .zig) return &.{};
+        var bindings: std.ArrayList(codegraph.ImportBinding) = .empty;
+        errdefer bindings.deinit(allocator);
+        for (outline.symbols.items) |sym| {
+            if (sym.kind != .import) continue;
+            const detail = sym.detail orelse continue;
+            const raw_path = extractStringLiteral(detail) orelse continue;
+            // Package imports such as `std`, `builtin`, and named modules do not
+            // identify an indexed file. The requested receiver resolution is for
+            // concrete Zig source imports.
+            if (!std.mem.endsWith(u8, raw_path, ".zig") or std.fs.path.isAbsolute(raw_path)) continue;
+            const target_path = resolveRelativeImportPath(outline.path, raw_path, allocator) orelse continue;
+            if (!self.outlines.contains(target_path)) continue;
+            try bindings.append(allocator, .{ .alias = sym.name, .target_path = target_path });
+        }
+        return bindings.toOwnedSlice(allocator);
+    }
+
     /// Build the resolved call graph once (idempotent, mutex-guarded). Must be
     /// called while holding at least a shared lock on `mu`. Retains edges for
     /// codedb_callpath and computes per-file centrality (PageRank by default).
@@ -5693,6 +5720,7 @@ pub const Explorer = struct {
         var it = self.outlines.iterator();
         while (it.next()) |entry| {
             const path = entry.key_ptr.*;
+            const import_bindings = self.callGraphZigImportBindings(entry.value_ptr, a) catch &.{};
             const ref = self.readContentForSearch(path, a) orelse continue;
             defer ref.deinit();
             const content = ref.data;
@@ -5714,7 +5742,13 @@ pub const Explorer = struct {
                 node_name.append(a, sym.name) catch return;
                 node_line.append(a, sym.line_start) catch return;
                 node_language_group.append(a, callGraphLanguageGroup(detectLanguage(path))) catch return;
-                funcs.append(a, .{ .id = id, .body = content[start..end] }) catch return;
+                funcs.append(a, .{
+                    .id = id,
+                    .body = content[start..end],
+                    .path = path,
+                    .imports = import_bindings,
+                    .extract_zig_thread_spawn_callbacks = entry.value_ptr.language == .zig,
+                }) catch return;
                 const gop = name_to_ids.getOrPut(sym.name) catch return;
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
                 gop.value_ptr.append(a, id) catch return;
@@ -5727,7 +5761,14 @@ pub const Explorer = struct {
         var n2i = name_to_ids.iterator();
         while (n2i.next()) |e| resolve.put(e.key_ptr.*, e.value_ptr.items) catch return;
 
-        var edges_tmp = codegraph.buildEdgesWithinGroups(a, funcs.items, &resolve, node_language_group.items, false) catch return;
+        var edges_tmp = codegraph.buildEdgesScoped(
+            a,
+            funcs.items,
+            &resolve,
+            node_path.items,
+            node_language_group.items,
+            false,
+        ) catch return;
         defer edges_tmp.deinit(a);
 
         const edges_owned = self.allocator.alloc(codegraph.Edge, edges_tmp.items.len) catch return;

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -6046,6 +6046,55 @@ pub const Explorer = struct {
         allocator: std.mem.Allocator,
         max_hops: usize,
     ) !?[]CallPathStep {
+        return self.findCallPathScoped(from_name, null, to_name, null, allocator, max_hops);
+    }
+
+    /// Return every call-graph node that matches a symbol name, optionally
+    /// narrowed to an exact project-relative path. Callers use this to make an
+    /// ambiguous bare endpoint explicit instead of silently choosing whichever
+    /// unrelated pair happens to be shortest.
+    pub fn findCallPathCandidates(
+        self: *Explorer,
+        name: []const u8,
+        path: ?[]const u8,
+        allocator: std.mem.Allocator,
+    ) ![]CallPathStep {
+        self.ensureSymbolIndex();
+        self.mu.lockShared();
+        defer self.mu.unlockShared();
+
+        self.ensureCallGraph(allocator);
+        const cg = self.call_graph orelse return try allocator.alloc(CallPathStep, 0);
+
+        var candidates: std.ArrayList(CallPathStep) = .empty;
+        errdefer candidates.deinit(allocator);
+        for (cg.node_name, 0..) |node_name, id| {
+            if (!std.mem.eql(u8, node_name, name)) continue;
+            if (path) |selected_path| {
+                if (!std.mem.eql(u8, cg.node_path[id], selected_path)) continue;
+            }
+            try candidates.append(allocator, .{
+                .path = cg.node_path[id],
+                .name = node_name,
+                .line = cg.node_line[id],
+            });
+        }
+        return try candidates.toOwnedSlice(allocator);
+    }
+
+    /// Shortest resolved call chain with optional exact project-relative
+    /// endpoint paths. The public name-only method above preserves existing
+    /// callers; interactive surfaces should first inspect candidates and ask
+    /// for a path when a bare name is ambiguous.
+    pub fn findCallPathScoped(
+        self: *Explorer,
+        from_name: []const u8,
+        from_path: ?[]const u8,
+        to_name: []const u8,
+        to_path: ?[]const u8,
+        allocator: std.mem.Allocator,
+        max_hops: usize,
+    ) !?[]CallPathStep {
         self.ensureSymbolIndex();
         self.mu.lockShared();
         defer self.mu.unlockShared();
@@ -6060,8 +6109,12 @@ pub const Explorer = struct {
 
         for (cg.node_name, 0..) |name, id| {
             const nid: codegraph.NodeId = @intCast(id);
-            if (std.mem.eql(u8, name, from_name)) try from_ids.append(allocator, nid);
-            if (std.mem.eql(u8, name, to_name)) try to_ids.append(allocator, nid);
+            if (std.mem.eql(u8, name, from_name) and (from_path == null or std.mem.eql(u8, cg.node_path[id], from_path.?))) {
+                try from_ids.append(allocator, nid);
+            }
+            if (std.mem.eql(u8, name, to_name) and (to_path == null or std.mem.eql(u8, cg.node_path[id], to_path.?))) {
+                try to_ids.append(allocator, nid);
+            }
         }
         if (from_ids.items.len == 0 or to_ids.items.len == 0) return null;
 

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -5801,12 +5801,59 @@ pub const Explorer = struct {
         self.ensureCallCentrality(allocator);
     }
 
+    fn appendCallGraphZigImportBinding(
+        bindings: *std.ArrayList(codegraph.ImportBinding),
+        allocator: std.mem.Allocator,
+        alias: []const u8,
+        target_path: []const u8,
+    ) !void {
+        for (bindings.items) |binding| {
+            if (std.mem.eql(u8, binding.alias, alias) and
+                std.mem.eql(u8, binding.target_path, target_path)) return;
+        }
+        try bindings.append(allocator, .{ .alias = alias, .target_path = target_path });
+    }
+
+    /// Resolve one literal Zig source import declared by `alias` in `outline`.
+    /// Duplicate declarations with different targets are malformed/ambiguous and
+    /// intentionally do not produce a graph fact.
+    fn callGraphZigImportedPath(
+        self: *Explorer,
+        outline: *const FileOutline,
+        alias: []const u8,
+        allocator: std.mem.Allocator,
+    ) ?[]const u8 {
+        if (outline.language != .zig) return null;
+        var found: ?[]const u8 = null;
+        for (outline.symbols.items) |sym| {
+            if (sym.kind != .import or !std.mem.eql(u8, sym.name, alias)) continue;
+            const detail = sym.detail orelse continue;
+            const raw_path = extractStringLiteral(detail) orelse continue;
+            // Package imports such as `std`, `builtin`, and named modules do not
+            // identify an indexed file. Resolution is deliberately limited to
+            // concrete Zig source imports.
+            if (!std.mem.endsWith(u8, raw_path, ".zig") or std.fs.path.isAbsolute(raw_path)) continue;
+            const target_path = resolveRelativeImportPath(outline.path, raw_path, allocator) orelse continue;
+            if (!self.outlines.contains(target_path)) continue;
+            if (found) |prior| {
+                if (!std.mem.eql(u8, prior, target_path)) return null;
+            } else {
+                found = target_path;
+            }
+        }
+        return found;
+    }
+
     /// Build the narrow module-alias facts used by the call graph for Zig.
     /// Zig file imports are relative even without a leading `./`, unlike the
     /// generic dependency resolver, so resolve them against the importing file.
+    /// Follow exact re-export chains only for qualifiers that occur in this file
+    /// (`pkg.engine.run` => `pkg` then `engine`), avoiding an eager traversal of
+    /// the whole module tree.
     fn callGraphZigImportBindings(
         self: *Explorer,
         outline: *const FileOutline,
+        content: []const u8,
         allocator: std.mem.Allocator,
     ) ![]const codegraph.ImportBinding {
         if (outline.language != .zig) return &.{};
@@ -5814,15 +5861,34 @@ pub const Explorer = struct {
         errdefer bindings.deinit(allocator);
         for (outline.symbols.items) |sym| {
             if (sym.kind != .import) continue;
-            const detail = sym.detail orelse continue;
-            const raw_path = extractStringLiteral(detail) orelse continue;
-            // Package imports such as `std`, `builtin`, and named modules do not
-            // identify an indexed file. The requested receiver resolution is for
-            // concrete Zig source imports.
-            if (!std.mem.endsWith(u8, raw_path, ".zig") or std.fs.path.isAbsolute(raw_path)) continue;
-            const target_path = resolveRelativeImportPath(outline.path, raw_path, allocator) orelse continue;
-            if (!self.outlines.contains(target_path)) continue;
-            try bindings.append(allocator, .{ .alias = sym.name, .target_path = target_path });
+            const target_path = self.callGraphZigImportedPath(outline, sym.name, allocator) orelse continue;
+            try appendCallGraphZigImportBinding(&bindings, allocator, sym.name, target_path);
+        }
+
+        const callees = try codegraph.extractCallees(allocator, content);
+        defer allocator.free(callees);
+        const callbacks = try codegraph.extractZigThreadSpawnCallbacks(allocator, content);
+        defer allocator.free(callbacks);
+        const call_sets = [_][]const codegraph.Callee{ callees, callbacks };
+        for (call_sets) |calls| {
+            for (calls) |callee| {
+                const qualifier = callee.qualifier orelse continue;
+                var segments = std.mem.splitScalar(u8, qualifier, '.');
+                const root_alias = segments.next() orelse continue;
+                var target_path = self.callGraphZigImportedPath(outline, root_alias, allocator) orelse continue;
+                var prefix_end = root_alias.len;
+                while (segments.next()) |segment| {
+                    const target_outline = self.outlines.getPtr(target_path) orelse break;
+                    target_path = self.callGraphZigImportedPath(target_outline, segment, allocator) orelse break;
+                    prefix_end += 1 + segment.len;
+                    try appendCallGraphZigImportBinding(
+                        &bindings,
+                        allocator,
+                        qualifier[0..prefix_end],
+                        target_path,
+                    );
+                }
+            }
         }
         return bindings.toOwnedSlice(allocator);
     }
@@ -5855,10 +5921,10 @@ pub const Explorer = struct {
         var it = self.outlines.iterator();
         while (it.next()) |entry| {
             const path = entry.key_ptr.*;
-            const import_bindings = self.callGraphZigImportBindings(entry.value_ptr, a) catch &.{};
             const ref = self.readContentForSearch(path, a) orelse continue;
             defer ref.deinit();
             const content = ref.data;
+            const import_bindings = self.callGraphZigImportBindings(entry.value_ptr, content, a) catch &.{};
             var offs: std.ArrayList(usize) = .empty;
             offs.append(a, 0) catch continue;
             for (content, 0..) |ch, i| {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -2279,7 +2279,8 @@ pub const Explorer = struct {
             outline.language == .javascript or outline.language == .rust or
             outline.language == .go_lang or outline.language == .php or
             outline.language == .dart or outline.language == .java or
-            outline.language == .kotlin or outline.language == .svelte or
+            outline.language == .kotlin or outline.language == .swift or
+            outline.language == .svelte or
             outline.language == .vue or outline.language == .astro or
             outline.language == .css or outline.language == .scss or
             outline.language == .protobuf or outline.language == .mlir or
@@ -7244,7 +7245,49 @@ pub const Explorer = struct {
             try appendOutlineSymbol(a, outline, name, .enum_def, line_num, line);
         } else if (extractIdentAfterKeyword(line, "func ")) |name| {
             try appendOutlineSymbol(a, outline, name, .function, line_num, line);
+        } else if (swiftSpecialMethodName(line)) |name| {
+            try appendOutlineSymbol(a, outline, name, .method, line_num, line);
         }
+    }
+
+    /// Swift initializers are declarations, but unlike ordinary methods their
+    /// identifier is the language keyword itself. Keep them in the outline as
+    /// methods so constructor lookups and call-graph bodies behave like other
+    /// member functions. The prefix guard rejects expression uses such as
+    /// `super.init()` and `value = Type.init`.
+    fn swiftSpecialMethodName(line: []const u8) ?[]const u8 {
+        const names = [_][]const u8{ "deinit", "init" };
+        for (names) |name| {
+            var search_from: usize = 0;
+            while (std.mem.indexOfPos(u8, line, search_from, name)) |pos| {
+                search_from = pos + name.len;
+                if (pos > 0 and isIdentChar(line[pos - 1])) continue;
+                const after_name = pos + name.len;
+                if (after_name < line.len and isIdentChar(line[after_name])) continue;
+                if (!isSwiftDeclarationPrefix(line[0..pos])) continue;
+
+                var cursor = after_name;
+                if (std.mem.eql(u8, name, "init") and cursor < line.len and
+                    (line[cursor] == '?' or line[cursor] == '!')) cursor += 1;
+                while (cursor < line.len and (line[cursor] == ' ' or line[cursor] == '\t')) cursor += 1;
+                if (std.mem.eql(u8, name, "init")) {
+                    if (cursor < line.len and line[cursor] == '(') return name;
+                } else if (cursor >= line.len or line[cursor] == '{') {
+                    return name;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn isSwiftDeclarationPrefix(prefix: []const u8) bool {
+        for (prefix) |ch| {
+            // Modifiers and attributes are fine; punctuation that starts an
+            // expression is not. This deliberately remains permissive for
+            // future Swift modifiers.
+            if (ch == '.' or ch == '=' or ch == '(' or ch == ')' or ch == ';') return false;
+        }
+        return true;
     }
 
     fn parseComponentLine(self: *Explorer, raw_line: []const u8, line_num: u32, outline: *FileOutline) !void {

--- a/src/explore.zig
+++ b/src/explore.zig
@@ -1841,10 +1841,13 @@ pub const Explorer = struct {
     /// ranking boost in searchContentRanked. Null until built; guarded by
     /// centrality_build_mu. Keys are borrowed `outlines` keys (stable).
     call_centrality: ?std.StringHashMap(f32) = null,
-    /// Retained resolved call graph (edges + adjacency + per-node metadata) for
-    /// codedb_callpath. Built lazily alongside centrality; may be rebuilt after a
-    /// snapshot load that restored centrality without edges.
+    /// Retained call graph (edges + adjacency + per-node metadata). Ranking
+    /// first builds the historical fast approximate graph; codedb_callpath
+    /// upgrades it in place to strict scoped/import-aware resolution.
     call_graph: ?CallGraph = null,
+    /// Ranking uses the historical fast approximate graph. User-visible
+    /// callpaths upgrade it in place to strict scoped/import-aware resolution.
+    call_graph_exact: bool = false,
     centrality_build_mu: cio.Mutex = .{},
     root_dir: ?std.Io.Dir = null,
     /// Absolute project root path (duped in setRoot) — needed to shell out to
@@ -2159,6 +2162,7 @@ pub const Explorer = struct {
         if (self.call_graph) |*cg| {
             cg.deinit(self.allocator);
             self.call_graph = null;
+            self.call_graph_exact = false;
         }
         if (self.call_centrality) |*cc| {
             cc.deinit();
@@ -5820,14 +5824,18 @@ pub const Explorer = struct {
     fn callGraphZigImportedPath(
         self: *Explorer,
         outline: *const FileOutline,
+        top_level_import_lines: *const U32HashMap(void),
         alias: []const u8,
+        require_public: bool,
         allocator: std.mem.Allocator,
     ) ?[]const u8 {
         if (outline.language != .zig) return null;
         var found: ?[]const u8 = null;
         for (outline.symbols.items) |sym| {
             if (sym.kind != .import or !std.mem.eql(u8, sym.name, alias)) continue;
+            if (!top_level_import_lines.contains(sym.line_start)) continue;
             const detail = sym.detail orelse continue;
+            if (require_public and !std.mem.startsWith(u8, std.mem.trim(u8, detail, " \t"), "pub ")) continue;
             const raw_path = extractStringLiteral(detail) orelse continue;
             // Package imports such as `std`, `builtin`, and named modules do not
             // identify an indexed file. Resolution is deliberately limited to
@@ -5844,12 +5852,121 @@ pub const Explorer = struct {
         return found;
     }
 
+    /// One lexical pass records lines whose `@import` token itself occurs at
+    /// file scope. Using the token depth (rather than the declaration's line)
+    /// also rejects `const S = struct { const x = @import(...); };` on line 1.
+    /// The resulting set is reused for every import in the file, avoiding the
+    /// former O(imports * file_bytes) prefix rescans on cold graph builds.
+    fn zigTopLevelImportLines(
+        content: []const u8,
+        outline: *const FileOutline,
+        allocator: std.mem.Allocator,
+    ) !U32HashMap(void) {
+        var lines = U32HashMap(void).init(allocator);
+        errdefer lines.deinit();
+        var last_import_line: u32 = 0;
+        for (outline.symbols.items) |sym| {
+            if (sym.kind == .import) last_import_line = @max(last_import_line, sym.line_start);
+        }
+        if (last_import_line == 0) return lines;
+        var brace_depth: usize = 0;
+        var block_comment_depth: usize = 0;
+        var string_quote: u8 = 0;
+        var escaped = false;
+        var line: u32 = 1;
+        var only_whitespace = true;
+        var i: usize = 0;
+        while (i < content.len and line <= last_import_line) : (i += 1) {
+            const c = content[i];
+            if (c == '\n') {
+                line += 1;
+                only_whitespace = true;
+                string_quote = 0;
+                escaped = false;
+                continue;
+            }
+            if (block_comment_depth > 0) {
+                if (c == '/' and i + 1 < content.len and content[i + 1] == '*') {
+                    block_comment_depth += 1;
+                    i += 1;
+                } else if (c == '*' and i + 1 < content.len and content[i + 1] == '/') {
+                    block_comment_depth -= 1;
+                    i += 1;
+                }
+                continue;
+            }
+            if (string_quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == string_quote) {
+                    string_quote = 0;
+                }
+                continue;
+            }
+            if (only_whitespace and (c == ' ' or c == '\t' or c == '\r')) continue;
+            if (only_whitespace and c == '\\' and i + 1 < content.len and content[i + 1] == '\\') {
+                while (i + 1 < content.len and content[i + 1] != '\n') i += 1;
+                continue;
+            }
+            only_whitespace = false;
+            if (c == '/' and i + 1 < content.len) {
+                if (content[i + 1] == '/') {
+                    while (i + 1 < content.len and content[i + 1] != '\n') i += 1;
+                    continue;
+                }
+                if (content[i + 1] == '*') {
+                    block_comment_depth = 1;
+                    i += 1;
+                    continue;
+                }
+            }
+            if (c == '"' or c == '\'') {
+                string_quote = c;
+            } else if (brace_depth == 0 and c == '@' and
+                std.mem.startsWith(u8, content[i..], "@import") and
+                (i + 7 == content.len or !isIdentChar(content[i + 7])))
+            {
+                try lines.put(line, {});
+            } else if (c == '{') {
+                brace_depth += 1;
+            } else if (c == '}' and brace_depth > 0) {
+                brace_depth -= 1;
+            }
+        }
+        return lines;
+    }
+
+    fn callGraphImportTarget(bindings: []const codegraph.ImportBinding, alias: []const u8) ?[]const u8 {
+        for (bindings) |binding| {
+            if (std.mem.eql(u8, binding.alias, alias)) return binding.target_path;
+        }
+        return null;
+    }
+
+    fn hasNestedZigImportQualifier(content: []const u8, bindings: []const codegraph.ImportBinding) bool {
+        if (bindings.len == 0) return false;
+        var search_from: usize = 0;
+        while (std.mem.indexOfScalarPos(u8, content, search_from, '.')) |dot| {
+            search_from = dot + 1;
+            var root_start = dot;
+            while (root_start > 0 and isIdentChar(content[root_start - 1])) root_start -= 1;
+            if (root_start == dot) continue;
+            if (callGraphImportTarget(bindings, content[root_start..dot]) == null) continue;
+            var segment_end = dot + 1;
+            const segment_start = segment_end;
+            while (segment_end < content.len and isIdentChar(content[segment_end])) segment_end += 1;
+            if (segment_end > segment_start and segment_end < content.len and content[segment_end] == '.') return true;
+        }
+        return false;
+    }
+
     /// Build the narrow module-alias facts used by the call graph for Zig.
     /// Zig file imports are relative even without a leading `./`, unlike the
     /// generic dependency resolver, so resolve them against the importing file.
-    /// Follow exact re-export chains only for qualifiers that occur in this file
-    /// (`pkg.engine.run` => `pkg` then `engine`), avoiding an eager traversal of
-    /// the whole module tree.
+    /// Nested re-export chains are added later from the already-extracted
+    /// function callees, so cold graph construction never scans a file twice.
     fn callGraphZigImportBindings(
         self: *Explorer,
         outline: *const FileOutline,
@@ -5859,45 +5976,62 @@ pub const Explorer = struct {
         if (outline.language != .zig) return &.{};
         var bindings: std.ArrayList(codegraph.ImportBinding) = .empty;
         errdefer bindings.deinit(allocator);
+        var top_level_import_lines = try zigTopLevelImportLines(content, outline, allocator);
+        defer top_level_import_lines.deinit();
         for (outline.symbols.items) |sym| {
             if (sym.kind != .import) continue;
-            const target_path = self.callGraphZigImportedPath(outline, sym.name, allocator) orelse continue;
+            const target_path = self.callGraphZigImportedPath(outline, &top_level_import_lines, sym.name, false, allocator) orelse continue;
             try appendCallGraphZigImportBinding(&bindings, allocator, sym.name, target_path);
         }
 
-        const callees = try codegraph.extractCallees(allocator, content);
-        defer allocator.free(callees);
-        const callbacks = try codegraph.extractZigThreadSpawnCallbacks(allocator, content);
-        defer allocator.free(callbacks);
-        const call_sets = [_][]const codegraph.Callee{ callees, callbacks };
-        for (call_sets) |calls| {
-            for (calls) |callee| {
-                const qualifier = callee.qualifier orelse continue;
-                var segments = std.mem.splitScalar(u8, qualifier, '.');
-                const root_alias = segments.next() orelse continue;
-                var target_path = self.callGraphZigImportedPath(outline, root_alias, allocator) orelse continue;
-                var prefix_end = root_alias.len;
-                while (segments.next()) |segment| {
-                    const target_outline = self.outlines.getPtr(target_path) orelse break;
-                    target_path = self.callGraphZigImportedPath(target_outline, segment, allocator) orelse break;
-                    prefix_end += 1 + segment.len;
-                    try appendCallGraphZigImportBinding(
-                        &bindings,
-                        allocator,
-                        qualifier[0..prefix_end],
-                        target_path,
-                    );
+        return bindings.toOwnedSlice(allocator);
+    }
+
+    fn extendCallGraphZigImportBindings(
+        self: *Explorer,
+        bindings: *std.ArrayList(codegraph.ImportBinding),
+        calls: []const codegraph.Callee,
+        allocator: std.mem.Allocator,
+    ) !void {
+        for (calls) |callee| {
+            const qualifier = callee.qualifier orelse continue;
+            var segments = std.mem.splitScalar(u8, qualifier, '.');
+            const root_alias = segments.next() orelse continue;
+            var target_path = callGraphImportTarget(bindings.items, root_alias) orelse continue;
+            var prefix_end = root_alias.len;
+            while (segments.next()) |segment| {
+                prefix_end += 1 + segment.len;
+                const prefix = qualifier[0..prefix_end];
+                if (callGraphImportTarget(bindings.items, prefix)) |cached| {
+                    target_path = cached;
+                    continue;
                 }
+                const target_outline = self.outlines.getPtr(target_path) orelse break;
+                const target_ref = self.readContentForSearch(target_path, allocator) orelse break;
+                var target_import_lines = zigTopLevelImportLines(target_ref.data, target_outline, allocator) catch {
+                    target_ref.deinit();
+                    break;
+                };
+                const next_path = self.callGraphZigImportedPath(
+                    target_outline,
+                    &target_import_lines,
+                    segment,
+                    true,
+                    allocator,
+                );
+                target_import_lines.deinit();
+                target_ref.deinit();
+                target_path = next_path orelse break;
+                try appendCallGraphZigImportBinding(bindings, allocator, prefix, target_path);
             }
         }
-        return bindings.toOwnedSlice(allocator);
     }
 
     /// Build the resolved call graph once (idempotent, mutex-guarded). Must be
     /// called while holding at least a shared lock on `mu`. Retains edges for
     /// codedb_callpath and computes per-file centrality (PageRank by default).
-    fn ensureCallGraph(self: *Explorer, allocator: std.mem.Allocator) void {
-        if (self.call_graph != null) return;
+    fn ensureCallGraphMode(self: *Explorer, allocator: std.mem.Allocator, exact: bool) void {
+        if (self.call_graph != null and (!exact or self.call_graph_exact)) return;
         // #564: never build (and cache) a graph from a deferred symbol index —
         // resolveCallees would see no definitions and the empty graph would be
         // cached forever. Callers that need the graph ensureSymbolIndex first;
@@ -5905,7 +6039,12 @@ pub const Explorer = struct {
         if (!self.symbol_index_complete) return;
         self.centrality_build_mu.lock();
         defer self.centrality_build_mu.unlock();
-        if (self.call_graph != null) return;
+        if (self.call_graph != null and (!exact or self.call_graph_exact)) return;
+        if (exact) {
+            if (self.call_graph) |*cg| cg.deinit(self.allocator);
+            self.call_graph = null;
+            self.call_graph_exact = false;
+        }
 
         var arena_state = std.heap.ArenaAllocator.init(allocator);
         defer arena_state.deinit();
@@ -5924,7 +6063,13 @@ pub const Explorer = struct {
             const ref = self.readContentForSearch(path, a) orelse continue;
             defer ref.deinit();
             const content = ref.data;
-            const import_bindings = self.callGraphZigImportBindings(entry.value_ptr, content, a) catch &.{};
+            const direct_import_bindings = if (exact)
+                self.callGraphZigImportBindings(entry.value_ptr, content, a) catch &.{}
+            else
+                &.{};
+            var import_bindings: std.ArrayList(codegraph.ImportBinding) = .empty;
+            import_bindings.appendSlice(a, direct_import_bindings) catch return;
+            const file_func_start = funcs.items.len;
             var offs: std.ArrayList(usize) = .empty;
             offs.append(a, 0) catch continue;
             for (content, 0..) |ch, i| {
@@ -5938,6 +6083,9 @@ pub const Explorer = struct {
                 const end_line = @min(sym.line_end, nlines);
                 const end = if (end_line < nlines) offs.items[end_line] else content.len;
                 if (end <= start) continue;
+                const body = content[start..end];
+                const is_zig = exact and entry.value_ptr.language == .zig;
+                const has_thread_spawn = is_zig and std.mem.indexOf(u8, body, "std.Thread.spawn") != null;
                 const id: codegraph.NodeId = @intCast(node_path.items.len);
                 node_path.append(a, path) catch return;
                 node_name.append(a, sym.name) catch return;
@@ -5945,15 +6093,16 @@ pub const Explorer = struct {
                 node_language_group.append(a, callGraphLanguageGroup(detectLanguage(path))) catch return;
                 funcs.append(a, .{
                     .id = id,
-                    .body = content[start..end],
+                    .body = body,
                     .path = path,
-                    .imports = import_bindings,
-                    .extract_zig_thread_spawn_callbacks = entry.value_ptr.language == .zig,
+                    .skip_zig_multiline_strings = is_zig and std.mem.indexOf(u8, body, "\\\\") != null,
+                    .extract_zig_thread_spawn_callbacks = has_thread_spawn,
                 }) catch return;
                 const gop = name_to_ids.getOrPut(sym.name) catch return;
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
                 gop.value_ptr.append(a, id) catch return;
             }
+            for (funcs.items[file_func_start..]) |*func| func.imports = import_bindings.items;
         }
         const n_nodes = node_path.items.len;
         if (n_nodes == 0) return;
@@ -5962,14 +6111,51 @@ pub const Explorer = struct {
         var n2i = name_to_ids.iterator();
         while (n2i.next()) |e| resolve.put(e.key_ptr.*, e.value_ptr.items) catch return;
 
-        var edges_tmp = codegraph.buildEdgesScoped(
-            a,
-            funcs.items,
-            &resolve,
-            node_path.items,
-            node_language_group.items,
-            false,
-        ) catch return;
+        if (exact) {
+            // Only the uncommon nested receiver shape needs a preparatory
+            // extraction; all other exact edges stream directly from bodies.
+            for (funcs.items) |*func| {
+                if (!hasNestedZigImportQualifier(func.body, func.imports)) continue;
+                const calls = codegraph.extractResolvableCallees(
+                    a,
+                    func.body,
+                    func.skip_zig_multiline_strings,
+                    func.imports,
+                    &resolve,
+                ) catch return;
+                func.preextracted_callees = calls;
+
+                const callbacks: ?[]const codegraph.Callee = if (func.extract_zig_thread_spawn_callbacks)
+                    codegraph.extractZigThreadSpawnCallbacks(a, func.body) catch return
+                else
+                    null;
+                func.preextracted_thread_callbacks = callbacks;
+
+                var enriched: std.ArrayList(codegraph.ImportBinding) = .empty;
+                enriched.appendSlice(a, func.imports) catch return;
+                self.extendCallGraphZigImportBindings(&enriched, calls, a) catch return;
+                if (callbacks) |items| self.extendCallGraphZigImportBindings(&enriched, items, a) catch return;
+                func.imports = enriched.items;
+            }
+        }
+
+        var edges_tmp = if (exact)
+            codegraph.buildEdgesScoped(
+                a,
+                funcs.items,
+                &resolve,
+                node_path.items,
+                node_language_group.items,
+                false,
+            ) catch return
+        else
+            codegraph.buildEdgesApproximate(
+                a,
+                funcs.items,
+                &resolve,
+                node_language_group.items,
+                false,
+            ) catch return;
         defer edges_tmp.deinit(a);
 
         const edges_owned = self.allocator.alloc(codegraph.Edge, edges_tmp.items.len) catch return;
@@ -6091,9 +6277,18 @@ pub const Explorer = struct {
             .node_name = nn,
             .node_line = nl,
         };
+        self.call_graph_exact = exact;
         // The graph-distance boost gate (`call_graph != null`) just flipped:
         // results cached before the build could differ from a fresh search.
         self.bumpSearchGen();
+    }
+
+    fn ensureCallGraph(self: *Explorer, allocator: std.mem.Allocator) void {
+        self.ensureCallGraphMode(allocator, false);
+    }
+
+    fn ensureExactCallGraph(self: *Explorer, allocator: std.mem.Allocator) void {
+        self.ensureCallGraphMode(allocator, true);
     }
 
     /// Build `call_centrality` once (idempotent, mutex-guarded). Must be called
@@ -6129,7 +6324,7 @@ pub const Explorer = struct {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
-        self.ensureCallGraph(allocator);
+        self.ensureExactCallGraph(allocator);
         const cg = self.call_graph orelse return try allocator.alloc(CallPathStep, 0);
 
         var candidates: std.ArrayList(CallPathStep) = .empty;
@@ -6165,7 +6360,7 @@ pub const Explorer = struct {
         self.mu.lockShared();
         defer self.mu.unlockShared();
 
-        self.ensureCallGraph(allocator);
+        self.ensureExactCallGraph(allocator);
         const cg = self.call_graph orelse return null;
 
         var from_ids: std.ArrayList(codegraph.NodeId) = .empty;

--- a/src/main.zig
+++ b/src/main.zig
@@ -532,22 +532,18 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
     } else if (bootstrap.commandRebuildsIndex(cmd)) {
         // `reindex` is the public spelling; `index` remains a compatibility
         // alias. coldLoadOrScan above already
-        // scanned + persisted the on-disk index for this cmd. Publish the same
-        // validated, atomically-written snapshot at the project root as well:
-        // snapshot freshness deliberately checks the in-repo copy first, so a
-        // stale old root snapshot would otherwise force every no-daemon query
-        // to rescan despite the fresh project-cache snapshot.
-        const snapshot_path = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{abs_root}) catch {
-            out.p("{s}✗{s} reindex could not allocate snapshot path\n", .{ s.red, s.reset });
-            out.flush();
-            std.process.exit(1);
-        };
-        defer allocator.free(snapshot_path);
-        snapshot_mod.writeSnapshotDual(io, &explorer, abs_root, snapshot_path, allocator) catch |err| {
+        // scanned + persisted the on-disk indexes for this cmd. Persist the
+        // validated snapshot to the user-writable central cache first, then
+        // mirror it into the checkout when possible. Read-only/system checkouts
+        // must still reindex successfully.
+        const root_snapshot_written = snapshot_mod.writeReindexSnapshots(io, &explorer, abs_root, allocator) catch |err| {
             out.p("{s}✗{s} reindex persisted indexes but could not write validated snapshot: {}\n", .{ s.red, s.reset, err });
             out.flush();
             std.process.exit(1);
         };
+        if (!root_snapshot_written) {
+            std.log.warn("reindex: central snapshot is ready; checkout is read-only so codedb.snapshot was not refreshed", .{});
+        }
         // Confirm and exit
         // cleanly. It used to fall through to "unknown command: index" + exit 1
         // even though the index had been built.

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const Explorer = @import("explore.zig").Explorer;
 const sty = @import("style.zig");
 const index_mod = @import("index.zig");
 const root_policy = @import("root_policy.zig");
+const snapshot_mod = @import("snapshot.zig");
 const nuke_mod = @import("nuke.zig");
 const update_mod = @import("update.zig");
 const codex_mod = @import("codex_setup.zig");
@@ -531,7 +532,23 @@ fn mainImpl(argv: []const [*:0]const u8) !void {
     } else if (bootstrap.commandRebuildsIndex(cmd)) {
         // `reindex` is the public spelling; `index` remains a compatibility
         // alias. coldLoadOrScan above already
-        // scanned + persisted the on-disk index for this cmd; confirm and exit
+        // scanned + persisted the on-disk index for this cmd. Publish the same
+        // validated, atomically-written snapshot at the project root as well:
+        // snapshot freshness deliberately checks the in-repo copy first, so a
+        // stale old root snapshot would otherwise force every no-daemon query
+        // to rescan despite the fresh project-cache snapshot.
+        const snapshot_path = std.fmt.allocPrint(allocator, "{s}/codedb.snapshot", .{abs_root}) catch {
+            out.p("{s}✗{s} reindex could not allocate snapshot path\n", .{ s.red, s.reset });
+            out.flush();
+            std.process.exit(1);
+        };
+        defer allocator.free(snapshot_path);
+        snapshot_mod.writeSnapshotDual(io, &explorer, abs_root, snapshot_path, allocator) catch |err| {
+            out.p("{s}✗{s} reindex persisted indexes but could not write validated snapshot: {}\n", .{ s.red, s.reset, err });
+            out.flush();
+            std.process.exit(1);
+        };
+        // Confirm and exit
         // cleanly. It used to fall through to "unknown command: index" + exit 1
         // even though the index had been built.
         if (cliNotifyRefresh(io, allocator, abs_root, data_dir)) |refreshed| {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2680,7 +2680,9 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
         // A whole-word match that only lands inside a literal or comment is a
         // mention, not an invocation — a `("name", "file")` table row, a
         // `test "…name…" {` declaration, or `init(); // then name() …`. (#682)
-        if (!hasWholeWordMatchInCode(r.line_text, name, lang)) continue;
+        // A whole-word mention is not enough: declarations, local variables,
+        // and Swift parameter labels are all code, yet none invokes the name.
+        if (!hasCallSiteInCode(r.line_text, name, lang)) continue;
         kept.append(alloc, r_idx) catch {};
     }
 
@@ -2777,17 +2779,18 @@ fn isIdentChar(c: u8) bool {
         c == '_';
 }
 
-/// Returns true when `needle` occurs as a whole-word identifier in code rather
-/// than in a string, raw/template literal, or comment. This is deliberately a
-/// line-local lexical scan: it handles complete spans on the current line and
-/// conservatively treats an unclosed block/raw span as consuming the remainder.
-fn hasWholeWordMatchInCode(line: []const u8, needle: []const u8, language: explore_mod.Language) bool {
-    return hasWholeWordMatchInCodeDepth(line, needle, language, 0);
+/// Returns true when an identifier occurs as a syntactic invocation rather than
+/// a declaration, variable, parameter label, literal, or comment. This is
+/// deliberately a line-local lexical scan: it handles complete spans on the
+/// current line and conservatively treats an unclosed block/raw span as
+/// consuming the remainder.
+fn hasCallSiteInCode(line: []const u8, needle: []const u8, language: explore_mod.Language) bool {
+    return hasCallSiteInCodeDepth(line, needle, language, 0);
 }
 
 const max_template_nesting = 16;
 
-fn hasWholeWordMatchInCodeDepth(line: []const u8, needle: []const u8, language: explore_mod.Language, template_depth: usize) bool {
+fn hasCallSiteInCodeDepth(line: []const u8, needle: []const u8, language: explore_mod.Language, template_depth: usize) bool {
     if (needle.len == 0 or line.len < needle.len) return false;
     const markers = lineCommentMarkers(language);
     var i: usize = 0;
@@ -2810,7 +2813,7 @@ fn hasWholeWordMatchInCodeDepth(line: []const u8, needle: []const u8, language: 
         if (line[i] == '`' and hasBacktickLiterals(language)) {
             if (language == .r) {
                 if (stringLiteralEnd(line, i)) |end| {
-                    if (std.mem.eql(u8, line[i + 1 .. end], needle)) return true;
+                    if (std.mem.eql(u8, line[i + 1 .. end], needle) and isCallSyntaxAfter(line, i, end + 1, language)) return true;
                     i = end + 1;
                     continue;
                 }
@@ -2857,11 +2860,42 @@ fn hasWholeWordMatchInCodeDepth(line: []const u8, needle: []const u8, language: 
             const before_ok = i == 0 or !isIdentChar(line[i - 1]);
             const after = i + needle.len;
             const after_ok = after >= line.len or !isIdentChar(line[after]);
-            if (before_ok and after_ok) return true;
+            if (before_ok and after_ok and isCallSyntaxAfter(line, i, after, language)) return true;
         }
         i += 1;
     }
     return false;
+}
+
+fn isCallSyntaxAfter(line: []const u8, start: usize, after_name: usize, language: explore_mod.Language) bool {
+    var cursor = after_name;
+    while (cursor < line.len and (line[cursor] == ' ' or line[cursor] == '\t')) cursor += 1;
+    if (cursor < line.len and line[cursor] == '(') return true;
+
+    if (language == .swift) {
+        // work?(), work!(), and withAnimation { ... } are valid Swift calls.
+        // A parameter label (since start:) and local let start do not match.
+        if (cursor < line.len and (line[cursor] == '?' or line[cursor] == '!')) {
+            cursor += 1;
+            while (cursor < line.len and (line[cursor] == ' ' or line[cursor] == '\t')) cursor += 1;
+            if (cursor < line.len and line[cursor] == '(') return true;
+        }
+        if (cursor < line.len and line[cursor] == '{') return true;
+    }
+
+    return language == .shell and isShellCommandInvocation(line, start, after_name);
+}
+
+fn isShellCommandInvocation(line: []const u8, start: usize, after_name: usize) bool {
+    // Shell functions may be called without parentheses, but only at command
+    // position: start of line or immediately after a shell command separator.
+    // This excludes echo helper, assignments, and ordinary word uses.
+    var before = start;
+    while (before > 0 and (line[before - 1] == ' ' or line[before - 1] == '\t')) before -= 1;
+    if (before > 0 and std.mem.indexOfScalar(u8, ";|&(", line[before - 1]) == null) return false;
+    if (after_name >= line.len) return true;
+    return line[after_name] == ' ' or line[after_name] == '\t' or
+        std.mem.indexOfScalar(u8, ";|&", line[after_name]) != null;
 }
 
 fn lineCommentMarkers(language: explore_mod.Language) []const []const u8 {
@@ -2947,7 +2981,7 @@ fn scanTemplateLiteral(line: []const u8, open: usize, needle: []const u8, langua
             const expression_start = i + 2;
             const expression_end = templateExpressionEnd(line, expression_start, language);
             const end = expression_end orelse line.len;
-            if (hasWholeWordMatchInCodeDepth(line[expression_start..end], needle, language, template_depth + 1)) {
+            if (hasCallSiteInCodeDepth(line[expression_start..end], needle, language, template_depth + 1)) {
                 return .{ .end = expression_end, .matched = true };
             }
             if (expression_end) |close| {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -2994,7 +2994,109 @@ fn isCallSyntaxAfter(line: []const u8, start: usize, after_name: usize, language
         if (cursor < line.len and line[cursor] == '{') return true;
     }
 
+    // A function value passed to another call is still a caller relationship:
+    // `spawn(.{}, worker, .{})`, `map(render)`, `lapply(xs, render)`. Keep this
+    // narrower than a generic identifier reference so locals such as
+    // `let start = ...` and named arguments such as `to: start` stay excluded.
+    if (isFunctionValueArgument(line, start, after_name, language)) return true;
+    if (language == .ruby and isRubyCommandInvocation(line, start, after_name)) return true;
     return language == .shell and isShellCommandInvocation(line, start, after_name);
+}
+
+fn isFunctionValueArgument(line: []const u8, start: usize, after_name: usize, language: explore_mod.Language) bool {
+    // Include a narrow dotted receiver chain in the argument. For example,
+    // `spawn(.{}, watcher.incrementalLoop, .{})` is a callback use of
+    // `incrementalLoop`; checking only the byte immediately before the final
+    // identifier would see `.` and incorrectly discard it.
+    var argument_start = start;
+    while (argument_start > 0) {
+        var dot = argument_start;
+        while (dot > 0 and (line[dot - 1] == ' ' or line[dot - 1] == '\t')) dot -= 1;
+        if (dot == 0 or line[dot - 1] != '.') break;
+        var receiver_end = dot - 1;
+        while (receiver_end > 0 and (line[receiver_end - 1] == ' ' or line[receiver_end - 1] == '\t')) receiver_end -= 1;
+        var receiver_start = receiver_end;
+        while (receiver_start > 0 and isIdentChar(line[receiver_start - 1])) receiver_start -= 1;
+        if (receiver_start == receiver_end) break;
+        argument_start = receiver_start;
+    }
+
+    var before = argument_start;
+    while (before > 0 and (line[before - 1] == ' ' or line[before - 1] == '\t')) before -= 1;
+    if (before == 0 or (line[before - 1] != '(' and line[before - 1] != ',')) return false;
+
+    var after = after_name;
+    while (after < line.len and (line[after] == ' ' or line[after] == '\t')) after += 1;
+    if (after >= line.len or (line[after] != ',' and line[after] != ')')) return false;
+
+    const open = enclosingOpenParenBefore(line, argument_start, language) orelse return false;
+    var callee_end = open;
+    while (callee_end > 0 and (line[callee_end - 1] == ' ' or line[callee_end - 1] == '\t')) callee_end -= 1;
+    var callee_start = callee_end;
+    while (callee_start > 0 and isIdentChar(line[callee_start - 1])) callee_start -= 1;
+    if (callee_start == callee_end) return false;
+    const callee = line[callee_start..callee_end];
+    const non_calls = [_][]const u8{
+        "if", "for", "while", "switch", "catch", "return", "sizeof", "typeof",
+    };
+    for (non_calls) |word| if (std.mem.eql(u8, callee, word)) return false;
+
+    // Reject bare parameters in common declaration forms: `fn foo(callback)`,
+    // `func foo(callback)`, `function foo(callback)`, and `def foo(callback)`.
+    // Typed C-family parameters do not satisfy the delimiter checks above.
+    if (callee_start > 0 and line[callee_start - 1] != '.') {
+        var leader_end = callee_start;
+        while (leader_end > 0 and (line[leader_end - 1] == ' ' or line[leader_end - 1] == '\t')) leader_end -= 1;
+        var leader_start = leader_end;
+        while (leader_start > 0 and isIdentChar(line[leader_start - 1])) leader_start -= 1;
+        const leader = line[leader_start..leader_end];
+        const declarations = [_][]const u8{ "fn", "func", "function", "def" };
+        for (declarations) |word| if (std.mem.eql(u8, leader, word)) return false;
+    }
+    return true;
+}
+
+fn enclosingOpenParenBefore(line: []const u8, limit: usize, language: explore_mod.Language) ?usize {
+    var stack: [64]usize = undefined;
+    var depth: usize = 0;
+    var i: usize = 0;
+    const markers = lineCommentMarkers(language);
+    while (i < @min(limit, line.len)) {
+        if (line[i] == '"' or line[i] == '\'') {
+            const end = stringLiteralEnd(line, i) orelse return null;
+            i = end + 1;
+            continue;
+        }
+        if (blockCommentAt(line, i, language)) |block| {
+            const end = block.end orelse return null;
+            i = end;
+            continue;
+        }
+        if (isLineCommentAt(line, i, language, markers)) return null;
+        if (line[i] == '(') {
+            if (depth == stack.len) return null;
+            stack[depth] = i;
+            depth += 1;
+        } else if (line[i] == ')' and depth > 0) {
+            depth -= 1;
+        }
+        i += 1;
+    }
+    return if (depth > 0) stack[depth - 1] else null;
+}
+
+fn isRubyCommandInvocation(line: []const u8, start: usize, after_name: usize) bool {
+    var before = start;
+    while (before > 0 and (line[before - 1] == ' ' or line[before - 1] == '\t')) before -= 1;
+    const receiver_call = before > 0 and line[before - 1] == '.';
+    const command_position = before == 0 or std.mem.indexOfScalar(u8, ";|&({", line[before - 1]) != null;
+    if (!receiver_call and !command_position) return false;
+
+    var cursor = after_name;
+    while (cursor < line.len and (line[cursor] == ' ' or line[cursor] == '\t')) cursor += 1;
+    if (cursor == line.len) return true;
+    if (cursor == after_name) return false;
+    return std.mem.indexOfScalar(u8, "=,:.)]}+-*/%<>", line[cursor]) == null;
 }
 
 fn isShellCommandInvocation(line: []const u8, start: usize, after_name: usize) bool {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -692,7 +692,7 @@ pub const tools_list =
     \\{"name":"codedb_search","description":"Replaces grep/rg for code search: ranked results with far fewer tokens than raw grep output. Exploratory substring/phrase search — use ONLY when you do NOT know the exact symbol name. If you know a symbol name, do NOT use this: codedb_symbol returns its definition, codedb_callers its call sites, codedb_word its every occurrence — each in one call. Substring full-text across the index (regex if regex=true). Pass format=json for structured output with search provenance meta.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Text to search for (substring match, or regex if regex=true)"},"max_results":{"type":"integer","description":"Page size (default: 20, raise to 50 for broad surveys)"},"offset":{"type":"integer","description":"Pagination offset into the ranked results (default: 0). When more results exist, the response ends with a 'more results ... offset=N' line; pass that offset to get the next page."},"scope":{"type":"boolean","description":"Annotate results with enclosing symbol scope (default: false)"},"compact":{"type":"boolean","description":"Skip comment and blank lines in results (default: false)"},"paths_only":{"type":"boolean","description":"Return path:line per result without the matching line text — ~50% fewer tokens per call, useful for broad surveys or for budget-conscious agents (default: false)"},"regex":{"type":"boolean","description":"Treat query as regex pattern (default: false)"},"path_glob":{"type":"string","description":"Filter results to paths matching this glob, e.g. '*.zig', 'src/**/*.zig', or '**/*.{yaml,yml}'. Bare patterns like '*.zig' are auto-promoted to '**/*.zig' to match nested files."},"format":{"type":"string","description":"Set to json for structured JSON output with provenance meta"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["query"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_word","description":"O(1) exact-identifier occurrences via inverted index — every (file, line) one exact word appears. Use ONLY for a single exact identifier; for its definition prefer codedb_symbol, for substrings or phrases use codedb_search.","inputSchema":{"type":"object","properties":{"word":{"type":"string","description":"Exact word/identifier to look up"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["word"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_callers","description":"Replaces grepping for call sites: PRIMARY tool for finding usages — reach for this FIRST when you need who calls or uses a symbol, instead of grepping with codedb_search. Finds every call site of a named symbol — fuses word-index occurrences with outline scope info. One round-trip vs codedb_word + codedb_outline-per-file. Returns {path, line, snippet, scope_name, scope_kind, scope_lines}. Excludes the symbol's own definition site.","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Symbol name (exact identifier match)"},"max_results":{"type":"integer","description":"Maximum call sites to return (default: 30, raise for hot symbols)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["name"]},"annotations":{"readOnlyHint":true}},
-    \\{"name":"codedb_callpath","description":"Shortest resolved call chain between two symbols via the local call graph (A→…→B). First move when you need how execution reaches a callee. Returns each hop as path:name@line.","inputSchema":{"type":"object","properties":{"from":{"type":"string","description":"Source symbol name (exact identifier)"},"to":{"type":"string","description":"Target symbol name (exact identifier)"},"max_hops":{"type":"integer","description":"Max call hops to search (default: 12)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["from","to"]},"annotations":{"readOnlyHint":true}},
+    \\{"name":"codedb_callpath","description":"Shortest resolved call chain between two symbols via the local call graph (A→…→B). Ambiguous bare names list candidates; pass from_path/to_path to select an exact project-relative file. Returns each hop as path:name@line.","inputSchema":{"type":"object","properties":{"from":{"type":"string","description":"Source symbol name (exact identifier)"},"from_path":{"type":"string","description":"Optional exact project-relative source file; required to disambiguate duplicate names"},"to":{"type":"string","description":"Target symbol name (exact identifier)"},"to_path":{"type":"string","description":"Optional exact project-relative target file; required to disambiguate duplicate names"},"max_hops":{"type":"integer","description":"Max call hops to search (default: 12)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["from","to"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_explain","description":"One-shot neighborhood of a symbol: definition body plus every call site. Replaces codedb_symbol body=true then codedb_callers. First move when you know the name.","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Exact symbol name"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["name"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_context","description":"Task-shaped composer: pass a natural-language task; returns ONE compact block of definitions, focused bodies, graph neighbors, ranked files, and snippets. Local BM25/symbol retrieval always runs first. Hybrid retrieval is the default: it searches an explicitly built local OpenPuffer ANN sidecar using one transient remote request containing the task plus a fixed public calibration string; when the sidecar is absent or stale it can rerank up to 24 bounded local candidates instead. Set semantic=local for an entirely on-device call. The hosted service stores neither the repository, request body, candidate paths, nor vectors. Failure keeps the local result and never runs a CPU model.","inputSchema":{"type":"object","properties":{"task":{"type":"string","description":"Natural-language task description (3-1024 chars). Include candidate identifiers (camelCase / snake_case) or \"quoted strings\" so the composer can extract keywords."},"max_tokens":{"type":"integer","description":"Approximate response token budget (compact reserves a conservative ~2.5 bytes/token; min 256). Evidence is admitted monotonically by value; omitted evidence is summarized once."},"detail":{"type":"string","enum":["compact","full"],"description":"compact (default) removes redundant framing and uses focused body/site excerpts. full uses verbose legacy-style sections and a reader.md prepend."},"document_hops":{"type":"integer","description":"Explicitly expand Markdown document links from ranked files (0 default, hard-capped at 2 hops and 64 files)."},"semantic":{"type":"string","enum":["local","hybrid"],"description":"hybrid (default) sends the task plus a fixed public calibration string when a compatible local ANN sidecar exists; otherwise it may send the task plus up to 24 locally selected relative paths with bounded snippets. local is the explicit on-device-only opt-out. Build the sidecar explicitly with codedb <root> semantic-index. The hosted lane is transient; custom endpoint retention is reported as unverified."},"format":{"type":"string","enum":["markdown","json"],"description":"markdown (default) preserves the compact text response. json returns schema-versioned sections, evidence provenance, reader.md validation, retrieval privacy, and machine-readable token-budget omissions."},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":["task"]},"annotations":{"readOnlyHint":true}},
     \\{"name":"codedb_hot","description":"Recently modified files, newest first — reach for this to see WHERE work is happening before searching an unfamiliar or mid-sprint codebase.","inputSchema":{"type":"object","properties":{"limit":{"type":"integer","description":"Number of files to return (default: 10)"},"project":{"type":"string","description":"Optional absolute path to a different project (must have codedb.snapshot)"}},"required":[]},"annotations":{"readOnlyHint":true}},
@@ -835,7 +835,9 @@ const mini_prop_descriptions = [_]PropDesc{
     .{ .name = "path_glob", .desc = "Glob filter on paths, e.g. 'src/**/*.zig'" },
     .{ .name = "task", .desc = "Task in natural language; include likely identifiers" },
     .{ .name = "from", .desc = "Source symbol name (exact identifier)" },
+    .{ .name = "from_path", .desc = "Exact project-relative source file for an ambiguous symbol" },
     .{ .name = "to", .desc = "Target symbol name (exact identifier)" },
+    .{ .name = "to_path", .desc = "Exact project-relative target file for an ambiguous symbol" },
     .{ .name = "max_hops", .desc = "Max call hops (default: 12)" },
     .{ .name = "max_tokens", .desc = "Response token budget (min 256, ~2.5 bytes/token)" },
     .{ .name = "detail", .desc = "compact (default) or full sections" },
@@ -2699,6 +2701,25 @@ fn handleCallers(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     }
 }
 
+fn appendAmbiguousCallpathEndpoint(
+    w: anytype,
+    label: []const u8,
+    name: []const u8,
+    path: ?[]const u8,
+    candidates: []const explore_mod.CallPathStep,
+) void {
+    if (path) |selected_path| {
+        w.print("ambiguous callpath {s} endpoint '{s}' in '{s}' ({d} definitions):\n", .{ label, name, selected_path, candidates.len }) catch {};
+    } else {
+        w.print("ambiguous callpath {s} endpoint '{s}' ({d} definitions); pass {s}_path=<project-relative path>:\n", .{ label, name, candidates.len, label }) catch {};
+    }
+    const shown = @min(candidates.len, 20);
+    for (candidates[0..shown]) |candidate| {
+        w.print("  - {s}:{s}@L{d}\n", .{ candidate.path, candidate.name, candidate.line }) catch {};
+    }
+    if (shown < candidates.len) w.print("  … {d} more candidates\n", .{candidates.len - shown}) catch {};
+}
+
 fn handleCallpath(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const from_name = getStr(args, "from") orelse {
         out.appendSlice(alloc, "error: missing 'from' argument") catch {};
@@ -2714,20 +2735,54 @@ fn handleCallpath(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out
         out.appendSlice(alloc, "error: 'from' and 'to' must be non-empty symbol names") catch {};
         return;
     }
+    const from_path = getStr(args, "from_path");
+    const to_path = getStr(args, "to_path");
     const max_hops: usize = if (getInt(args, "max_hops")) |n| @intCast(@max(1, @min(n, 64))) else 12;
 
-    const steps = explorer.findCallPath(from_name, to_name, alloc, max_hops) catch {
+    const from_candidates = explorer.findCallPathCandidates(from_name, from_path, alloc) catch {
+        out.appendSlice(alloc, "error: callpath search failed") catch {};
+        return;
+    };
+    defer alloc.free(from_candidates);
+    const to_candidates = explorer.findCallPathCandidates(to_name, to_path, alloc) catch {
+        out.appendSlice(alloc, "error: callpath search failed") catch {};
+        return;
+    };
+    defer alloc.free(to_candidates);
+
+    const w = cio.listWriter(out, alloc);
+    if (from_candidates.len == 0) {
+        if (from_path) |selected_path| {
+            w.print("no source symbol '{s}' in '{s}'\n", .{ from_name, selected_path }) catch {};
+        } else {
+            w.print("no source symbol '{s}'\n", .{from_name}) catch {};
+        }
+        return;
+    }
+    if (to_candidates.len == 0) {
+        if (to_path) |selected_path| {
+            w.print("no target symbol '{s}' in '{s}'\n", .{ to_name, selected_path }) catch {};
+        } else {
+            w.print("no target symbol '{s}'\n", .{to_name}) catch {};
+        }
+        return;
+    }
+    if (from_candidates.len > 1 or to_candidates.len > 1) {
+        if (from_candidates.len > 1) appendAmbiguousCallpathEndpoint(w, "from", from_name, from_path, from_candidates);
+        if (to_candidates.len > 1) appendAmbiguousCallpathEndpoint(w, "to", to_name, to_path, to_candidates);
+        return;
+    }
+
+    const steps = explorer.findCallPathScoped(from_name, from_path, to_name, to_path, alloc, max_hops) catch {
         out.appendSlice(alloc, "error: callpath search failed") catch {};
         return;
     };
     const path = steps orelse {
-        const w = cio.listWriter(out, alloc);
         w.print("no call path from '{s}' to '{s}' within {d} hops\n", .{ from_name, to_name, max_hops }) catch {};
         return;
     };
     defer alloc.free(path);
 
-    const w = cio.listWriter(out, alloc);
     w.print("call path ({d} hops): {s} → {s}\n", .{ path.len - 1, from_name, to_name }) catch {};
     for (path, 0..) |step, i| {
         if (i > 0) w.print("  → ", .{}) catch {};
@@ -2735,6 +2790,62 @@ fn handleCallpath(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out
         if (i + 1 < path.len) w.print("\n", .{}) catch {};
     }
     w.print("\n", .{}) catch {};
+}
+
+test "callpath requires paths for duplicate endpoints and preserves unique names" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("src/first.zig",
+        \\pub fn main() void { run(); }
+        \\fn run() void {}
+    );
+    try explorer.indexFile("src/second.zig",
+        \\pub fn main() void { run(); }
+        \\fn run() void {}
+    );
+    try explorer.indexFile("src/unique.zig",
+        \\pub fn onlyMain() void { onlyRun(); }
+        \\fn onlyRun() void {}
+    );
+
+    var args: std.json.ObjectMap = .empty;
+    defer args.deinit(testing.allocator);
+    try args.put(testing.allocator, "from", .{ .string = "main" });
+    try args.put(testing.allocator, "to", .{ .string = "run" });
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    handleCallpath(testing.allocator, &args, &out, &explorer);
+    try testing.expect(std.mem.indexOf(u8, out.items, "ambiguous callpath from endpoint 'main'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/first.zig:main") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/second.zig:run") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "call path (") == null);
+
+    out.clearRetainingCapacity();
+    try args.put(testing.allocator, "from_path", .{ .string = "src/first.zig" });
+    try args.put(testing.allocator, "to_path", .{ .string = "src/first.zig" });
+    handleCallpath(testing.allocator, &args, &out, &explorer);
+    try testing.expect(std.mem.indexOf(u8, out.items, "call path (1 hops): main → run") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/first.zig:main") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/second.zig") == null);
+
+    out.clearRetainingCapacity();
+    try args.put(testing.allocator, "from", .{ .string = "onlyMain" });
+    try args.put(testing.allocator, "to", .{ .string = "onlyRun" });
+    _ = args.swapRemove("from_path");
+    _ = args.swapRemove("to_path");
+    handleCallpath(testing.allocator, &args, &out, &explorer);
+    try testing.expect(std.mem.indexOf(u8, out.items, "call path (1 hops): onlyMain → onlyRun") != null);
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    out.clearRetainingCapacity();
+    const cli_args = [_][]const u8{ "main", "run", "--from-path", "src/second.zig", "--to-path=src/second.zig" };
+    try testing.expectEqual(
+        @as(?u8, 0),
+        runCliTool(testing.io, testing.allocator, &explorer, &store, ".", "callpath", &cli_args, 0, &out),
+    );
+    try testing.expect(std.mem.indexOf(u8, out.items, "src/second.zig:main") != null);
 }
 
 fn handleExplain(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
@@ -5800,9 +5911,29 @@ pub fn runCliTool(
         handleChanges(alloc, &m, out, store);
         return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "callpath") or std.mem.eql(u8, cmd, "path")) {
-        if (args.len < cmd_args_start + 2) return cliUsage(alloc, out, "callpath <from> <to>");
+        if (args.len < cmd_args_start + 2 or std.mem.startsWith(u8, args[cmd_args_start], "-") or std.mem.startsWith(u8, args[cmd_args_start + 1], "-")) {
+            return cliUsage(alloc, out, "callpath <from> <to> [--from-path <project-relative path>] [--to-path <project-relative path>]");
+        }
         m.put(alloc, "from", .{ .string = args[cmd_args_start] }) catch return 1;
         m.put(alloc, "to", .{ .string = args[cmd_args_start + 1] }) catch return 1;
+        var arg_i = cmd_args_start + 2;
+        while (arg_i < args.len) : (arg_i += 1) {
+            const arg = args[arg_i];
+            if (std.mem.eql(u8, arg, "--from-path") or std.mem.eql(u8, arg, "--to-path")) {
+                arg_i += 1;
+                if (arg_i >= args.len) {
+                    return cliUsage(alloc, out, "callpath <from> <to> [--from-path <project-relative path>] [--to-path <project-relative path>]");
+                }
+                const key = if (std.mem.eql(u8, arg, "--from-path")) "from_path" else "to_path";
+                m.put(alloc, key, .{ .string = args[arg_i] }) catch return 1;
+            } else if (std.mem.startsWith(u8, arg, "--from-path=")) {
+                m.put(alloc, "from_path", .{ .string = arg["--from-path=".len..] }) catch return 1;
+            } else if (std.mem.startsWith(u8, arg, "--to-path=")) {
+                m.put(alloc, "to_path", .{ .string = arg["--to-path=".len..] }) catch return 1;
+            } else {
+                return cliUsage(alloc, out, "callpath <from> <to> [--from-path <project-relative path>] [--to-path <project-relative path>]");
+            }
+        }
         handleCallpath(alloc, &m, out, explorer);
         return finishCli(out, out_start);
     } else if (std.mem.eql(u8, cmd, "explain") or std.mem.eql(u8, cmd, "around")) {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3862,7 +3862,14 @@ fn handleContext(
     };
     var by_file = std.StringHashMap(PerFile).init(A);
 
-    const SymRef = struct { kw: []const u8, kind: []const u8, path: []const u8, line: u32, line_end: u32 };
+    const SymRef = struct {
+        kw: []const u8,
+        kind: []const u8,
+        path: []const u8,
+        line: u32,
+        line_end: u32,
+        focused: bool = false,
+    };
     var sym_refs: std.ArrayList(SymRef) = .empty;
     var seen_syms = std.StringHashMap(void).init(A);
     var caller_evidence: std.ArrayList(ContextEvidenceItem) = .empty;
@@ -3870,11 +3877,17 @@ fn handleContext(
     var callee_evidence: std.ArrayList(ContextEvidenceItem) = .empty;
 
     for (candidates.items) |kw| {
-        // Symbol definitions (best-effort; ignore failures).
-        if (explorer.findAllSymbols(kw, A)) |defs| {
-            var accepted: usize = 0;
+        // Symbol definitions (best-effort; ignore failures). Context is a
+        // navigation surface, so select before the per-keyword cap using the
+        // same production-path priority as codedb_explain/codedb_find. That
+        // policy also suppresses import/comment rows whenever a real
+        // definition of this exact name exists.
+        if (explorer.searchSymbols(.{
+            .name = kw,
+            .max_results = 3,
+            .rank_policy = .navigation,
+        }, A)) |defs| {
             for (defs) |d| {
-                if (accepted >= 3) break;
                 if (architecture_intent and isLowSignalArchitecturePath(d.path)) continue;
                 const key = std.fmt.allocPrint(A, "{s}|{s}|{d}", .{ d.path, kw, d.symbol.line_start }) catch continue;
                 if (seen_syms.contains(key)) continue;
@@ -3886,7 +3899,6 @@ fn handleContext(
                     .line = d.symbol.line_start,
                     .line_end = d.symbol.line_end,
                 }) catch break;
-                accepted += 1;
             }
         } else |_| {}
 
@@ -3903,6 +3915,47 @@ fn handleContext(
         }
     }
     const pf_kwloop = cio.nanoTimestamp();
+
+    // Focus at most three real definitions across the whole task. Previously
+    // four exact matches disabled every body/caller/callee expansion, so a few
+    // generic words could erase the one useful definition. Imports/comments
+    // are fallback focus only when the task found no real definition at all.
+    var focused_count: usize = 0;
+    for (sym_refs.items) |*sr| {
+        if (focused_count >= 3) break;
+        if (std.mem.eql(u8, sr.kind, "import") or std.mem.eql(u8, sr.kind, "comment_block")) continue;
+        sr.focused = true;
+        focused_count += 1;
+    }
+    if (focused_count == 0) {
+        for (sym_refs.items) |*sr| {
+            if (focused_count >= 3) break;
+            sr.focused = true;
+            focused_count += 1;
+        }
+    }
+
+    // Definition lines are stronger sites than arbitrary early lexical hits.
+    // Seed each focused definition into its file's bounded preview window so
+    // an MCP header comment or a patch repeating the task words cannot consume
+    // all three slots ahead of the actual dispatch body.
+    for (sym_refs.items) |sr| {
+        if (!sr.focused) continue;
+        const gop = by_file.getOrPut(sr.path) catch continue;
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        var already_seeded = false;
+        for (gop.value_ptr.top.items) |hit| {
+            if (hit.line == sr.line) {
+                already_seeded = true;
+                break;
+            }
+        }
+        if (already_seeded) continue;
+        if (gop.value_ptr.top.items.len >= CONTEXT_TOP_LINES_PER_FILE) {
+            _ = gop.value_ptr.top.pop();
+        }
+        gop.value_ptr.top.insert(A, 0, .{ .line = sr.line, .text = sr.kw }) catch {};
+    }
 
     // Rank files by a composite score: raw hits, +bonus when the file
     // contains a symbol definition for any keyword (definition beats usage),
@@ -4296,16 +4349,13 @@ fn handleContext(
         const wsl = cio.listWriter(&sec_syms_lean, A);
         wsr.print("\n## Symbol definitions\n", .{}) catch {};
         wsl.print("\n## Symbol definitions\n", .{}) catch {};
-        // Enhancement (closes T1 flask variance gap): when there are ≤3
-        // symbol definitions, inline each symbol's FULL body (capped at 40
-        // lines) so the agent doesn't need a follow-up `codedb_read`. For wider
-        // result sets this would bloat the response, so cap at 3. The lean
-        // variant (def lines only) is the budget fallback.
-        const inline_bodies = sym_refs.items.len <= 3;
+        // Inline the three focused definitions selected above (each capped at
+        // 40 lines) even when the task also found lower-priority collisions.
+        // The lean variant (declaration lines only) remains the budget fallback.
         for (sym_refs.items) |sr| {
             wsr.print("- {s} ({s}) — {s}:{d}\n", .{ sr.kw, sr.kind, sr.path, sr.line }) catch {};
             wsl.print("- {s} ({s}) — {s}:{d}\n", .{ sr.kw, sr.kind, sr.path, sr.line }) catch {};
-            if (inline_bodies) {
+            if (sr.focused) {
                 const body_end: u32 = if (sr.line_end > sr.line) @min(sr.line_end, sr.line +| 39) else sr.line;
                 _ = explorer.appendLineRange(sr.path, sr.line, body_end, "       ", A, &sec_syms_rich) catch false;
             }
@@ -4319,7 +4369,7 @@ fn handleContext(
         // follow-ups. Examples this targets directly:
         //   T1 flask: before_request → preprocess_request in app.py
         //   T2 regex: Builder::build → meta::Regex::new in regex.rs
-        if (inline_bodies) {
+        if (focused_count > 0) {
             const wc = cio.listWriter(&sec_callers, A);
             const wt = cio.listWriter(&sec_tests, A);
             var any_callers = false;
@@ -4334,6 +4384,7 @@ fn handleContext(
             // searches = 180 µs of redundant work on the bench task.
             var searched_kw = std.StringHashMap(void).init(A);
             for (sym_refs.items) |sr| {
+                if (!sr.focused) continue;
                 if (total_shown >= 6) break;
                 if (searched_kw.contains(sr.kw)) continue;
                 searched_kw.put(sr.kw, {}) catch {};
@@ -4411,11 +4462,12 @@ fn handleContext(
         // defined. This is the dependency side of the neighborhood — pairs with
         // the Callers section above so the agent sees both who calls a symbol and
         // what it calls, without a follow-up codedb_outline/read on the callees.
-        if (inline_bodies) {
+        if (focused_count > 0) {
             const wcal = cio.listWriter(&sec_calls, A);
             var any_callees = false;
             var done_sym = std.StringHashMap(void).init(A);
             for (sym_refs.items) |sr| {
+                if (!sr.focused) continue;
                 const sym_key = std.fmt.allocPrint(A, "{s}:{d}", .{ sr.path, sr.line }) catch continue;
                 if (done_sym.contains(sym_key)) continue;
                 done_sym.put(sym_key, {}) catch {};

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -1984,33 +1984,6 @@ fn renderOutlineOrSkeleton(
     return explorer.renderOutline(path, alloc, out, compact);
 }
 
-fn genericEntrypointPathPriority(path: []const u8) i32 {
-    if (isLowSignalArchitecturePath(path)) return -1000;
-    const base = std.fs.path.basename(path);
-    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
-    if (!std.ascii.eqlIgnoreCase(stem, "main")) return 0;
-    if (std.mem.startsWith(u8, path, "src/")) return 1000;
-    if (std.mem.indexOfScalar(u8, path, '/') == null) return 900;
-    if (pathHasSegmentIgnoreCase(path, "cmd")) return 800;
-    return 200;
-}
-
-fn prioritizeGenericEntrypoint(name: ?[]const u8, fuzzy: bool, results: []Explorer.ScoredSymbolResult) void {
-    const exact_name = name orelse return;
-    if (fuzzy or !std.ascii.eqlIgnoreCase(exact_name, "main")) return;
-    std.mem.sort(Explorer.ScoredSymbolResult, results, {}, struct {
-        fn lessThan(_: void, a: Explorer.ScoredSymbolResult, b: Explorer.ScoredSymbolResult) bool {
-            const ap = genericEntrypointPathPriority(a.path);
-            const bp = genericEntrypointPathPriority(b.path);
-            if (ap != bp) return ap > bp;
-            if (a.score != b.score) return a.score > b.score;
-            const path_order = std.mem.order(u8, a.path, b.path);
-            if (path_order != .eq) return path_order == .lt;
-            return a.symbol.line_start < b.symbol.line_start;
-        }
-    }.lessThan);
-}
-
 fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: *std.ArrayList(u8), explorer: *Explorer) void {
     const name = getStr(args, "name");
     const prefix = getStr(args, "prefix");
@@ -2058,7 +2031,11 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         .pattern = pattern,
         .kind = kind,
         .fuzzy = fuzzy,
-        .max_results = max_results,
+        // Retain one sentinel row so truncation is observable. Top-K selection
+        // still uses the requested structural/navigation comparator, so the
+        // first max_results rows are identical to an exact-size query.
+        .max_results = max_results + 1,
+        .rank_policy = if (getBool(args, "prefer_entrypoint")) .navigation else .structural,
     };
 
     const results = explorer.searchSymbols(spec, alloc) catch {
@@ -2069,10 +2046,6 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         return;
     };
-    // Explain is the opinionated one-shot neighborhood tool; keep the lower-
-    // level codedb_symbol ordering byte-for-byte stable for callers that rely
-    // on its deterministic structural index order.
-    if (getBool(args, "prefer_entrypoint")) prioritizeGenericEntrypoint(name, fuzzy, results);
     defer {
         for (results) |r| {
             alloc.free(r.path);
@@ -2081,19 +2054,21 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         }
         alloc.free(results);
     }
+    const truncated = results.len > max_results;
+    const shown_results = results[0..@min(results.len, max_results)];
 
     if (json_fmt) {
         out.appendSlice(alloc, "{\"ok\":true,\"tool\":\"codedb_symbol\",\"count\":") catch {};
         var cnt_buf: [16]u8 = undefined;
-        const cnt_s = std.fmt.bufPrint(&cnt_buf, "{d}", .{results.len}) catch "0";
+        const cnt_s = std.fmt.bufPrint(&cnt_buf, "{d}", .{shown_results.len}) catch "0";
         out.appendSlice(alloc, cnt_s) catch {};
         out.appendSlice(alloc, ",\"match_mode\":") catch {};
         appendJsonStr(out, alloc, symbolMatchModeLabel(spec));
         out.appendSlice(alloc, ",\"meta\":{\"index\":\"symbol_index+outline\",\"match_mode\":") catch {};
         appendJsonStr(out, alloc, symbolMatchModeLabel(spec));
-        out.append(alloc, '}') catch {};
+        out.appendSlice(alloc, if (truncated) ",\"truncated\":true}" else ",\"truncated\":false}") catch {};
         out.appendSlice(alloc, ",\"results\":[") catch {};
-        for (results, 0..) |r, i| {
+        for (shown_results, 0..) |r, i| {
             if (i > 0) out.append(alloc, ',') catch {};
             out.appendSlice(alloc, "{\"path\":") catch {};
             appendJsonStr(out, alloc, r.path);
@@ -2115,7 +2090,7 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
         return;
     }
 
-    if (results.len == 0) {
+    if (shown_results.len == 0) {
         out.appendSlice(alloc, "no results") catch {};
         if (name) |n| {
             out.appendSlice(alloc, " for: ") catch {};
@@ -2126,11 +2101,11 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
 
     const w = cio.listWriter(out, alloc);
     if (name) |n| {
-        w.print("{d} results for '{s}':\n", .{ results.len, n }) catch {};
+        w.print("{d} results for '{s}':\n", .{ shown_results.len, n }) catch {};
     } else {
-        w.print("{d} symbol results:\n", .{results.len}) catch {};
+        w.print("{d} symbol results:\n", .{shown_results.len}) catch {};
     }
-    for (results) |r| {
+    for (shown_results) |r| {
         w.print("  {s}:{d} ({s}) {s}", .{ r.path, r.symbol.line_start, @tagName(r.symbol.kind), r.symbol.name }) catch {};
         if (r.symbol.detail) |d| w.print("  // {s}", .{d}) catch {};
         w.writeAll("\n") catch {};
@@ -2159,7 +2134,8 @@ fn handleSymbol(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out: 
             }
         }
     }
-    if (depsHint(results.len)) |h| out.appendSlice(alloc, h) catch {};
+    if (truncated) w.print("… more symbol results truncated (raise max_results; cap 200)\n", .{}) catch {};
+    if (depsHint(shown_results.len)) |h| out.appendSlice(alloc, h) catch {};
 }
 
 // Issue #626: agents reach for codedb_search with a bare symbol name and skip
@@ -2788,7 +2764,10 @@ fn handleExplain(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out:
     const def_text = if (def_out.items.len > cap) def_out.items[0..cap] else def_out.items;
     const call_text = if (call_out.items.len > cap) call_out.items[0..cap] else call_out.items;
     const w = cio.listWriter(out, alloc);
-    w.print("## definition\n{s}\n\n## callers\n{s}", .{ def_text, call_text }) catch {};
+    w.print("## definition\n{s}", .{def_text}) catch {};
+    if (def_out.items.len > cap) w.print("\n… definition output truncated at {d} bytes", .{cap}) catch {};
+    w.print("\n\n## callers\n{s}", .{call_text}) catch {};
+    if (call_out.items.len > cap) w.print("\n… callers output truncated at {d} bytes", .{cap}) catch {};
 }
 
 fn isIdentChar(c: u8) bool {

--- a/src/query.zig
+++ b/src/query.zig
@@ -139,28 +139,69 @@ pub fn runQuery(io: std.Io, allocator: std.mem.Allocator, explorer: *Explorer, s
             return 1;
         };
         const t0 = cio.nanoTimestamp();
-        if (explorer.findSymbol(name, allocator) catch return 1) |r| {
-            defer {
+        const result_cap: usize = 5;
+        const results = explorer.searchSymbols(.{
+            .name = name,
+            .max_results = result_cap + 1,
+            .rank_policy = .navigation,
+        }, allocator) catch return 1;
+        defer {
+            for (results) |r| {
                 allocator.free(r.path);
                 allocator.free(r.symbol.name);
                 if (r.symbol.detail) |d| allocator.free(d);
             }
+            allocator.free(results);
+        }
+        if (results.len > 0) {
             const elapsed = cio.nanoTimestamp() - t0;
             var dur_buf: [64]u8 = undefined;
-            const kind = @tagName(r.symbol.kind);
-            out.p("{s}\xe2\x9c\x93{s} {s}{s}{s} {s}{s}{s}  {s}{s}{s}:{s}{d}{s}  {s}{s}{s}\n", .{
-                s.green,                       s.reset,
-                s.kindColor(kind),             kind,
-                s.reset,                       s.bold,
-                name,                          s.reset,
-                s.dim,                         r.path,
-                s.reset,                       s.cyan,
-                r.symbol.line_start,           s.reset,
-                sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
-                s.reset,
-            });
-            if (r.symbol.detail) |d| {
-                out.p("  {s}{s}{s}\n", .{ s.dim, d, s.reset });
+            const truncated = results.len > result_cap;
+            const shown = results[0..@min(results.len, result_cap)];
+            if (shown.len == 1 and !truncated) {
+                const r = shown[0];
+                const kind = @tagName(r.symbol.kind);
+                out.p("{s}\xe2\x9c\x93{s} {s}{s}{s} {s}{s}{s}  {s}{s}{s}:{s}{d}{s}  {s}{s}{s}\n", .{
+                    s.green,                       s.reset,
+                    s.kindColor(kind),             kind,
+                    s.reset,                       s.bold,
+                    name,                          s.reset,
+                    s.dim,                         r.path,
+                    s.reset,                       s.cyan,
+                    r.symbol.line_start,           s.reset,
+                    sty.durationColor(s, elapsed), sty.formatDuration(&dur_buf, elapsed),
+                    s.reset,
+                });
+                if (r.symbol.detail) |d| out.p("  {s}{s}{s}\n", .{ s.dim, d, s.reset });
+            } else {
+                out.p("{s}\xe2\x9c\x93{s} {d}{s} exact definitions for {s}{s}{s} (ranked)  {s}{s}{s}\n", .{
+                    s.green,
+                    s.reset,
+                    shown.len,
+                    if (truncated) "+" else "",
+                    s.bold,
+                    name,
+                    s.reset,
+                    sty.durationColor(s, elapsed),
+                    sty.formatDuration(&dur_buf, elapsed),
+                    s.reset,
+                });
+                for (shown, 1..) |r, rank| {
+                    const kind = @tagName(r.symbol.kind);
+                    out.p("  {d}. {s}{s}{s}  {s}{s}{s}:{s}{d}{s}\n", .{
+                        rank,
+                        s.kindColor(kind),
+                        kind,
+                        s.reset,
+                        s.dim,
+                        r.path,
+                        s.reset,
+                        s.cyan,
+                        r.symbol.line_start,
+                        s.reset,
+                    });
+                }
+                if (truncated) out.p("  {s}\xe2\x80\xa6 more exact definitions truncated; use `codedb symbol {s}`{s}\n", .{ s.dim, name, s.reset });
             }
         } else {
             out.p("{s}\xe2\x9c\x97{s} not found: {s}{s}{s}\n", .{

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1653,6 +1653,38 @@ pub fn writeSnapshotDual(
     try copyToProjectCache(io, explorer, root_path, output_path, allocator);
 }
 
+/// Reindex persistence is central-cache first so a read-only checkout remains
+/// fully usable. Returns whether the best-effort in-repo mirror was refreshed.
+/// The central snapshot is mandatory and atomically written; the root copy uses
+/// the same validated bytes and is also atomic when the checkout is writable.
+pub fn writeReindexSnapshots(
+    io: std.Io,
+    explorer: *Explorer,
+    root_path: []const u8,
+    allocator: std.mem.Allocator,
+) !bool {
+    try writeProjectCacheSnapshot(io, explorer, root_path, allocator);
+
+    const hash = std.hash.Wyhash.hash(0, root_path);
+    const home_raw = cio.homeDir() orelse return false;
+    const central_path = try std.fmt.allocPrint(
+        allocator,
+        "{s}/.codedb/projects/{x}/codedb.snapshot",
+        .{ home_raw, hash },
+    );
+    defer allocator.free(central_path);
+    const central_file = std.Io.Dir.cwd().openFile(io, central_path, .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+    }) catch return false;
+    defer central_file.close(io);
+
+    const root_dir = explorer.root_dir orelse return false;
+    copyOpenFileAtomic(io, central_file, root_dir, "codedb.snapshot", allocator) catch return false;
+    ensureGitIgnoresSnapshot(io, root_path, allocator);
+    return true;
+}
+
 fn writePrivateFileAtomic(io: std.Io, dir: std.Io.Dir, name: []const u8, data: []const u8, allocator: std.mem.Allocator) !void {
     const tmp = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ name, cio.randU64() });
     defer allocator.free(tmp);

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -3091,6 +3091,33 @@ test "issue-656: call graph is stale and dangling after a file edit" {
     try testing.expect(after != null);
 }
 
+test "Swift multiline bodies and initializers participate in call paths" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("Sources/App/Flow.swift",
+        \\final class Flow {
+        \\    init(
+        \\        enabled: Bool
+        \\    ) {
+        \\        if enabled {
+        \\            configure()
+        \\        }
+        \\    }
+        \\
+        \\    func configure() {
+        \\    }
+        \\}
+    );
+
+    const path = (try explorer_inst.findCallPath("init", "configure", testing.allocator, 2)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(path);
+    try testing.expectEqual(@as(usize, 2), path.len);
+    try testing.expectEqualStrings("init", path[0].name);
+    try testing.expectEqualStrings("configure", path[1].name);
+}
+
 test "issue-718: call paths do not cross languages through name collisions" {
     var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer_inst.deinit();

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -1710,10 +1710,11 @@ test "symbol-index: O(1) findSymbol via symbol_index" {
     defer arena.deinit();
     var explorer = Explorer.init(arena.allocator(), Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
 
-    try explorer.indexFile("math.zig", "pub fn add(a: i32, b: i32) i32 { return a + b; }\npub fn subtract(a: i32, b: i32) i32 { return a - b; }\n");
     try explorer.indexFile("utils.zig", "pub fn add(x: f64, y: f64) f64 { return x + y; }\npub fn format() void {}\n");
+    try explorer.indexFile("math.zig", "pub fn add(a: i32, b: i32) i32 { return a + b; }\npub fn subtract(a: i32, b: i32) i32 { return a - b; }\n");
 
-    // findSymbol should return first match via index
+    // The hash lookup stays O(1), but exact-name collisions are ranked instead
+    // of inheriting insertion order (utils was indexed first above).
     const result = try explorer.findSymbol("add", testing.allocator);
     try testing.expect(result != null);
     const r = result.?;
@@ -1723,6 +1724,7 @@ test "symbol-index: O(1) findSymbol via symbol_index" {
         if (r.symbol.detail) |d| testing.allocator.free(d);
     }
     try testing.expectEqualStrings("add", r.symbol.name);
+    try testing.expectEqualStrings("math.zig", r.path);
 
     // findAllSymbols should return both
     const all = try explorer.findAllSymbols("add", testing.allocator);

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -163,6 +163,7 @@ test "issue-725: Zig Thread.spawn callback rejects malformed calls" {
         \\std.Thread.spawn(.{}, truncated,
         \\std.Thread.spawn(.{}, fourArgs, .{}, extra)
         \\std.Thread.spawn(.{}, mismatched, .{])
+        \\std.Thread.spawn(([)], crossed, .{})
         \\std.Thread.spawn(.{}, expression + value, .{})
         \\std.Thread.spawn(.{}, "unterminated, .{})
     ;

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -157,6 +157,27 @@ test "issue-725: Zig Thread.spawn callback resolves only within its file" {
     try testing.expectEqual(@as(codegraph.NodeId, 1), edges.items[0].to);
 }
 
+test "issue-725: Zig Thread.spawn callback rejects malformed calls" {
+    const malformed =
+        \\std.Thread.spawn(.{}, onlyTwo)
+        \\std.Thread.spawn(.{}, truncated,
+        \\std.Thread.spawn(.{}, fourArgs, .{}, extra)
+        \\std.Thread.spawn(.{}, mismatched, .{])
+        \\std.Thread.spawn(.{}, expression + value, .{})
+        \\std.Thread.spawn(.{}, "unterminated, .{})
+    ;
+    const callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, malformed);
+    defer testing.allocator.free(callbacks);
+    try testing.expectEqual(@as(usize, 0), callbacks.len);
+
+    var stress: std.ArrayList(u8) = .empty;
+    defer stress.deinit(testing.allocator);
+    for (0..256) |_| try stress.appendSlice(testing.allocator, "std.Thread.spawn(");
+    const stress_callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, stress.items);
+    defer testing.allocator.free(stress_callbacks);
+    try testing.expectEqual(@as(usize, 0), stress_callbacks.len);
+}
+
 test "issue-725: Zig Thread.spawn callback resolves an imported function value" {
     const imports = [_]codegraph.ImportBinding{
         .{ .alias = "watcher", .target_path = "src/watcher.zig" },

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -32,21 +32,125 @@ test "codegraph: extractCallees finds calls, filters keywords" {
     var found_method = false;
     var found_dothing = false;
     for (callees) |c| {
-        if (std.mem.eql(u8, c, "helper")) found_helper = true;
-        if (std.mem.eql(u8, c, "compute")) found_compute = true;
-        if (std.mem.eql(u8, c, "method")) found_method = true;
-        if (std.mem.eql(u8, c, "doThing")) found_dothing = true;
-        try testing.expect(!std.mem.eql(u8, c, "if"));
-        try testing.expect(!std.mem.eql(u8, c, "while"));
-        try testing.expect(!std.mem.eql(u8, c, "return"));
+        if (std.mem.eql(u8, c.name, "helper")) found_helper = true;
+        if (std.mem.eql(u8, c.name, "compute")) found_compute = true;
+        if (std.mem.eql(u8, c.name, "method")) {
+            found_method = true;
+            try testing.expectEqualStrings("obj", c.qualifier.?);
+        }
+        if (std.mem.eql(u8, c.name, "doThing")) found_dothing = true;
+        try testing.expect(!std.mem.eql(u8, c.name, "if"));
+        try testing.expect(!std.mem.eql(u8, c.name, "while"));
+        try testing.expect(!std.mem.eql(u8, c.name, "return"));
     }
     try testing.expect(found_helper and found_compute and found_method and found_dothing);
     // compute appears twice but is deduped.
     var compute_count: usize = 0;
-    for (callees) |c| if (std.mem.eql(u8, c, "compute")) {
+    for (callees) |c| if (std.mem.eql(u8, c.name, "compute")) {
         compute_count += 1;
     };
     try testing.expectEqual(@as(usize, 1), compute_count);
+}
+
+test "issue-725: extractCallees keeps qualified receivers distinct" {
+    const callees = try codegraph.extractCallees(
+        testing.allocator,
+        "server.run(); run(); workspace.run(); std.Thread.spawn(.{}, worker, .{});",
+    );
+    defer testing.allocator.free(callees);
+
+    try testing.expectEqual(@as(usize, 4), callees.len);
+    try testing.expectEqualStrings("run", callees[0].name);
+    try testing.expectEqualStrings("server", callees[0].qualifier.?);
+    try testing.expectEqualStrings("run", callees[1].name);
+    try testing.expect(callees[1].qualifier == null);
+    try testing.expectEqualStrings("workspace", callees[2].qualifier.?);
+    try testing.expectEqualStrings("spawn", callees[3].name);
+    try testing.expectEqualStrings("std.Thread", callees[3].qualifier.?);
+}
+
+test "issue-725: scoped edges resolve imports and skip same-language ambiguity" {
+    const imports = [_]codegraph.ImportBinding{
+        .{ .alias = "server", .target_path = "src/server.zig" },
+    };
+    const funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = "server.run();", .path = "src/main.zig", .imports = &imports },
+        .{ .id = 1, .body = "", .path = "src/server.zig" },
+        .{ .id = 2, .body = "", .path = "src/workspace.zig" },
+    };
+    const paths = [_][]const u8{ "src/main.zig", "src/server.zig", "src/workspace.zig" };
+    const groups = [_]u8{ 1, 1, 1 };
+    const run_ids = [_]codegraph.NodeId{ 1, 2 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("run", &run_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), edges.items.len);
+    try testing.expectEqual(@as(codegraph.NodeId, 1), edges.items[0].to);
+
+    const ambiguous_funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = "run();", .path = "src/main.zig" },
+        funcs[1],
+        funcs[2],
+    };
+    var ambiguous_edges = try codegraph.buildEdgesScoped(testing.allocator, &ambiguous_funcs, &resolve, &paths, &groups, false);
+    defer ambiguous_edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 0), ambiguous_edges.items.len);
+}
+
+test "issue-725: bare calls prefer the unique same-file helper" {
+    const funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = "persistLocked();", .path = "src/mergequeue.zig" },
+        .{ .id = 1, .body = "", .path = "src/mergequeue.zig" },
+        .{ .id = 2, .body = "", .path = "src/reviews.zig" },
+    };
+    const paths = [_][]const u8{ "src/mergequeue.zig", "src/mergequeue.zig", "src/reviews.zig" };
+    const groups = [_]u8{ 1, 1, 1 };
+    const helper_ids = [_]codegraph.NodeId{ 1, 2 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("persistLocked", &helper_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), edges.items.len);
+    try testing.expectEqual(@as(codegraph.NodeId, 1), edges.items[0].to);
+}
+
+test "issue-725: Zig Thread.spawn callback resolves only within its file" {
+    const body =
+        \\// std.Thread.spawn(.{}, ghost, .{});
+        \\const text = "std.Thread.spawn(.{}, stringGhost, .{})";
+        \\const thread = try std.Thread.spawn(.{}, connection, .{ stream });
+    ;
+    const callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, body);
+    defer testing.allocator.free(callbacks);
+    try testing.expectEqual(@as(usize, 1), callbacks.len);
+    try testing.expectEqualStrings("connection", callbacks[0]);
+
+    const funcs = [_]codegraph.FuncInput{
+        .{
+            .id = 0,
+            .body = body,
+            .path = "src/server.zig",
+            .extract_zig_thread_spawn_callbacks = true,
+        },
+        .{ .id = 1, .body = "", .path = "src/server.zig" },
+        .{ .id = 2, .body = "", .path = "experiments/server.zig" },
+    };
+    const paths = [_][]const u8{ "src/server.zig", "src/server.zig", "experiments/server.zig" };
+    const groups = [_]u8{ 1, 1, 1 };
+    const connection_ids = [_]codegraph.NodeId{ 1, 2 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("connection", &connection_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), edges.items.len);
+    try testing.expectEqual(@as(codegraph.NodeId, 1), edges.items[0].to);
 }
 
 test "codegraph: buildEdges resolves callees + inDegree centrality" {
@@ -2714,9 +2818,9 @@ test "audit: extractCallees ignores comment/string mentions" {
     defer testing.allocator.free(callees);
     var saw_real = false;
     for (callees) |c| {
-        if (std.mem.eql(u8, c, "realCall")) saw_real = true;
-        try testing.expect(!std.mem.eql(u8, c, "ghostFn"));
-        try testing.expect(!std.mem.eql(u8, c, "stringOnlyFn"));
+        if (std.mem.eql(u8, c.name, "realCall")) saw_real = true;
+        try testing.expect(!std.mem.eql(u8, c.name, "ghostFn"));
+        try testing.expect(!std.mem.eql(u8, c.name, "stringOnlyFn"));
     }
     try testing.expect(saw_real); // real call in code is still captured
 }
@@ -2953,6 +3057,104 @@ test "issue-718: call paths do not cross languages through name collisions" {
     const path = try explorer_inst.findCallPath("handle", "parseRequest", testing.allocator, 4);
     defer if (path) |steps| testing.allocator.free(steps);
     try testing.expect(path == null);
+}
+
+test "issue-725: call graph resolves imported receiver and same-file helper" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("src/main.zig",
+        \\const server = @import("server.zig");
+        \\pub fn cmdServe() void {
+        \\    server.run();
+        \\}
+    );
+    try explorer_inst.indexFile("src/server.zig",
+        \\pub fn run() void {
+        \\    serverOnly();
+        \\}
+        \\fn serverOnly() void {}
+    );
+    try explorer_inst.indexFile("src/workspace.zig",
+        \\pub fn run() void {
+        \\    workspaceOnly();
+        \\}
+        \\fn workspaceOnly() void {}
+    );
+
+    const imported = (try explorer_inst.findCallPath("cmdServe", "run", testing.allocator, 4)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(imported);
+    try testing.expectEqual(@as(usize, 2), imported.len);
+    try testing.expectEqualStrings("src/server.zig", imported[1].path);
+
+    const real_chain = try explorer_inst.findCallPath("cmdServe", "serverOnly", testing.allocator, 4);
+    defer if (real_chain) |steps| testing.allocator.free(steps);
+    try testing.expect(real_chain != null);
+    const fabricated_chain = try explorer_inst.findCallPath("cmdServe", "workspaceOnly", testing.allocator, 4);
+    defer if (fabricated_chain) |steps| testing.allocator.free(steps);
+    try testing.expect(fabricated_chain == null);
+
+    try explorer_inst.indexFile("src/mergequeue.zig",
+        \\pub fn enqueue() void {
+        \\    persistLocked();
+        \\}
+        \\fn persistLocked() void {
+        \\    correctOnly();
+        \\}
+        \\fn correctOnly() void {}
+    );
+    try explorer_inst.indexFile("src/reviews.zig",
+        \\fn persistLocked() void {
+        \\    wrongOnly();
+        \\}
+        \\fn wrongOnly() void {}
+    );
+
+    const local = (try explorer_inst.findCallPath("enqueue", "persistLocked", testing.allocator, 4)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(local);
+    try testing.expectEqualStrings("src/mergequeue.zig", local[1].path);
+    const correct = try explorer_inst.findCallPath("enqueue", "correctOnly", testing.allocator, 4);
+    defer if (correct) |steps| testing.allocator.free(steps);
+    try testing.expect(correct != null);
+    const wrong = try explorer_inst.findCallPath("enqueue", "wrongOnly", testing.allocator, 4);
+    defer if (wrong) |steps| testing.allocator.free(steps);
+    try testing.expect(wrong == null);
+}
+
+test "issue-725: Zig Thread.spawn callback adds a unique same-file edge" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("src/server.zig",
+        \\pub fn run() void {
+        \\    const thread = std.Thread.spawn(.{}, connection, .{}) catch return;
+        \\    _ = thread;
+        \\}
+        \\fn connection() void {
+        \\    handle();
+        \\}
+        \\fn handle() void {}
+    );
+    try explorer_inst.indexFile("experiments/server.zig",
+        \\fn connection() void {
+        \\    decoyOnly();
+        \\}
+        \\fn decoyOnly() void {}
+    );
+
+    const callback = (try explorer_inst.findCallPath("run", "connection", testing.allocator, 4)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(callback);
+    try testing.expectEqual(@as(usize, 2), callback.len);
+    try testing.expectEqualStrings("src/server.zig", callback[1].path);
+    const real_chain = try explorer_inst.findCallPath("run", "handle", testing.allocator, 4);
+    defer if (real_chain) |steps| testing.allocator.free(steps);
+    try testing.expect(real_chain != null);
+    const decoy_chain = try explorer_inst.findCallPath("run", "decoyOnly", testing.allocator, 4);
+    defer if (decoy_chain) |steps| testing.allocator.free(steps);
+    try testing.expect(decoy_chain == null);
 }
 
 test "render caches preserve output and invalidate on mutation" {

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -100,6 +100,33 @@ test "issue-725: scoped edges resolve imports and skip same-language ambiguity" 
     try testing.expectEqual(@as(usize, 0), ambiguous_edges.items.len);
 }
 
+test "issue-725: scoped edges prefer the longest exact import qualifier" {
+    const imports = [_]codegraph.ImportBinding{
+        .{ .alias = "zigrep", .target_path = "zigrep/src/root.zig" },
+        .{ .alias = "zigrep.engine", .target_path = "zigrep/src/exec/search_engine.zig" },
+    };
+    const funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = "zigrep.engine.run();", .path = "zigrep/src/main.zig", .imports = &imports },
+        .{ .id = 1, .body = "", .path = "zigrep/src/root.zig" },
+        .{ .id = 2, .body = "", .path = "zigrep/src/exec/search_engine.zig" },
+    };
+    const paths = [_][]const u8{
+        "zigrep/src/main.zig",
+        "zigrep/src/root.zig",
+        "zigrep/src/exec/search_engine.zig",
+    };
+    const groups = [_]u8{ 1, 1, 1 };
+    const run_ids = [_]codegraph.NodeId{ 1, 2 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("run", &run_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), edges.items.len);
+    try testing.expectEqual(@as(codegraph.NodeId, 2), edges.items[0].to);
+}
+
 test "issue-725: bare calls prefer the unique same-file helper" {
     const funcs = [_]codegraph.FuncInput{
         .{ .id = 0, .body = "persistLocked();", .path = "src/mergequeue.zig" },
@@ -3204,6 +3231,38 @@ test "issue-725: call graph resolves imported receiver and same-file helper" {
     const wrong = try explorer_inst.findCallPath("enqueue", "wrongOnly", testing.allocator, 4);
     defer if (wrong) |steps| testing.allocator.free(steps);
     try testing.expect(wrong == null);
+}
+
+test "issue-725: call graph follows an exact Zig re-export chain" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("zigrep/src/main.zig",
+        \\const zigrep = @import("root.zig");
+        \\pub fn main() void {
+        \\    zigrep.engine.run();
+        \\}
+    );
+    try explorer_inst.indexFile("zigrep/src/root.zig",
+        \\pub const engine = @import("exec/search_engine.zig");
+        \\pub fn run() void {}
+    );
+    try explorer_inst.indexFile("zigrep/src/exec/search_engine.zig",
+        \\pub fn run() void {
+        \\    engineOnly();
+        \\}
+        \\fn engineOnly() void {}
+    );
+
+    const imported = (try explorer_inst.findCallPath("main", "run", testing.allocator, 4)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(imported);
+    try testing.expectEqual(@as(usize, 2), imported.len);
+    try testing.expectEqualStrings("zigrep/src/exec/search_engine.zig", imported[1].path);
+
+    const real_chain = try explorer_inst.findCallPath("main", "engineOnly", testing.allocator, 4);
+    defer if (real_chain) |steps| testing.allocator.free(steps);
+    try testing.expect(real_chain != null);
 }
 
 test "issue-725: Zig Thread.spawn callback adds a unique same-file edge" {

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -124,11 +124,15 @@ test "issue-725: Zig Thread.spawn callback resolves only within its file" {
         \\// std.Thread.spawn(.{}, ghost, .{});
         \\const text = "std.Thread.spawn(.{}, stringGhost, .{})";
         \\const thread = try std.Thread.spawn(.{}, connection, .{ stream });
+        \\const watcher_thread = try std.Thread.spawn(.{}, watcher.incrementalLoop, .{ stream });
     ;
     const callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, body);
     defer testing.allocator.free(callbacks);
-    try testing.expectEqual(@as(usize, 1), callbacks.len);
-    try testing.expectEqualStrings("connection", callbacks[0]);
+    try testing.expectEqual(@as(usize, 2), callbacks.len);
+    try testing.expectEqualStrings("connection", callbacks[0].name);
+    try testing.expect(callbacks[0].qualifier == null);
+    try testing.expectEqualStrings("incrementalLoop", callbacks[1].name);
+    try testing.expectEqualStrings("watcher", callbacks[1].qualifier.?);
 
     const funcs = [_]codegraph.FuncInput{
         .{
@@ -146,6 +150,34 @@ test "issue-725: Zig Thread.spawn callback resolves only within its file" {
     var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
     defer resolve.deinit();
     try resolve.put("connection", &connection_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), edges.items.len);
+    try testing.expectEqual(@as(codegraph.NodeId, 1), edges.items[0].to);
+}
+
+test "issue-725: Zig Thread.spawn callback resolves an imported function value" {
+    const imports = [_]codegraph.ImportBinding{
+        .{ .alias = "watcher", .target_path = "src/watcher.zig" },
+    };
+    const funcs = [_]codegraph.FuncInput{
+        .{
+            .id = 0,
+            .body = "std.Thread.spawn(.{}, watcher.incrementalLoop, .{});",
+            .path = "src/commands.zig",
+            .imports = &imports,
+            .extract_zig_thread_spawn_callbacks = true,
+        },
+        .{ .id = 1, .body = "", .path = "src/watcher.zig" },
+        .{ .id = 2, .body = "", .path = "experiments/watcher.zig" },
+    };
+    const paths = [_][]const u8{ "src/commands.zig", "src/watcher.zig", "experiments/watcher.zig" };
+    const groups = [_]u8{ 1, 1, 1 };
+    const callback_ids = [_]codegraph.NodeId{ 1, 2 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("incrementalLoop", &callback_ids);
 
     var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
     defer edges.deinit(testing.allocator);

--- a/src/test_explore.zig
+++ b/src/test_explore.zig
@@ -127,6 +127,30 @@ test "issue-725: scoped edges prefer the longest exact import qualifier" {
     try testing.expectEqual(@as(codegraph.NodeId, 2), edges.items[0].to);
 }
 
+test "issue-725: three conflicting longest import bindings are safely ambiguous" {
+    const imports = [_]codegraph.ImportBinding{
+        .{ .alias = "pkg.engine", .target_path = "src/a.zig" },
+        .{ .alias = "pkg.engine", .target_path = "src/b.zig" },
+        .{ .alias = "pkg.engine", .target_path = "src/c.zig" },
+    };
+    const funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = "pkg.engine.run();", .path = "src/main.zig", .imports = &imports },
+        .{ .id = 1, .body = "", .path = "src/a.zig" },
+        .{ .id = 2, .body = "", .path = "src/b.zig" },
+        .{ .id = 3, .body = "", .path = "src/c.zig" },
+    };
+    const paths = [_][]const u8{ "src/main.zig", "src/a.zig", "src/b.zig", "src/c.zig" };
+    const groups = [_]u8{ 1, 1, 1, 1 };
+    const run_ids = [_]codegraph.NodeId{ 1, 2, 3 };
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("run", &run_ids);
+
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 0), edges.items.len);
+}
+
 test "issue-725: bare calls prefer the unique same-file helper" {
     const funcs = [_]codegraph.FuncInput{
         .{ .id = 0, .body = "persistLocked();", .path = "src/mergequeue.zig" },
@@ -204,6 +228,33 @@ test "issue-725: Zig Thread.spawn callback rejects malformed calls" {
     const stress_callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, stress.items);
     defer testing.allocator.free(stress_callbacks);
     try testing.expectEqual(@as(usize, 0), stress_callbacks.len);
+}
+
+test "issue-725: Zig multiline strings do not create call or callback edges" {
+    const body =
+        \\pub fn usage() void {
+        \\    const text =
+        \\        \\\\std.Thread.spawn(.{}, connection, .{});
+        \\    _ = text;
+        \\}
+    ;
+    const callbacks = try codegraph.extractZigThreadSpawnCallbacks(testing.allocator, body);
+    defer testing.allocator.free(callbacks);
+    try testing.expectEqual(@as(usize, 0), callbacks.len);
+
+    const funcs = [_]codegraph.FuncInput{
+        .{ .id = 0, .body = body, .path = "src/main.zig", .extract_zig_thread_spawn_callbacks = true },
+        .{ .id = 1, .body = "", .path = "src/main.zig" },
+    };
+    const paths = [_][]const u8{ "src/main.zig", "src/main.zig" };
+    const groups = [_]u8{ 1, 1 };
+    const connection_ids = [_]codegraph.NodeId{1};
+    var resolve = std.StringHashMap([]const codegraph.NodeId).init(testing.allocator);
+    defer resolve.deinit();
+    try resolve.put("connection", &connection_ids);
+    var edges = try codegraph.buildEdgesScoped(testing.allocator, &funcs, &resolve, &paths, &groups, false);
+    defer edges.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 0), edges.items.len);
 }
 
 test "issue-725: Zig Thread.spawn callback resolves an imported function value" {
@@ -3254,6 +3305,10 @@ test "issue-725: call graph follows an exact Zig re-export chain" {
         \\fn engineOnly() void {}
     );
 
+    // Ranking may build the fast approximate graph first; callpath must replace
+    // it with strict import-aware resolution rather than reusing stale edges.
+    explorer_inst.buildCallCentrality(testing.allocator);
+
     const imported = (try explorer_inst.findCallPath("main", "run", testing.allocator, 4)) orelse
         return error.TestExpectedEqual;
     defer testing.allocator.free(imported);
@@ -3263,6 +3318,42 @@ test "issue-725: call graph follows an exact Zig re-export chain" {
     const real_chain = try explorer_inst.findCallPath("main", "engineOnly", testing.allocator, 4);
     defer if (real_chain) |steps| testing.allocator.free(steps);
     try testing.expect(real_chain != null);
+}
+
+test "issue-725: nested Zig imports are not module re-exports" {
+    var explorer_inst = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer_inst.deinit();
+
+    try explorer_inst.indexFile("src/main.zig",
+        \\const pkg = @import("root.zig");
+        \\pub fn main() void {
+        \\    pkg.engine.run();
+        \\    pkg.decoy.run();
+        \\}
+    );
+    try explorer_inst.indexFile("src/root.zig",
+        \\pub const engine = struct {
+        \\    pub fn run() void {}
+        \\};
+        \\const Other = struct {
+        \\    const engine = @import("decoy.zig");
+        \\};
+        \\pub const decoy = struct { const hidden = @import("decoy.zig"); };
+    );
+    try explorer_inst.indexFile("src/decoy.zig",
+        \\pub fn run() void {
+        \\    decoyOnly();
+        \\}
+        \\fn decoyOnly() void {}
+    );
+
+    const real = (try explorer_inst.findCallPath("main", "run", testing.allocator, 4)) orelse
+        return error.TestExpectedEqual;
+    defer testing.allocator.free(real);
+    try testing.expectEqualStrings("src/root.zig", real[1].path);
+    const fabricated = try explorer_inst.findCallPath("main", "decoyOnly", testing.allocator, 4);
+    defer if (fabricated) |steps| testing.allocator.free(steps);
+    try testing.expect(fabricated == null);
 }
 
 test "issue-725: Zig Thread.spawn callback adds a unique same-file edge" {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2577,6 +2577,92 @@ test "issue-570: codedb_context falls back to plain words for all-lowercase task
     try testing.expect(std.mem.indexOf(u8, out.items, "ranking") != null);
 }
 
+test "issue-725: codedb_context focuses production definitions and seeds their sites" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try setTestProjectRoot(&explorer);
+
+    // The first candidate (MCP) deliberately fills src/mcp.zig's three lexical
+    // preview slots before the later `dispatch` keyword is searched. The exact
+    // task also finds more than three symbol rows, which used to disable every
+    // focused body.
+    try explorer.indexFile("src/mcp.zig",
+        \\// MCP tool registry overview
+        \\// filler
+        \\// MCP project routing notes
+        \\// filler
+        \\// MCP calls and validation notes
+        \\// filler
+        \\// filler
+        \\// filler
+        \\pub fn dispatch() void {
+        \\    const canonical_project_validation = true;
+        \\    _ = canonical_project_validation;
+        \\}
+    );
+    try explorer.indexFile("website/src/dispatch.zig",
+        \\pub fn dispatch() void {
+        \\    const website_dispatch_decoy = true;
+        \\    _ = website_dispatch_decoy;
+        \\}
+    );
+    try explorer.indexFile("src/semantic.zig",
+        \\pub fn validate() void {
+        \\    const provider_validation = true;
+        \\    _ = provider_validation;
+        \\}
+    );
+    try explorer.indexFile("bench/validate.py", "def validate():\n    return 'bench'\n");
+    try explorer.indexFile("experiments/validate.py", "def validate():\n    return 'experiment'\n");
+    try explorer.indexFile("src/test_mcp.zig",
+        \\const dispatch = @import("dispatch_fixture.zig");
+        \\test "one" { const MCP = @import("mcp.zig"); _ = MCP; }
+        \\test "two" { const MCP = @import("mcp.zig"); _ = MCP; }
+        \\test "three" { const MCP = @import("mcp.zig"); _ = MCP; }
+        \\_ = dispatch;
+    );
+    try explorer.indexFile(
+        "patches/696-mcp-list-dir.patch",
+        "PATCH_DECOY MCP dispatch validate project calls MCP dispatch validate project calls\n",
+    );
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, explorer.root_path.?, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        \\{"task":"how does MCP tool dispatch validate project paths and route calls?","semantic":"local"}
+    ,
+        .{},
+    );
+    defer parsed.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    bench_ctx.runDispatch(io, testing.allocator, .codedb_context, &parsed.value.object, &out, &store, &explorer, &agents);
+
+    const defs_start = std.mem.indexOf(u8, out.items, "## Symbol definitions") orelse return error.TestUnexpectedResult;
+    const files_start = std.mem.indexOfPos(u8, out.items, defs_start, "## Most-relevant files") orelse return error.TestUnexpectedResult;
+    const definitions = out.items[defs_start..files_start];
+    try testing.expect(std.mem.indexOf(u8, definitions, "canonical_project_validation") != null);
+    try testing.expect(std.mem.indexOf(u8, definitions, "dispatch (import)") == null);
+
+    const sites_start = std.mem.indexOfPos(u8, out.items, files_start, "## Top sites") orelse return error.TestUnexpectedResult;
+    const sites = out.items[sites_start..];
+    const canonical_pos = std.mem.indexOf(u8, sites, "canonical_project_validation") orelse return error.TestUnexpectedResult;
+    if (std.mem.indexOf(u8, sites, "website_dispatch_decoy")) |decoy_pos| {
+        try testing.expect(canonical_pos < decoy_pos);
+    }
+    if (std.mem.indexOf(u8, sites, "PATCH_DECOY")) |patch_pos| {
+        try testing.expect(canonical_pos < patch_pos);
+    }
+}
+
 test "issue-718: architecture context prefers canonical docs and entrypoints" {
     try testing.expect(mcp_mod.isArchitectureOverviewTask("overview of the project architecture and source layout"));
     try testing.expect(!mcp_mod.isArchitectureOverviewTask("fix architecturePathPriority"));

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -3860,6 +3860,19 @@ test "reindex refreshes root snapshot so no-daemon queries do not rescan" {
     // refreshed only the central cache copy, while freshness checks preferred
     // this stale root copy and forced the next no-daemon lookup to scan again.
     try tmp.dir.writeFile(io, .{ .sub_path = "project/src/main.zig", .data = "pub fn freshSymbol() void {}\n" });
+    // A central snapshot is mandatory, but the in-repo mirror is best-effort:
+    // system/CI checkouts can be readable without being writable.
+    if (builtin.os.tag != .windows) {
+        var project_z_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const project_z = try cio.bufPrintZ(&project_z_buf, "{s}", .{project_root});
+        try testing.expectEqual(@as(c_int, 0), std.c.chmod(project_z.ptr, 0o555));
+    }
+    defer if (builtin.os.tag != .windows) {
+        var project_z_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (cio.bufPrintZ(&project_z_buf, "{s}", .{project_root})) |project_z| {
+            _ = std.c.chmod(project_z.ptr, 0o755);
+        } else |_| {}
+    };
     const reindexed = try cio.runCapture(.{
         .allocator = testing.allocator,
         .argv = &.{ builtCodedbExe(), project_root, "reindex" },
@@ -4682,7 +4695,7 @@ test "issue-682: codedb_callers keeps a call after a string containing the comme
     defer out.deinit(testing.allocator);
 
     try renderCallersFixture(arena.allocator(), &.{
-        .{ "url.zig", "pub fn callerA() void {\n    fetch(\"https://x\", renderX());\n}\n" },
+        .{ "url.zig", "pub fn callerA() void {\n    fetch(\"https://x\", renderX);\n}\n" },
     }, "renderX", &out);
 
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'renderX'") != null);
@@ -4796,11 +4809,33 @@ test "issue: codedb_callers keeps a symbol used outside a string on a line that 
     defer out.deinit(testing.allocator);
 
     try renderCallersFixture(arena.allocator(), &.{
-        .{ "mixed.zig", "pub fn callerA() void {\n    foo(\"msg\", renderX());\n}\n" },
+        .{ "mixed.zig", "pub fn callerA() void {\n    foo(\"msg\", renderX);\n}\n" },
     }, "renderX", &out);
 
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'renderX'") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "mixed.zig:2") != null);
+}
+
+test "issue-725: codedb_callers keeps callback arguments and Ruby command calls" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    try renderCallersFixture(arena.allocator(), &.{
+        .{ "thread.zig", "pub fn callerA() void {\n    _ = std.Thread.spawn(.{}, callbacks.renderX, .{});\n}\n" },
+        .{ "map.js", "function callerB(items) {\n    return items.map(renderX);\n}\n" },
+        .{ "map.py", "def caller_c(items):\n    return map(renderX, items)\n" },
+        .{ "command.rb", "def caller_d(item)\n  renderX item\nend\n" },
+        .{ "not-calls.js", "function takes(renderX) {\n    const copy = renderX;\n}\n" },
+    }, "renderX", &out);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "4 call sites for 'renderX'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "thread.zig:2") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "map.js:2") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "map.py:2") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "command.rb:2") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "not-calls.js") == null);
 }
 
 test "OpenWispr: callers excludes Swift declarations, locals, and parameter labels" {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -2626,7 +2626,14 @@ test "issue-718: explain main puts the package entrypoint first" {
     var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     defer explorer.deinit();
     try setTestProjectRoot(&explorer);
-    try explorer.indexFile("experiments/probe.py", "def main():\n    return 1\n");
+    // More than codedb_symbol/explain's default cap. The old implementation
+    // selected 50 lexicographic paths first and only then boosted src/main.zig,
+    // so the entrypoint was already gone before ranking ran.
+    for (0..51) |i| {
+        const path = try std.fmt.allocPrint(testing.allocator, "experiments/probe_{d}.py", .{i});
+        defer testing.allocator.free(path);
+        try explorer.indexFile(path, "def main():\n    return 1\n");
+    }
     try explorer.indexFile("src/main.zig", "pub fn main() void {}\n");
 
     var store = Store.init(testing.allocator);
@@ -2647,8 +2654,67 @@ test "issue-718: explain main puts the package entrypoint first" {
     bench_ctx.runDispatch(io, testing.allocator, .codedb_explain, &parsed.value.object, &out, &store, &explorer, &agents);
 
     const entrypoint_pos = std.mem.indexOf(u8, out.items, "src/main.zig") orelse return error.TestUnexpectedResult;
-    const experiment_pos = std.mem.indexOf(u8, out.items, "experiments/probe.py") orelse return error.TestUnexpectedResult;
+    const experiment_pos = std.mem.indexOf(u8, out.items, "experiments/probe_0.py") orelse return error.TestUnexpectedResult;
     try testing.expect(entrypoint_pos < experiment_pos);
+    try testing.expect(std.mem.indexOf(u8, out.items, "more symbol results truncated") != null);
+
+    // The legacy CLI `find` now uses the same pre-cap navigation order and
+    // discloses that its compact collision list omitted further definitions.
+    var cli_sink: std.ArrayList(u8) = .empty;
+    defer cli_sink.deinit(testing.allocator);
+    var cli_out = out_mod.Out{ .file = cio.File.stdout(), .alloc = testing.allocator, .sink = &cli_sink };
+    const cli_args = [_][]const u8{ "codedb", ".", "find", "main" };
+    try testing.expectEqual(@as(u8, 0), query_mod.runQuery(io, testing.allocator, &explorer, &store, ".", "find", &cli_args, 3, &cli_out, sty.off));
+    cli_out.flush();
+    const cli_entrypoint_pos = std.mem.indexOf(u8, cli_sink.items, "src/main.zig") orelse return error.TestUnexpectedResult;
+    const cli_experiment_pos = std.mem.indexOf(u8, cli_sink.items, "experiments/probe_0.py") orelse return error.TestUnexpectedResult;
+    try testing.expect(cli_entrypoint_pos < cli_experiment_pos);
+    try testing.expect(std.mem.indexOf(u8, cli_sink.items, "more exact definitions truncated") != null);
+}
+
+test "issue-725: codedb_symbol preserves structural order and reports truncation" {
+    var explorer = Explorer.init(testing.allocator, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer explorer.deinit();
+    try explorer.indexFile("z.py", "def sharedName():\n    pass\n");
+    try explorer.indexFile("a.py", "def sharedName():\n    pass\n");
+    try explorer.indexFile("m.py", "def sharedName():\n    pass\n");
+
+    var store = Store.init(testing.allocator);
+    defer store.deinit();
+    var agents = AgentRegistry.init(testing.allocator);
+    defer agents.deinit();
+    _ = try agents.register("__filesystem__");
+    var bench_ctx = mcp_mod.BenchContext.init(testing.allocator, ".", Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
+    defer bench_ctx.deinit();
+
+    {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"sharedName\",\"max_results\":2}", .{});
+        defer parsed.deinit();
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(testing.allocator);
+        bench_ctx.runDispatch(io, testing.allocator, .codedb_symbol, &parsed.value.object, &out, &store, &explorer, &agents);
+        const a_pos = std.mem.indexOf(u8, out.items, "a.py") orelse return error.TestUnexpectedResult;
+        const m_pos = std.mem.indexOf(u8, out.items, "m.py") orelse return error.TestUnexpectedResult;
+        try testing.expect(a_pos < m_pos);
+        try testing.expect(std.mem.indexOf(u8, out.items, "z.py") == null);
+        try testing.expect(std.mem.indexOf(u8, out.items, "more symbol results truncated") != null);
+    }
+
+    {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"sharedName\",\"max_results\":2,\"format\":\"json\"}", .{});
+        defer parsed.deinit();
+        var out: std.ArrayList(u8) = .empty;
+        defer out.deinit(testing.allocator);
+        bench_ctx.runDispatch(io, testing.allocator, .codedb_symbol, &parsed.value.object, &out, &store, &explorer, &agents);
+        const rendered = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.items, .{});
+        defer rendered.deinit();
+        const obj = rendered.value.object;
+        try testing.expect(obj.get("meta").?.object.get("truncated").?.bool);
+        const rows = obj.get("results").?.array.items;
+        try testing.expectEqual(@as(usize, 2), rows.len);
+        try testing.expectEqualStrings("a.py", rows[0].object.get("path").?.string);
+        try testing.expectEqualStrings("m.py", rows[1].object.get("path").?.string);
+    }
 }
 
 test "issue-688: codedb_context json exposes typed provenance and preserves markdown default" {

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -3729,6 +3729,73 @@ test "reindex is public, parses with or without a root, and appears in help" {
     try testing.expect(std.mem.indexOf(u8, sink.items, "force a fresh filesystem scan") != null);
 }
 
+test "reindex refreshes root snapshot so no-daemon queries do not rescan" {
+    try buildCliForHelpTests();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "project/src");
+    try tmp.dir.createDirPath(io, ".home");
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/src/main.zig", .data = "pub fn oldSymbol() void {}\n" });
+
+    var project_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const project_len = try tmp.dir.realPathFile(io, "project", &project_buf);
+    const project_root = project_buf[0..project_len];
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home_len = try tmp.dir.realPathFile(io, ".home", &home_buf);
+    const test_home = home_buf[0..home_len];
+
+    const g_allow = EnvVarGuard.save("CODEDB_ALLOW_TEMP");
+    defer g_allow.restore();
+    const g_home = EnvVarGuard.save("HOME");
+    defer g_home.restore();
+    const g_profile = EnvVarGuard.save("USERPROFILE");
+    defer g_profile.restore();
+    const g_daemon = EnvVarGuard.save("CODEDB_NO_CLI_DAEMON");
+    defer g_daemon.restore();
+    const g_telemetry = EnvVarGuard.save("CODEDB_NO_TELEMETRY");
+    defer g_telemetry.restore();
+    cio.posixSetenv("CODEDB_ALLOW_TEMP", "1");
+    cio.posixSetenv("HOME", test_home);
+    cio.posixSetenv("USERPROFILE", test_home);
+    cio.posixSetenv("CODEDB_NO_CLI_DAEMON", "1");
+    cio.posixSetenv("CODEDB_NO_TELEMETRY", "1");
+
+    const old_snapshot = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ builtCodedbExe(), project_root, "snapshot" },
+        .max_output_bytes = 128 * 1024,
+    });
+    defer testing.allocator.free(old_snapshot.stdout);
+    defer testing.allocator.free(old_snapshot.stderr);
+    try testing.expectEqual(@as(u8, 0), old_snapshot.term.Exited);
+
+    // Leave an out-of-date in-repo snapshot behind. Before this fix reindex
+    // refreshed only the central cache copy, while freshness checks preferred
+    // this stale root copy and forced the next no-daemon lookup to scan again.
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/src/main.zig", .data = "pub fn freshSymbol() void {}\n" });
+    const reindexed = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ builtCodedbExe(), project_root, "reindex" },
+        .max_output_bytes = 128 * 1024,
+    });
+    defer testing.allocator.free(reindexed.stdout);
+    defer testing.allocator.free(reindexed.stderr);
+    try testing.expectEqual(@as(u8, 0), reindexed.term.Exited);
+
+    const warm = try cio.runCapture(.{
+        .allocator = testing.allocator,
+        .argv = &.{ builtCodedbExe(), project_root, "symbol", "freshSymbol" },
+        .max_output_bytes = 128 * 1024,
+    });
+    defer testing.allocator.free(warm.stdout);
+    defer testing.allocator.free(warm.stderr);
+    try testing.expectEqual(@as(u8, 0), warm.term.Exited);
+    try testing.expect(std.mem.indexOf(u8, warm.stdout, "loaded snapshot") != null);
+    try testing.expect(std.mem.indexOf(u8, warm.stdout, "indexed") == null);
+    try testing.expect(std.mem.indexOf(u8, warm.stdout, "freshSymbol") != null);
+}
+
 test "issue-632: codedb_read raw mode coverage — full-file byte-exact, default unchanged" {
     // Broader coverage for #632: (a) raw full-file read is byte-exact (no hash
     // header, no line-number prefix, no full-file hint); (b) the default ranged

--- a/src/test_mcp.zig
+++ b/src/test_mcp.zig
@@ -4529,7 +4529,7 @@ test "issue-682: codedb_callers keeps a call after a string containing the comme
     defer out.deinit(testing.allocator);
 
     try renderCallersFixture(arena.allocator(), &.{
-        .{ "url.zig", "pub fn callerA() void {\n    fetch(\"https://x\", renderX);\n}\n" },
+        .{ "url.zig", "pub fn callerA() void {\n    fetch(\"https://x\", renderX());\n}\n" },
     }, "renderX", &out);
 
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'renderX'") != null);
@@ -4643,9 +4643,39 @@ test "issue: codedb_callers keeps a symbol used outside a string on a line that 
     defer out.deinit(testing.allocator);
 
     try renderCallersFixture(arena.allocator(), &.{
-        .{ "mixed.zig", "pub fn callerA() void {\n    foo(\"msg\", renderX);\n}\n" },
+        .{ "mixed.zig", "pub fn callerA() void {\n    foo(\"msg\", renderX());\n}\n" },
     }, "renderX", &out);
 
     try testing.expect(std.mem.indexOf(u8, out.items, "1 call sites for 'renderX'") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "mixed.zig:2") != null);
+}
+
+test "OpenWispr: callers excludes Swift declarations, locals, and parameter labels" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    try renderCallersFixture(arena.allocator(), &.{
+        .{ "definition.swift", "func start() {}\n" },
+        .{
+            "calls.swift",
+            \\func caller(since start: Date) {
+            \\    let start = Date()
+            \\    let snapshot = start
+            \\    start()
+            \\    start?()
+            \\    start {
+            \\    }
+            \\}
+        },
+    }, "start", &out);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "3 call sites for 'start'") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:1") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:2") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:3") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:4") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:5") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "calls.swift:6") != null);
 }

--- a/src/test_parser.zig
+++ b/src/test_parser.zig
@@ -1725,8 +1725,17 @@ test "issue-392: Swift parser" {
         \\public struct Greeter {
         \\    let name: String
         \\
+        \\    public init(
+        \\        name: String
+        \\    ) {
+        \\        self.name = name
+        \\    }
+        \\
         \\    public func greet() -> String {
         \\        return "Hello, \(name)"
+        \\    }
+        \\
+        \\    deinit {
         \\    }
         \\}
         \\
@@ -1761,6 +1770,10 @@ test "issue-392: Swift parser" {
     var found_enum = false;
     var found_top_fn = false;
     var found_method = false;
+    var found_init = false;
+    var found_deinit = false;
+    var init_start: u32 = 0;
+    var init_end: u32 = 0;
     for (outline.symbols.items) |sym| {
         if (std.mem.eql(u8, sym.name, "Greeter")) found_struct = true;
         if (std.mem.eql(u8, sym.name, "HomeViewController")) found_class = true;
@@ -1768,6 +1781,12 @@ test "issue-392: Swift parser" {
         if (std.mem.eql(u8, sym.name, "LoadState")) found_enum = true;
         if (std.mem.eql(u8, sym.name, "topLevel")) found_top_fn = true;
         if (std.mem.eql(u8, sym.name, "greet")) found_method = true;
+        if (std.mem.eql(u8, sym.name, "init")) {
+            found_init = sym.kind == .method;
+            init_start = sym.line_start;
+            init_end = sym.line_end;
+        }
+        if (std.mem.eql(u8, sym.name, "deinit")) found_deinit = sym.kind == .method;
     }
     try testing.expect(found_struct);
     try testing.expect(found_class);
@@ -1775,6 +1794,14 @@ test "issue-392: Swift parser" {
     try testing.expect(found_enum);
     try testing.expect(found_top_fn);
     try testing.expect(found_method);
+    try testing.expect(found_init);
+    try testing.expect(found_deinit);
+    // Swift functions use braces too. A multiline initializer must retain its
+    // body range rather than collapsing to its declaration line.
+    try testing.expect(init_end > init_start);
+    const init_body = (try explorer.getSymbolBody("Sources/App/Greeter.swift", init_start, init_end, testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer testing.allocator.free(init_body);
+    try testing.expect(std.mem.indexOf(u8, init_body, "self.name = name") != null);
 }
 
 test "issue-532: ReScript parser" {

--- a/src/test_search.zig
+++ b/src/test_search.zig
@@ -2238,12 +2238,17 @@ test "find: symbol fast-path classifier + lookup" {
     var explorer = Explorer.init(alloc, Explorer.DEFAULT_CONTENT_CACHE_CAPACITY);
     try explorer.indexFile("src/auth.zig", "pub fn getTokenProvider() void {}\n");
     try explorer.indexFile("src/use.zig", "const getTokenProvider = @import(\"auth.zig\").getTokenProvider;\n");
+    try explorer.indexFile("experiments/probe_a.py", "def getTokenProvider():\n    return 1\n");
+    try explorer.indexFile("experiments/probe_b.py", "def getTokenProvider():\n    return 2\n");
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
-    try testing.expect(explorer.renderSymbolDefsFast("getTokenProvider", alloc, &out, 10));
-    try testing.expect(std.mem.indexOf(u8, out.items, "src/auth.zig") != null);
+    try testing.expect(explorer.renderSymbolDefsFast("getTokenProvider", alloc, &out, 2));
+    const canonical_pos = std.mem.indexOf(u8, out.items, "src/auth.zig") orelse return error.TestUnexpectedResult;
+    const probe_pos = std.mem.indexOf(u8, out.items, "experiments/probe_a.py") orelse return error.TestUnexpectedResult;
+    try testing.expect(canonical_pos < probe_pos);
     try testing.expect(std.mem.indexOf(u8, out.items, "(function)") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "more exact symbol matches truncated") != null);
 
     var miss: std.ArrayList(u8) = .empty;
     defer miss.deinit(alloc);

--- a/vendor/openpuffer/README.md
+++ b/vendor/openpuffer/README.md
@@ -52,6 +52,8 @@ Memory knobs (same as the binary):
   is int8-only and `vector()` / `vectorConst()` are empty.
 - `index.writeSlabs(path)` then `loaded.loadMmap(path)` demand-pages a snapshot
   (`MAP_PRIVATE` + heap append). `isMmapBacked()` is true after load.
+- mmap persistence is currently POSIX-only; on Windows, `writeSlabs` and
+  `loadMmap` return `error.UnsupportedPlatform` with no silent fallback.
 
 Public surface: `Hnsw`, `Options`, `SearchResult`, and vector helpers
 (`dot`, `cosineDistance`, `l2Norm`, `normalize`, `dotI8`).

--- a/vendor/openpuffer/UPSTREAM.md
+++ b/vendor/openpuffer/UPSTREAM.md
@@ -16,9 +16,9 @@ package files and MIT license.
   Zig 0.17 fix is intentionally absent because codedb vendors no server code.
 - POSIX HMLS persistence and macOS mmap coverage are synced through upstream
   [PR #31](https://github.com/justrach/openpuffer/pull/31), merged at
-  `b76cbfdafbad152a460dc956ed7482140ddacc6c`. The 1536D-only traversal prefix
-  remains disabled for codedb's 512D profile, as enforced by the upstream
-  dimension guard and recall regression.
+  `b76cbfdafbad152a460dc956ed7482140ddacc6c`. Upstream's model-specific 1536D
+  traversal prefix is disabled in this vendor because codedb accepts arbitrary
+  providers at that width; every configured dimension is traversed in full.
 - Included from upstream: `src/lib.zig`, `src/hnsw.zig`, `src/vector.zig`, `src/rss.zig`,
   `build.zig.zon`, `LICENSE`, `README.md`
 - Local adapter: `build.zig` exposes only upstream's `src/lib.zig` module and

--- a/vendor/openpuffer/UPSTREAM.md
+++ b/vendor/openpuffer/UPSTREAM.md
@@ -4,7 +4,7 @@ This directory contains only the pure-Zig in-process HNSW engine from
 [justrach/openpuffer](https://github.com/justrach/openpuffer), plus its Zig
 package files and MIT license.
 
-- Upstream revision: `90a06a713c18ec0e35a4727f013c6ac0f0551a5b`
+- Upstream revision: `b76cbfdafbad152a460dc956ed7482140ddacc6c`
 - Upstream library merge: [PR #16](https://github.com/justrach/openpuffer/pull/16)
 - The codedb adapter's 512D search profile (`ef=48`, rerank x2) comes from the
   real-repository/synthetic recall gate merged in upstream
@@ -14,7 +14,12 @@ package files and MIT license.
   [PR #30](https://github.com/justrach/openpuffer/pull/30), merged at
   `5596b785faf0c4fcf3a77f999a1d6883789ae454`. The accompanying server-only
   Zig 0.17 fix is intentionally absent because codedb vendors no server code.
-- Included from upstream: `src/lib.zig`, `src/hnsw.zig`, `src/vector.zig`,
+- POSIX HMLS persistence and macOS mmap coverage are synced through upstream
+  [PR #31](https://github.com/justrach/openpuffer/pull/31), merged at
+  `b76cbfdafbad152a460dc956ed7482140ddacc6c`. The 1536D-only traversal prefix
+  remains disabled for codedb's 512D profile, as enforced by the upstream
+  dimension guard and recall regression.
+- Included from upstream: `src/lib.zig`, `src/hnsw.zig`, `src/vector.zig`, `src/rss.zig`,
   `build.zig.zon`, `LICENSE`, `README.md`
 - Local adapter: `build.zig` exposes only upstream's `src/lib.zig` module and
   runs the included library/HNSW/vector tests; the omitted executable/server

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -19,8 +19,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const vecmath = @import("vector.zig");
+const rss = @import("rss.zig");
 const posix = std.posix;
-const linux = std.os.linux;
 
 /// Persist envelope magic ('OPSN' le). Duplicated so this file does not
 /// import persist.zig (persist already imports hnsw).
@@ -506,7 +506,9 @@ pub fn Hnsw(comptime D: type) type {
                     std.atomic.spinLoopHint();
                     continue;
                 }
-                const approx = @as(f64, @floatFromInt(vecmath.dotI8(qq, self.qvecConst(id)))) *
+                const stored = self.qvecConst(id);
+                const n = @min(qq.len, stored.len);
+                const approx = @as(f64, @floatFromInt(vecmath.dotI8(qq[0..n], stored[0..n]))) *
                     qs * self.qscaleOf(id);
                 const g2 = @atomicLoad(u32, &self.vec_gen.items[id], .acquire);
                 if (g1 == g2) return @max(0.0, 1.0 - @as(f32, @floatCast(approx)));
@@ -525,10 +527,19 @@ pub fn Hnsw(comptime D: type) type {
             s: *const Self,
             qq: []const i8,
             qs: f32,
+            n: usize,
             pub inline fn dist(d: @This(), id: u32) f32 {
-                return d.s.distQ(d.qq, d.qs, id);
+                const n = @min(d.n, d.qq.len);
+                return d.s.distQ(d.qq[0..n], d.qs, id);
             }
         };
+
+        /// The E037 shortcut was measured only for the fixed 1536-d engine
+        /// profile. Other dimensions must keep their full traversal vector;
+        /// applying it to codedb's 512-d profile reduced recall@24 to 0.7549.
+        fn searchPrefix(self: *const Self) usize {
+            return if (self.dim == 1536) 1408 else self.dim;
+        }
 
         fn markVisited(visited: *std.DynamicBitSetUnmanaged, alloc: std.mem.Allocator, id: u32) !void {
             if (id >= visited.capacity()) {
@@ -596,6 +607,13 @@ pub fn Hnsw(comptime D: type) type {
                 // concurrently supplied/in-memory graph. Untrusted sidecars
                 // must never turn an invariant violation into a process panic.
                 if (layer >= self.layerCount(c.id)) return error.InvalidNeighborLayer;
+                if (candidates.count() > 0) {
+                    @prefetch(self.neighborSlotsConst(candidates.peek().?.id, layer).ptr, .{
+                        .rw = .read,
+                        .locality = 3,
+                        .cache = .data,
+                    });
+                }
                 var nbr_buf: [64]u32 = undefined;
                 const nbrs = self.snapshotNeighbors(c.id, layer, &nbr_buf);
                 for (nbrs, 0..) |nid, ni| {
@@ -777,7 +795,7 @@ pub fn Hnsw(comptime D: type) type {
 
             var visited = try std.DynamicBitSetUnmanaged.initEmpty(scratch, self.len() + 2048);
             defer visited.deinit(scratch);
-            const qctx = QDist{ .s = self, .qq = q.q8, .qs = q.scale };
+            const qctx = QDist{ .s = self, .qq = q.q8, .qs = q.scale, .n = q.q8.len };
             const ep_id = self.entryPoint().?;
             var ep: [1]Candidate = .{.{ .id = ep_id, .d = qctx.dist(ep_id) }};
             var cur = self.getMaxLevel();
@@ -962,7 +980,7 @@ pub fn Hnsw(comptime D: type) type {
                 }
                 break :blk buf;
             };
-            const ctx = QDist{ .s = self, .qq = qq, .qs = qs };
+            const ctx = QDist{ .s = self, .qq = qq, .qs = qs, .n = self.searchPrefix() };
 
             var visited = try std.DynamicBitSetUnmanaged.initEmpty(alloc, self.len() + 2048);
             defer visited.deinit(alloc);
@@ -2019,6 +2037,20 @@ pub fn Hnsw(comptime D: type) type {
     };
 }
 
+test "search prefix is restricted to its measured 1536-d profile" {
+    const Index = Hnsw(void);
+    var codedb = Index.init(std.testing.allocator, 512, .{});
+    defer codedb.deinit();
+    var embedding = Index.init(std.testing.allocator, 768, .{});
+    defer embedding.deinit();
+    var engine = Index.init(std.testing.allocator, 1536, .{});
+    defer engine.deinit();
+
+    try std.testing.expectEqual(@as(usize, 512), codedb.searchPrefix());
+    try std.testing.expectEqual(@as(usize, 768), embedding.searchPrefix());
+    try std.testing.expectEqual(@as(usize, 1408), engine.searchPrefix());
+}
+
 test "hnsw finds planted neighbor" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -2302,23 +2334,11 @@ test "hnsw store_f32=false serialize/load and update" {
 }
 
 fn rssKiBSelf() ?u64 {
-    const fd = posix.openat(posix.AT.FDCWD, "/proc/self/status", .{ .ACCMODE = .RDONLY }, 0) catch return null;
-    defer _ = linux.close(fd);
-    var buf: [4096]u8 = undefined;
-    const n = linux.read(fd, &buf, buf.len);
-    if (posix.errno(n) != .SUCCESS) return null;
-    const text = buf[0..n];
-    const key = "VmRSS:";
-    const idx = std.mem.indexOf(u8, text, key) orelse return null;
-    var rest = text[idx + key.len ..];
-    while (rest.len > 0 and (rest[0] == ' ' or rest[0] == '\t')) rest = rest[1..];
-    var end: usize = 0;
-    while (end < rest.len and rest[end] >= '0' and rest[end] <= '9') end += 1;
-    return std.fmt.parseInt(u64, rest[0..end], 10) catch null;
+    return rss.currentKiB();
 }
 
 test "hnsw slab mmap reopen + insert append buffer" {
-    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const alloc = arena_state.allocator();
@@ -2338,7 +2358,10 @@ test "hnsw slab mmap reopen + insert append buffer" {
     const planted = try index.insert(&v);
     const before = try index.search(&v, 5, 64, alloc);
 
-    const path = "/tmp/openpuffer-mmap-roundtrip.slabs";
+    var path_buf: [160]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "/tmp/openpuffer-mmap-roundtrip-{x}.slabs", .{
+        @intFromPtr(&path_buf),
+    });
     try index.writeSlabs(path);
 
     var loaded = Hnsw(void).init(alloc, dim, .{});
@@ -2386,8 +2409,9 @@ test "hnsw slab mmap reopen + insert append buffer" {
 }
 
 test "slab mmap vs alloc RSS (blank slabs)" {
-    if (builtin.os.tag != .linux) return error.SkipZigTest;
-    const scale = builtin.mode != .debug;
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const mode_name = @tagName(builtin.mode);
+    const scale = !(std.mem.eql(u8, mode_name, "Debug") or std.mem.eql(u8, mode_name, "debug"));
     const cases = [_]struct { n: usize, dim: usize }{
         .{ .n = if (scale) 20_000 else 256, .dim = if (scale) 1536 else 64 },
         .{ .n = if (scale) 200_000 else 0, .dim = 1536 },
@@ -2396,7 +2420,10 @@ test "slab mmap vs alloc RSS (blank slabs)" {
     for (cases) |c| {
         if (c.n == 0) continue;
         var path_buf: [128]u8 = undefined;
-        const path = try std.fmt.bufPrint(&path_buf, "/tmp/openpuffer-mmap-rss-{d}.slabs", .{c.n});
+        const path = try std.fmt.bufPrint(&path_buf, "/tmp/openpuffer-mmap-rss-{d}-{x}.slabs", .{
+            c.n,
+            @intFromPtr(&path_buf),
+        });
         try Hnsw(void).writeBlankSlabs(path, c.n, c.dim, .{});
 
         const baseline = rssKiBSelf() orelse 0;

--- a/vendor/openpuffer/src/hnsw.zig
+++ b/vendor/openpuffer/src/hnsw.zig
@@ -534,11 +534,12 @@ pub fn Hnsw(comptime D: type) type {
             }
         };
 
-        /// The E037 shortcut was measured only for the fixed 1536-d engine
-        /// profile. Other dimensions must keep their full traversal vector;
-        /// applying it to codedb's 512-d profile reduced recall@24 to 0.7549.
+        /// CodeDB accepts arbitrary embedding providers, so dimension alone
+        /// cannot identify the 1536D distribution used to validate upstream's
+        /// E037 prefix shortcut. Traverse every configured dimension here;
+        /// reranking cannot recover a true neighbor excluded during traversal.
         fn searchPrefix(self: *const Self) usize {
-            return if (self.dim == 1536) 1408 else self.dim;
+            return self.dim;
         }
 
         fn markVisited(visited: *std.DynamicBitSetUnmanaged, alloc: std.mem.Allocator, id: u32) !void {
@@ -2037,7 +2038,7 @@ pub fn Hnsw(comptime D: type) type {
     };
 }
 
-test "search prefix is restricted to its measured 1536-d profile" {
+test "codedb vendor traverses the full width for every embedding provider" {
     const Index = Hnsw(void);
     var codedb = Index.init(std.testing.allocator, 512, .{});
     defer codedb.deinit();
@@ -2048,7 +2049,7 @@ test "search prefix is restricted to its measured 1536-d profile" {
 
     try std.testing.expectEqual(@as(usize, 512), codedb.searchPrefix());
     try std.testing.expectEqual(@as(usize, 768), embedding.searchPrefix());
-    try std.testing.expectEqual(@as(usize, 1408), engine.searchPrefix());
+    try std.testing.expectEqual(@as(usize, 1536), engine.searchPrefix());
 }
 
 test "hnsw finds planted neighbor" {

--- a/vendor/openpuffer/src/rss.zig
+++ b/vendor/openpuffer/src/rss.zig
@@ -1,0 +1,121 @@
+//! Current and peak resident set size.
+//!
+//! Linux: `/proc/self/status` `VmRSS` (current) and `VmHWM` (peak), in KiB.
+//! macOS: `mach_task_basic_info` `resident_size` / `resident_size_max`, in bytes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Sample = struct {
+    current_kib: u64,
+    peak_kib: ?u64 = null,
+};
+
+pub fn sampleSelf() ?Sample {
+    if (builtin.os.tag == .linux) return linuxSelf();
+    if (builtin.os.tag == .macos) return darwinSelf();
+    return null;
+}
+
+pub fn currentKiB() ?u64 {
+    const sample = sampleSelf() orelse return null;
+    return sample.current_kib;
+}
+
+pub fn currentMiB() ?u64 {
+    const kib = currentKiB() orelse return null;
+    return kib / 1024;
+}
+
+pub fn peakMiB() ?u64 {
+    const sample = sampleSelf() orelse return null;
+    const kib = sample.peak_kib orelse return null;
+    return kib / 1024;
+}
+
+pub fn parseLinuxStatus(text: []const u8) ?Sample {
+    const current = parseStatusKiB(text, "VmRSS:") orelse return null;
+    return .{
+        .current_kib = current,
+        .peak_kib = parseStatusKiB(text, "VmHWM:"),
+    };
+}
+
+pub fn parseStatusKiB(text: []const u8, key: []const u8) ?u64 {
+    const idx = std.mem.indexOf(u8, text, key) orelse return null;
+    var rest = text[idx + key.len ..];
+    while (rest.len > 0 and (rest[0] == ' ' or rest[0] == '\t')) rest = rest[1..];
+    var end: usize = 0;
+    while (end < rest.len and rest[end] >= '0' and rest[end] <= '9') end += 1;
+    if (end == 0) return null;
+    return std.fmt.parseInt(u64, rest[0..end], 10) catch null;
+}
+
+fn linuxSelf() ?Sample {
+    const posix = std.posix;
+    const linux = std.os.linux;
+    const fd = posix.openat(posix.AT.FDCWD, "/proc/self/status", .{ .ACCMODE = .RDONLY }, 0) catch return null;
+    defer _ = linux.close(fd);
+    var buf: [4096]u8 = undefined;
+    const n = linux.read(fd, &buf, buf.len);
+    if (posix.errno(n) != .SUCCESS) return null;
+    return parseLinuxStatus(buf[0..n]);
+}
+
+const mach = if (builtin.os.tag == .macos) struct {
+    const MACH_TASK_BASIC_INFO: c_int = 20;
+    const Info = extern struct {
+        virtual_size: u64,
+        resident_size: u64,
+        resident_size_max: u64,
+        user_seconds: i32,
+        user_microseconds: i32,
+        system_seconds: i32,
+        system_microseconds: i32,
+        policy: i32,
+        suspend_count: i32,
+    };
+    extern "c" fn mach_task_self() u32;
+    extern "c" fn task_info(task: u32, flavor: c_int, info: *anyopaque, count: *u32) c_int;
+} else struct {};
+
+fn darwinSelf() ?Sample {
+    if (comptime builtin.os.tag != .macos) return null;
+    var info: mach.Info = std.mem.zeroes(mach.Info);
+    var count: u32 = @intCast(@sizeOf(mach.Info) / @sizeOf(u32));
+    const result = mach.task_info(mach.mach_task_self(), mach.MACH_TASK_BASIC_INFO, @ptrCast(&info), &count);
+    if (result != 0) return null;
+    return .{
+        .current_kib = info.resident_size / 1024,
+        .peak_kib = info.resident_size_max / 1024,
+    };
+}
+
+test "parseLinuxStatus reads VmRSS and VmHWM" {
+    const fixture =
+        "Name: openpuffer\n" ++
+        "VmPeak:   512000 kB\n" ++
+        "VmSize:   500000 kB\n" ++
+        "VmHWM:   300000 kB\n" ++
+        "VmRSS:   291432 kB\n";
+    const sample = parseLinuxStatus(fixture) orelse return error.ParseFailed;
+    try std.testing.expectEqual(@as(u64, 291432), sample.current_kib);
+    try std.testing.expectEqual(@as(u64, 300000), sample.peak_kib.?);
+    try std.testing.expectEqual(@as(u64, 284), sample.current_kib / 1024);
+}
+
+test "parseLinuxStatus requires VmRSS" {
+    try std.testing.expect(parseLinuxStatus("VmHWM:\t10 kB\n") == null);
+    try std.testing.expect(parseStatusKiB("VmRSS:\n", "VmRSS:") == null);
+}
+
+test "self sample is numeric on supported hosts" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const sample = sampleSelf() orelse return error.RssUnavailable;
+    try std.testing.expect(sample.current_kib > 0);
+}
+
+test "MiB conversion is floor(kib/1024)" {
+    try std.testing.expectEqual(@as(u64, 0), @as(u64, 1023) / 1024);
+    try std.testing.expectEqual(@as(u64, 1), @as(u64, 1024) / 1024);
+}


### PR DESCRIPTION
## Summary

- make common-name navigation deterministic before truncation, with explicit path scoping and honest ambiguity instead of arbitrary callpaths
- resolve exact same-file, imported receiver, Zig thread-callback, and nested Zig re-export edges without repository-wide guessing
- preserve full Swift function bodies and filter caller results to real invocation syntax
- make `reindex` atomically persist root and central snapshots so the next no-daemon query loads instead of rescanning
- focus `codedb_context` on production definitions before imports/tests/generated collisions
- update the vendored OpenPuffer backend through upstream PR #31 while retaining CodeDB's malformed-sidecar hardening and full-width recall
- version the warm CLI proxy handshake so a newly installed binary replaces a stale daemon instead of silently serving old retrieval behavior

Fixes #725.

## Validation

- `zig build test --summary all` — 31/31 build steps; 1,454 passed, 4 skipped
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/tmp/codedb-fix-name-resolution-725` — 76/76
- `python3 scripts/fd_regression_test.py --binary zig-out/bin/codedb` — 45 descriptors at both 128 and 2,048 files (bounded, corpus-size independent)
- ReleaseFast build succeeded
- Zigrepper (945 files): `main` resolves exactly to `zigrep/src/exec/search_engine.zig:run`; warm snapshot load verified
- OpenWispr (125 files): `toggleDictation` resolves directly to `beginDictation`; Swift bodies restored; `start` caller false positives reduced
- CodeDB (660 files): production `src/main.zig:main` ranks first; scoped MCP/watcher callpaths resolve correctly; `.env*` and `*.pem` return no matches

No version bump, tag, or release is included in this PR.
