### PR TITLE
release: v0.2.5850 concurrent warm queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.2.5850 - 2026-08-29
+
+- **Concurrent warm CLI queries for multi-agent workloads.** On macOS and Linux,
+  each project's warm daemon now dispatches up to eight read-only CLI queries
+  concurrently instead of serializing every terminal and agent behind one
+  connection. Daemon handoff stops new admissions and drains accepted work
+  before releasing shared index state. Eight concurrent hybrid context calls
+  completed in 2.69 seconds instead of 6.44 seconds in the release benchmark,
+  a 58% wall-time reduction with unchanged result parity. No configuration or
+  API-key setup is required; hybrid retrieval, device-bound authentication, and
+  the compact managed transport remain the defaults. Windows keeps its existing
+  sequential named-pipe dispatcher pending an equivalent safe handoff design.
+
 ## 0.2.5849 - 2026-08-28
 
 - **Compact hosted embedding transport.** The managed endpoint now negotiates

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5849",
+    .version = "0.2.5850",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/releases/0.2.5850.md
+++ b/docs/releases/0.2.5850.md
@@ -1,0 +1,76 @@
+# CodeDB 0.2.5850
+
+CodeDB 0.2.5850 removes a serialization bottleneck in the warm per-project CLI
+daemon. Multiple terminals and coding agents can now run queries against the
+same live index concurrently without additional setup.
+
+## What changed
+
+- The macOS and Linux Unix-socket dispatcher accepts up to eight concurrent
+  read-only queries per project daemon.
+- The limit is fixed and bounded: it allows useful overlap with the managed
+  semantic lane without creating an unbounded local connection or thread surge.
+- A version handoff or daemon-yield request stops new admissions, wakes the
+  blocking listener, and drains all accepted queries before the daemon releases
+  its `Explorer`, `Store`, and project-root state.
+- Allocation used by detached workers is thread-safe and isolated from the
+  daemon caller's allocator.
+- The Windows named-pipe dispatcher remains sequential for this release. It will
+  only become concurrent after it has the same bounded ownership and handoff
+  guarantees as the POSIX path.
+
+The public CLI and MCP interfaces are unchanged. Existing clients get the new
+behavior as soon as the updated daemon replaces the old one.
+
+## Performance
+
+The release candidate was compared with the previous implementation using eight
+simultaneous hybrid `context` calls against the same warm project:
+
+| Metric | Before | 0.2.5850 | Change |
+| --- | ---: | ---: | ---: |
+| Batch wall time | 6.44 s | 2.69 s | 58% faster |
+| Median request latency | 3.30 s | 2.18 s | 34% faster |
+| Slowest request | 6.43 s | 2.68 s | 58% faster |
+| Successful requests | 8/8 | 8/8 | unchanged |
+
+A local-only eight-query run completed in about 302 ms with all eight requests
+successful. The paired benchmark gate found no gating regression: corpus parity
+and provenance both passed, and the measured `codedb_context` delta remained
+below the regression threshold.
+
+The managed embedding service already performs bounded request merging and GPU
+dynamic batching, so this release does not add Cloudflare Queues or KV to the
+request path. In a separate 32-request load test, 800 embeddings completed with
+100% success in 161.6 ms (about 4,951 inputs/s); adding another remote queue
+would increase latency without addressing the local serialization bottleneck
+fixed here.
+
+## Out-of-box behavior
+
+No endpoint, token, or tuning variable is required:
+
+- Hybrid retrieval remains the default; `semantic=local`, `--local`, or
+  `--no-semantic` remains the explicit local-only opt-out.
+- Managed access continues to use automatic device-bound enrollment and signed
+  requests. Explicit bearer tokens are only for custom endpoints.
+- Compact float16 transport remains negotiated automatically with safe JSON
+  compatibility for custom or older endpoints.
+- Sensitive paths remain excluded, and managed-lane failure still falls back to
+  local retrieval rather than a CPU embedding model.
+
+## Verification and distribution
+
+The release was gated by the complete Zig unit suite, all 76 MCP end-to-end
+scenarios, the macOS resource regression, and the paired benchmark/parity check.
+Release binaries are produced for macOS Apple Silicon and Intel, Linux arm64 and
+x86_64, and Windows x86_64. Both macOS binaries are Developer ID signed with the
+hardened runtime and submitted to Apple's notarization service before upload.
+Published SHA-256 checksums cover the exact downloadable bytes.
+
+Install or update with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/justrach/codedb/main/install/install.sh | sh
+codedb update
+```

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5849",
+  "version": "0.2.5850",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -886,7 +886,11 @@ fn cliWorkerWaitForIdle(active: *std.atomic.Value(u8)) void {
 fn cliServePosixQuery(job: *CliPosixQueryJob) void {
     // c_allocator is thread-safe and avoids sharing a caller-owned test arena
     // across detached workers.
-    defer cliWorkerSlotRelease(job.active_queries);
+    // Capture the counter before destroying `job`: defers run in reverse order,
+    // so the allocation is freed first and the final slot release must not
+    // dereference that freed record.
+    const active_queries = job.active_queries;
+    defer cliWorkerSlotRelease(active_queries);
     defer std.heap.c_allocator.destroy(job);
 
     const retire = cliServeConn(job.io, std.heap.c_allocator, job.explorer, job.store, job.abs_root, job.conn);

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5849";
+pub const semver = "0.2.5850";


### PR DESCRIPTION
## Summary
- bump CodeDB and codedeebee to 0.2.5850
- document the bounded eight-way POSIX warm-query dispatcher and measured multi-agent improvement
- fix the optimized detached-worker cleanup ordering found by the release E2E gate
- preserve zero-touch hybrid defaults and document the Windows boundary

## Validation
- zig build test --summary all: 263 passed, 4 skipped
- optimized issue-690 live-refresh scenario: 5/5 consecutive passes
- optimized MCP E2E: 76/76 passed
- default hybrid smoke: 8 concurrent requests, 8/8 successful, with endpoint/token overrides removed
- npm pack --dry-run: codedeebee@0.2.5850
- git diff --check and release-file formatting checks passed