### PR TITLE
fix: restore native Windows indexing on Zig 0.17

### DIFF
--- a/scripts/windows_runtime_smoke.ps1
+++ b/scripts/windows_runtime_smoke.ps1
@@ -1,0 +1,50 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Binary,
+
+    [string]$LegacyBinary = ""
+)
+
+$ErrorActionPreference = "Stop"
+$root = Join-Path $env:TEMP ("codedb-windows-smoke-" + [guid]::NewGuid().ToString("N"))
+$fresh = Join-Path $root "fresh"
+$legacy = Join-Path $root "legacy"
+
+function Invoke-CodeDB {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Executable @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "codedb exited with $LASTEXITCODE`: $Executable $($Arguments -join ' ')"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path (Join-Path $fresh "src") | Out-Null
+    Set-Content -NoNewline -Path (Join-Path $fresh "src/main.zig") -Value "pub fn greet() void {}"
+
+    Invoke-CodeDB $Binary "--version"
+    Invoke-CodeDB $Binary "--help"
+    Invoke-CodeDB $Binary $fresh "reindex"
+    Invoke-CodeDB $Binary $fresh "context" "--local" "find" "greet"
+
+    if ($LegacyBinary) {
+        New-Item -ItemType Directory -Force -Path (Join-Path $legacy "src") | Out-Null
+        Set-Content -NoNewline -Path (Join-Path $legacy "src/main.zig") -Value "pub fn legacy_greet() void {}"
+        Invoke-CodeDB $LegacyBinary $legacy "index"
+        Invoke-CodeDB $Binary $legacy "status"
+        Invoke-CodeDB $Binary $legacy "context" "--local" "find" "legacy_greet"
+        Invoke-CodeDB $Binary $legacy "reindex"
+    }
+
+    Write-Host "Windows runtime smoke passed"
+}
+finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $root
+}

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -114,20 +114,22 @@ pub fn loadBestSnapshot(
     const canonical_root = explorer.root_path orelse return false;
     if (!project_file.rootMatchesPath(io, root_dir, abs_root)) return false;
 
-    const root_snapshot: ?std.Io.File = root_dir.openFile(io, "codedb.snapshot", .{
+    var root_snapshot: ?std.Io.File = root_dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch null;
+    if (root_snapshot) |*file| project_file.prepareNoFollowFile(file);
     defer if (root_snapshot) |file| file.close(io);
 
     const central_dir: ?std.Io.Dir = std.Io.Dir.cwd().openDir(io, data_dir, .{ .follow_symlinks = false }) catch null;
     defer if (central_dir) |dir| dir.close(io);
-    const central_snapshot: ?std.Io.File = if (central_dir) |dir| dir.openFile(io, "codedb.snapshot", .{
+    var central_snapshot: ?std.Io.File = if (central_dir) |dir| dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch null else null;
+    if (central_snapshot) |*file| project_file.prepareNoFollowFile(file);
     defer if (central_snapshot) |file| file.close(io);
 
     const root_mtime = if (root_snapshot) |file| snapshotFileMtime(io, file) else null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -448,11 +448,12 @@ const ProjectCache = struct {
                 const central_dir_path = std.fmt.bufPrint(&central_buf, "{s}/.codedb/projects/{x}", .{ home, hash }) catch break :blk false;
                 var central_dir = std.Io.Dir.cwd().openDir(io, central_dir_path, .{ .follow_symlinks = false }) catch break :blk false;
                 defer central_dir.close(io);
-                const central_file = central_dir.openFile(io, "codedb.snapshot", .{
+                var central_file = central_dir.openFile(io, "codedb.snapshot", .{
                     .allow_directory = false,
                     .follow_symlinks = false,
                     .resolve_beneath = true,
                 }) catch break :blk false;
+                project_file_read.prepareNoFollowFile(&central_file);
                 defer central_file.close(io);
                 break :blk snapshot_mod.loadSnapshotValidatedFromFile(io, central_file, canonical_root, &new_entry.explorer, &new_entry.store, self.alloc);
             };

--- a/src/project_file.zig
+++ b/src/project_file.zig
@@ -6,10 +6,19 @@
 //! check/retarget/open race, while `resolve_beneath` keeps resolution anchored
 //! to the supplied project directory capability.
 const std = @import("std");
+const builtin = @import("builtin");
 const project_path = @import("project_path.zig");
 const root_policy = @import("root_policy.zig");
 
 pub const isAllowedPath = project_path.isReadable;
+
+/// `follow_symlinks = false` maps to an asynchronous Windows handle in Zig
+/// 0.17, but the returned File is currently tagged as blocking. Correct the
+/// metadata so reads wait for normal asynchronous completion instead of
+/// treating `STATUS_PENDING` as an impossible result.
+pub fn prepareNoFollowFile(file: *std.Io.File) void {
+    if (builtin.os.tag == .windows) file.flags.nonblocking = true;
+}
 
 pub fn rootIsAllowed(io: std.Io, dir: std.Io.Dir) bool {
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -51,6 +60,8 @@ fn openValidatedAtRoot(
     });
     errdefer file.close(io);
 
+    prepareNoFollowFile(&file);
+
     // Validate the object actually opened, not a pre-open realpath. The file
     // handle cannot be retargeted underneath this check, so an allowed-looking
     // directory alias such as `alias -> .ssh` cannot bypass the sensitive-path
@@ -76,6 +87,12 @@ fn openValidatedAtRoot(
     if (!isAllowedPath(normalized_buf[0..rel.len])) return error.AccessDenied;
 
     return file;
+}
+
+test "no-follow file metadata matches the Windows handle mode" {
+    var file: std.Io.File = .{ .handle = undefined, .flags = .{ .nonblocking = false } };
+    prepareNoFollowFile(&file);
+    try std.testing.expectEqual(builtin.os.tag == .windows, file.flags.nonblocking);
 }
 
 fn openValidated(io: std.Io, dir: std.Io.Dir, path: []const u8) !std.Io.File {

--- a/src/semantic_auth.zig
+++ b/src/semantic_auth.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const cio = @import("cio.zig");
 const release_info = @import("release_info.zig");
+const project_file = @import("project_file.zig");
 
 const Ed25519 = std.crypto.sign.Ed25519;
 const Sha256 = std.crypto.hash.sha2.Sha256;
@@ -266,7 +267,7 @@ fn readCredential(
     dir: std.Io.Dir,
     dir_path: []const u8,
 ) !?DeviceCredential {
-    const file = dir.openFile(io, credential_file_name, .{
+    var file = dir.openFile(io, credential_file_name, .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
@@ -274,6 +275,7 @@ fn readCredential(
         error.FileNotFound => return null,
         else => return err,
     };
+    project_file.prepareNoFollowFile(&file);
     defer file.close(io);
     const stat = try file.stat(io);
     if (stat.size > max_credential_bytes) return error.InvalidDeviceCredentials;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -691,11 +691,12 @@ pub fn loadSnapshotValidatedFromRoot(
     store: *Store,
     allocator: std.mem.Allocator,
 ) bool {
-    const file = root_dir.openFile(io, "codedb.snapshot", .{
+    var file = root_dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch return false;
+    project_file.prepareNoFollowFile(&file);
     defer file.close(io);
     return loadSnapshotValidatedFromFile(io, file, expected_root, explorer, store, allocator);
 }
@@ -1673,10 +1674,11 @@ pub fn writeReindexSnapshots(
         .{ home_raw, hash },
     );
     defer allocator.free(central_path);
-    const central_file = std.Io.Dir.cwd().openFile(io, central_path, .{
+    var central_file = std.Io.Dir.cwd().openFile(io, central_path, .{
         .allow_directory = false,
         .follow_symlinks = false,
     }) catch return false;
+    project_file.prepareNoFollowFile(&central_file);
     defer central_file.close(io);
 
     const root_dir = explorer.root_dir orelse return false;
@@ -1733,11 +1735,12 @@ fn copyOpenFileAtomic(io: std.Io, source: std.Io.File, dest_dir: std.Io.Dir, des
 }
 
 fn openRegularFileNoFollow(io: std.Io, dir: std.Io.Dir, name: []const u8) !std.Io.File {
-    const source = try dir.openFile(io, name, .{
+    var source = try dir.openFile(io, name, .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     });
+    project_file.prepareNoFollowFile(&source);
     errdefer source.close(io);
     const source_stat = try source.stat(io);
     if (source_stat.kind != .file) return error.InvalidSnapshotSource;


### PR DESCRIPTION
## Summary
- correct Zig 0.17 Windows handle metadata after secure `follow_symlinks = false` opens
- apply the correction to source reads, snapshots, MCP project cache, and device credentials
- add a native PowerShell runtime smoke test covering fresh reindex/context and a v0.2.5841 index upgrade

## Root cause
On Windows, Zig 0.17 opens no-follow handles for asynchronous I/O but currently returns `std.Io.File.flags.nonblocking = false`. Positional reads then treat the normal `STATUS_PENDING` result as unreachable. ReleaseFast surfaced this as `fatal: Unexpected`; Debug identified `std/Io/Threaded.zig:10078` through `project_file.readAllocNoFollow`.

The fix preserves the no-follow and resolve-beneath security boundaries and only corrects the handle metadata used by Zig threaded I/O.

## Verification
- `zig build test`
- `python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project /Users/blackfloofie/tmp/codedb-windows-trace` (76/76)
- native Windows Server 2025 Daytona run, ReleaseFast x86_64-windows:
  - fresh `reindex`: pass
  - snapshot-backed `context --local`: pass
  - v0.2.5841 index -> fixed binary status/context/reindex: pass
  - checked-in `scripts/windows_runtime_smoke.ps1`: pass
  - unmodified v0.2.5850 asset: still reproduces `fatal: Unexpected`

No Wine path is used.