### PR TITLE
release: complete 0.2.5851 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 0.2.5851 - 2026-09-01
+
+- **Windows indexing works again.** Zig 0.17 can return pending positional
+  reads for no-follow Windows handles while reporting them as blocking. CodeDB
+  now preserves the no-follow/resolve-beneath security boundary and corrects
+  the handle metadata before reading project files, snapshots, MCP caches, and
+  device credentials. A native Windows Server smoke covers fresh indexes and
+  upgrades from 0.2.5841.
+- **More intent-aware hybrid ranking.** Production and architecture queries
+  more strongly demote tests, fixtures, generated frontend output, and debug
+  artifacts while preserving explicit requests for those files. The paired
+  benchmark and corpus-parity gate remains green.
+- **Backward-compatible Jina migration.** New semantic indexes use
+  `jinaai/jina-embeddings-v2-base-code` at 512 dimensions. Older clients remain
+  on Qwen, both hosted GPU routes stay live, and model-specific vector-space
+  identities prevent incompatible ANN sidecars from being mixed. Run
+  `codedb /path/to/repo semantic-index` once to build the new local sidecar.
+
 ## 0.2.5850 - 2026-08-29
 
 - **Concurrent warm CLI queries for multi-agent workloads.** On macOS and Linux,

--- a/docs/releases/0.2.5851.md
+++ b/docs/releases/0.2.5851.md
@@ -1,8 +1,33 @@
 # CodeDB 0.2.5851
 
-CodeDB 0.2.5851 begins a backward-compatible managed embedding migration.
+CodeDB 0.2.5851 restores native Windows indexing, improves intent-aware hybrid
+ranking, and begins a backward-compatible managed embedding migration.
 Existing clients remain on Qwen while this release opts into the smaller,
 faster Jina code model. Both routes remain available on the hosted service.
+
+## Windows runtime repair
+
+CodeDB 0.2.5849 and 0.2.5850 could terminate with `fatal: Unexpected` while
+reading ordinary repository files on Windows. Zig 0.17 opens a no-follow
+Windows handle for overlapped I/O but can expose that handle as blocking in its
+`File` metadata; a normal pending positional read then reaches an unreachable
+branch. CodeDB now corrects that metadata without weakening no-follow or
+resolve-beneath path enforcement.
+
+The repair covers project source reads, snapshots, MCP project caches, and
+device credentials. The checked-in native Windows Server smoke validates a
+fresh index, context retrieval, reindexing, and an upgrade from a 0.2.5841
+index. It also reproduces the old 0.2.5850 failure so the gate cannot pass by
+testing only compilation.
+
+## Ranking behavior
+
+Hybrid context now responds more strongly to production and architecture
+intent. Tests, fixtures, generated frontend output, and debug artifacts are
+demoted for phrases such as `production only` or `exclude tests`, without
+removing those files from the index or hiding them when the query asks for
+them. The macOS resource gate and paired benchmark/corpus-parity comparison
+both passed with the new weights.
 
 ## Compatibility behavior
 
@@ -39,3 +64,17 @@ The Jina model is Apache-2.0 licensed. The pre-release evaluation found roughly
 quality remained workload-dependent. Keeping both routes live makes the
 migration observable and reversible rather than forcing old installations onto
 a different vector space.
+
+## Verification and distribution
+
+The release passed the complete Zig unit suite, all 76 MCP end-to-end
+scenarios, native Windows Server 2025 fresh/upgrade tests, the macOS
+resource/watcher gate, and the paired benchmark/parity gate. A production
+0.2.5851 smoke built a 512D Jina OpenPuffer sidecar and used it in hybrid
+retrieval. The hosted Qwen and Jina routes both run fused CUDA backends; there
+is no CPU embedding fallback.
+
+Release artifacts cover macOS Apple Silicon and Intel, Linux arm64 and x86_64,
+and Windows x86_64. The two macOS binaries are Developer ID signed with the
+hardened runtime and notarized before the exact downloadable bytes are
+published with SHA-256 checksums.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5850",
+  "version": "0.2.5851",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",


### PR DESCRIPTION
Fix the final release metadata before main/tagging:

- bump the codedeebee npm launcher to 0.2.5851
- add the 0.2.5851 changelog entry
- document the Windows runtime repair, ranking behavior, Jina migration, verification matrix, and signed/notarized artifact policy

Validation: git diff --check; codedeebee@0.2.5851 npm pack --dry-run.