### PR TITLE
release: v0.2.5850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.2.5850 - 2026-08-29
+
+- **Concurrent warm CLI queries for multi-agent workloads.** On macOS and Linux,
+  each project's warm daemon now dispatches up to eight read-only CLI queries
+  concurrently instead of serializing every terminal and agent behind one
+  connection. Daemon handoff stops new admissions and drains accepted work
+  before releasing shared index state. Eight concurrent hybrid context calls
+  completed in 2.69 seconds instead of 6.44 seconds in the release benchmark,
+  a 58% wall-time reduction with unchanged result parity. No configuration or
+  API-key setup is required; hybrid retrieval, device-bound authentication, and
+  the compact managed transport remain the defaults. Windows keeps its existing
+  sequential named-pipe dispatcher pending an equivalent safe handoff design.
+
 ## 0.2.5849 - 2026-08-28
 
 - **Compact hosted embedding transport.** The managed endpoint now negotiates

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5849",
+    .version = "0.2.5850",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/releases/0.2.5850.md
+++ b/docs/releases/0.2.5850.md
@@ -1,0 +1,76 @@
+# CodeDB 0.2.5850
+
+CodeDB 0.2.5850 removes a serialization bottleneck in the warm per-project CLI
+daemon. Multiple terminals and coding agents can now run queries against the
+same live index concurrently without additional setup.
+
+## What changed
+
+- The macOS and Linux Unix-socket dispatcher accepts up to eight concurrent
+  read-only queries per project daemon.
+- The limit is fixed and bounded: it allows useful overlap with the managed
+  semantic lane without creating an unbounded local connection or thread surge.
+- A version handoff or daemon-yield request stops new admissions, wakes the
+  blocking listener, and drains all accepted queries before the daemon releases
+  its `Explorer`, `Store`, and project-root state.
+- Allocation used by detached workers is thread-safe and isolated from the
+  daemon caller's allocator.
+- The Windows named-pipe dispatcher remains sequential for this release. It will
+  only become concurrent after it has the same bounded ownership and handoff
+  guarantees as the POSIX path.
+
+The public CLI and MCP interfaces are unchanged. Existing clients get the new
+behavior as soon as the updated daemon replaces the old one.
+
+## Performance
+
+The release candidate was compared with the previous implementation using eight
+simultaneous hybrid `context` calls against the same warm project:
+
+| Metric | Before | 0.2.5850 | Change |
+| --- | ---: | ---: | ---: |
+| Batch wall time | 6.44 s | 2.69 s | 58% faster |
+| Median request latency | 3.30 s | 2.18 s | 34% faster |
+| Slowest request | 6.43 s | 2.68 s | 58% faster |
+| Successful requests | 8/8 | 8/8 | unchanged |
+
+A local-only eight-query run completed in about 302 ms with all eight requests
+successful. The paired benchmark gate found no gating regression: corpus parity
+and provenance both passed, and the measured `codedb_context` delta remained
+below the regression threshold.
+
+The managed embedding service already performs bounded request merging and GPU
+dynamic batching, so this release does not add Cloudflare Queues or KV to the
+request path. In a separate 32-request load test, 800 embeddings completed with
+100% success in 161.6 ms (about 4,951 inputs/s); adding another remote queue
+would increase latency without addressing the local serialization bottleneck
+fixed here.
+
+## Out-of-box behavior
+
+No endpoint, token, or tuning variable is required:
+
+- Hybrid retrieval remains the default; `semantic=local`, `--local`, or
+  `--no-semantic` remains the explicit local-only opt-out.
+- Managed access continues to use automatic device-bound enrollment and signed
+  requests. Explicit bearer tokens are only for custom endpoints.
+- Compact float16 transport remains negotiated automatically with safe JSON
+  compatibility for custom or older endpoints.
+- Sensitive paths remain excluded, and managed-lane failure still falls back to
+  local retrieval rather than a CPU embedding model.
+
+## Verification and distribution
+
+The release was gated by the complete Zig unit suite, all 76 MCP end-to-end
+scenarios, the macOS resource regression, and the paired benchmark/parity check.
+Release binaries are produced for macOS Apple Silicon and Intel, Linux arm64 and
+x86_64, and Windows x86_64. Both macOS binaries are Developer ID signed with the
+hardened runtime and submitted to Apple's notarization service before upload.
+Published SHA-256 checksums cover the exact downloadable bytes.
+
+Install or update with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/justrach/codedb/main/install/install.sh | sh
+codedb update
+```

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5849",
+  "version": "0.2.5850",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -886,7 +886,11 @@ fn cliWorkerWaitForIdle(active: *std.atomic.Value(u8)) void {
 fn cliServePosixQuery(job: *CliPosixQueryJob) void {
     // c_allocator is thread-safe and avoids sharing a caller-owned test arena
     // across detached workers.
-    defer cliWorkerSlotRelease(job.active_queries);
+    // Capture the counter before destroying `job`: defers run in reverse order,
+    // so the allocation is freed first and the final slot release must not
+    // dereference that freed record.
+    const active_queries = job.active_queries;
+    defer cliWorkerSlotRelease(active_queries);
     defer std.heap.c_allocator.destroy(job);
 
     const retire = cliServeConn(job.io, std.heap.c_allocator, job.explorer, job.store, job.abs_root, job.conn);

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -35,6 +35,10 @@ const cliIsQueryCmd = cli_args.cliIsQueryCmd;
 //   response (daemon→client): [u8 exit_code][u32 out_len][out_bytes]
 const cli_blob_max: u32 = 64 * 1024;
 const cli_response_max: u32 = 16 * 1024 * 1024;
+/// A warm project daemon is shared by every terminal and agent using that
+/// project. Keep enough read-only queries in flight to match the hosted
+/// embedding lane without allowing an unbounded local connection stampede.
+const cli_max_concurrent_queries: u8 = 8;
 
 fn cliResponseLenAllowed(out_len: u32) bool {
     return out_len <= cli_response_max;
@@ -628,9 +632,12 @@ pub fn cliAcquireListener(sock_path: []const u8, retry: bool, retry_interval_ms:
 
 /// Daemon side. Bind a per-project Unix socket and serve framed query requests
 /// against the warm `explorer`/`store`. Runs on its own detached thread so it
-/// never blocks the daemon's primary loop. Connections are handled sequentially
-/// (CLI calls are infrequent and runQuery already tolerates concurrent reads
-/// from the watcher).
+/// never blocks the daemon's primary loop. POSIX query connections are handled
+/// concurrently with a small fixed cap; a handoff frame wakes the listener and
+/// drains already-accepted work before the daemon retires. `runQuery` already
+/// tolerates concurrent reads from watcher refreshes. Windows keeps the existing
+/// sequential named-pipe path until it has an equivalent bounded ownership
+/// handoff implementation.
 ///
 /// `last_activity_ms` is bumped to the current ms timestamp at the start of
 /// every accepted connection so a time-based idle watchdog (cli-daemon) can
@@ -784,27 +791,129 @@ fn cliDaemonListenPosix(io: std.Io, allocator: std.mem.Allocator, explorer: *Exp
 
     std.log.info("cli-proxy: listening on {s}", .{sock_path});
 
-    while (true) {
+    var active_queries = std.atomic.Value(u8).init(0);
+    var retire_requested = std.atomic.Value(bool).init(false);
+
+    while (!retire_requested.load(.acquire)) {
         const conn = std.c.accept(listenfd, null, null);
         if (conn < 0) {
             if (std.c.errno(conn) == .INTR) continue;
+            if (retire_requested.load(.acquire)) break;
             // Listener went bad; stop the loop (daemon still serves its main API).
-            return;
+            break;
         }
         // Record activity for the cli-daemon idle watchdog before serving.
         last_activity_ms.store(cio.milliTimestamp(), .release);
-        const yield_requested = cliServeConn(io, allocator, explorer, store, abs_root, conn);
-        _ = std.c.close(conn);
-        if (yield_requested) {
-            // #619 handover: give the socket up right away. The `defer`
-            // above closes the listener and unlinks the path so the
-            // requesting daemon's next bind attempt succeeds; `shutdown` is
-            // set so any caller watching it (e.g. the cli-daemon idle
-            // watchdog) treats this exactly like a lost bind race.
-            shutdown.store(true, .release);
-            return;
+
+        if (!cliWorkerSlotAcquire(&active_queries, &retire_requested, shutdown)) {
+            _ = std.c.close(conn);
+            break;
+        }
+        const job = std.heap.c_allocator.create(CliPosixQueryJob) catch {
+            cliWorkerSlotRelease(&active_queries);
+            const retire = cliServeConn(io, allocator, explorer, store, abs_root, conn);
+            _ = std.c.close(conn);
+            if (retire) retire_requested.store(true, .release);
+            continue;
+        };
+        job.* = .{
+            .io = io,
+            .explorer = explorer,
+            .store = store,
+            .abs_root = abs_root,
+            .conn = conn,
+            .listenfd = listenfd,
+            .active_queries = &active_queries,
+            .retire_requested = &retire_requested,
+        };
+        const worker = std.Thread.spawn(.{}, cliServePosixQuery, .{job}) catch {
+            std.heap.c_allocator.destroy(job);
+            cliWorkerSlotRelease(&active_queries);
+            const retire = cliServeConn(io, allocator, explorer, store, abs_root, conn);
+            _ = std.c.close(conn);
+            if (retire) retire_requested.store(true, .release);
+            continue;
+        };
+        worker.detach();
+
+        if (retire_requested.load(.acquire)) {
+            break;
         }
     }
+
+    // The daemon owns Explorer/Store and abs_root. Do not let their lifetime
+    // end while a detached query still reads them.
+    cliWorkerWaitForIdle(&active_queries);
+    if (retire_requested.load(.acquire)) {
+        // #619/version handover: only publish process shutdown after all
+        // already-accepted queries have completed safely.
+        shutdown.store(true, .release);
+    }
+}
+
+const CliPosixQueryJob = struct {
+    io: std.Io,
+    explorer: *Explorer,
+    store: *Store,
+    abs_root: []const u8,
+    conn: CliConn,
+    listenfd: c_int,
+    active_queries: *std.atomic.Value(u8),
+    retire_requested: *std.atomic.Value(bool),
+};
+
+fn cliWorkerSlotAcquire(active: *std.atomic.Value(u8), retire_requested: *std.atomic.Value(bool), shutdown: *std.atomic.Value(bool)) bool {
+    while (!retire_requested.load(.acquire) and !shutdown.load(.acquire)) {
+        const current = active.load(.acquire);
+        if (current < cli_max_concurrent_queries and
+            active.cmpxchgWeak(current, current + 1, .acq_rel, .acquire) == null)
+        {
+            return true;
+        }
+        cio.sleepMs(1);
+    }
+    return false;
+}
+
+fn cliWorkerSlotRelease(active: *std.atomic.Value(u8)) void {
+    _ = active.fetchSub(1, .release);
+}
+
+fn cliWorkerWaitForIdle(active: *std.atomic.Value(u8)) void {
+    while (active.load(.acquire) != 0) cio.sleepMs(1);
+}
+
+fn cliServePosixQuery(job: *CliPosixQueryJob) void {
+    // c_allocator is thread-safe and avoids sharing a caller-owned test arena
+    // across detached workers.
+    defer cliWorkerSlotRelease(job.active_queries);
+    defer std.heap.c_allocator.destroy(job);
+
+    const retire = cliServeConn(job.io, std.heap.c_allocator, job.explorer, job.store, job.abs_root, job.conn);
+    _ = std.c.close(job.conn);
+    if (retire) {
+        job.retire_requested.store(true, .release);
+        // Wake the listener's blocking accept so it can stop admitting work,
+        // drain the active workers, and relinquish the socket promptly.
+        _ = std.c.shutdown(job.listenfd, std.c.SHUT.RDWR);
+    }
+}
+
+test "cli worker gate caps concurrent POSIX queries" {
+    var active = std.atomic.Value(u8).init(0);
+    var retire_requested = std.atomic.Value(bool).init(false);
+    var shutdown = std.atomic.Value(bool).init(false);
+
+    for (0..cli_max_concurrent_queries) |_| {
+        try std.testing.expect(cliWorkerSlotAcquire(&active, &retire_requested, &shutdown));
+    }
+    try std.testing.expectEqual(cli_max_concurrent_queries, active.load(.acquire));
+
+    retire_requested.store(true, .release);
+    try std.testing.expect(!cliWorkerSlotAcquire(&active, &retire_requested, &shutdown));
+    for (0..cli_max_concurrent_queries) |_| cliWorkerSlotRelease(&active);
+    cliWorkerWaitForIdle(&active);
+    try std.testing.expectEqual(@as(u8, 0), active.load(.acquire));
 }
 
 /// Handle one client connection: read the framed request, run the query into a

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5849";
+pub const semver = "0.2.5850";


### PR DESCRIPTION
## CodeDB 0.2.5850

Ships bounded concurrent warm CLI query dispatch for multi-agent and multi-terminal workloads on macOS and Linux.

- up to eight simultaneous read-only queries per warm project daemon
- safe handoff that stops admissions and drains accepted work before releasing shared state
- optimized worker cleanup lifetime fixed and validated after the release gate caught it
- zero-touch hybrid retrieval, device-bound authentication, and compact managed transport remain the defaults
- no endpoint or token configuration required
- Windows retains the safe sequential named-pipe path for this release

Measured on eight concurrent hybrid context calls: 6.44 s to 2.69 s batch wall time (58% reduction), with 8/8 successful and parity preserved.

Validation: 263 unit tests passed (4 skipped), 76/76 MCP E2E, five repeated optimized live-reindex passes, macOS resource regression green, paired benchmark/parity green, default hybrid 8-request smoke green, and codedeebee@0.2.5850 package dry-run green.