### PR TITLE
release: codedb 0.2.5848

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.2.5848 - 2026-08-28
+
+- **Production-measured semantic indexing concurrency is release-locked.**
+  Managed indexing continues to send at most 25 chunks per request with four
+  concurrent batches (100 chunks per wave). A release-gating regression test
+  now prevents the default from drifting to the supported eight-batch ceiling:
+  on the 256-chunk hosted-lane hill climb, four completed in 6.1 seconds while
+  eight regressed to 16.7 seconds from queue and network contention. Custom
+  endpoints can still opt into a different value with
+  `CODEDB_SEMANTIC_INDEX_CONCURRENCY`.
+
 ## 0.2.5847 - 2026-08-28
 
 - **Managed semantic implementation stays behind the interface.** Context

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5847",
+    .version = "0.2.5848",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5847",
+  "version": "0.2.5848",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5847";
+pub const semver = "0.2.5848";

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -1401,6 +1401,14 @@ test "semantic ANN replacement removes only the previously referenced slab" {
 }
 
 test "semantic ANN wave uses the public 25-item batch boundary" {
+    // This is the hosted-lane Pareto point measured against the production
+    // TurboAPI/TEI queue. Raising the default to the supported maximum of 8
+    // regressed the 256-chunk end-to-end run from 6.1s to 16.7s. Keep the
+    // override for custom endpoints, but make an accidental default drift a
+    // release-gating test failure.
+    try std.testing.expectEqual(@as(usize, 4), default_parallel_batches);
+    try std.testing.expectEqual(@as(usize, 25), semantic.max_index_documents);
+    try std.testing.expectEqual(@as(usize, 100), default_parallel_batches * semantic.max_index_documents);
     try std.testing.expectEqual(@as(usize, 1), embeddingBatchCount(semantic.max_index_documents));
     try std.testing.expectEqual(@as(usize, 2), embeddingBatchCount(semantic.max_index_documents + 1));
     try std.testing.expectEqual(


### PR DESCRIPTION
## Release 0.2.5848

- keep managed semantic indexing at the production-measured 25 × 4 Pareto point
- add a release-gating assertion for the 100-chunk request wave
- preserve the 1–8 concurrency override for custom embedding endpoints

This release intentionally does not include the experimental float16 response protocol.

## Gates

- pinned Zig 0.17 unit suite: 31/31 build steps
- MCP E2E: 76/76
- GitHub macOS resource regression: passed
- GitHub paired counterbalanced benchmark and parity gate: passed

Feature PR: #728
