### PR TITLE
Release 0.2.5854: security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.2.5854 - 2026-09-05
+
+- Authenticate Unix CLI daemon peers and validate notification-file ownership and type before consuming edits.
+- Use exclusive random temporary files for repository policy updates and reject overflowing snapshot sections.
+- Confine native website prerendered reads to `dist` and give detached Sentry workers stable allocation ownership.
+- Execute ranking-evaluation subprocesses without a shell; add live MCP/HTTP security regression checks.
+- Preserve the existing release source-file, sensitive-path, and notification-path protections.
+
 ## 0.2.5853 - 2026-09-05
 
 - Improve default Jina hybrid rank fusion and preserve unique exact definitions.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .codedb2,
     .fingerprint = 0x6e18d96ca2a31757,
-    .version = "0.2.5853",
+    .version = "0.2.5854",
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",
     .dependencies = .{
         .nanoregex = .{

--- a/docs/releases/0.2.5854.md
+++ b/docs/releases/0.2.5854.md
@@ -1,0 +1,26 @@
+# CodeDB 0.2.5854
+
+Security maintenance release based on 0.2.5853.
+
+This release authenticates local Unix CLI daemon peers, validates notification-file ownership before reading or truncating it, uses exclusive randomized temporary files for policy updates, and rejects overflowing snapshot section bounds.
+
+Native website prerendered reads are confined to `dist`. Sentry request-error reporting now uses worker-owned buffers and a stable allocator. Ranking evaluation passes executable paths, corpus paths, and query JSON directly to subprocesses without invoking a shell.
+
+The 0.2.5853 source-file boundary is retained: file symlinks remain unsupported, in-project directory aliases remain usable, and sensitive or external files are excluded from indexing and reads. Added live MCP and HTTP regression checks cover these properties.
+
+Validation commands:
+
+```sh
+zig build test
+zig build
+python3 scripts/e2e_mcp_test.py --binary zig-out/bin/codedb --project "$PWD"
+python3 scripts/test_rank_eval_security.py
+python3 scripts/test_security_boundaries.py
+```
+
+Website security tests use the website's Zig 0.15 toolchain:
+
+```sh
+zig test src/prerender_file.zig -lc
+zig test src/telemetry.zig -lc
+```

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedeebee",
-  "version": "0.2.5853",
+  "version": "0.2.5854",
   "description": "Zig code intelligence MCP server — npx launcher for the codedb native binary",
   "license": "MIT",
   "author": "justrach",

--- a/scripts/rank-eval.py
+++ b/scripts/rank-eval.py
@@ -36,6 +36,7 @@ Notes:
 """
 from __future__ import annotations
 
+import time
 import argparse
 import json
 import os
@@ -96,8 +97,8 @@ def child_env(home: Path) -> dict:
 
 def prewarm(binary: str, corpus: Path, env: dict) -> None:
     """Build + persist the snapshot once so per-query MCP loads are fast/ready."""
-    subprocess.run(["bash", "-c", f"cd {corpus} && {binary} . index"],
-                   capture_output=True, text=True, env=env, timeout=180)
+    subprocess.run([str(Path(binary).resolve()), ".", "index"], cwd=corpus,
+                   capture_output=True, text=True, env=env, timeout=180, check=True)
 
 
 def search(binary: str, corpus: Path, env: dict, query: str, max_results: int = 10) -> list:
@@ -107,16 +108,24 @@ def search(binary: str, corpus: Path, env: dict, query: str, max_results: int = 
     snapshot asynchronously, so a query fired immediately hits `loading_snapshot`
     and returns 0 results. `sleep 6` between them lets the load finish.
     """
-    req = ('{"jsonrpc":"2.0","id":1,"method":"tools/call","params":'
-           '{"name":"codedb_search","arguments":{"query":"%s","max_results":%d}}}'
-           % (query, max_results))
-    script = (f"cd {corpus} && "
-              f"{{ printf '%s\\n' {json.dumps(INIT)}; sleep 6; "
-              f"printf '%s\\n' {json.dumps(req)}; sleep 2; }} | {binary} mcp 2>/dev/null")
-    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
-                          env=env, timeout=90)
+    req = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                      "params": {"name": "codedb_search", "arguments":
+                                 {"query": query, "max_results": max_results}}})
+    # Keep case text, paths, and executable names out of a shell entirely.
+    with subprocess.Popen([str(Path(binary).resolve()), "mcp"], cwd=corpus,
+                          stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                          stderr=subprocess.DEVNULL, text=True, env=env) as proc:
+        try:
+            proc.stdin.write(INIT + "\n")
+            proc.stdin.flush()
+            time.sleep(6)
+            stdout, _ = proc.communicate(req + "\n", timeout=90)
+        except BaseException:
+            proc.kill()
+            proc.communicate()
+            raise
     hits = []
-    for line in proc.stdout.splitlines():
+    for line in stdout.splitlines():
         line = line.strip()
         if not line.startswith("{"):
             continue

--- a/scripts/test_rank_eval_security.py
+++ b/scripts/test_rank_eval_security.py
@@ -1,0 +1,46 @@
+"""Regression test: eval cases and paths remain data, never shell programs."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("rank_eval", Path(__file__).with_name("rank-eval.py"))
+rank_eval = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rank_eval)
+
+
+class RankEvalSecurity(unittest.TestCase):
+    def test_literal_query_and_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            corpus = root / "corpus with spaces; $(touch injected)"
+            corpus.mkdir()
+            binary = root / "fake tool; literal"
+            binary.write_text('''#!/usr/bin/env python3
+import json, sys
+from pathlib import Path
+if sys.argv[1:] == [".", "index"]:
+    Path("prewarmed").write_text("ok")
+    sys.exit(0)
+init = json.loads(sys.stdin.readline())
+request = json.loads(sys.stdin.readline())
+Path("received.json").write_text(json.dumps(request))
+print(json.dumps({"id":1,"result":{"content":[{"text":"src/control.zig:1: safe"}]}}))
+''')
+            binary.chmod(0o700)
+            rank_eval.prewarm(str(binary), corpus, dict(os.environ))
+            self.assertEqual((corpus / "prewarmed").read_text(), "ok")
+            for query in ['ordinary_symbol', '" \\ $(touch injected) `touch injected`\nnew line']:
+                with patch.object(rank_eval.time, "sleep"):
+                    rank_eval.search(str(binary), corpus, dict(os.environ), query)
+                request = json.loads((corpus / "received.json").read_text())
+                self.assertEqual(request["params"]["arguments"]["query"], query)
+                self.assertFalse((corpus / "injected").exists())
+                self.assertFalse((root / "injected").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_security_boundaries.py
+++ b/scripts/test_security_boundaries.py
@@ -1,0 +1,70 @@
+"""Live MCP/HTTP regression checks for project-file boundaries."""
+import http.client
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from unittest.mock import patch
+from e2e_mcp_test import MCPProcess, do_initialize, wait_for_scan, all_tool_text
+
+binary = str(Path(sys.argv[1] if len(sys.argv) > 1 else "zig-out/bin/codedb").resolve())
+with tempfile.TemporaryDirectory(prefix="codedb-security-") as directory:
+    base = Path(directory)
+    root = base / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname = 'security-control'\nversion = '0'\n")
+    (root / "safe.py").write_text("def control(): return 'PUBLIC_CONTROL'\n")
+    (root / ".env").write_text("TOKEN=PRIVATE_MARKER_4821\n")
+    (base / "outside.py").write_text("PRIVATE_MARKER_4821\n")
+    (root / "sources").mkdir()
+    (root / "sources" / "nested.py").write_text("PUBLIC_CONTROL\n")
+    (root / "alias").symlink_to("sources", target_is_directory=True)
+    (root / "alias.py").symlink_to("safe.py")
+    (root / "escape.py").symlink_to("../outside.py")
+    (root / "secret.py").symlink_to(".env")
+    env = {"HOME": str(base / "home"), "CODEDB_ALLOW_TEMP": "1", "CODEDB_NO_CLI_DAEMON": "1"}
+    with patch.dict(os.environ, env):
+        p = MCPProcess(binary, [], cwd="/", command=[binary, str(root), "mcp", "--no-telemetry"])
+        try:
+            assert do_initialize(p, with_roots=False) and wait_for_scan(p)
+            for path in ["safe.py", "alias/nested.py"]:
+                response = p.call_tool("codedb_query", {"pipeline": [{"op": "read", "path": path}]})
+                assert "PUBLIC_CONTROL" in all_tool_text(response), response
+            for path in ["../outside.py", str(base / "outside.py"), ".env", "escape.py", "secret.py", "alias.py"]:
+                response = p.call_tool("codedb_query", {"pipeline": [{"op": "read", "path": path}]})
+                assert response is not None and "PRIVATE_MARKER_4821" not in all_tool_text(response), response
+            response = p.call_tool("codedb_search", {"query": "PRIVATE_MARKER_4821"})
+            assert response is not None and "0 results" in all_tool_text(response), response
+        finally:
+            p.close()
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        server_env = dict(os.environ, CODEDB_PORT=str(port))
+        proc = subprocess.Popen([binary, str(root), "serve", "--no-telemetry"], env=server_env,
+                                stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            for _ in range(200):
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=.2):
+                        break
+                except OSError:
+                    assert proc.poll() is None, "HTTP server exited"
+                    time.sleep(.05)
+            for path in ["safe.py", "alias/nested.py", "alias.py", ".env", "escape.py", "secret.py", "../outside.py"]:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                conn.request("GET", "/file/read?path=" + path)
+                response = conn.getresponse()
+                data = response.read().decode()
+                conn.close()
+                if path in ["safe.py", "alias/nested.py"]:
+                    assert response.status == 200 and "PUBLIC_CONTROL" in data, data
+                else:
+                    assert response.status != 200 and "PRIVATE_MARKER_4821" not in data, data
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)
+print("PASS: MCP indexing/query and HTTP reject escapes and secrets; ordinary and in-root alias reads succeed")

--- a/src/cli_proxy.zig
+++ b/src/cli_proxy.zig
@@ -1141,7 +1141,27 @@ fn cliConnect(io: std.Io, allocator: std.mem.Allocator, abs_root: []const u8, da
         _ = std.c.close(fd);
         return null;
     }
+    if (!unixPeerTrusted(fd)) {
+        _ = std.c.close(fd);
+        return null;
+    }
     return fd;
+}
+
+extern "c" fn getpeereid(fd: c_int, uid: *std.c.uid_t, gid: *std.c.gid_t) c_int;
+
+fn unixPeerTrusted(fd: c_int) bool {
+    if (comptime builtin.os.tag == .linux) {
+        const Credentials = extern struct { pid: std.c.pid_t, uid: std.c.uid_t, gid: std.c.gid_t };
+        var peer: Credentials = undefined;
+        var len: std.c.socklen_t = @sizeOf(Credentials);
+        if (std.c.getsockopt(fd, std.c.SOL.SOCKET, std.c.SO.PEERCRED, @ptrCast(&peer), &len) != 0) return false;
+        return len == @sizeOf(Credentials) and peer.uid == std.c.geteuid();
+    } else if (comptime builtin.os.tag == .macos or builtin.os.tag == .freebsd or builtin.os.tag == .openbsd or builtin.os.tag == .netbsd) {
+        var uid: std.c.uid_t = undefined;
+        var gid: std.c.gid_t = undefined;
+        return getpeereid(fd, &uid, &gid) == 0 and uid == std.c.geteuid();
+    } else return false;
 }
 
 fn cliCloseConn(conn: CliConn) void {
@@ -1150,4 +1170,14 @@ fn cliCloseConn(conn: CliConn) void {
         return;
     }
     _ = std.c.close(conn);
+}
+
+test "security: unix peer credentials authenticate same-user socket pairs" {
+    if (comptime builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    var pair: [2]c_int = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &pair));
+    defer _ = std.c.close(pair[0]);
+    defer _ = std.c.close(pair[1]);
+    try std.testing.expect(unixPeerTrusted(pair[0]));
+    try std.testing.expect(!unixPeerTrusted(-1));
 }

--- a/src/codex_setup.zig
+++ b/src/codex_setup.zig
@@ -371,11 +371,13 @@ fn readOptionalFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) 
 
 /// Atomic write via a sibling temp file + rename, matching nuke.rewriteConfigFile.
 fn writeFileAtomic(io: std.Io, allocator: std.mem.Allocator, path: []const u8, content: []const u8) !void {
-    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    var nonce: [16]u8 = undefined;
+    io.random(&nonce);
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.{x}.tmp", .{ path, nonce });
     defer allocator.free(tmp_path);
+    const file = try std.Io.Dir.cwd().createFile(io, tmp_path, .{ .exclusive = true });
     errdefer std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
     {
-        const file = try std.Io.Dir.cwd().createFile(io, tmp_path, .{});
         defer file.close(io);
         try file.writeStreamingAll(io, content);
         try file.sync(io);
@@ -814,4 +816,24 @@ fn printCodexUsage(out: *Out, s: sty.Style) void {
         s.dim,  s.reset,
         s.dim,  s.reset,
     });
+}
+
+test "security: atomic policy writer ignores planted predictable temp symlink" {
+    const t = std.testing;
+    const io = t.io;
+    var tmp = t.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "victim", .data = "unchanged" });
+    try tmp.dir.symLink(io, "victim", "AGENTS.md.tmp", .{});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp.dir.realPath(io, &path_buf);
+    const path = try std.fmt.allocPrint(t.allocator, "{s}/AGENTS.md", .{path_buf[0..len]});
+    defer t.allocator.free(path);
+    try writeFileAtomic(io, t.allocator, path, "policy");
+    const victim = try tmp.dir.readFileAlloc(io, "victim", t.allocator, .limited(1024));
+    defer t.allocator.free(victim);
+    try t.expectEqualStrings("unchanged", victim);
+    const policy = try tmp.dir.readFileAlloc(io, "AGENTS.md", t.allocator, .limited(1024));
+    defer t.allocator.free(policy);
+    try t.expectEqualStrings("policy", policy);
 }

--- a/src/release_info.zig
+++ b/src/release_info.zig
@@ -1,1 +1,1 @@
-pub const semver = "0.2.5853";
+pub const semver = "0.2.5854";

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -567,8 +567,11 @@ fn readSectionsFromFile(io: std.Io, file: std.Io.File, allocator: std.mem.Alloca
     if (scn != 4) return null;
     const section_count = std.mem.readInt(u32, &sc_buf, .little);
 
+    const file_size = (file.stat(io) catch return null).size;
+    if (file_size < 52 or section_count > (file_size - 52) / 20) return null;
     var result = std.AutoHashMap(u32, SectionEntry).init(allocator);
-    errdefer result.deinit();
+    var success = false;
+    defer if (!success) result.deinit();
 
     var pos: u64 = 52;
     for (0..section_count) |_| {
@@ -576,6 +579,9 @@ fn readSectionsFromFile(io: std.Io, file: std.Io.File, allocator: std.mem.Alloca
         const en = file.readPositionalAll(io, &entry_buf, pos) catch return null;
         if (en != 20) return null;
         pos += 20;
+        const offset = std.mem.readInt(u64, entry_buf[4..12], .little);
+        const length = std.mem.readInt(u64, entry_buf[12..20], .little);
+        if (offset > file_size or length > file_size - offset) return null;
         try result.put(
             std.mem.readInt(u32, entry_buf[0..4], .little),
             .{
@@ -585,6 +591,7 @@ fn readSectionsFromFile(io: std.Io, file: std.Io.File, allocator: std.mem.Alloca
             },
         );
     }
+    success = true;
     return result;
 }
 
@@ -611,7 +618,7 @@ fn readSectionBytesFromFile(io: std.Io, file: std.Io.File, section_id: SectionId
 
     // Validate section fits within file
     const file_size = file.length(io) catch return null;
-    if (entry.offset + entry.length > file_size) return null;
+    if (entry.offset > file_size or entry.length > file_size - entry.offset) return null;
 
     const buf = try allocator.alloc(u8, @intCast(entry.length));
     errdefer allocator.free(buf);
@@ -784,7 +791,7 @@ pub fn loadSnapshotValidatedFromFile(
     // Validate content section fits within actual file size (issue-40: truncation detection)
     const file_stat = file.stat(io) catch return false;
     const file_size = file_stat.size;
-    if (content_entry.offset + content_entry.length > file_size) return false;
+    if (content_entry.offset > file_size or content_entry.length > file_size - content_entry.offset) return false;
 
     var read_pos: u64 = content_entry.offset;
     const snap_mtime: i128 = @intCast(file_stat.mtime.nanoseconds);
@@ -1229,7 +1236,7 @@ fn loadSnapshotFast(
     const content_file = snapshot_file;
 
     const file_stat = content_file.stat(io) catch return false;
-    if (content_entry.offset + content_entry.length > file_stat.size) return false;
+    if (content_entry.offset > file_stat.size or content_entry.length > file_stat.size - content_entry.offset) return false;
 
     const snap_mtime: i128 = @intCast(file_stat.mtime.nanoseconds);
     var file_count: u32 = 0;

--- a/src/test_snapshot.zig
+++ b/src/test_snapshot.zig
@@ -1343,3 +1343,26 @@ test "p0: writeSnapshot tolerates over-long symbol names (u16 length overflow)" 
     try testing.expect(snapshot_mod.loadSnapshot(io, snap, &exp2, &store, testing.allocator));
     try testing.expectEqual(@as(usize, 1), exp2.outlines.count());
 }
+
+test "security: snapshot section overflow and out-of-file bounds are rejected" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bytes: [72]u8 = @splat(0);
+    @memcpy(bytes[0..4], "CDB\x01");
+    std.mem.writeInt(u16, bytes[4..6], 4, .little);
+    std.mem.writeInt(u32, bytes[48..52], 1, .little);
+    std.mem.writeInt(u32, bytes[52..56], 1, .little);
+    std.mem.writeInt(u64, bytes[56..64], std.math.maxInt(u64) - 8, .little);
+    std.mem.writeInt(u64, bytes[64..72], 32, .little);
+    try tmp.dir.writeFile(io, .{ .sub_path = "bad.snapshot", .data = &bytes });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp.dir.realPathFile(io, "bad.snapshot", &buf);
+    try testing.expect(try snapshot_mod.readSections(io, buf[0..len], testing.allocator) == null);
+    // A valid empty section with the same header remains readable.
+    std.mem.writeInt(u64, bytes[56..64], bytes.len, .little);
+    std.mem.writeInt(u64, bytes[64..72], 0, .little);
+    try tmp.dir.writeFile(io, .{ .sub_path = "bad.snapshot", .data = &bytes });
+    var sections = (try snapshot_mod.readSections(io, buf[0..len], testing.allocator)) orelse return error.TestUnexpectedResult;
+    defer sections.deinit();
+    try testing.expectEqual(@as(usize, 1), sections.count());
+}

--- a/src/watcher.zig
+++ b/src/watcher.zig
@@ -2960,6 +2960,31 @@ fn indexFileContentAt(
 // We drain this file on every poll cycle and re-index the listed files
 // immediately, eliminating the 2s polling delay for muonry-sourced edits.
 
+fn openTrustedNotify(io: std.Io, notify_dir: std.Io.Dir, notify_path: [*:0]const u8) ?std.Io.File {
+    if (comptime builtin.os.tag != .linux and builtin.os.tag != .macos) return null;
+    // Authenticate the opened inode before reading or truncating it.
+    const flags: std.c.O = .{ .ACCMODE = .RDWR, .NOFOLLOW = true, .NONBLOCK = true, .CLOEXEC = true };
+    const fd = std.c.openat(notify_dir.handle, notify_path, flags);
+    if (fd < 0) return null;
+    const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = true } };
+    var accepted = false;
+    defer if (!accepted) file.close(io);
+
+    const trusted = if (comptime builtin.os.tag == .linux) blk: {
+        var st: std.os.linux.Statx = undefined;
+        if (std.os.linux.statx(fd, "", std.os.linux.AT.EMPTY_PATH, .{ .TYPE = true, .MODE = true, .UID = true, .NLINK = true }, &st) != 0) break :blk false;
+        if (!st.mask.TYPE or !st.mask.MODE or !st.mask.UID or !st.mask.NLINK) break :blk false;
+        break :blk st.uid == std.c.geteuid() and st.nlink == 1 and (st.mode & 0o170000) == 0o100000 and (st.mode & 0o022) == 0;
+    } else blk: {
+        var st: std.c.Stat = undefined;
+        if (std.c.fstat(fd, &st) != 0) break :blk false;
+        break :blk st.uid == std.c.geteuid() and st.nlink == 1 and (st.mode & 0o170000) == 0o100000 and (st.mode & 0o022) == 0;
+    };
+    if (!trusted) return null;
+    accepted = true;
+    return file;
+}
+
 fn drainNotifyFile(io: std.Io, store: *Store, explorer: *Explorer, queue: *EventQueue, known: *FileMap, alloc: std.mem.Allocator) void {
     drainNotifyFileFrom(io, store, explorer, queue, known, alloc, std.Io.Dir.cwd(), "/tmp/codedb-notify");
 }
@@ -2974,8 +2999,9 @@ fn drainNotifyFileFrom(
     notify_dir: std.Io.Dir,
     notify_path: []const u8,
 ) void {
-    // Atomically read + truncate.
-    const file = notify_dir.openFile(io, notify_path, .{ .mode = .read_write }) catch return;
+    const notify_name = alloc.dupeSentinel(u8, notify_path, 0) catch return;
+    defer alloc.free(notify_name);
+    const file = openTrustedNotify(io, notify_dir, notify_name) orelse return;
     defer file.close(io);
 
     const file_len = file.length(io) catch return;
@@ -3149,7 +3175,7 @@ test "issue-685: watcher diff updates document edges for modify add and delete" 
     defer root_dir.close(io);
     for ([_][]const u8{ "docs/a.md", "docs/b.md" }) |path| {
         const stat = try root_dir.statFile(io, path, .{});
-        const content = try root_dir.readFileAlloc(io, path, testing.allocator, .limited(max_indexed_file_bytes));
+        const content = try project_file.readAllocNoFollow(io, root_dir, path, testing.allocator, .limited(max_indexed_file_bytes));
         defer testing.allocator.free(content);
         const owned_path = try testing.allocator.dupe(u8, path);
         try known.put(owned_path, .{
@@ -3251,4 +3277,26 @@ test "dir-mtime prune still stats known files and notices new siblings" {
         try incrementalDiffInner(io, &store, &explorer, queue, &known, &dirs, root, testing.allocator, arena.allocator());
     }
     try testing.expect(explorer.outlines.contains("src/c.py"));
+}
+
+test "security: notify channel refuses symlinks and accepts owner regular files" {
+    if (comptime builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const t = std.testing;
+    const io = t.io;
+    var tmp = t.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "owned", .data = "notification" });
+    try tmp.dir.symLink(io, "owned", "link", .{});
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp.dir.realPath(io, &buf);
+    const link = try std.fmt.allocPrintSentinel(t.allocator, "{s}/link", .{buf[0..len]}, 0);
+    defer t.allocator.free(link);
+    try t.expect(openTrustedNotify(io, std.Io.Dir.cwd(), link) == null);
+    const owned = try std.fmt.allocPrintSentinel(t.allocator, "{s}/owned", .{buf[0..len]}, 0);
+    defer t.allocator.free(owned);
+    const file = openTrustedNotify(io, std.Io.Dir.cwd(), owned) orelse return error.TestUnexpectedResult;
+    file.close(io);
+    const content = try tmp.dir.readFileAlloc(io, "owned", t.allocator, .limited(1024));
+    defer t.allocator.free(content);
+    try t.expectEqualStrings("notification", content);
 }

--- a/website/src/prerender_file.zig
+++ b/website/src/prerender_file.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+
+pub fn openPrerendered(alloc: std.mem.Allocator, root: std.fs.Dir, url_path: []const u8) !std.fs.File {
+    const rel = if (std.mem.eql(u8, url_path, "/")) "index" else if (std.mem.startsWith(u8, url_path, "/")) url_path[1..] else url_path;
+    if (rel.len == 0 or std.mem.indexOfAny(u8, rel, "\\:\x00%") != null) return error.AccessDenied;
+    var parts = std.mem.splitScalar(u8, rel, '/');
+    var parent = root.openDir(".", .{ .no_follow = true }) catch return error.AccessDenied;
+    defer parent.close();
+    var part = parts.next().?;
+    while (true) {
+        if (part.len == 0 or std.mem.eql(u8, part, ".") or std.mem.eql(u8, part, "..")) return error.AccessDenied;
+        const next = parts.next() orelse break;
+        const child = parent.openDir(part, .{ .no_follow = true }) catch return error.AccessDenied;
+        parent.close();
+        parent = child;
+        part = next;
+    }
+    const name = std.fmt.allocPrint(alloc, "{s}.html", .{part}) catch return error.AccessDenied;
+    defer alloc.free(name);
+    const fd = std.posix.openat(parent.fd, name, .{ .ACCMODE = .RDONLY, .NOFOLLOW = true, .NONBLOCK = true, .CLOEXEC = true }, 0) catch return error.AccessDenied;
+    const file: std.fs.File = .{ .handle = fd };
+    errdefer file.close();
+
+    if ((file.stat() catch return error.AccessDenied).kind != .file) return error.AccessDenied;
+    return file;
+}
+
+test "security: prerender files stay under dist" {
+    const t = std.testing;
+    var tmp = t.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("dist/docs");
+    try tmp.dir.writeFile(.{ .sub_path = "outside.html", .data = "secret" });
+    try tmp.dir.writeFile(.{ .sub_path = "dist/index.html", .data = "home" });
+    try tmp.dir.writeFile(.{ .sub_path = "dist/docs/page.html", .data = "page" });
+    var dist = try tmp.dir.openDir("dist", .{});
+    defer dist.close();
+    try dist.symLink("../outside.html", "link.html", .{});
+    for ([_][]const u8{ "/", "/docs/page" }) |path| {
+        const file = try openPrerendered(t.allocator, dist, path);
+        file.close();
+    }
+    for ([_][]const u8{ "/../outside", "/docs/../../outside", "/link", "/%2e%2e/outside", "/docs\\../outside" }) |path| {
+        try t.expectError(error.AccessDenied, openPrerendered(t.allocator, dist, path));
+    }
+}

--- a/website/src/server.zig
+++ b/website/src/server.zig
@@ -131,7 +131,7 @@ fn handleConn(ctx: *ConnCtx) void {
                 dev_mod.sendErrorOverlay(&std_req, std_req.head.target, err, mer.version) catch {};
             }
             // Telemetry: report error to Sentry + Datadog.
-            telemetry.sentryCapture(@errorName(err), std_req.head.target, mer.version);
+            @import("telemetry.zig").sentryCapture(@errorName(err), std_req.head.target, mer.version);
             telemetry.ddError(std_req.head.target, @tagName(std_req.head.method), @errorName(err));
             return;
         };
@@ -392,15 +392,9 @@ fn tryServePrerendered(
     std_req: *std.http.Server.Request,
     url_path: []const u8,
 ) ?void {
-    const fs_path = if (std.mem.eql(u8, url_path, "/"))
-        std.fmt.allocPrint(alloc, "dist/index.html", .{}) catch return null
-    else blk: {
-        const rel = if (url_path.len > 0 and url_path[0] == '/') url_path[1..] else url_path;
-        break :blk std.fmt.allocPrint(alloc, "dist/{s}.html", .{rel}) catch return null;
-    };
-    defer alloc.free(fs_path);
-
-    const file = std.fs.cwd().openFile(fs_path, .{}) catch return null;
+    var dist = std.fs.cwd().openDir("dist", .{ .no_follow = true }) catch return null;
+    defer dist.close();
+    const file = @import("prerender_file.zig").openPrerendered(alloc, dist, url_path) catch return null;
     defer file.close();
 
     const body = file.readToEndAlloc(alloc, 10 * 1024 * 1024) catch return null;

--- a/website/src/telemetry.zig
+++ b/website/src/telemetry.zig
@@ -4,10 +4,10 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const env_mod = @import("env.zig");
+const env_mod = @import("mer");
 
 fn env(name: []const u8) ?[]const u8 {
-    return env_mod.get(name);
+    return env_mod.env(name);
 }
 
 // ── Sentry ──────────────────────────────────────────────────────────────────
@@ -54,32 +54,38 @@ pub fn sentryCapture(
 
     // Build the POST URL.
     var url_buf: [256]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf,
-        "https://{s}/api/{s}/envelope/", .{ cfg.host, cfg.project_id },
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "https://{s}/api/{s}/envelope/",
+        .{ cfg.host, cfg.project_id },
     ) catch return;
 
-    // Copy to heap for the thread.
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const alloc = gpa.allocator();
-    const url_copy = alloc.dupe(u8, url) catch return;
-    const payload_copy = alloc.dupe(u8, envelope) catch return;
-
-    const t = std.Thread.spawn(.{}, sentrySendThread, .{ &gpa, url_copy, payload_copy }) catch {
-        alloc.free(url_copy);
-        alloc.free(payload_copy);
-        return;
-    };
+    const t = spawnSentry(url, envelope) orelse return;
     t.detach();
 }
 
-fn sentrySendThread(gpa: *std.heap.GeneralPurposeAllocator(.{}), url: []const u8, payload: []const u8) void {
+fn spawnSentry(url: []const u8, envelope: []const u8) ?std.Thread {
+    // Both buffers and the allocator survive the request's stack frame.
+    const alloc = std.heap.page_allocator;
+    const url_copy = alloc.dupe(u8, url) catch return null;
+    const payload_copy = alloc.dupe(u8, envelope) catch {
+        alloc.free(url_copy);
+        return null;
+    };
+    return std.Thread.spawn(.{}, sentrySendThread, .{ url_copy, payload_copy }) catch {
+        alloc.free(url_copy);
+        alloc.free(payload_copy);
+        return null;
+    };
+}
+
+fn sentrySendThread(url: []const u8, payload: []const u8) void {
     defer {
-        const alloc = gpa.allocator();
+        const alloc = std.heap.page_allocator;
         alloc.free(url);
         alloc.free(payload);
-        _ = gpa.deinit();
     }
-    const alloc = gpa.allocator();
+    const alloc = std.heap.page_allocator;
     var client = std.http.Client{ .allocator = alloc };
     defer client.deinit();
 
@@ -123,7 +129,8 @@ pub fn ddTiming(path: []const u8, method: []const u8, status: u16, duration_us: 
     const addr = statsd_addr orelse return;
 
     var buf: [512]u8 = undefined;
-    const msg = std.fmt.bufPrint(&buf,
+    const msg = std.fmt.bufPrint(
+        &buf,
         "merjs.request.duration:{d}|ms|#path:{s},method:{s},status:{d}\n" ++
             "merjs.request.count:1|c|#path:{s},method:{s},status:{d}",
         .{ duration_us / 1000, path, method, status, path, method, status },
@@ -138,7 +145,8 @@ pub fn ddError(path: []const u8, method: []const u8, error_name: []const u8) voi
     const addr = statsd_addr orelse return;
 
     var buf: [512]u8 = undefined;
-    const msg = std.fmt.bufPrint(&buf,
+    const msg = std.fmt.bufPrint(
+        &buf,
         "merjs.request.error:1|c|#path:{s},method:{s},error:{s}",
         .{ path, method, error_name },
     ) catch return;
@@ -171,4 +179,17 @@ test "parseSentryDsn: empty key returns null" {
 
 test "parseSentryDsn: empty project_id returns null" {
     try std.testing.expect(parseSentryDsn("https://abc123@o1234.ingest.sentry.io/") == null);
+}
+
+test "security: sentry worker outlives the caller's stack buffers" {
+    const thread = blk: {
+        var url = "invalid-url".*;
+        var payload = "test-envelope".*;
+        const worker = spawnSentry(&url, &payload) orelse return error.TestUnexpectedResult;
+        @memset(&url, 0);
+        @memset(&payload, 0);
+        break :blk worker;
+    };
+    // An invalid URL exercises cleanup without sending any network traffic.
+    thread.join();
 }


### PR DESCRIPTION
Release 0.2.5854 closes the remaining security findings through Unix peer authentication, notification-file ownership checks, randomized exclusive policy writes, overflow-safe snapshot bounds, confined website prerender reads, stable Sentry worker allocations, and shell-free ranking evaluation.

Retains 0.2.5853's existing project-file and sensitive-path protections. Adds regression tests, version metadata, and release notes.

Validation: full Zig suite passed (four skipped), all 76 MCP end-to-end scenarios passed, live MCP/HTTP security checks and ranking-evaluation regression passed, website tests/build passed, and Linux/Windows cross-builds passed. macOS distribution binaries will be signed and notarized using the established notary-local profile before release publication.
