### PR TITLE
Merge update resolution fix into main

### DIFF
--- a/install/worker.js
+++ b/install/worker.js
@@ -1,5 +1,4 @@
 const GITHUB_REPO = "justrach/codedb";
-const FALLBACK_VERSION = "0.2.56";
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/install/install.sh`;
 
 export default {
@@ -49,28 +48,25 @@ async function serveInstallScript() {
 }
 
 async function serveLatestVersion() {
-  const resp = await fetch(
-    `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
-    { headers: { "User-Agent": "codedb-worker", Accept: "application/vnd.github.v3+json" } }
-  );
-
-  if (resp.ok) {
-    const release = await resp.json();
-    const version = release.tag_name.replace(/^v/, "");
-    return new Response(JSON.stringify({ version }), {
-      headers: {
-        "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=60",
-      },
-    });
+  try {
+    const resp = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      { headers: { "User-Agent": "codedb-worker", Accept: "application/vnd.github.v3+json" } }
+    );
+    if (resp.ok) {
+      const release = await resp.json();
+      if (typeof release.tag_name === "string" && /^v?\d+\.\d+\.\d+$/.test(release.tag_name)) {
+        return new Response(JSON.stringify({ version: release.tag_name.replace(/^v/, "") }), {
+          headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" },
+        });
+      }
+    }
+  } catch {
+    // Network errors and invalid responses must not advertise a stale release.
   }
-
-  // Fallback: hardcoded latest version (update on each release)
-  return new Response(JSON.stringify({ version: FALLBACK_VERSION }), {
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "public, max-age=60",
-    },
+  return new Response(JSON.stringify({ error: "Unable to check the latest release. Please retry later." }), {
+    status: 503,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
 }
 

--- a/scripts/test_update_resolution.py
+++ b/scripts/test_update_resolution.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Exercise update resolution without network access or replacing a binary."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+binary = str(Path(sys.argv[1]).resolve())
+original_hash = hashlib.sha256(Path(binary).read_bytes()).digest()
+version = subprocess.check_output([binary, '--version'], text=True).strip().split()[-1]
+with tempfile.TemporaryDirectory() as directory:
+    curl = Path(directory) / 'curl'
+    curl.write_text('''#!/usr/bin/env python3
+import os, sys
+url = sys.argv[-1]
+if url.endswith('/releases/latest'):
+    if os.environ['SCENARIO'] == 'equal':
+        print(os.environ['LATEST_JSON'])
+        sys.exit(0)
+    sys.exit(22)
+if url.endswith('/latest.json'):
+    if os.environ['SCENARIO'] == 'stale':
+        print('{"version":"0.2.56"}')
+        sys.exit(0)
+    sys.exit(22)
+print('UNEXPECTED_DOWNLOAD', file=sys.stderr)
+sys.exit(99)
+''')
+    curl.chmod(0o755)
+    env = dict(os.environ, PATH=directory + os.pathsep + os.environ['PATH'], NO_COLOR='1')
+    env.pop('CODEDB_VERSION', None)
+    env.pop('CODEDB_URL', None)
+    for scenario, code, expected in [
+        ('equal', 0, 'already up to date'),
+        ('stale', 1, 'cannot confirm the latest release'),
+        ('unavailable', 1, 'CouldNotResolveLatestVersion'),
+        ('explicit', 1, 'requested by CODEDB_VERSION'),
+    ]:
+        case = dict(env, SCENARIO=scenario, LATEST_JSON=json.dumps({'tag_name': 'v' + version}))
+        if scenario == 'explicit':
+            case['CODEDB_VERSION'] = '0.2.56'
+        result = subprocess.run([binary, 'update'], env=case, capture_output=True, text=True)
+        assert result.returncode == code, (scenario, result)
+        assert expected in result.stdout, (scenario, result)
+        assert hashlib.sha256(Path(binary).read_bytes()).digest() == original_hash
+        print(f'PASS: {scenario}')

--- a/src/update.zig
+++ b/src/update.zig
@@ -62,7 +62,11 @@ pub fn run(io: std.Io, stdout: cio.File, s: sty.Style, allocator: std.mem.Alloca
             return;
         },
         .gt => {
-            out.p("{s}✗{s} refusing to replace codedb {s} with older release {s}\n", .{ s.red, s.reset, release_info.semver, resolved.value });
+            if (resolved.source == .env) {
+                out.p("{s}✗{s} refusing to replace codedb {s} with older release {s} requested by CODEDB_VERSION\n", .{ s.red, s.reset, release_info.semver, resolved.value });
+            } else {
+                out.p("{s}✗{s} cannot confirm the latest release: update source reports {s}, older than installed codedb {s}. No changes made; please retry later.\n", .{ s.red, s.reset, resolved.value, release_info.semver });
+            }
             std.process.exit(1);
         },
         .lt => {},

--- a/tests/update-worker.test.mjs
+++ b/tests/update-worker.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+for (const file of ['install/worker.js', 'website/worker/worker.js']) {
+  test(`${file}: latest release never falls back to a fabricated version`, async () => {
+    const source = await readFile(new URL(`../${file}`, import.meta.url), 'utf8');
+    const { default: worker } = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const tag of ['v0.2.5854', '0.2.5854']) {
+        globalThis.fetch = async () => Response.json({ tag_name: tag });
+        const response = await worker.fetch(new Request('https://example.com/latest.json'));
+        assert.equal(response.status, 200);
+        assert.deepEqual(await response.json(), { version: '0.2.5854' });
+      }
+      for (const upstream of [
+        async () => new Response('', { status: 403 }),
+        async () => new Response('', { status: 500 }),
+        async () => { throw new Error('network unavailable'); },
+        async () => new Response('invalid JSON'),
+        ...[{}, { tag_name: null }, { tag_name: 42 }, { tag_name: '' }, { tag_name: 'invalid' }].map(body => async () => Response.json(body)),
+      ]) {
+        globalThis.fetch = upstream;
+        const response = await worker.fetch(new Request('https://example.com/latest.json'));
+        assert.equal(response.status, 503);
+        assert.equal(response.headers.get('Cache-Control'), 'no-store');
+        const body = await response.json();
+        assert.equal('version' in body, false);
+        assert.match(body.error, /retry/i);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+}

--- a/website/worker/worker.js
+++ b/website/worker/worker.js
@@ -1,7 +1,6 @@
 // codedb — Cloudflare Workers fetch handler (static site + install binary proxy)
 
 const GITHUB_REPO = "justrach/codedb";
-const FALLBACK_VERSION = "0.2.2";
 
 const securityHeaders = {
   "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
@@ -44,19 +43,25 @@ export default {
 };
 
 async function serveLatestVersion() {
-  const resp = await fetch(
-    `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
-    { headers: { "User-Agent": "codedb-worker", Accept: "application/vnd.github.v3+json" } }
-  );
-  if (resp.ok) {
-    const release = await resp.json();
-    const version = release.tag_name.replace(/^v/, "");
-    return new Response(JSON.stringify({ version }), {
-      headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=300" },
-    });
+  try {
+    const resp = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      { headers: { "User-Agent": "codedb-worker", Accept: "application/vnd.github.v3+json" } }
+    );
+    if (resp.ok) {
+      const release = await resp.json();
+      if (typeof release.tag_name === "string" && /^v?\d+\.\d+\.\d+$/.test(release.tag_name)) {
+        return new Response(JSON.stringify({ version: release.tag_name.replace(/^v/, "") }), {
+          headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" },
+        });
+      }
+    }
+  } catch {
+    // Network errors and invalid responses must not advertise a stale release.
   }
-  return new Response(JSON.stringify({ version: FALLBACK_VERSION }), {
-    headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" },
+  return new Response(JSON.stringify({ error: "Unable to check the latest release. Please retry later." }), {
+    status: 503,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
 }
 


### PR DESCRIPTION
Bring the tested update-resolution fix from release/0.2.5854 into main. Removes hardcoded fallback versions in the public workers and clarifies stale automatic metadata versus an explicit downgrade request in the CLI.

Validation: ReleaseFast build, worker tests, four CLI resolution scenarios, macOS resource checks, and paired benchmark gate passed in #745. The production endpoint fix is deployed and merged in justrach/codedb-cloud#54. This merges source only; published release binaries are unchanged.

Refs #742.
