### PR TITLE
release: migrate legacy Qwen sidecars to Jina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 0.2.5852 - 2026-09-01
+
+- **Automatic legacy semantic-sidecar migration.** The first hybrid MCP query
+  that encounters the exact former hosted-Qwen vector space returns through
+  bounded exact Jina reranking, then starts one background Jina rebuild. The
+  existing OpenPuffer generation remains intact until the replacement passes
+  source, Git, metadata, calibration, and vector-space checks and commits
+  atomically. Custom providers, fresh repositories, and Windows stay explicit;
+  `CODEDB_NO_AUTO_SEMANTIC_MIGRATION=1` disables the migration.
+- **Lifecycle and privacy are release-gated.** Project eviction and shutdown
+  join the migration worker before releasing shared index state, while the
+  existing sensitive-path filters continue to run before every remote batch.
+  Provider failure keeps local retrieval and never starts a CPU fallback.
+
 ## 0.2.5851 - 2026-09-01
 
 - **Windows indexing works again.** Zig 0.17 can return pending positional

--- a/README.md
+++ b/README.md
@@ -467,21 +467,25 @@ embedding service. In the default hybrid mode:
 - provider/network failure keeps the local result and never invokes a CPU
   embedding fallback.
 
-The local ANN is built only by an explicit command:
+Build a new local ANN explicitly with:
 
 ```bash
 codedb /path/to/repo semantic-index
 ```
 
-CodeDB 0.2.5851 stages the managed embedding migration without breaking older
+CodeDB 0.2.5851 staged the managed embedding migration without breaking older
 clients. Versions through 0.2.5850 continue to request
 `Qwen/Qwen3-Embedding-0.6B`; 0.2.5851 and later request
 `jinaai/jina-embeddings-v2-base-code`. The service keeps both routes live. An
 existing Qwen ANN sidecar is rejected by the new client's model/vector-space
-check and hybrid retrieval safely uses transient exact reranking until the user
-runs `semantic-index` once to replace it with a Jina sidecar. CodeDB never
-mixes vectors from the two models and never uploads a repository automatically
-during update or ordinary queries.
+check. Starting in 0.2.5852, the first hybrid MCP query still returns through
+the bounded exact Jina reranker, then schedules one background rebuild of that
+exact legacy hosted-Qwen sidecar. The old OpenPuffer generation remains intact
+until the Jina replacement passes source, Git, metadata, and vector-space
+validation and commits atomically. Custom endpoints/model overrides and new
+repositories are never auto-built; set `CODEDB_NO_AUTO_SEMANTIC_MIGRATION=1`
+to disable even this legacy migration. CodeDB never mixes vectors from the two
+models.
 
 It splits already-indexable files into bounded 832-byte source chunks, uses
 four concurrent 25-item requests by default (explicitly configurable from one
@@ -493,8 +497,9 @@ On lookup, codedb checks model/vector-space identity, Git/content freshness,
 and the bounded metadata before opening the slab. Metadata heap use is capped
 at 64 MiB and graph-validation reads at 128 MiB; vector slabs remain
 demand-paged rather than being copied into the query process.
-It never scans or uploads `.env`, `.env.*`, `.envrc`, credentials, private keys, or other paths on
-the sensitive-file denylist. Ordinary indexing does not build this sidecar.
+It never scans or uploads `.env`, `.env.*`, `.envrc`, credentials, private keys,
+or other paths on the sensitive-file denylist. Ordinary lexical indexing does
+not build this sidecar.
 
 The default managed semantic lane is free to call and requires no API token or
 manual setup. On first use, CodeDB creates a local Ed25519 installation key,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5851",
+    .version = "0.2.5852",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,10 +99,11 @@ command returns the local result and does not run an embedding model on CPU.
 `--semantic` and `--hybrid` remain accepted compatibility aliases for the
 default; `--local` (or `--no-semantic`) is the explicit on-device-only mode.
 
-`semantic-index` is the only ANN build trigger. It sends bounded 832-byte code
-chunks using four concurrent 25-item requests by default (configurable from one
-to eight) and stores a small mapping plus a generation-named, validated `.hmls`
-mmap slab under codedb's local per-project data directory (0700/0600 on POSIX).
+`semantic-index` is the explicit ANN build trigger. It sends bounded 832-byte
+code chunks using four concurrent 25-item requests by default (configurable
+from one to eight) and stores a small mapping plus a generation-named,
+validated `.hmls` mmap slab under codedb's local per-project data directory
+(0700/0600 on POSIX).
 Queries verify vector-space identity and repository freshness before
 mmap. Metadata heap use is capped at 64 MiB, graph validation at 128 MiB, and
 the vector slab stays demand-paged instead of being copied into RSS.
@@ -120,15 +121,21 @@ CodeDB 0.2.5851 changes the managed default to
 request `Qwen/Qwen3-Embedding-0.6B`, and the hosted service serves both model
 names during the migration. Sidecar metadata includes the model, dimensions,
 query encoding, document-card encoding, and a calibration vector. A new client
-therefore refuses an old Qwen sidecar and uses transient exact reranking until
-you explicitly replace it:
+therefore refuses an old Qwen sidecar rather than searching it with Jina
+vectors. In 0.2.5852, the first hybrid MCP query returns via transient exact
+reranking and schedules one background rebuild when—and only when—the sidecar
+exactly matches CodeDB's former hosted-Qwen vector space. You can still replace
+it explicitly:
 
 ```bash
 codedb /path/to/repo semantic-index
 ```
 
-That command transactionally replaces the old generation. Updating the binary
-does not automatically send repository contents or build a semantic sidecar.
+Both paths replace the old generation transactionally. The previous sidecar is
+kept until the new Jina generation has passed source/Git freshness and metadata
+validation. Custom endpoints, model overrides, fresh repositories, Windows
+(until OpenPuffer has native mmap loading there), and
+`CODEDB_NO_AUTO_SEMANTIC_MIGRATION=1` remain explicit-only.
 
 ## Daemon Management
 

--- a/docs/releases/0.2.5852.md
+++ b/docs/releases/0.2.5852.md
@@ -1,0 +1,41 @@
+# CodeDB 0.2.5852
+
+CodeDB 0.2.5852 is a focused migration hotfix for repositories that already
+have a local OpenPuffer ANN created by CodeDB's former hosted Qwen default.
+
+## Automatic Qwen-to-Jina sidecar migration
+
+The first hybrid MCP query that encounters the exact legacy hosted-Qwen vector
+space now behaves in two phases:
+
+1. It returns normally through the existing bounded exact Jina reranker, so an
+   incompatible vector is never searched and retrieval does not wait for a
+   repository-wide rebuild.
+2. It schedules one background Jina rebuild owned by that project's semantic
+   search cache. Later hybrid queries use the new mmap-backed OpenPuffer sidecar
+   after it commits.
+
+The migration is deliberately narrow. It does not auto-build a sidecar for a
+new repository and does not touch custom endpoints or model overrides. Set
+`CODEDB_NO_AUTO_SEMANTIC_MIGRATION=1` to keep all sidecar builds explicit.
+Windows keeps bounded exact Jina reranking until OpenPuffer provides its native
+mmap load path there.
+
+## Safety and concurrency
+
+- The old Qwen generation remains referenced until the Jina slab and metadata
+  pass source-content, live filesystem, Git HEAD, record-range, calibration,
+  and vector-space checks and the metadata rename commits atomically.
+- One cache can launch at most one migration worker. Cache destruction and
+  project eviction join the worker before freeing its Explorer or Store.
+- `.env`, `.env.*`, `.envrc`, credentials, private keys, and every other
+  sensitive denylisted path remain excluded before any remote batch is formed.
+- Provider failures keep the local lexical result. CodeDB never falls back to
+  a CPU embedding model.
+
+## Compatibility
+
+The hosted service continues to run both explicit routes: released clients
+through 0.2.5850 use Qwen, while 0.2.5851 and later use Jina. No endpoint,
+token, or user configuration change is required. This release changes only the
+local persistence migration after a compatible client is installed.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5851",
+  "version": "0.2.5852",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -260,9 +260,9 @@ pub fn runSnapshot(ctx: *RunCtx) void {
     }
 }
 
-/// Explicitly build the local file-card ANN sidecar. This is never triggered
-/// by an ordinary query because indexing sends bounded, safe code-chunk cards
-/// to the configured embedding endpoint.
+/// Explicitly build the local file-card ANN sidecar. Ordinary queries do not
+/// create a new sidecar, except for the narrowly recognized hosted-Qwen to
+/// hosted-Jina migration owned by the MCP SearchCache.
 pub fn runSemanticIndex(ctx: *RunCtx) void {
     const stats = semantic_index.build(
         ctx.io,

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -4214,6 +4214,7 @@ fn handleContext(
     }
 
     var use_exact_semantic_fallback = false;
+    var schedule_legacy_semantic_migration = false;
     if (semantic_requested) ann_lane: {
         const data_dir = getProjectDataDir(A, rooted_project) orelse {
             retrieval.semantic = "unavailable";
@@ -4345,6 +4346,7 @@ fn handleContext(
         } else |err| {
             retrieval.semantic = "unavailable";
             retrieval.detail = @errorName(err);
+            schedule_legacy_semantic_migration = err == error.AnnModelMismatch;
             use_exact_semantic_fallback = switch (err) {
                 error.AnnIndexMissing,
                 error.InvalidAnnSidecar,
@@ -4443,6 +4445,30 @@ fn handleContext(
             }
         } else {
             retrieval.semantic = "no_candidates";
+        }
+    }
+
+    // Prioritize the bounded exact rerank above, then rebuild the recognized
+    // hosted-Qwen sidecar concurrently with the rest of the session. SearchCache
+    // owns and joins the worker, so project eviction or shutdown cannot free the
+    // Explorer/Store while migration is still reading them.
+    if (schedule_legacy_semantic_migration) {
+        if (semantic_cache) |cache| {
+            const data_dir = getProjectDataDir(A, rooted_project);
+            if (data_dir) |project_data_dir| {
+                switch (semantic_index_mod.scheduleLegacyHostedMigration(
+                    io,
+                    cache,
+                    explorer,
+                    store,
+                    rooted_project,
+                    project_data_dir,
+                )) {
+                    .scheduled => retrieval.detail = "AnnSidecarMigrationScheduled",
+                    .in_progress => retrieval.detail = "AnnSidecarMigrationInProgress",
+                    .not_eligible => {},
+                }
+            }
         }
     }
 

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5851";
+pub const semver = "0.2.5852";

--- a/src/semantic_index.zig
+++ b/src/semantic_index.zig
@@ -1,6 +1,8 @@
 //! Persistent, local code-chunk ANN index for hybrid codedb retrieval.
 //!
-//! Building is explicit: `codedb <root> semantic-index`. Safe, bounded file
+//! Building is explicit with `codedb <root> semantic-index`, except that a
+//! sidecar produced by the former hosted Qwen default is migrated once in the
+//! background when a hybrid query first encounters it. Safe, bounded file
 //! chunks are embedded remotely in batches, while the vectors, HNSW graph, and
 //! record mapping are written only to codedb's per-project local data dir.
 //! Querying sends only the user's bounded query and searches OpenPuffer in
@@ -39,6 +41,7 @@ pub const max_records: usize = 250_000;
 /// the 650-700 MiB query RSS profile that mmap is meant to avoid.
 pub const max_metadata_bytes: usize = 64 * 1024 * 1024;
 pub const max_slab_bytes: usize = 1024 * 1024 * 1024;
+pub const auto_migration_opt_out_env = "CODEDB_NO_AUTO_SEMANTIC_MIGRATION";
 
 const magic = [8]u8{ 'C', 'D', 'B', 'A', 'N', 'N', '0', '3' };
 const format_version: u16 = 3;
@@ -154,20 +157,102 @@ const CachedLoaded = struct {
 /// generation and is never queried.
 pub const SearchCache = struct {
     mu: cio.RwLock = .{},
+    migration_mu: cio.Mutex = .{},
     allocator: std.mem.Allocator,
     cached: ?CachedLoaded = null,
+    migration_thread: ?std.Thread = null,
+    migration_state: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(MigrationState.idle)),
 
     pub fn init(allocator: std.mem.Allocator) SearchCache {
         return .{ .allocator = allocator };
     }
 
     pub fn deinit(self: *SearchCache) void {
+        // A migration borrows the owning Explorer and Store. Join it before
+        // ProjectCache tears either one down, and before releasing this cache
+        // whose atomic state the worker updates on completion.
+        self.migration_mu.lock();
+        const migration_thread = self.migration_thread;
+        self.migration_thread = null;
+        self.migration_mu.unlock();
+        if (migration_thread) |thread| thread.join();
+
         self.mu.lock();
         defer self.mu.unlock();
         if (self.cached) |*cached| cached.loaded.deinit();
         self.cached = null;
     }
+
+    pub fn migrationState(self: *const SearchCache) MigrationState {
+        return @enumFromInt(self.migration_state.load(.acquire));
+    }
 };
+
+pub const MigrationState = enum(u8) {
+    idle,
+    running,
+    succeeded,
+    failed,
+};
+
+pub const MigrationSchedule = enum {
+    not_eligible,
+    scheduled,
+    in_progress,
+};
+
+const MigrationJob = struct {
+    io: std.Io,
+    cache: *SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []u8,
+    data_dir: []u8,
+
+    fn run(self: *MigrationJob) void {
+        const allocator = std.heap.page_allocator;
+        const result = build(self.io, allocator, self.explorer, self.store, self.project_root, self.data_dir);
+        if (result) |stats| {
+            self.cache.migration_state.store(@intFromEnum(MigrationState.succeeded), .release);
+            std.log.info(
+                "semantic sidecar migration committed: {d} chunks from {d} files in {d} ms",
+                .{ stats.records, stats.files_indexed, stats.elapsed_ns / std.time.ns_per_ms },
+            );
+        } else |err| {
+            self.cache.migration_state.store(@intFromEnum(MigrationState.failed), .release);
+            std.log.warn("semantic sidecar migration failed: {s}", .{@errorName(err)});
+        }
+        allocator.free(self.project_root);
+        allocator.free(self.data_dir);
+        allocator.destroy(self);
+    }
+};
+
+fn createMigrationJob(
+    io: std.Io,
+    cache: *SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+) !*MigrationJob {
+    const allocator = std.heap.page_allocator;
+    const job = try allocator.create(MigrationJob);
+    errdefer allocator.destroy(job);
+    const owned_root = try allocator.dupe(u8, project_root);
+    errdefer allocator.free(owned_root);
+    const owned_data_dir = try allocator.dupe(u8, data_dir);
+    errdefer allocator.free(owned_data_dir);
+    job.* = .{
+        .io = io,
+        .cache = cache,
+        .explorer = explorer,
+        .store = store,
+        .project_root = owned_root,
+        .data_dir = owned_data_dir,
+    };
+    return job;
+}
 
 fn elapsedNs(since: i128) u64 {
     const now = cio.nanoTimestamp();
@@ -914,6 +999,79 @@ fn validateLoadedConfig(config: *const semantic.Config, loaded: *const Loaded) !
     if (config.vectorSpaceId() != loaded.vector_space_id) return error.AnnVectorSpaceMismatch;
 }
 
+fn isLegacyHostedVectorSpace(
+    current: *const semantic.Config,
+    stored_model: []const u8,
+    stored_dimensions: u16,
+    stored_vector_space_id: u64,
+) bool {
+    // Automatic repository-wide embedding is deliberately limited to the one
+    // vector space shipped as CodeDB's hosted default before Jina. Custom URLs,
+    // custom model overrides, malformed metadata, and merely similar Qwen
+    // sidecars remain explicit user decisions.
+    if (!std.mem.eql(u8, current.url, semantic.default_url) or
+        !std.mem.eql(u8, current.model, semantic.default_model) or
+        current.dimensions != semantic.default_dimensions or
+        !std.mem.eql(u8, stored_model, semantic.legacy_qwen_model) or
+        stored_dimensions != semantic.default_dimensions)
+    {
+        return false;
+    }
+    const legacy = semantic.Config{
+        .url = semantic.default_url,
+        .model = semantic.legacy_qwen_model,
+        .token = null,
+        .dimensions = semantic.default_dimensions,
+        .timeout_ms = semantic.default_timeout_ms,
+    };
+    return stored_vector_space_id == legacy.vectorSpaceId();
+}
+
+/// Schedule a single transactional Qwen-to-Jina sidecar migration owned by
+/// `cache`. The old generation stays referenced until build() atomically
+/// publishes the validated replacement. The exact semantic fallback can serve
+/// the triggering request while this worker runs.
+pub fn scheduleLegacyHostedMigration(
+    io: std.Io,
+    cache: *SearchCache,
+    explorer: *Explorer,
+    store: *Store,
+    project_root: []const u8,
+    data_dir: []const u8,
+) MigrationSchedule {
+    if (comptime builtin.os.tag == .windows) return .not_eligible;
+    if (cio.posixGetenv(auto_migration_opt_out_env) != null) return .not_eligible;
+
+    const config = semantic.Config.fromEnv();
+    config.validate() catch return .not_eligible;
+    var loaded = loadMetadata(io, std.heap.page_allocator, data_dir) catch return .not_eligible;
+    defer loaded.deinit();
+    if (!isLegacyHostedVectorSpace(&config, loaded.model, loaded.dimensions, loaded.vector_space_id)) {
+        return .not_eligible;
+    }
+
+    cache.migration_mu.lock();
+    defer cache.migration_mu.unlock();
+    switch (cache.migrationState()) {
+        .running => return .in_progress,
+        .idle => {},
+        .succeeded, .failed => return .not_eligible,
+    }
+
+    const allocator = std.heap.page_allocator;
+    const job = createMigrationJob(io, cache, explorer, store, project_root, data_dir) catch return .not_eligible;
+
+    cache.migration_state.store(@intFromEnum(MigrationState.running), .release);
+    cache.migration_thread = std.Thread.spawn(.{}, MigrationJob.run, .{job}) catch {
+        cache.migration_state.store(@intFromEnum(MigrationState.failed), .release);
+        allocator.free(job.project_root);
+        allocator.free(job.data_dir);
+        allocator.destroy(job);
+        return .not_eligible;
+    };
+    return .scheduled;
+}
+
 fn searchLoaded(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -1176,9 +1334,87 @@ test "semantic ANN sidecar accepts Jina 512D and rejects a legacy Qwen vector sp
     var legacy_config = config;
     legacy_config.model = semantic.legacy_qwen_model;
     try testing.expectError(error.AnnModelMismatch, validateLoadedConfig(&legacy_config, &restored));
+    try testing.expect(isLegacyHostedVectorSpace(
+        &config,
+        semantic.legacy_qwen_model,
+        semantic.default_dimensions,
+        legacy_config.vectorSpaceId(),
+    ));
+    try testing.expect(!isLegacyHostedVectorSpace(
+        &config,
+        semantic.default_model,
+        semantic.default_dimensions,
+        config.vectorSpaceId(),
+    ));
+    var custom_current = config;
+    custom_current.url = "http://localhost:8080/v1/embeddings";
+    try testing.expect(!isLegacyHostedVectorSpace(
+        &custom_current,
+        semantic.legacy_qwen_model,
+        semantic.default_dimensions,
+        legacy_config.vectorSpaceId(),
+    ));
+    try testing.expect(!isLegacyHostedVectorSpace(
+        &config,
+        semantic.legacy_qwen_model,
+        semantic.default_dimensions,
+        legacy_config.vectorSpaceId() ^ 1,
+    ));
     const results = try restored.index.search(&b, 1, testing.allocator);
     defer testing.allocator.free(results);
     try testing.expectEqual(@as(u32, 1), results[0].id);
+
+    if (builtin.os.tag != .windows and
+        std.mem.eql(u8, config.url, semantic.default_url) and
+        std.mem.eql(u8, config.model, semantic.default_model))
+    {
+        // Repoint metadata at the exact former hosted default, then prove that
+        // an already-running migration is recognized without launching a
+        // duplicate worker or touching the Explorer/Store arguments.
+        _ = try writeMetadata(
+            io,
+            testing.allocator,
+            dir_path,
+            semantic.legacy_qwen_model,
+            semantic.default_dimensions,
+            1234,
+            legacy_config.vectorSpaceId(),
+            &calibration,
+            null,
+            slab_name,
+            &.{
+                .{ .path = "src/a.zig", .line_start = 1, .line_end = 2 },
+                .{ .path = "src/b.zig", .line_start = 8, .line_end = 12 },
+            },
+        );
+        var cache = SearchCache.init(testing.allocator);
+        defer cache.deinit();
+        cache.migration_state.store(@intFromEnum(MigrationState.running), .release);
+        var explorer = Explorer.init(testing.allocator, 1024);
+        defer explorer.deinit();
+        var store = Store.init(testing.allocator);
+        defer store.deinit();
+        try testing.expectEqual(
+            MigrationSchedule.in_progress,
+            scheduleLegacyHostedMigration(io, &cache, &explorer, &store, dir_path, dir_path),
+        );
+        try testing.expect(cache.migration_thread == null);
+    }
+}
+
+test "semantic search cache joins its migration worker before destruction" {
+    const testing = std.testing;
+    var finished = std.atomic.Value(bool).init(false);
+    var cache = SearchCache.init(testing.allocator);
+    cache.migration_state.store(@intFromEnum(MigrationState.running), .release);
+    cache.migration_thread = try std.Thread.spawn(.{}, struct {
+        fn run(done: *std.atomic.Value(bool)) void {
+            cio.sleepMs(20);
+            done.store(true, .release);
+        }
+    }.run, .{&finished});
+    cache.deinit();
+    try testing.expect(finished.load(.acquire));
 }
 
 test "semantic repository fingerprint survives cold scan snapshot reload" {


### PR DESCRIPTION
## Summary

- recognize only the exact legacy hosted-Qwen 512D sidecar
- serve the triggering hybrid request through bounded exact Jina reranking,
  then schedule one background rebuild
- keep the old OpenPuffer generation until the Jina replacement validates and
  commits atomically
- join the migration worker before project-cache eviction or shutdown
- preserve custom-provider, Windows, sensitive-path, and no-CPU-fallback
  boundaries
- document the opt-out: `CODEDB_NO_AUTO_SEMANTIC_MIGRATION=1`
- bump release metadata to 0.2.5852

## Verification

- `zig build test`
- `zig build test-ann`
- `zig build test-semantic-index`
- vendored OpenPuffer `zig build test` (recall@10 = 1.000)
- MCP E2E: 76/76
- ReleaseFast cross-builds: macOS x86_64, Linux x86_64/aarch64, Windows x86_64
- production-backed smoke: legacy Qwen sidecar → first exact Jina result →
  1.52s background rebuild → next query `ann_applied` through mmap OpenPuffer
