### PR TITLE
release: CodeDB 0.2.5849

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.2.5849 - 2026-08-28
+
+- **Compact hosted embedding transport.** The managed endpoint now negotiates
+  base64-encoded little-endian float16 vectors, cutting the measured 25×512
+  response from 172 KB to 36 KB raw and from 62 KB to 26 KB compressed. The
+  client validates encoding, byte length, row indices, dimensions, model
+  identity, and finite values before use. Custom endpoints and older managed
+  deployments retain ordinary JSON-float compatibility, including one bounded
+  fallback request with a freshly signed proof.
+
 ## 0.2.5848 - 2026-08-28
 
 - **Production-measured semantic indexing concurrency is release-locked.**

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5848",
+    .version = "0.2.5849",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5848",
+  "version": "0.2.5849",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5848";
+pub const semver = "0.2.5849";


### PR DESCRIPTION
## Release
- negotiate compact base64 little-endian float16 vectors for the managed embedding lane
- retain JSON-float compatibility for custom endpoints and older managed deployments
- strictly validate response encoding, dimensions, indices, model, and finite values

## Validation
- feature PR #730 is merged and its benchmark/resource matrix is green
- `zig build test`
- ReleaseFast build reports `codedb 0.2.5849`
- MCP E2E: 76/76
- live authenticated hybrid request succeeded against the deployed production origin and edge