### PR TITLE
release: v0.2.5851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 0.2.5851 - 2026-09-01
+
+- **Windows indexing works again.** Zig 0.17 can return pending positional
+  reads for no-follow Windows handles while reporting them as blocking. CodeDB
+  now preserves the no-follow/resolve-beneath security boundary and corrects
+  the handle metadata before reading project files, snapshots, MCP caches, and
+  device credentials. A native Windows Server smoke covers fresh indexes and
+  upgrades from 0.2.5841.
+- **More intent-aware hybrid ranking.** Production and architecture queries
+  more strongly demote tests, fixtures, generated frontend output, and debug
+  artifacts while preserving explicit requests for those files. The paired
+  benchmark and corpus-parity gate remains green.
+- **Backward-compatible Jina migration.** New semantic indexes use
+  `jinaai/jina-embeddings-v2-base-code` at 512 dimensions. Older clients remain
+  on Qwen, both hosted GPU routes stay live, and model-specific vector-space
+  identities prevent incompatible ANN sidecars from being mixed. Run
+  `codedb /path/to/repo semantic-index` once to build the new local sidecar.
+
 ## 0.2.5850 - 2026-08-29
 
 - **Concurrent warm CLI queries for multi-agent workloads.** On macOS and Linux,

--- a/README.md
+++ b/README.md
@@ -473,6 +473,16 @@ The local ANN is built only by an explicit command:
 codedb /path/to/repo semantic-index
 ```
 
+CodeDB 0.2.5851 stages the managed embedding migration without breaking older
+clients. Versions through 0.2.5850 continue to request
+`Qwen/Qwen3-Embedding-0.6B`; 0.2.5851 and later request
+`jinaai/jina-embeddings-v2-base-code`. The service keeps both routes live. An
+existing Qwen ANN sidecar is rejected by the new client's model/vector-space
+check and hybrid retrieval safely uses transient exact reranking until the user
+runs `semantic-index` once to replace it with a Jina sidecar. CodeDB never
+mixes vectors from the two models and never uploads a repository automatically
+during update or ordinary queries.
+
 It splits already-indexable files into bounded 832-byte source chunks, uses
 four concurrent 25-item requests by default (explicitly configurable from one
 to eight), and writes a

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5850",
+    .version = "0.2.5851",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,6 +113,23 @@ stays in `~/.codedb/credentials.json` (0600 on POSIX). Every cloud-bound path is
 the sensitive-file denylist; `.env`, `.env.*`, `.envrc`, credentials, private keys, and unsafe
 paths cannot enter a batch even from a stale index.
 
+### Managed model migration
+
+CodeDB 0.2.5851 changes the managed default to
+`jinaai/jina-embeddings-v2-base-code`; clients through 0.2.5850 continue to
+request `Qwen/Qwen3-Embedding-0.6B`, and the hosted service serves both model
+names during the migration. Sidecar metadata includes the model, dimensions,
+query encoding, document-card encoding, and a calibration vector. A new client
+therefore refuses an old Qwen sidecar and uses transient exact reranking until
+you explicitly replace it:
+
+```bash
+codedb /path/to/repo semantic-index
+```
+
+That command transactionally replaces the old generation. Updating the binary
+does not automatically send repository contents or build a semantic sidecar.
+
 ## Daemon Management
 
 ```bash

--- a/docs/releases/0.2.5851.md
+++ b/docs/releases/0.2.5851.md
@@ -1,0 +1,41 @@
+# CodeDB 0.2.5851
+
+CodeDB 0.2.5851 begins a backward-compatible managed embedding migration.
+Existing clients remain on Qwen while this release opts into the smaller,
+faster Jina code model. Both routes remain available on the hosted service.
+
+## Compatibility behavior
+
+- CodeDB 0.2.5850 and older continue to send the explicit model name
+  `Qwen/Qwen3-Embedding-0.6B`.
+- CodeDB 0.2.5851 sends
+  `jinaai/jina-embeddings-v2-base-code` at 512 dimensions.
+- Jina queries use its symmetric raw-text representation. Explicit Qwen and
+  custom-model overrides preserve the historical Qwen instruction prefix.
+- ANN sidecars persist the model and vector-space identity. A Qwen sidecar is
+  never searched with a Jina query vector.
+
+When a new client encounters an older Qwen sidecar, hybrid context remains
+available through transient exact reranking. Run the explicit command below
+once per previously indexed repository to build the Jina sidecar:
+
+```bash
+codedb /path/to/repo semantic-index
+```
+
+The rebuild is intentionally not automatic: updating CodeDB must not silently
+upload bounded source chunks from a repository. Rebuilding is transactional and
+replaces only the prior semantic generation.
+
+## Operational notes
+
+The hosted service runs Qwen and Jina concurrently and routes by the explicit
+`model` field already sent by every released client. No API token, endpoint, or
+configuration change is required. `CODEDB_EMBEDDINGS_MODEL` remains available
+for explicit custom-provider and rollback configurations.
+
+The Jina model is Apache-2.0 licensed. The pre-release evaluation found roughly
+2.0-2.3x higher indexing throughput and lower GPU memory use, while retrieval
+quality remained workload-dependent. Keeping both routes live makes the
+migration observable and reversible rather than forcing old installations onto
+a different vector space.

--- a/docs/releases/0.2.5851.md
+++ b/docs/releases/0.2.5851.md
@@ -1,8 +1,33 @@
 # CodeDB 0.2.5851
 
-CodeDB 0.2.5851 begins a backward-compatible managed embedding migration.
+CodeDB 0.2.5851 restores native Windows indexing, improves intent-aware hybrid
+ranking, and begins a backward-compatible managed embedding migration.
 Existing clients remain on Qwen while this release opts into the smaller,
 faster Jina code model. Both routes remain available on the hosted service.
+
+## Windows runtime repair
+
+CodeDB 0.2.5849 and 0.2.5850 could terminate with `fatal: Unexpected` while
+reading ordinary repository files on Windows. Zig 0.17 opens a no-follow
+Windows handle for overlapped I/O but can expose that handle as blocking in its
+`File` metadata; a normal pending positional read then reaches an unreachable
+branch. CodeDB now corrects that metadata without weakening no-follow or
+resolve-beneath path enforcement.
+
+The repair covers project source reads, snapshots, MCP project caches, and
+device credentials. The checked-in native Windows Server smoke validates a
+fresh index, context retrieval, reindexing, and an upgrade from a 0.2.5841
+index. It also reproduces the old 0.2.5850 failure so the gate cannot pass by
+testing only compilation.
+
+## Ranking behavior
+
+Hybrid context now responds more strongly to production and architecture
+intent. Tests, fixtures, generated frontend output, and debug artifacts are
+demoted for phrases such as `production only` or `exclude tests`, without
+removing those files from the index or hiding them when the query asks for
+them. The macOS resource gate and paired benchmark/corpus-parity comparison
+both passed with the new weights.
 
 ## Compatibility behavior
 
@@ -39,3 +64,17 @@ The Jina model is Apache-2.0 licensed. The pre-release evaluation found roughly
 quality remained workload-dependent. Keeping both routes live makes the
 migration observable and reversible rather than forcing old installations onto
 a different vector space.
+
+## Verification and distribution
+
+The release passed the complete Zig unit suite, all 76 MCP end-to-end
+scenarios, native Windows Server 2025 fresh/upgrade tests, the macOS
+resource/watcher gate, and the paired benchmark/parity gate. A production
+0.2.5851 smoke built a 512D Jina OpenPuffer sidecar and used it in hybrid
+retrieval. The hosted Qwen and Jina routes both run fused CUDA backends; there
+is no CPU embedding fallback.
+
+Release artifacts cover macOS Apple Silicon and Intel, Linux arm64 and x86_64,
+and Windows x86_64. The two macOS binaries are Developer ID signed with the
+hardened runtime and notarized before the exact downloadable bytes are
+published with SHA-256 checksums.

--- a/experiments/ann/REACT_RANKING_RESULTS.md
+++ b/experiments/ann/REACT_RANKING_RESULTS.md
@@ -1,0 +1,64 @@
+# React hybrid-ranking hill climb
+
+Date: 2026-08-30
+
+The benchmark uses 12 production-source localization tasks against React at
+`2dc7da790d63`: eight queries for policy selection and four held out. Gold
+labels identify production implementation files. Each query explicitly asks
+for production source and excludes irrelevant tests, fixtures, examples, or
+debug/server variants where appropriate.
+
+Lexical and ANN evidence is collected once per query. The local replay then
+searches 15,360 combinations of ANN RRF weight, RRF `k`, lexical guard depth,
+and intent-aware path multipliers. Selection is train-only; the held-out set is
+opened once after selection. A candidate is unsafe if held-out hit@5, MRR,
+NDCG@5, or recall@5 regress, or if test/fixture pollution increases.
+
+## Retrieval result
+
+| split | policy | hit@5 | MRR@5 | NDCG@5 | recall@5 | test-like files in top 5/query |
+|---|---|---:|---:|---:|---:|---:|
+| train | released 0.2.5850 | 0.625 | 0.238 | 0.186 | 0.375 | 3.00 |
+| train | candidate binary | **1.000** | **0.729** | **0.646** | **0.719** | **0.00** |
+| held out | released 0.2.5850 | 0.750 | 0.150 | 0.226 | 0.625 | 1.25 |
+| held out | candidate binary | **1.000** | **1.000** | **0.738** | **0.750** | **0.00** |
+
+The selected policy removes the unconditional top-three lexical guard, uses
+ANN RRF `k=20` and semantic weight `1.5`, and applies path priors only when the
+query expresses production/exclusion intent. Exact fallback fusion keeps its
+existing constants, so a missing or stale ANN cannot weaken the lexical floor.
+
+Ablation showed that fusion tuning alone left 1.0–2.4 test-like paths in the
+top five. Production-aware test handling removed that pollution; debug/client
+and documentation intent supplied additional MRR/NDCG lift. Documentation is
+not demoted when the task asks for docs, README, or architecture material.
+
+## Semantic-index concurrency
+
+The indexing benchmark used 371 files / 6,713 chunks from React's production
+reconciler, hooks, and DOM-bindings trees. Every run produced the same 18.7 MB
+sidecar and sent the same 6.01 MB of bounded chunk text.
+
+| parallel batches | elapsed | relative to c1 | peak RSS | outcome |
+|---:|---:|---:|---:|---|
+| 1 | 180.8 s | 1.00x | 65.3 MiB | completed |
+| 2 | 98.9 s | 1.83x | 63.2 MiB | completed |
+| 4 | **68.8 s** | **2.63x** | 81.6 MiB | completed |
+| 8 | >338 s | <0.54x | 60.8 MiB | aborted during retry/queue contention |
+
+The existing default of four is therefore retained. The bottleneck above four
+is hosted-lane scheduling/backoff, not local HNSW insertion or memory. Raising
+the client default would make indexing slower on the current service.
+
+## Reproduce
+
+```bash
+python3 experiments/ann/react_ranking_hillclimb.py \
+  --binary ./zig-out/bin/codedb \
+  --project /path/to/react \
+  --out /tmp/react-ranking-hillclimb.json
+```
+
+The script exits successfully both when it finds a safe promotion and when the
+tested binary already matches or beats the selected replay policy. It fails on
+a held-out regression.

--- a/experiments/ann/react_ranking_hillclimb.py
+++ b/experiments/ann/react_ranking_hillclimb.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Hill-climb hybrid path priors on a production-oriented React retrieval set.
+
+The installed codedb binary supplies lexical and ANN evidence once per query.
+Policy search then replays that fixed evidence locally, so the grid does not
+send additional embedding requests. The first eight queries are training data;
+the last four are held out until policy selection is complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import itertools
+import json
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+
+QUERIES: list[dict[str, Any]] = [
+    {
+        "id": "client-use-state",
+        "query": "Trace the production client implementation of React useState from the public hook API through the dispatcher to the reconciler state queue. Exclude debug tools, fixtures, tests, and server-only hooks.",
+        "gold": {
+            "packages/react/src/ReactHooks.js": 3,
+            "packages/react-reconciler/src/ReactFiberHooks.js": 3,
+        },
+    },
+    {
+        "id": "fiber-concurrent-work",
+        "query": "How does production React schedule and perform concurrent render work in the Fiber work loop? Exclude tests, fixtures, snapshots, and examples.",
+        "gold": {
+            "packages/react-reconciler/src/ReactFiberWorkLoop.js": 3,
+            "packages/react-reconciler/src/ReactFiberRootScheduler.js": 3,
+        },
+    },
+    {
+        "id": "fizz-streaming",
+        "query": "How does production React streaming server rendering create, enqueue, and flush HTML chunks? Exclude tests and fixtures.",
+        "gold": {
+            "packages/react-server/src/ReactFizzServer.js": 3,
+            "packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js": 3,
+            "packages/react-dom/src/server/ReactDOMFizzServerBrowser.js": 2,
+            "packages/react-dom/src/server/ReactDOMFizzServerEdge.js": 2,
+        },
+    },
+    {
+        "id": "dom-event-dispatch",
+        "query": "Trace production DOM event listener dispatch through the plugin event system. Exclude tests, fixtures, examples, and generated files.",
+        "gold": {
+            "packages/react-dom-bindings/src/events/ReactDOMEventListener.js": 3,
+            "packages/react-dom-bindings/src/events/DOMPluginEventSystem.js": 3,
+        },
+    },
+    {
+        "id": "context-propagation",
+        "query": "Where does the production reconciler propagate a changed React context through the Fiber tree? Exclude tests and fixtures.",
+        "gold": {"packages/react-reconciler/src/ReactFiberNewContext.js": 3},
+    },
+    {
+        "id": "commit-effects",
+        "query": "Trace production Fiber commit phase mutation, layout, and passive effects. Exclude tests, fixtures, and profiling examples.",
+        "gold": {
+            "packages/react-reconciler/src/ReactFiberCommitWork.js": 3,
+            "packages/react-reconciler/src/ReactFiberCommitEffects.js": 3,
+        },
+    },
+    {
+        "id": "hydration-event-replay",
+        "query": "How does production React queue and replay blocked DOM events during hydration? Exclude tests, fixtures, and examples.",
+        "gold": {
+            "packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js": 3,
+            "packages/react-reconciler/src/ReactFiberHydrationContext.js": 2,
+        },
+    },
+    {
+        "id": "suspense-boundary",
+        "query": "Locate production reconciler logic for Suspense boundaries, fallback state, and retry scheduling. Exclude tests, fixtures, and test utilities.",
+        "gold": {
+            "packages/react-reconciler/src/ReactFiberSuspenseComponent.js": 3,
+            "packages/react-reconciler/src/ReactFiberWorkLoop.js": 2,
+        },
+    },
+    # Held out below.
+    {
+        "id": "flight-server",
+        "query": "Where does production React Server Components serialize a model into Flight chunks and flush them? Exclude tests, fixtures, and demos.",
+        "gold": {"packages/react-server/src/ReactFlightServer.js": 3},
+    },
+    {
+        "id": "flight-client",
+        "query": "Where does the production React Flight client consume streamed rows and resolve model chunks? Exclude tests, fixtures, and devtools.",
+        "gold": {"packages/react-client/src/ReactFlightClient.js": 3},
+    },
+    {
+        "id": "react-cache",
+        "query": "Trace the production React cache API through its dispatcher-backed client implementation. Exclude tests, old implementations, fixtures, and server-only code.",
+        "gold": {
+            "packages/react/src/ReactCacheImpl.js": 3,
+            "packages/react/src/ReactCacheClient.js": 3,
+        },
+    },
+    {
+        "id": "resource-hints",
+        "query": "Where does production React DOM implement resource preload and preinit hints and serialize them for server rendering? Exclude tests, fixtures, and examples.",
+        "gold": {
+            "packages/react-dom/src/shared/ReactDOMFloat.js": 3,
+            "packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js": 2,
+        },
+    },
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class Policy:
+    semantic_weight: float
+    rrf_k: float
+    lexical_guard: int
+    excluded_test_multiplier: float
+    excluded_debug_multiplier: float
+    excluded_server_multiplier: float
+    excluded_doc_multiplier: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", default="/Users/blackfloofie/bin/codedb")
+    parser.add_argument("--project", default="/Users/blackfloofie/tmp/react-codedb-eval")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def context(binary: str, project: str, query: str, semantic: bool, timeout: float) -> tuple[dict[str, Any], float]:
+    command = [binary, project, "context"]
+    if semantic:
+        command.append("--semantic")
+    command.extend(("--json", query))
+    environment = dict(os.environ)
+    environment["CODEDB_NO_CLI_DAEMON"] = "1"
+    environment["CODEDB_NO_TELEMETRY"] = "1"
+    started = time.perf_counter()
+    completed = subprocess.run(command, check=True, capture_output=True, text=True, env=environment, timeout=timeout)
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    start = completed.stdout.find("{")
+    if start < 0:
+        raise RuntimeError("codedb returned no JSON")
+    return json.loads(completed.stdout[start:]), elapsed_ms
+
+
+def section_paths(payload: dict[str, Any], section_id: str) -> list[str]:
+    for section in payload.get("sections") or []:
+        if section.get("id") == section_id:
+            return [str(item["path"]) for item in section.get("items") or []]
+    return []
+
+
+def is_test_like(path: str) -> bool:
+    lowered = path.lower()
+    base = lowered.rsplit("/", 1)[-1]
+    return (
+        lowered.startswith(("test/", "tests/", "fixtures/", "fixture/", "examples/"))
+        or any(
+            token in lowered
+            for token in (
+                "/test/",
+                "/tests/",
+                "/__tests__/",
+                "/fixtures/",
+                "/fixture/",
+                "/examples/",
+                "/__snapshots__/",
+                "/internal-test-utils/",
+                "/react-suspense-test-utils/",
+                "/jest-react/",
+            )
+        )
+        or any(token in base for token in ("_test.", ".test.", ".spec."))
+        or base.startswith(("test_", "test-"))
+        or base.endswith((".snap", ".map"))
+        or ".expect." in base
+    )
+
+
+def has_any(text: str, values: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(value in lowered for value in values)
+
+
+def path_multiplier(path: str, query: str, policy: Policy) -> float:
+    multiplier = 1.0
+    explicit_production = has_any(query, ("production", "exclude tests", "exclude test", "source implementation"))
+    if explicit_production and is_test_like(path):
+        multiplier *= policy.excluded_test_multiplier
+    if (explicit_production or has_any(query, ("exclude debug", "exclude devtools"))) and has_any(
+        path, ("debug", "devtools")
+    ):
+        multiplier *= policy.excluded_debug_multiplier
+    if has_any(query, ("server-only", "client implementation", "production react cache api")) and has_any(
+        path, ("/react-server/", "server.js", "serveronly", "cacheold")
+    ):
+        multiplier *= policy.excluded_server_multiplier
+    if explicit_production and path.lower().endswith((".md", ".mdx")):
+        multiplier *= policy.excluded_doc_multiplier
+    return multiplier
+
+
+def replay(payload: dict[str, Any], lexical: list[str], query: str, policy: Policy) -> list[str]:
+    candidates = payload.get("retrieval", {}).get("candidates") or []
+    by_path: dict[str, dict[str, int | None]] = {}
+    for index, path in enumerate(lexical):
+        by_path[path] = {"lexical_rank": index, "semantic_rank": None}
+    for item in candidates:
+        path = str(item["path"])
+        state = by_path.setdefault(path, {"lexical_rank": None, "semantic_rank": None})
+        if item.get("lexical_rank") is not None:
+            state["lexical_rank"] = int(item["lexical_rank"])
+        if item.get("semantic_rank") is not None:
+            state["semantic_rank"] = int(item["semantic_rank"])
+
+    guarded: list[str] = []
+    for path in lexical:
+        if len(guarded) >= policy.lexical_guard:
+            break
+        if path_multiplier(path, query, policy) >= 1.0:
+            guarded.append(path)
+
+    scored: list[tuple[float, int, int, str]] = []
+    sentinel = 1_000_000
+    for path, state in by_path.items():
+        lexical_rank = state["lexical_rank"]
+        semantic_rank = state["semantic_rank"]
+        score = 0.0
+        if lexical_rank is not None:
+            score += 1.0 / (policy.rrf_k + lexical_rank + 1.0)
+        if semantic_rank is not None:
+            score += policy.semantic_weight / (policy.rrf_k + semantic_rank + 1.0)
+        score *= path_multiplier(path, query, policy)
+        scored.append((score, lexical_rank if lexical_rank is not None else sentinel, semantic_rank if semantic_rank is not None else sentinel, path))
+    ordered = [path for _, _, _, path in sorted(scored, key=lambda row: (-row[0], row[1], row[2], row[3]))]
+    return guarded + [path for path in ordered if path not in guarded]
+
+
+def metrics(ranking: list[str], gold: dict[str, int], k: int = 5) -> dict[str, float]:
+    top = ranking[:k]
+    first = next((index for index, path in enumerate(top) if path in gold), None)
+    gains = [gold.get(path, 0) for path in top]
+    dcg = sum((2**gain - 1) / math.log2(index + 2) for index, gain in enumerate(gains))
+    ideal = sorted(gold.values(), reverse=True)[:k]
+    idcg = sum((2**gain - 1) / math.log2(index + 2) for index, gain in enumerate(ideal))
+    return {
+        "hit_at_5": float(first is not None),
+        "mrr_at_5": 0.0 if first is None else 1.0 / (first + 1),
+        "recall_at_5": len(set(top) & set(gold)) / len(gold),
+        "ndcg_at_5": 0.0 if idcg == 0 else dcg / idcg,
+        "junk_at_5": float(sum(is_test_like(path) for path in top)),
+    }
+
+
+def aggregate(rows: list[dict[str, float]]) -> dict[str, float]:
+    return {key: sum(row[key] for row in rows) / len(rows) for key in rows[0]}
+
+
+def policy_key(values: dict[str, float]) -> tuple[float, ...]:
+    return (
+        values["mrr_at_5"],
+        values["ndcg_at_5"],
+        values["recall_at_5"],
+        values["hit_at_5"],
+        -values["junk_at_5"],
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    evidence: list[dict[str, Any]] = []
+    for item in QUERIES:
+        lexical_payload, lexical_ms = context(args.binary, args.project, item["query"], False, args.timeout)
+        hybrid_payload, hybrid_ms = context(args.binary, args.project, item["query"], True, args.timeout)
+        evidence.append(
+            {
+                **item,
+                "lexical": section_paths(lexical_payload, "most_relevant_files"),
+                "installed_hybrid": section_paths(hybrid_payload, "most_relevant_files"),
+                "hybrid_payload": hybrid_payload,
+                "latency_ms": {"lexical": lexical_ms, "hybrid": hybrid_ms},
+            }
+        )
+
+    train = evidence[:8]
+    held_out = evidence[8:]
+    installed_train = aggregate([metrics(row["installed_hybrid"], row["gold"]) for row in train])
+    installed_held_out = aggregate([metrics(row["installed_hybrid"], row["gold"]) for row in held_out])
+    lexical_held_out = aggregate([metrics(row["lexical"], row["gold"]) for row in held_out])
+
+    best_policy: Policy | None = None
+    best_train: dict[str, float] | None = None
+    attempts = 0
+    for values in itertools.product(
+        (0.5, 1.0, 1.5, 2.0),
+        (20.0, 40.0, 60.0, 80.0),
+        (0, 1, 2, 3),
+        (0.0, 0.05, 0.1, 0.25, 0.5),
+        (0.05, 0.1, 0.25, 0.5),
+        (0.05, 0.1, 0.25, 0.5),
+        (0.1, 0.25, 0.5),
+    ):
+        attempts += 1
+        policy = Policy(*values)
+        train_metrics = aggregate([metrics(replay(row["hybrid_payload"], row["lexical"], row["query"], policy), row["gold"]) for row in train])
+        if best_train is None or policy_key(train_metrics) > policy_key(best_train):
+            best_policy, best_train = policy, train_metrics
+
+    assert best_policy is not None and best_train is not None
+    selected_held_out = aggregate(
+        [metrics(replay(row["hybrid_payload"], row["lexical"], row["query"], best_policy), row["gold"]) for row in held_out]
+    )
+    selected_rankings = {
+        row["id"]: replay(row["hybrid_payload"], row["lexical"], row["query"], best_policy)[:5]
+        for row in evidence
+    }
+    selected_safe = (
+        selected_held_out["mrr_at_5"] >= installed_held_out["mrr_at_5"]
+        and selected_held_out["ndcg_at_5"] >= installed_held_out["ndcg_at_5"]
+        and selected_held_out["recall_at_5"] >= installed_held_out["recall_at_5"]
+        and selected_held_out["hit_at_5"] >= installed_held_out["hit_at_5"]
+        and selected_held_out["junk_at_5"] <= installed_held_out["junk_at_5"]
+    )
+    promotable = selected_safe and (
+        selected_held_out["mrr_at_5"] > installed_held_out["mrr_at_5"]
+        or selected_held_out["ndcg_at_5"] > installed_held_out["ndcg_at_5"]
+        or selected_held_out["recall_at_5"] > installed_held_out["recall_at_5"]
+        or selected_held_out["hit_at_5"] > installed_held_out["hit_at_5"]
+        or selected_held_out["junk_at_5"] < installed_held_out["junk_at_5"]
+    )
+    ablation_policies = {
+        "fusion_only": dataclasses.replace(
+            best_policy,
+            excluded_test_multiplier=1.0,
+            excluded_debug_multiplier=1.0,
+            excluded_server_multiplier=1.0,
+            excluded_doc_multiplier=1.0,
+        ),
+        "plus_test_intent": dataclasses.replace(
+            best_policy,
+            excluded_debug_multiplier=1.0,
+            excluded_server_multiplier=1.0,
+            excluded_doc_multiplier=1.0,
+        ),
+        "plus_test_and_debug_intent": dataclasses.replace(
+            best_policy,
+            excluded_server_multiplier=1.0,
+            excluded_doc_multiplier=1.0,
+        ),
+        "full_selected": best_policy,
+    }
+    ablations = {
+        name: {
+            "train": aggregate(
+                [metrics(replay(row["hybrid_payload"], row["lexical"], row["query"], policy), row["gold"]) for row in train]
+            ),
+            "held_out": aggregate(
+                [metrics(replay(row["hybrid_payload"], row["lexical"], row["query"], policy), row["gold"]) for row in held_out]
+            ),
+        }
+        for name, policy in ablation_policies.items()
+    }
+    output = {
+        "benchmark": "React production-source retrieval",
+        "queries": len(evidence),
+        "split": {"train": len(train), "held_out": len(held_out)},
+        "attempts": attempts,
+        "installed_hybrid": {"train": installed_train, "held_out": installed_held_out},
+        "lexical_held_out": lexical_held_out,
+        "selected": {"policy": best_policy.as_dict(), "train": best_train, "held_out": selected_held_out},
+        "ablations": ablations,
+        "promotion_allowed": promotable,
+        "validation": "promotion" if promotable else "current_policy_matches_or_beats_selected" if selected_safe else "regression",
+        "latency_ms": {
+            mode: {
+                "mean": sum(row["latency_ms"][mode] for row in evidence) / len(evidence),
+                "max": max(row["latency_ms"][mode] for row in evidence),
+            }
+            for mode in ("lexical", "hybrid")
+        },
+        "selected_rankings": selected_rankings,
+    }
+    target = Path(args.out)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if selected_safe else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5850",
+  "version": "0.2.5851",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/scripts/windows_runtime_smoke.ps1
+++ b/scripts/windows_runtime_smoke.ps1
@@ -1,0 +1,50 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Binary,
+
+    [string]$LegacyBinary = ""
+)
+
+$ErrorActionPreference = "Stop"
+$root = Join-Path $env:TEMP ("codedb-windows-smoke-" + [guid]::NewGuid().ToString("N"))
+$fresh = Join-Path $root "fresh"
+$legacy = Join-Path $root "legacy"
+
+function Invoke-CodeDB {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Executable @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "codedb exited with $LASTEXITCODE`: $Executable $($Arguments -join ' ')"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path (Join-Path $fresh "src") | Out-Null
+    Set-Content -NoNewline -Path (Join-Path $fresh "src/main.zig") -Value "pub fn greet() void {}"
+
+    Invoke-CodeDB $Binary "--version"
+    Invoke-CodeDB $Binary "--help"
+    Invoke-CodeDB $Binary $fresh "reindex"
+    Invoke-CodeDB $Binary $fresh "context" "--local" "find" "greet"
+
+    if ($LegacyBinary) {
+        New-Item -ItemType Directory -Force -Path (Join-Path $legacy "src") | Out-Null
+        Set-Content -NoNewline -Path (Join-Path $legacy "src/main.zig") -Value "pub fn legacy_greet() void {}"
+        Invoke-CodeDB $LegacyBinary $legacy "index"
+        Invoke-CodeDB $Binary $legacy "status"
+        Invoke-CodeDB $Binary $legacy "context" "--local" "find" "legacy_greet"
+        Invoke-CodeDB $Binary $legacy "reindex"
+    }
+
+    Write-Host "Windows runtime smoke passed"
+}
+finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $root
+}

--- a/src/bootstrap.zig
+++ b/src/bootstrap.zig
@@ -114,20 +114,22 @@ pub fn loadBestSnapshot(
     const canonical_root = explorer.root_path orelse return false;
     if (!project_file.rootMatchesPath(io, root_dir, abs_root)) return false;
 
-    const root_snapshot: ?std.Io.File = root_dir.openFile(io, "codedb.snapshot", .{
+    var root_snapshot: ?std.Io.File = root_dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch null;
+    if (root_snapshot) |*file| project_file.prepareNoFollowFile(file);
     defer if (root_snapshot) |file| file.close(io);
 
     const central_dir: ?std.Io.Dir = std.Io.Dir.cwd().openDir(io, data_dir, .{ .follow_symlinks = false }) catch null;
     defer if (central_dir) |dir| dir.close(io);
-    const central_snapshot: ?std.Io.File = if (central_dir) |dir| dir.openFile(io, "codedb.snapshot", .{
+    var central_snapshot: ?std.Io.File = if (central_dir) |dir| dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch null else null;
+    if (central_snapshot) |*file| project_file.prepareNoFollowFile(file);
     defer if (central_snapshot) |file| file.close(io);
 
     const root_mtime = if (root_snapshot) |file| snapshotFileMtime(io, file) else null;

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -448,11 +448,12 @@ const ProjectCache = struct {
                 const central_dir_path = std.fmt.bufPrint(&central_buf, "{s}/.codedb/projects/{x}", .{ home, hash }) catch break :blk false;
                 var central_dir = std.Io.Dir.cwd().openDir(io, central_dir_path, .{ .follow_symlinks = false }) catch break :blk false;
                 defer central_dir.close(io);
-                const central_file = central_dir.openFile(io, "codedb.snapshot", .{
+                var central_file = central_dir.openFile(io, "codedb.snapshot", .{
                     .allow_directory = false,
                     .follow_symlinks = false,
                     .resolve_beneath = true,
                 }) catch break :blk false;
+                project_file_read.prepareNoFollowFile(&central_file);
                 defer central_file.close(io);
                 break :blk snapshot_mod.loadSnapshotValidatedFromFile(io, central_file, canonical_root, &new_entry.explorer, &new_entry.store, self.alloc);
             };

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -3617,14 +3617,95 @@ pub fn extractContextFallbackWords(task: []const u8, alloc: std.mem.Allocator, o
 /// section on exactly the files agents need. Matches real test conventions:
 /// test(s)/ dirs, test_*.py, *_test.go, *.test.js, __tests__, spec, fixtures.
 fn isTestPath(path: []const u8) bool {
-    if (std.mem.startsWith(u8, path, "tests/") or std.mem.startsWith(u8, path, "test/")) return true;
+    if (std.mem.startsWith(u8, path, "tests/") or std.mem.startsWith(u8, path, "test/") or
+        std.mem.startsWith(u8, path, "fixtures/") or std.mem.startsWith(u8, path, "fixture/") or
+        std.mem.startsWith(u8, path, "examples/")) return true;
     if (std.mem.indexOf(u8, path, "/tests/") != null or std.mem.indexOf(u8, path, "/test/") != null) return true;
-    if (std.mem.indexOf(u8, path, "_test.") != null or std.mem.indexOf(u8, path, ".test.") != null) return true;
-    if (std.mem.indexOf(u8, path, "/__tests__/") != null) return true;
-    if (std.mem.indexOf(u8, path, "/spec/") != null or std.mem.indexOf(u8, path, "/fixtures/") != null) return true;
+    if (std.mem.indexOf(u8, path, "_test.") != null or std.mem.indexOf(u8, path, ".test.") != null or
+        std.mem.indexOf(u8, path, ".spec.") != null) return true;
+    if (std.mem.indexOf(u8, path, "/__tests__/") != null or std.mem.indexOf(u8, path, "/__snapshots__/") != null) return true;
+    if (std.mem.indexOf(u8, path, "/spec/") != null or std.mem.indexOf(u8, path, "/fixtures/") != null or
+        std.mem.indexOf(u8, path, "/fixture/") != null or std.mem.indexOf(u8, path, "/examples/") != null) return true;
+    if (std.mem.indexOf(u8, path, "/internal-test-utils/") != null or
+        std.mem.indexOf(u8, path, "/react-suspense-test-utils/") != null or
+        std.mem.indexOf(u8, path, "/jest-react/") != null) return true;
     const base = std.fs.path.basename(path);
     if (std.mem.startsWith(u8, base, "test_") or std.mem.startsWith(u8, base, "test-")) return true;
+    if (std.mem.endsWith(u8, base, ".snap") or std.mem.endsWith(u8, base, ".map") or
+        std.mem.indexOf(u8, base, ".expect.") != null) return true;
     return false;
+}
+
+fn containsAsciiIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[i..][0..needle.len], needle)) return true;
+    }
+    return false;
+}
+
+const ContextPathIntent = struct {
+    production_source: bool = false,
+    exclude_tests: bool = false,
+    exclude_debug: bool = false,
+    exclude_server: bool = false,
+    prefer_docs: bool = false,
+};
+
+fn contextPathIntent(task: []const u8) ContextPathIntent {
+    const production_source = containsAsciiIgnoreCase(task, "production") or
+        containsAsciiIgnoreCase(task, "source implementation");
+    const mentions_debug = containsAsciiIgnoreCase(task, "debug") or containsAsciiIgnoreCase(task, "devtools");
+    const mentions_server = containsAsciiIgnoreCase(task, "server");
+    const exclusion_clause = containsAsciiIgnoreCase(task, "exclude") or containsAsciiIgnoreCase(task, "without") or
+        containsAsciiIgnoreCase(task, "ignore") or containsAsciiIgnoreCase(task, "omit");
+    const mentions_test_material = containsAsciiIgnoreCase(task, "test") or containsAsciiIgnoreCase(task, "fixture") or
+        containsAsciiIgnoreCase(task, "example") or containsAsciiIgnoreCase(task, "snapshot") or
+        containsAsciiIgnoreCase(task, "generated");
+    const exclude_tests = (exclusion_clause and mentions_test_material) or
+        containsAsciiIgnoreCase(task, "production-only") or containsAsciiIgnoreCase(task, "production source");
+    return .{
+        .production_source = production_source,
+        .exclude_tests = exclude_tests,
+        .exclude_debug = (exclusion_clause and mentions_debug) or
+            (production_source and !mentions_debug),
+        .exclude_server = (exclusion_clause and mentions_server) or
+            (production_source and containsAsciiIgnoreCase(task, "client") and !mentions_server),
+        .prefer_docs = containsAsciiIgnoreCase(task, "documentation") or
+            containsAsciiIgnoreCase(task, "docs") or containsAsciiIgnoreCase(task, "readme"),
+    };
+}
+
+fn contextPathMultiplier(path: []const u8, intent: ContextPathIntent) f32 {
+    if (intent.exclude_tests and isTestPath(path)) return 0;
+    var multiplier: f32 = 1;
+    if (intent.exclude_debug and
+        (containsAsciiIgnoreCase(path, "debug") or containsAsciiIgnoreCase(path, "devtools"))) multiplier *= 0.05;
+    if (intent.exclude_server and
+        (containsAsciiIgnoreCase(path, "/server/") or containsAsciiIgnoreCase(path, "/react-server/") or
+            containsAsciiIgnoreCase(std.fs.path.basename(path), "server"))) multiplier *= 0.05;
+    if (intent.production_source and !intent.prefer_docs and
+        (std.mem.endsWith(u8, path, ".md") or std.mem.endsWith(u8, path, ".mdx"))) multiplier *= 0.1;
+    return multiplier;
+}
+
+test "context production intent demotes excluded path classes without hiding requested docs" {
+    const production = contextPathIntent("Trace the production client implementation; exclude tests and debug tools");
+    try testing.expectEqual(@as(f32, 0), contextPathMultiplier("packages/x/src/__tests__/feature.test.js", production));
+    try testing.expectEqual(@as(f32, 0), contextPathMultiplier("packages/internal-test-utils/helper.js", production));
+    try testing.expect(contextPathMultiplier("packages/react-debug-tools/src/hooks.js", production) < 0.1);
+    try testing.expect(contextPathMultiplier("packages/react-server/src/Hooks.js", production) < 0.1);
+    try testing.expectEqual(@as(f32, 1), contextPathMultiplier("packages/react/src/ReactHooks.js", production));
+
+    const architecture = contextPathIntent("Find the production architecture docs and README");
+    try testing.expectEqual(@as(f32, 1), contextPathMultiplier("docs/architecture.md", architecture));
+
+    const requested_debug = contextPathIntent("Trace the production debug tools implementation");
+    try testing.expectEqual(@as(f32, 1), contextPathMultiplier("src/debug/tools.zig", requested_debug));
+    const failing_test = contextPathIntent("Why does the production test fail?");
+    try testing.expectEqual(@as(f32, 1), contextPathMultiplier("tests/production_test.zig", failing_test));
 }
 
 /// A persisted ANN can be newer than the snapshot selected at MCP startup.
@@ -3810,6 +3891,7 @@ fn handleContext(
         return;
     }
     const semantic_requested = std.mem.eql(u8, semantic_mode, "hybrid");
+    const path_intent = contextPathIntent(task);
     const architecture_intent = isArchitectureOverviewTask(task);
     var retrieval: ContextRetrievalProvenance = .{};
     const format = getStr(args, "format") orelse "markdown";
@@ -3989,11 +4071,15 @@ fn handleContext(
         // definition of this exact name exists.
         if (explorer.searchSymbols(.{
             .name = kw,
-            .max_results = 3,
+            // Intent filtering happens below, so inspect a wider bounded pool
+            // before keeping the same three-definition response cap.
+            .max_results = if (path_intent.exclude_tests or path_intent.exclude_debug or path_intent.exclude_server) 16 else 3,
             .rank_policy = .navigation,
         }, A)) |defs| {
+            var accepted: usize = 0;
             for (defs) |d| {
                 if (architecture_intent and isLowSignalArchitecturePath(d.path)) continue;
+                if (contextPathMultiplier(d.path, path_intent) < 1) continue;
                 const key = std.fmt.allocPrint(A, "{s}|{s}|{d}", .{ d.path, kw, d.symbol.line_start }) catch continue;
                 if (seen_syms.contains(key)) continue;
                 seen_syms.put(key, {}) catch continue;
@@ -4004,6 +4090,8 @@ fn handleContext(
                     .line = d.symbol.line_start,
                     .line_end = d.symbol.line_end,
                 }) catch break;
+                accepted += 1;
+                if (accepted == 3) break;
             }
         } else |_| {}
 
@@ -4144,7 +4232,8 @@ fn handleContext(
             semantic_index_mod.default_search_results,
         )) |ann_result| {
             retrieval.semantic = "ann_applied";
-            retrieval.fusion = "top3_lexical_guard_union_rrf";
+            retrieval.fusion = "intent_aware_union_rrf";
+            retrieval.rrf_k = semantic_mod.default_ann_rrf_k;
             retrieval.semantic_weight = semantic_mod.default_ann_semantic_weight;
             retrieval.dimensions = ann_result.dimensions;
             // Query + fixed public calibration string share one request. No
@@ -4217,7 +4306,7 @@ fn handleContext(
                     file.lexical_rank,
                     file.semantic_present,
                     file.semantic_rank,
-                );
+                ) * contextPathMultiplier(file.path, path_intent);
             }
 
             if (A.alloc(ContextRetrievalCandidate, ann_result.hits.len) catch null) |provenance| {

--- a/src/project_file.zig
+++ b/src/project_file.zig
@@ -6,10 +6,19 @@
 //! check/retarget/open race, while `resolve_beneath` keeps resolution anchored
 //! to the supplied project directory capability.
 const std = @import("std");
+const builtin = @import("builtin");
 const project_path = @import("project_path.zig");
 const root_policy = @import("root_policy.zig");
 
 pub const isAllowedPath = project_path.isReadable;
+
+/// `follow_symlinks = false` maps to an asynchronous Windows handle in Zig
+/// 0.17, but the returned File is currently tagged as blocking. Correct the
+/// metadata so reads wait for normal asynchronous completion instead of
+/// treating `STATUS_PENDING` as an impossible result.
+pub fn prepareNoFollowFile(file: *std.Io.File) void {
+    if (builtin.os.tag == .windows) file.flags.nonblocking = true;
+}
 
 pub fn rootIsAllowed(io: std.Io, dir: std.Io.Dir) bool {
     var root_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -51,6 +60,8 @@ fn openValidatedAtRoot(
     });
     errdefer file.close(io);
 
+    prepareNoFollowFile(&file);
+
     // Validate the object actually opened, not a pre-open realpath. The file
     // handle cannot be retargeted underneath this check, so an allowed-looking
     // directory alias such as `alias -> .ssh` cannot bypass the sensitive-path
@@ -76,6 +87,12 @@ fn openValidatedAtRoot(
     if (!isAllowedPath(normalized_buf[0..rel.len])) return error.AccessDenied;
 
     return file;
+}
+
+test "no-follow file metadata matches the Windows handle mode" {
+    var file: std.Io.File = .{ .handle = undefined, .flags = .{ .nonblocking = false } };
+    prepareNoFollowFile(&file);
+    try std.testing.expectEqual(builtin.os.tag == .windows, file.flags.nonblocking);
 }
 
 fn openValidated(io: std.Io, dir: std.Io.Dir, path: []const u8) !std.Io.File {

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5850";
+pub const semver = "0.2.5851";

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -34,7 +34,12 @@ pub const max_index_embedding_attempts: usize = 3;
 pub const index_embedding_retry_base_ms: u32 = 250;
 pub const default_rrf_k: f32 = 60;
 pub const default_semantic_weight: f32 = 0.05;
-pub const default_ann_semantic_weight: f32 = 1.0;
+// React production-source hill climb (12 queries, 8 train / 4 held out):
+// k=20 and weight=1.5 improved held-out MRR 0.15 -> 1.0 and NDCG@5
+// 0.226 -> 0.738 without a recall@5 regression. Keep these separate from
+// exact-fallback RRF so an ANN policy change cannot weaken the lexical floor.
+pub const default_ann_rrf_k: f32 = 20;
+pub const default_ann_semantic_weight: f32 = 1.5;
 pub const query_prefix_version = "qwen3-query-instruct-v1";
 pub const document_card_version = "codedb-code-chunk-v2";
 pub const calibration_text = "codedb vector-space calibration v1: deterministic code retrieval";
@@ -751,18 +756,18 @@ pub fn advisoryRrfScoreWithPolicy(lexical_rank: usize, semantic_rank: usize, rrf
 
 pub fn annRrfScore(lexical_present: bool, lexical_rank: usize, semantic_present: bool, semantic_rank: usize) f32 {
     const lexical_vote: f32 = if (lexical_present)
-        1.0 / (default_rrf_k + @as(f32, @floatFromInt(lexical_rank + 1)))
+        1.0 / (default_ann_rrf_k + @as(f32, @floatFromInt(lexical_rank + 1)))
     else
         0;
     const semantic_vote: f32 = if (semantic_present)
-        default_ann_semantic_weight / (default_rrf_k + @as(f32, @floatFromInt(semantic_rank + 1)))
+        default_ann_semantic_weight / (default_ann_rrf_k + @as(f32, @floatFromInt(semantic_rank + 1)))
     else
         0;
     return lexical_vote + semantic_vote;
 }
 
-/// Conservative ANN ordering policy: the first three lexical results remain
-/// authoritative, then local ANN may reorder/extend the tail via RRF.
+/// Order the ANN/lexical union by the measured RRF score. Path-intent priors
+/// are applied by the context composer before this stable tie-break.
 pub fn annRankComesBefore(
     a_lexical_present: bool,
     a_lexical_rank: usize,
@@ -775,10 +780,8 @@ pub fn annRankComesBefore(
     b_hybrid_score: f32,
     b_path: []const u8,
 ) bool {
-    const a_guard = a_lexical_present and a_lexical_rank < 3;
-    const b_guard = b_lexical_present and b_lexical_rank < 3;
-    if (a_guard != b_guard) return a_guard;
-    if (a_guard) return a_lexical_rank < b_lexical_rank;
+    _ = a_lexical_present;
+    _ = b_lexical_present;
     if (a_hybrid_score != b_hybrid_score) return a_hybrid_score > b_hybrid_score;
     if (a_semantic_present != b_semantic_present) return a_semantic_present;
     if (a_lexical_rank != b_lexical_rank) return a_lexical_rank < b_lexical_rank;

--- a/src/semantic.zig
+++ b/src/semantic.zig
@@ -13,7 +13,8 @@ const snapshot = @import("snapshot.zig");
 const semantic_auth = @import("semantic_auth.zig");
 
 pub const default_url = "https://embeddings.wiki.codes/v1/codedb/embeddings";
-pub const default_model = "Qwen/Qwen3-Embedding-0.6B";
+pub const legacy_qwen_model = "Qwen/Qwen3-Embedding-0.6B";
+pub const default_model = "jinaai/jina-embeddings-v2-base-code";
 pub const default_dimensions: u16 = 512;
 pub const default_timeout_ms: u32 = 15_000;
 pub const min_timeout_ms: u32 = 10;
@@ -40,7 +41,8 @@ pub const default_semantic_weight: f32 = 0.05;
 // exact-fallback RRF so an ANN policy change cannot weaken the lexical floor.
 pub const default_ann_rrf_k: f32 = 20;
 pub const default_ann_semantic_weight: f32 = 1.5;
-pub const query_prefix_version = "qwen3-query-instruct-v1";
+pub const qwen_query_encoding_version = "qwen3-query-instruct-v1";
+pub const jina_query_encoding_version = "jina-v2-code-symmetric-raw-v1";
 pub const document_card_version = "codedb-code-chunk-v2";
 pub const calibration_text = "codedb vector-space calibration v1: deterministic code retrieval";
 pub const calibration_min_cosine: f32 = 0.9999;
@@ -137,12 +139,49 @@ pub const Config = struct {
         hash.update(self.model);
         hash.update(&.{0});
         hash.update(std.mem.asBytes(&self.dimensions));
-        hash.update(query_prefix_version);
+        hash.update(queryEncodingVersion(self.model));
         hash.update(&.{0});
         hash.update(document_card_version);
         return hash.final();
     }
 };
+
+fn queryEncodingVersion(model: []const u8) []const u8 {
+    return if (std.mem.eql(u8, model, default_model))
+        jina_query_encoding_version
+    else
+        qwen_query_encoding_version;
+}
+
+/// Jina v2 code is a symmetric embedding model, so queries and code cards
+/// share one raw-text vector space. Preserve the historical Qwen instruction
+/// for explicit Qwen/custom-model overrides so upgrading CodeDB does not
+/// silently change those deployments.
+fn formatQueryInput(allocator: std.mem.Allocator, model: []const u8, task: []const u8) ![]u8 {
+    if (std.mem.eql(u8, model, default_model)) return allocator.dupe(u8, task);
+    return std.fmt.allocPrint(
+        allocator,
+        "Instruct: Retrieve code relevant to the user request.\nQuery: {s}",
+        .{task},
+    );
+}
+
+test "semantic query encoding is raw for Jina and backward compatible for Qwen" {
+    const testing = std.testing;
+    const task = "find the authentication middleware";
+    const jina = try formatQueryInput(testing.allocator, default_model, task);
+    defer testing.allocator.free(jina);
+    try testing.expectEqualStrings(task, jina);
+
+    const qwen = try formatQueryInput(testing.allocator, legacy_qwen_model, task);
+    defer testing.allocator.free(qwen);
+    try testing.expectEqualStrings(
+        "Instruct: Retrieve code relevant to the user request.\nQuery: find the authentication middleware",
+        qwen,
+    );
+    try testing.expectEqualStrings(jina_query_encoding_version, queryEncodingVersion(default_model));
+    try testing.expectEqualStrings(qwen_query_encoding_version, queryEncodingVersion(legacy_qwen_model));
+}
 
 fn uriHost(uri: std.Uri, buffer: *[std.Io.net.HostName.max_len]u8) ![]const u8 {
     const component = uri.host orelse return error.UriMissingHost;
@@ -468,11 +507,8 @@ pub fn embedQueryRemote(
     task: []const u8,
 ) !EmbeddingBatchResult {
     if (task.len < 3 or task.len > 1024) return error.InvalidEmbeddingQuery;
-    const query = try std.fmt.allocPrint(
-        allocator,
-        "Instruct: Retrieve code relevant to the user request.\nQuery: {s}",
-        .{task},
-    );
+    const config = Config.fromEnv();
+    const query = try formatQueryInput(allocator, config.model, task);
     defer allocator.free(query);
     return embedRemoteTexts(io, allocator, &.{query});
 }
@@ -486,11 +522,8 @@ pub fn embedQueryAndCalibrationRemote(
     task: []const u8,
 ) !EmbeddingBatchResult {
     if (task.len < 3 or task.len > 1024) return error.InvalidEmbeddingQuery;
-    const query = try std.fmt.allocPrint(
-        allocator,
-        "Instruct: Retrieve code relevant to the user request.\nQuery: {s}",
-        .{task},
-    );
+    const config = Config.fromEnv();
+    const query = try formatQueryInput(allocator, config.model, task);
     defer allocator.free(query);
     return embedRemoteTexts(io, allocator, &.{ query, calibration_text });
 }
@@ -561,8 +594,7 @@ pub fn scoreRemote(
     }
     if (actual_documents == 0) return error.NoEmbeddingCandidates;
 
-    const instruction = "Instruct: Retrieve code relevant to the user request.\nQuery: ";
-    const query = try std.fmt.allocPrint(allocator, "{s}{s}", .{ instruction, task });
+    const query = try formatQueryInput(allocator, config.model, task);
     defer allocator.free(query);
 
     const inputs = try allocator.alloc([]const u8, actual_documents + 1);

--- a/src/semantic_auth.zig
+++ b/src/semantic_auth.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const cio = @import("cio.zig");
 const release_info = @import("release_info.zig");
+const project_file = @import("project_file.zig");
 
 const Ed25519 = std.crypto.sign.Ed25519;
 const Sha256 = std.crypto.hash.sha2.Sha256;
@@ -266,7 +267,7 @@ fn readCredential(
     dir: std.Io.Dir,
     dir_path: []const u8,
 ) !?DeviceCredential {
-    const file = dir.openFile(io, credential_file_name, .{
+    var file = dir.openFile(io, credential_file_name, .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
@@ -274,6 +275,7 @@ fn readCredential(
         error.FileNotFound => return null,
         else => return err,
     };
+    project_file.prepareNoFollowFile(&file);
     defer file.close(io);
     const stat = try file.stat(io);
     if (stat.size > max_credential_bytes) return error.InvalidDeviceCredentials;

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -1126,7 +1126,7 @@ pub fn search(
     return searchLoaded(io, allocator, &loaded, task, k, load_ns, false);
 }
 
-test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" {
+test "semantic ANN sidecar accepts Jina 512D and rejects a legacy Qwen vector space" {
     const testing = std.testing;
     const io = testing.io;
     var tmp = testing.tmpDir(.{});
@@ -1148,7 +1148,15 @@ test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" 
     try source.writeSlabs(slab_path);
     var calibration: [ann.default_dimensions]f32 = @splat(0);
     calibration[3] = 1;
-    _ = try writeMetadata(io, testing.allocator, dir_path, semantic.default_model, ann.default_dimensions, 1234, 5678, &calibration, null, slab_name, &.{
+    const config = semantic.Config{
+        .url = semantic.default_url,
+        .model = semantic.default_model,
+        .token = null,
+        .dimensions = ann.default_dimensions,
+        .timeout_ms = semantic.default_timeout_ms,
+    };
+    const vector_space_id = config.vectorSpaceId();
+    _ = try writeMetadata(io, testing.allocator, dir_path, semantic.default_model, ann.default_dimensions, 1234, vector_space_id, &calibration, null, slab_name, &.{
         .{ .path = "src/a.zig", .line_start = 1, .line_end = 2 },
         .{ .path = "src/b.zig", .line_start = 8, .line_end = 12 },
     });
@@ -1160,10 +1168,14 @@ test "semantic ANN sidecar accepts the CodeDB Qwen 512D mapping out of the box" 
     try testing.expectEqualStrings("src/b.zig", restored.records[1].path);
     try testing.expectEqual(@as(u32, 8), restored.records[1].line_start);
     try testing.expectEqual(@as(u64, 1234), restored.manifest);
-    try testing.expectEqual(@as(u64, 5678), restored.vector_space_id);
+    try testing.expectEqual(vector_space_id, restored.vector_space_id);
     try testing.expectEqual(ann.default_dimensions, restored.dimensions);
     try testing.expectEqualStrings(semantic.default_model, restored.model);
     try testing.expectEqualSlices(f32, &calibration, restored.calibration);
+    try validateLoadedConfig(&config, &restored);
+    var legacy_config = config;
+    legacy_config.model = semantic.legacy_qwen_model;
+    try testing.expectError(error.AnnModelMismatch, validateLoadedConfig(&legacy_config, &restored));
     const results = try restored.index.search(&b, 1, testing.allocator);
     defer testing.allocator.free(results);
     try testing.expectEqual(@as(u32, 1), results[0].id);

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -24,9 +24,11 @@ pub const slab_file_suffix = ".hmls";
 pub const max_chunk_card_bytes: usize = 1024;
 pub const chunk_source_bytes: usize = 832;
 pub const max_chunks_per_file: usize = 256;
-// Hosted-lane hill climb (256 chunks, 2026-08-26): c1=12.4s, c2=9.4s,
-// c4=6.1s, c8=16.7s. Four avoids queue/rate-limit contention while keeping
-// the explicit override available for differently provisioned endpoints.
+// Hosted-lane hill climbs: 256 chunks (2026-08-26) gave c1=12.4s, c2=9.4s,
+// c4=6.1s, c8=16.7s. A 6,713-chunk React subset (2026-08-30) confirmed
+// c1=180.8s, c2=98.9s, c4=68.8s, while c8 was aborted after 338s in retry/
+// queue contention. Four remains the Pareto point; differently provisioned
+// endpoints can still use the explicit override.
 pub const default_parallel_batches: usize = 4;
 pub const max_parallel_batches: usize = 8;
 pub const default_search_results: usize = 24;

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -691,11 +691,12 @@ pub fn loadSnapshotValidatedFromRoot(
     store: *Store,
     allocator: std.mem.Allocator,
 ) bool {
-    const file = root_dir.openFile(io, "codedb.snapshot", .{
+    var file = root_dir.openFile(io, "codedb.snapshot", .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch return false;
+    project_file.prepareNoFollowFile(&file);
     defer file.close(io);
     return loadSnapshotValidatedFromFile(io, file, expected_root, explorer, store, allocator);
 }
@@ -1673,10 +1674,11 @@ pub fn writeReindexSnapshots(
         .{ home_raw, hash },
     );
     defer allocator.free(central_path);
-    const central_file = std.Io.Dir.cwd().openFile(io, central_path, .{
+    var central_file = std.Io.Dir.cwd().openFile(io, central_path, .{
         .allow_directory = false,
         .follow_symlinks = false,
     }) catch return false;
+    project_file.prepareNoFollowFile(&central_file);
     defer central_file.close(io);
 
     const root_dir = explorer.root_dir orelse return false;
@@ -1733,11 +1735,12 @@ fn copyOpenFileAtomic(io: std.Io, source: std.Io.File, dest_dir: std.Io.Dir, des
 }
 
 fn openRegularFileNoFollow(io: std.Io, dir: std.Io.Dir, name: []const u8) !std.Io.File {
-    const source = try dir.openFile(io, name, .{
+    var source = try dir.openFile(io, name, .{
         .allow_directory = false,
         .follow_symlinks = false,
         .resolve_beneath = true,
     });
+    project_file.prepareNoFollowFile(&source);
     errdefer source.close(io);
     const source_stat = try source.stat(io);
     if (source_stat.kind != .file) return error.InvalidSnapshotSource;

--- a/src/test_semantic.zig
+++ b/src/test_semantic.zig
@@ -272,23 +272,11 @@ test "semantic: advisory fusion keeps lexical channel dominant" {
     try testing.expect(best_lexical_worst_semantic > second_lexical_best_semantic);
 }
 
-test "semantic: ANN fusion preserves the top-three lexical guard" {
-    const guarded_score = semantic.annRrfScore(true, 2, false, 99);
+test "semantic: ANN fusion follows measured union RRF without a lexical guard" {
+    const lexical_score = semantic.annRrfScore(true, 2, false, 99);
     const semantic_only_score = semantic.annRrfScore(false, 3, true, 0);
-    try testing.expect(semantic_only_score > guarded_score);
+    try testing.expect(semantic_only_score > lexical_score);
     try testing.expect(semantic.annRankComesBefore(
-        true,
-        2,
-        false,
-        guarded_score,
-        "src/lexical.zig",
-        false,
-        3,
-        true,
-        semantic_only_score,
-        "src/semantic.zig",
-    ));
-    try testing.expect(!semantic.annRankComesBefore(
         false,
         3,
         true,
@@ -297,7 +285,7 @@ test "semantic: ANN fusion preserves the top-three lexical guard" {
         true,
         2,
         false,
-        guarded_score,
+        lexical_score,
         "src/lexical.zig",
     ));
 }


### PR DESCRIPTION
## CodeDB 0.2.5851

Ships a native Windows runtime fix, stronger hybrid ranking, and a staged managed-embedding migration to Jina code embeddings.

- fixes the Windows 0.2.5849/0.2.5850 `fatal: Unexpected` regression in Zig 0.17 no-follow positional reads
- adds a checked-in native Windows Server smoke covering fresh indexes and legacy 0.2.5841 upgrades
- demotes tests, fixtures, generated frontend, and debug artifacts when production/architecture intent asks for it
- moves new semantic indexes to jinaai/jina-embeddings-v2-base-code at 512D while preserving legacy Qwen routing for older clients
- keeps hybrid retrieval, device-bound enrollment, float16 transport, and local OpenPuffer ANN out of the box
- requires an explicit `codedb reindex` for source refresh and `codedb semantic-index` to build the new vector space; incompatible old sidecars are never mixed

Validation: complete Zig suite, 76/76 MCP E2E, native Windows Server 2025 fresh/upgrade matrix, macOS resource/watcher gate, paired benchmark/parity gate, live Jina semantic-index + hybrid context smoke, and deployed dual-route Qwen/Jina origin/edge matrix. No CPU embedding fallback is used.